### PR TITLE
feat: user management UI — create, edit, deactivate, delete, search

### DIFF
--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -117,3 +117,65 @@ export async function deleteUser(userId: string) {
     before: { name: target?.name, email: target?.email },
   })
 }
+
+export async function reactivateUser(userId: string) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  await db.update(users).set({ isActive: 'true', updatedAt: new Date() }).where(
+    and(eq(users.id, userId), eq(users.organizationId, orgId))
+  )
+
+  await writeAuditLog({
+    action: 'user.reactivate',
+    entityType: 'user',
+    entityId: userId,
+    userId: session.user.id,
+    organizationId: orgId,
+  })
+}
+
+export async function editUser(userId: string, formData: FormData) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const name = formData.get('name') as string
+  const email = formData.get('email') as string
+  const role = formData.get('role') as 'admin' | 'contributor' | 'viewer'
+  const newPassword = formData.get('password') as string | null
+
+  const before = await db.query.users.findFirst({ where: eq(users.id, userId) })
+
+  // Last-admin guard for role demotion
+  if (before?.role === 'admin' && role !== 'admin') {
+    const [adminCount] = await db.select({ count: count() }).from(users).where(
+      and(eq(users.organizationId, orgId), eq(users.role, 'admin'), eq(users.isActive, 'true'))
+    )
+    if (adminCount.count <= 1) throw new Error('Cannot demote the last admin')
+  }
+
+  const updates: Partial<typeof users.$inferInsert> = {
+    name,
+    email,
+    role,
+    updatedAt: new Date(),
+  }
+
+  if (newPassword && newPassword.length >= 8) {
+    updates.passwordHash = await bcrypt.hash(newPassword, 12)
+  }
+
+  await db.update(users).set(updates).where(
+    and(eq(users.id, userId), eq(users.organizationId, orgId))
+  )
+
+  await writeAuditLog({
+    action: 'user.edit',
+    entityType: 'user',
+    entityId: userId,
+    userId: session.user.id,
+    organizationId: orgId,
+    before: { name: before?.name, email: before?.email, role: before?.role },
+    after: { name, email, role },
+  })
+}

--- a/apps/govea/src/app/(admin)/users/page.tsx
+++ b/apps/govea/src/app/(admin)/users/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { isAdmin } from '@/lib/rbac'
 import { getUsers } from '@/actions/users'
+import { UserTable } from './user-table'
 
 export default async function UsersPage() {
   const session = await auth()
@@ -12,38 +13,10 @@ export default async function UsersPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold text-gray-900">Users</h1>
-      <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              {['Name', 'Email', 'Role', 'Status'].map(h => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{h}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {userList.map(u => (
-              <tr key={u.id}>
-                <td className="px-4 py-3 text-sm text-gray-900">{u.name}</td>
-                <td className="px-4 py-3 text-sm text-gray-500">{u.email}</td>
-                <td className="px-4 py-3">
-                  <span className={`rounded px-2 py-0.5 text-xs font-medium ${
-                    u.role === 'admin' ? 'bg-purple-100 text-purple-800' :
-                    u.role === 'contributor' ? 'bg-green-100 text-green-800' :
-                    'bg-gray-100 text-gray-600'
-                  }`}>{u.role}</span>
-                </td>
-                <td className="px-4 py-3">
-                  <span className={`rounded px-2 py-0.5 text-xs font-medium ${
-                    u.isActive === 'true' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'
-                  }`}>{u.isActive === 'true' ? 'Active' : 'Inactive'}</span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
       </div>
+      <UserTable users={userList} currentUserId={session.user.id} />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/users/user-table.tsx
+++ b/apps/govea/src/app/(admin)/users/user-table.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import type { User } from '@/db/schema'
+import { createUser, editUser, deactivateUser, reactivateUser, deleteUser } from '@/actions/users'
+import { useRouter } from 'next/navigation'
+
+type UserRow = Pick<User, 'id' | 'name' | 'email' | 'role' | 'isActive'>
+
+interface Props {
+  users: UserRow[]
+  currentUserId: string
+}
+
+const ROLE_STYLES: Record<string, string> = {
+  admin: 'bg-purple-100 text-purple-800',
+  contributor: 'bg-green-100 text-green-800',
+  viewer: 'bg-gray-100 text-gray-600',
+}
+
+export function UserTable({ users, currentUserId }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  // Search / filter
+  const [search, setSearch] = useState('')
+  const [roleFilter, setRoleFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+
+  // Modal state
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<UserRow | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<UserRow | null>(null)
+
+  const refresh = () => router.refresh()
+
+  const filtered = users.filter(u => {
+    const matchSearch = !search ||
+      u.name?.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+    const matchRole = roleFilter === 'all' || u.role === roleFilter
+    const matchStatus = statusFilter === 'all' ||
+      (statusFilter === 'active' ? u.isActive === 'true' : u.isActive !== 'true')
+    return matchSearch && matchRole && matchStatus
+  })
+
+  const adminCount = users.filter(u => u.role === 'admin' && u.isActive === 'true').length
+
+  async function handleCreate(formData: FormData) {
+    startTransition(async () => {
+      await createUser(formData)
+      setCreateOpen(false)
+      refresh()
+    })
+  }
+
+  async function handleEdit(formData: FormData) {
+    if (!editTarget) return
+    startTransition(async () => {
+      await editUser(editTarget.id, formData)
+      setEditTarget(null)
+      refresh()
+    })
+  }
+
+  async function handleDeactivate(user: UserRow) {
+    startTransition(async () => {
+      await deactivateUser(user.id)
+      refresh()
+    })
+  }
+
+  async function handleReactivate(user: UserRow) {
+    startTransition(async () => {
+      await reactivateUser(user.id)
+      refresh()
+    })
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    startTransition(async () => {
+      await deleteUser(deleteTarget.id)
+      setDeleteTarget(null)
+      refresh()
+    })
+  }
+
+  const isLastAdmin = (user: UserRow) => user.role === 'admin' && adminCount <= 1
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="search"
+          placeholder="Search by name or email…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm w-64 focus:border-blue-500 focus:outline-none"
+        />
+        <select
+          value={roleFilter}
+          onChange={e => setRoleFilter(e.target.value)}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+        >
+          <option value="all">All roles</option>
+          <option value="admin">Admin</option>
+          <option value="contributor">Contributor</option>
+          <option value="viewer">Viewer</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value)}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+        >
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+        <button
+          onClick={() => setCreateOpen(true)}
+          className="ml-auto rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Add user
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {['Name', 'Email', 'Role', 'Status', 'Actions'].map(h => (
+                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-400">No users match the current filters.</td>
+              </tr>
+            )}
+            {filtered.map(u => {
+              const inactive = u.isActive !== 'true'
+              const isSelf = u.id === currentUserId
+              const lastAdmin = isLastAdmin(u)
+              return (
+                <tr key={u.id} className={inactive ? 'opacity-50' : ''}>
+                  <td className="px-4 py-3 text-sm text-gray-900">{u.name ?? '—'}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{u.email}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded px-2 py-0.5 text-xs font-medium ${ROLE_STYLES[u.role]}`}>{u.role}</span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded px-2 py-0.5 text-xs font-medium ${inactive ? 'bg-red-50 text-red-600' : 'bg-green-50 text-green-700'}`}>
+                      {inactive ? 'Inactive' : 'Active'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => setEditTarget(u)}
+                        className="text-xs text-blue-600 hover:underline"
+                      >
+                        Edit
+                      </button>
+                      {!isSelf && (
+                        <>
+                          {inactive ? (
+                            <button
+                              onClick={() => handleReactivate(u)}
+                              disabled={isPending}
+                              className="text-xs text-green-600 hover:underline disabled:opacity-40"
+                            >
+                              Reactivate
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => handleDeactivate(u)}
+                              disabled={isPending || lastAdmin}
+                              title={lastAdmin ? 'Cannot deactivate the last admin' : undefined}
+                              className="text-xs text-yellow-600 hover:underline disabled:opacity-40"
+                            >
+                              Deactivate
+                            </button>
+                          )}
+                          <button
+                            onClick={() => setDeleteTarget(u)}
+                            disabled={isPending || lastAdmin}
+                            title={lastAdmin ? 'Cannot delete the last admin' : undefined}
+                            className="text-xs text-red-600 hover:underline disabled:opacity-40"
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Create modal */}
+      {createOpen && (
+        <Modal title="Add user" onClose={() => setCreateOpen(false)}>
+          <form action={handleCreate} className="space-y-3">
+            <Field label="Name" name="name" type="text" required />
+            <Field label="Email" name="email" type="email" required />
+            <Field label="Password" name="password" type="password" required minLength={8} />
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Role</label>
+              <select name="role" defaultValue="viewer" className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none">
+                <option value="viewer">Viewer</option>
+                <option value="contributor">Contributor</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <ModalActions onCancel={() => setCreateOpen(false)} submitLabel="Create user" isPending={isPending} />
+          </form>
+        </Modal>
+      )}
+
+      {/* Edit modal */}
+      {editTarget && (
+        <Modal title="Edit user" onClose={() => setEditTarget(null)}>
+          <form action={handleEdit} className="space-y-3">
+            <Field label="Name" name="name" type="text" required defaultValue={editTarget.name ?? ''} />
+            <Field label="Email" name="email" type="email" required defaultValue={editTarget.email} />
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Role</label>
+              <select name="role" defaultValue={editTarget.role} className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none">
+                <option value="viewer">Viewer</option>
+                <option value="contributor">Contributor</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <Field label="New password (leave blank to keep current)" name="password" type="password" minLength={8} />
+            <ModalActions onCancel={() => setEditTarget(null)} submitLabel="Save changes" isPending={isPending} />
+          </form>
+        </Modal>
+      )}
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <Modal title="Delete user" onClose={() => setDeleteTarget(null)}>
+          <p className="text-sm text-gray-600">
+            Are you sure you want to permanently delete <strong>{deleteTarget.name ?? deleteTarget.email}</strong>? This cannot be undone.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <button onClick={() => setDeleteTarget(null)} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">
+              Cancel
+            </button>
+            <button onClick={handleDelete} disabled={isPending} className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-40">
+              {isPending ? 'Deleting…' : 'Delete'}
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+// --- Shared sub-components ---
+
+function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, ...props }: { label: string } & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700">{label}</label>
+      <input
+        {...props}
+        className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+      />
+    </div>
+  )
+}
+
+function ModalActions({ onCancel, submitLabel, isPending }: { onCancel: () => void; submitLabel: string; isPending: boolean }) {
+  return (
+    <div className="flex justify-end gap-2 pt-2">
+      <button type="button" onClick={onCancel} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">
+        Cancel
+      </button>
+      <button type="submit" disabled={isPending} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-40">
+        {isPending ? 'Saving…' : submitLabel}
+      </button>
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@govea/core':
         specifier: workspace:*
         version: link:../../packages/core
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -60,6 +63,9 @@ importers:
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.59.1
+      '@types/bcryptjs':
+        specifier: ^2.4.6
+        version: 2.4.6
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -819,6 +825,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/bcryptjs@2.4.6':
+    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -839,6 +848,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1838,6 +1850,8 @@ snapshots:
   '@turbo/windows-arm64@2.9.3':
     optional: true
 
+  '@types/bcryptjs@2.4.6': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1858,6 +1872,8 @@ snapshots:
       picomatch: 2.3.2
 
   arg@5.0.2: {}
+
+  bcryptjs@2.4.3: {}
 
   binary-extensions@2.3.0: {}
 


### PR DESCRIPTION
Closes #20

## Summary
- **`/users` page** split into a server component (data fetching + auth) and a `UserTable` client component (interactivity)
- **Search and filter** — real-time filter by name/email, role dropdown, and active/inactive status; no page reload required
- **Add user modal** — name, email, password, role fields; wired to existing `createUser` action
- **Edit user modal** — pre-filled with current values; supports name, email, role, and optional password reset; wired to new `editUser` action with last-admin guard
- **Deactivate / Reactivate** — toggle per row; button label and colour reflect current state; last-admin guard disables deactivation
- **Delete** — confirmation modal before executing; disabled for the last admin and for the current user (no self-delete)
- **New server actions** — `reactivateUser` and `editUser`, both with audit logging

## Test plan
- [ ] Sign in as Admin via dev shortcut → visit `/users`
- [ ] Add user form opens, creates a new user, row appears on refresh
- [ ] Edit user changes name/email/role; last-admin demotion shows disabled state
- [ ] Deactivate a non-admin user — row goes inactive/muted; Reactivate restores it
- [ ] Deactivating the last admin is blocked (button disabled)
- [ ] Delete confirmation modal appears; user is removed after confirming
- [ ] Search filters by name and email in real time
- [ ] Role and status dropdowns narrow the list correctly
- [ ] All actions appear in the audit log at `/audit`
- [ ] Viewer and Contributor visiting `/users` are redirected to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)