### PR TITLE
[codex] Add tenant-scoped capability rules

### DIFF
--- a/business-architecture/capabilities/cms/content-management/cm-content-types.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-types.md
@@ -1,0 +1,27 @@
+# Capability: Content Types
+
+## What It Does
+The system must allow administrators to define and configure the structure of content — what fields exist, what types they are, and what rules apply — entirely from the admin UI without writing code.
+
+## Personas
+- **CMS Administrator** — defines and maintains content type schemas as the organization's needs evolve
+
+## Behaviors
+- Define a content type with a name, label, and set of fields
+- Add, edit, and remove fields from an existing content type
+- Supported field types: text, rich text, boolean, date/time, number, taxonomy, relation (link to another content type), URL
+- Mark fields as required or optional
+- Configure field-level validation rules
+- Enable or disable workflow and audit trail per content type
+- Preview the content type form before publishing the schema
+
+## Rules
+- Content type changes must not destroy existing content — removing a field hides it, it does not delete stored data
+- At least one field must be designated as the display title for each content type
+- Content type names must be unique within an organization
+- Content types must be scoped to an organization
+- Built-in content types (Organization, Persona, Capability, Application, ADR) are editable but not deletable in v1
+
+## Links
+- Depends on: IAM — Role-Based Access Control
+- Related: Content Authoring, Content Relationships, Taxonomy Management

--- a/business-architecture/capabilities/cms/content-management/cm-taxonomy-management.md
+++ b/business-architecture/capabilities/cms/content-management/cm-taxonomy-management.md
@@ -1,0 +1,30 @@
+# Capability: Taxonomy Management
+
+## What It Does
+The system must provide a hierarchical categorization system that content items can be tagged against. GovEA ships with a default government capability taxonomy that agencies can customize to match their structure.
+
+## Personas
+- **CMS Administrator** — manages taxonomy terms; customizes the default taxonomy to fit the agency
+- **Content Viewer** — navigates and filters content by taxonomy term
+
+## Behaviors
+- Define taxonomy vocabularies (e.g. Capability Domain, Jurisdiction Type)
+- Add, edit, and delete taxonomy terms within a vocabulary
+- Organize terms in a hierarchy (parent/child relationships)
+- Tag content items with one or more taxonomy terms
+- Filter content lists by taxonomy term
+- Ship a default government capability taxonomy (10 domains, 50+ sub-domains) as a seed
+
+## Default Government Capability Taxonomy Domains
+Administrative Services, Public Safety, Infrastructure & Public Works, Community Development, Health & Human Services, Parks/Recreation/Culture, Transportation, Information Technology, Finance & Revenue, Legislative & Executive
+
+## Rules
+- Deleting a taxonomy term does not delete content tagged with it — the tag is removed from the content item
+- Taxonomy vocabularies and terms must be scoped to an organization
+- Taxonomy terms must be unique within their vocabulary for that organization
+- The default taxonomy is editable — agencies can rename, add, or remove terms
+- A content item may be tagged with terms from multiple vocabularies
+
+## Links
+- Depends on: Content Types
+- Related: Content Authoring, Content Search & Filtering

--- a/business-architecture/capabilities/cms/iam/iam-role-based-access-control.md
+++ b/business-architecture/capabilities/cms/iam/iam-role-based-access-control.md
@@ -1,0 +1,33 @@
+# Capability: Role-Based Access Control
+
+## What It Does
+The system must control what each user can see and do based on their assigned role. Permissions are enforced consistently across the UI, API, and data layer.
+
+## Personas
+- **CMS Administrator** — assigns roles to users; understands what each role can do
+- **Content Viewer** — subject to role enforcement; receives read-only access by default
+
+## Behaviors
+- Enforce three built-in roles: Admin, Contributor, Viewer
+- Prevent users from accessing features or content outside their role's permissions
+- Allow an Admin to change a user's role at any time
+- SSO users are assigned the Viewer role automatically on first login
+- Display only the UI elements a user has permission to use — do not show and then block
+
+## Roles
+
+| Role | Permissions |
+|---|---|
+| Admin | Full access — manage users, org settings, all content |
+| Contributor | Create and edit content — no user management, no delete |
+| Viewer | Read-only access to published content |
+
+## Rules
+- Roles are fixed in v1 — custom role creation is out of scope
+- Permission enforcement must occur server-side; UI hiding alone is not sufficient
+- A user can hold only one role per organization at a time
+- Role assignments must be scoped to an organization
+
+## Links
+- Depends on: User Management
+- Related: SSO Authentication, Local Authentication

--- a/business-architecture/capabilities/cms/iam/iam-user-management.md
+++ b/business-architecture/capabilities/cms/iam/iam-user-management.md
@@ -1,0 +1,25 @@
+# Capability: User Management
+
+## What It Does
+The system must be able to create, edit, deactivate, and delete user accounts. Administrators manage users entirely through the UI — no CLI or database access required.
+
+## Personas
+- **CMS Administrator** — owns this capability; performs all user management tasks
+
+## Behaviors
+- Create a new user account with name, email, and role assignment
+- Edit an existing user's profile, email, or role
+- Deactivate a user account without deleting it (preserves audit history)
+- Delete a user account permanently
+- View a list of all users with their role and account status
+- Search and filter the user list
+
+## Rules
+- At least one Admin account must exist per organization at all times — the last Admin for an organization cannot be deactivated or deleted
+- Deactivated users cannot log in but their content and audit records are preserved
+- User records must be scoped to an organization
+- Email addresses must be unique within an organization
+
+## Links
+- Depends on: Role-Based Access Control
+- Related: SSO Authentication, IAM Audit Trail, First-Run Setup


### PR DESCRIPTION
## Summary
- Scope IAM users and role assignments to an organization
- Scope content types and taxonomy vocabularies/terms to an organization
- Change uniqueness rules from global to organization-scoped where needed

## Why
Issue #5 flagged that single-tenant wording in these capability rules could lock in data-model assumptions that make v2 multi-tenancy harder.

## Validation
- Documentation-only change
- Ran `git diff --cached --check` before committing

Closes #5