### PR TITLE
feat: add theme switcher with GovEA and ServiceNow themes

### DIFF
--- a/apps/govea/src/actions/settings.ts
+++ b/apps/govea/src/actions/settings.ts
@@ -1,0 +1,40 @@
+'use server'
+
+import { db } from '@/db/client'
+import { organizations } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { writeAuditLog } from '@/lib/audit'
+import { themes } from '@/lib/themes'
+import { redirect } from 'next/navigation'
+
+export async function updateOrgTheme(themeId: string) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user as any)) throw new Error('Forbidden')
+
+  const orgId = (session.user as any).organizationId!
+
+  // Validate theme ID
+  const valid = themes.find(t => t.id === themeId)
+  if (!valid) throw new Error('Invalid theme')
+
+  const before = await db.query.organizations.findFirst({
+    where: eq(organizations.id, orgId),
+  })
+
+  await db.update(organizations)
+    .set({ theme: themeId, updatedAt: new Date() })
+    .where(eq(organizations.id, orgId))
+
+  await writeAuditLog({
+    action: 'settings.theme_changed',
+    entityType: 'organization',
+    entityId: orgId,
+    userId: session.user.id,
+    organizationId: orgId,
+    before: { theme: before?.theme },
+    after: { theme: themeId },
+  })
+}

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -3,6 +3,10 @@ import { auth } from '@/lib/auth'
 import { signOut } from '@/lib/auth'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { db } from '@/db/client'
+import { organizations } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { getTheme, themeToStyleString } from '@/lib/themes'
 import type { Role } from '@/lib/rbac'
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
@@ -10,6 +14,18 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   if (!session?.user) redirect('/login')
 
   const role = (session.user as any).role as Role
+
+  // Load org theme
+  let themeStyle = ''
+  if ((session.user as any).organizationId) {
+    const org = await db.query.organizations.findFirst({
+      where: eq(organizations.id, (session.user as any).organizationId),
+    })
+    if (org) {
+      const theme = getTheme(org.theme)
+      themeStyle = themeToStyleString(theme)
+    }
+  }
 
   const navLinks = [
     { href: '/dashboard', label: 'Dashboard', roles: ['admin', 'contributor', 'viewer'] as Role[] },
@@ -31,9 +47,17 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b bg-white">
+      {themeStyle && <style dangerouslySetInnerHTML={{ __html: themeStyle }} />}
+      <header
+        className="border-b"
+        style={{
+          backgroundColor: 'hsl(var(--header-bg))',
+          borderColor: 'hsl(var(--header-border))',
+          color: 'hsl(var(--header-fg))',
+        }}
+      >
         <div className="flex h-14 items-center gap-6 px-6">
-          <span className="font-bold text-foreground tracking-tight">GovEA</span>
+          <span className="font-bold tracking-tight" style={{ color: 'hsl(var(--header-fg))' }}>GovEA</span>
           <nav className="flex items-center gap-1">
             {navLinks
               .filter(l => l.roles.includes(role))
@@ -41,14 +65,17 @@ export default async function AdminLayout({ children }: { children: React.ReactN
                 <a
                   key={l.href}
                   href={l.href}
-                  className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                  className="rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-white/10"
+                  style={{ color: 'hsl(var(--header-fg) / 0.8)' }}
                 >
                   {l.label}
                 </a>
               ))}
           </nav>
           <div className="ml-auto flex items-center gap-3">
-            <span className="text-sm text-muted-foreground">{session.user.email}</span>
+            <span className="text-sm" style={{ color: 'hsl(var(--header-fg) / 0.7)' }}>
+              {session.user.email}
+            </span>
             <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', roleBadgeClass[role])}>
               {role}
             </span>
@@ -56,7 +83,15 @@ export default async function AdminLayout({ children }: { children: React.ReactN
               'use server'
               await signOut({ redirectTo: '/login' })
             }}>
-              <Button variant="ghost" size="sm" type="submit">Sign out</Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                type="submit"
+                className="hover:bg-white/10"
+                style={{ color: 'hsl(var(--header-fg))' }}
+              >
+                Sign out
+              </Button>
             </form>
           </div>
         </div>

--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -1,10 +1,104 @@
-export default function SettingsPage() {
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { db } from '@/db/client'
+import { organizations } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { themes } from '@/lib/themes'
+import { updateOrgTheme } from '@/actions/settings'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export default async function SettingsPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const org = (session.user as any).organizationId
+    ? await db.query.organizations.findFirst({
+        where: eq(organizations.id, (session.user as any).organizationId),
+      })
+    : null
+
+  const activeTheme = org?.theme ?? 'govea'
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
         <p className="text-muted-foreground mt-1">Organization configuration and preferences.</p>
       </div>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Appearance</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">Choose a theme for your organization.</p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {themes.map(theme => {
+            const isActive = theme.id === activeTheme
+            return (
+              <form key={theme.id} action={async () => {
+                'use server'
+                await updateOrgTheme(theme.id)
+                redirect('/settings')
+              }}>
+                <button
+                  type="submit"
+                  className={cn(
+                    'w-full text-left rounded-lg border-2 overflow-hidden transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+                    isActive ? 'border-primary shadow-sm' : 'border-transparent hover:border-border'
+                  )}
+                >
+                  {/* Preview */}
+                  <div className="h-24 flex flex-col">
+                    {/* Header strip */}
+                    <div
+                      className="h-8 flex items-center px-3 gap-1.5"
+                      style={{ backgroundColor: theme.previewColors.header }}
+                    >
+                      <div className="w-2 h-2 rounded-full opacity-60" style={{ backgroundColor: theme.previewColors.primary }} />
+                      <div className="h-1.5 w-12 rounded-full opacity-40" style={{ backgroundColor: theme.previewColors.primary }} />
+                      <div className="ml-auto h-1.5 w-8 rounded-full opacity-30" style={{ backgroundColor: theme.previewColors.primary }} />
+                    </div>
+                    {/* Body */}
+                    <div
+                      className="flex-1 p-2 flex gap-1.5 items-start"
+                      style={{ backgroundColor: theme.previewColors.background }}
+                    >
+                      <div className="flex flex-col gap-1 flex-1">
+                        <div className="h-1.5 w-16 rounded-full bg-current opacity-20" />
+                        <div className="h-2.5 w-full rounded bg-white border border-current/10" />
+                        <div className="h-2.5 w-full rounded bg-white border border-current/10" />
+                      </div>
+                      <div
+                        className="h-5 w-12 rounded text-[8px] font-bold flex items-center justify-center text-white flex-shrink-0"
+                        style={{ backgroundColor: theme.previewColors.primary }}
+                      >
+                        Save
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Label */}
+                  <div className="px-3 py-2.5 bg-card border-t border-border flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{theme.name}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">{theme.description}</p>
+                    </div>
+                    {isActive && (
+                      <div className="h-5 w-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-2">
+                        <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      </div>
+                    )}
+                  </div>
+                </button>
+              </form>
+            )
+          })}
+        </div>
+      </section>
     </div>
   )
 }

--- a/apps/govea/src/db/migrations/0002_wet_captain_marvel.sql
+++ b/apps/govea/src/db/migrations/0002_wet_captain_marvel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ADD COLUMN "theme" text DEFAULT 'govea' NOT NULL;

--- a/apps/govea/src/db/migrations/meta/0002_snapshot.json
+++ b/apps/govea/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1223 @@
+{
+  "id": "a30b98c8-6275-4cef-81b8-4ffb1733bed0",
+  "prevId": "ec7439ed-bb4d-4916-ab30-ed0e066b09c0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'govea'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personas": {
+      "name": "personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personas_organization_id_organizations_id_fk": {
+          "name": "personas_organization_id_organizations_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personas_created_by_users_id_fk": {
+          "name": "personas_created_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personas_updated_by_users_id_fk": {
+          "name": "personas_updated_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capabilities_organization_id_organizations_id_fk": {
+          "name": "capabilities_organization_id_organizations_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capabilities_created_by_users_id_fk": {
+          "name": "capabilities_created_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capabilities_updated_by_users_id_fk": {
+          "name": "capabilities_updated_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_personas": {
+      "name": "capability_personas",
+      "schema": "",
+      "columns": {
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capability_personas_capability_id_capabilities_id_fk": {
+          "name": "capability_personas_capability_id_capabilities_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capability_personas_persona_id_personas_id_fk": {
+          "name": "capability_personas_persona_id_personas_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "personas",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_capabilities": {
+      "name": "application_capabilities",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_capabilities_application_id_applications_id_fk": {
+          "name": "application_capabilities_application_id_applications_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_capabilities_capability_id_capabilities_id_fk": {
+          "name": "application_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosting_model": {
+          "name": "hosting_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "applications_organization_id_organizations_id_fk": {
+          "name": "applications_organization_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_users_id_fk": {
+          "name": "applications_created_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "applications_updated_by_users_id_fk": {
+          "name": "applications_updated_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adrs": {
+      "name": "adrs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consequences": {
+          "name": "consequences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "adr_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adrs_organization_id_organizations_id_fk": {
+          "name": "adrs_organization_id_organizations_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adrs_created_by_users_id_fk": {
+          "name": "adrs_created_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "adrs_updated_by_users_id_fk": {
+          "name": "adrs_updated_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taxonomy_terms": {
+      "name": "taxonomy_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taxonomy_terms_organization_id_organizations_id_fk": {
+          "name": "taxonomy_terms_organization_id_organizations_id_fk",
+          "tableFrom": "taxonomy_terms",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_organization_id_organizations_id_fk": {
+          "name": "audit_log_organization_id_organizations_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "contributor",
+        "viewer"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.lifecycle_status": {
+      "name": "lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "sunset",
+        "decommissioned",
+        "planned"
+      ]
+    },
+    "public.adr_status": {
+      "name": "adr_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "accepted",
+        "deprecated",
+        "superseded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775352875123,
       "tag": "0001_lean_makkari",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775409107456,
+      "tag": "0002_wet_captain_marvel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -4,6 +4,7 @@ export const organizations = pgTable('organizations', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
+  theme: text('theme').notNull().default('govea'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })

--- a/apps/govea/src/lib/themes.ts
+++ b/apps/govea/src/lib/themes.ts
@@ -1,0 +1,97 @@
+export type ThemeId = 'govea' | 'servicenow'
+
+export interface ThemeDefinition {
+  id: ThemeId
+  name: string
+  description: string
+  previewColors: {
+    header: string   // hex for preview swatch
+    primary: string
+    background: string
+  }
+  vars: Record<string, string>
+}
+
+export const themes: ThemeDefinition[] = [
+  {
+    id: 'govea',
+    name: 'GovEA',
+    description: 'Clean, professional blue. WCAG AA compliant.',
+    previewColors: {
+      header: '#ffffff',
+      primary: '#1a4fba',
+      background: '#f8f9fb',
+    },
+    vars: {
+      '--background': '0 0% 100%',
+      '--foreground': '222 47% 11%',
+      '--card': '0 0% 100%',
+      '--card-foreground': '222 47% 11%',
+      '--popover': '0 0% 100%',
+      '--popover-foreground': '222 47% 11%',
+      '--primary': '221 83% 40%',
+      '--primary-foreground': '210 40% 98%',
+      '--secondary': '214 32% 95%',
+      '--secondary-foreground': '222 47% 11%',
+      '--muted': '214 32% 95%',
+      '--muted-foreground': '215 16% 47%',
+      '--accent': '214 32% 95%',
+      '--accent-foreground': '222 47% 11%',
+      '--destructive': '0 84% 60%',
+      '--destructive-foreground': '210 40% 98%',
+      '--border': '214 32% 91%',
+      '--input': '214 32% 91%',
+      '--ring': '221 83% 40%',
+      '--radius': '0.375rem',
+      '--header-bg': '0 0% 100%',
+      '--header-fg': '222 47% 11%',
+      '--header-border': '214 32% 91%',
+    },
+  },
+  {
+    id: 'servicenow',
+    name: 'ServiceNow',
+    description: 'Dark header with purple accents. Familiar to ServiceNow users.',
+    previewColors: {
+      header: '#1c2433',
+      primary: '#6b3fa0',
+      background: '#f7f7f7',
+    },
+    vars: {
+      '--background': '210 17% 97%',
+      '--foreground': '220 20% 18%',
+      '--card': '0 0% 100%',
+      '--card-foreground': '220 20% 18%',
+      '--popover': '0 0% 100%',
+      '--popover-foreground': '220 20% 18%',
+      '--primary': '270 44% 44%',
+      '--primary-foreground': '0 0% 98%',
+      '--secondary': '220 14% 93%',
+      '--secondary-foreground': '220 20% 18%',
+      '--muted': '220 14% 93%',
+      '--muted-foreground': '220 9% 46%',
+      '--accent': '270 44% 94%',
+      '--accent-foreground': '270 44% 30%',
+      '--destructive': '0 84% 60%',
+      '--destructive-foreground': '0 0% 98%',
+      '--border': '220 13% 87%',
+      '--input': '220 13% 87%',
+      '--ring': '270 44% 44%',
+      '--radius': '0.25rem',
+      '--header-bg': '222 33% 17%',
+      '--header-fg': '210 20% 90%',
+      '--header-border': '222 33% 23%',
+    },
+  },
+]
+
+export function getTheme(id: string): ThemeDefinition {
+  return themes.find(t => t.id === id) ?? themes[0]
+}
+
+export function themeToStyleString(theme: ThemeDefinition): string {
+  const vars = Object.entries(theme.vars)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('; ')
+  return `:root { ${vars} }`
+}


### PR DESCRIPTION
## Summary

- Adds `theme` column to the `organizations` table (default: `govea`) with migration
- Creates `src/lib/themes.ts` defining two themes as full CSS variable sets:
  - **GovEA** — professional blue, white header, WCAG AA compliant
  - **ServiceNow** — dark navy header (`#1c2433`), purple primary, familiar to ServiceNow users
- Adds `--header-bg`, `--header-fg`, and `--header-border` CSS variables to support per-theme header styling
- Updates admin layout to load the org's theme from the DB server-side and inject it via `<style>` tag — no flash, fully SSR-safe
- Adds `src/actions/settings.ts` with `updateOrgTheme()` server action, including theme validation and audit logging (`settings.theme_changed`)
- Builds a Settings page with visual theme cards showing live color previews (header strip + body + primary accent), active theme highlighted with a checkmark
- Theme change takes effect immediately on the next page load — no restart required

## Test plan

- [ ] Go to Settings as Admin — confirm both theme cards render with correct color previews
- [ ] Click ServiceNow — confirm dark navy header and purple accents apply across all pages
- [ ] Click GovEA — confirm switch back to blue header works
- [ ] Confirm active theme card shows the checkmark ring
- [ ] Check Audit Log — confirm `settings.theme_changed` entries are recorded
- [ ] Sign in as Contributor — confirm Settings page is visible but theme cards are non-functional (server action enforces admin-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)