### PR TITLE
feat: per-org customizable persona types

### DIFF
--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { personas } from '@/db/schema'
+import { personas, personaTypes } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -21,6 +21,63 @@ async function requireAdmin() {
   if (!isAdmin(session.user as any)) throw new Error('Forbidden')
   return session
 }
+
+// ── Persona Types ─────────────────────────────────────────────────────────────
+
+export async function getPersonaTypes(organizationId: string) {
+  return db.query.personaTypes.findMany({
+    where: (pt, { eq }) => eq(pt.organizationId, organizationId),
+    orderBy: (pt, { asc }) => [asc(pt.name)],
+  })
+}
+
+export async function createPersonaType(name: string) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const trimmed = name.trim()
+  if (!trimmed) throw new Error('Name is required')
+
+  const [pt] = await db.insert(personaTypes).values({
+    name: trimmed,
+    organizationId: orgId,
+  }).onConflictDoNothing().returning()
+
+  if (pt) {
+    await writeAuditLog({
+      action: 'persona_type.create',
+      entityType: 'persona_type',
+      entityId: pt.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name: trimmed },
+    })
+  }
+}
+
+export async function deletePersonaType(typeId: string) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const before = await db.query.personaTypes.findFirst({
+    where: eq(personaTypes.id, typeId),
+  })
+
+  await db.delete(personaTypes).where(
+    and(eq(personaTypes.id, typeId), eq(personaTypes.organizationId, orgId))
+  )
+
+  await writeAuditLog({
+    action: 'persona_type.delete',
+    entityType: 'persona_type',
+    entityId: typeId,
+    userId: session.user.id,
+    organizationId: orgId,
+    before: { name: before?.name },
+  })
+}
+
+// ── Personas ──────────────────────────────────────────────────────────────────
 
 export async function getPersonas(organizationId: string) {
   return db.query.personas.findMany({

--- a/apps/govea/src/app/(admin)/personas/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { getPersonas } from '@/actions/personas'
+import { getPersonas, getPersonaTypes } from '@/actions/personas'
 import { PersonaTable } from './persona-table'
 import type { Role } from '@/lib/rbac'
 
@@ -11,7 +11,10 @@ export default async function PersonasPage() {
   const orgId = (session.user as any).organizationId as string
   const role = (session.user as any).role as Role
 
-  const personaList = await getPersonas(orgId)
+  const [personaList, typeList] = await Promise.all([
+    getPersonas(orgId),
+    getPersonaTypes(orgId),
+  ])
 
   return (
     <div className="space-y-6">
@@ -19,7 +22,7 @@ export default async function PersonasPage() {
         <h1 className="text-2xl font-bold tracking-tight">Personas</h1>
         <p className="text-muted-foreground mt-1">People your organization serves and the needs they have.</p>
       </div>
-      <PersonaTable personas={personaList} role={role} />
+      <PersonaTable personas={personaList} personaTypes={typeList} role={role} />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import type { Persona } from '@/db/schema'
-import { createPersona, editPersona, deletePersona } from '@/actions/personas'
+import type { Persona, PersonaType } from '@/db/schema'
+import { createPersona, editPersona, deletePersona, createPersonaType, deletePersonaType } from '@/actions/personas'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -20,10 +20,9 @@ type PersonaRow = Pick<Persona, 'id' | 'name' | 'description' | 'type' | 'status
 
 interface Props {
   personas: PersonaRow[]
+  personaTypes: PersonaType[]
   role: Role
 }
-
-const PERSONA_TYPES = ['citizen', 'staff', 'elected official', 'external partner']
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -43,7 +42,7 @@ const VISIBILITY_LABELS: Record<string, string> = {
   instance: 'Instance-wide',
 }
 
-export function PersonaTable({ personas, role }: Props) {
+export function PersonaTable({ personas, personaTypes, role }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -53,6 +52,8 @@ export function PersonaTable({ personas, role }: Props) {
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<PersonaRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<PersonaRow | null>(null)
+  const [manageTypesOpen, setManageTypesOpen] = useState(false)
+  const [newTypeName, setNewTypeName] = useState('')
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -92,6 +93,22 @@ export function PersonaTable({ personas, role }: Props) {
     })
   }
 
+  async function handleAddType() {
+    if (!newTypeName.trim()) return
+    startTransition(async () => {
+      await createPersonaType(newTypeName.trim())
+      setNewTypeName('')
+      refresh()
+    })
+  }
+
+  async function handleDeleteType(typeId: string) {
+    startTransition(async () => {
+      await deletePersonaType(typeId)
+      refresh()
+    })
+  }
+
   return (
     <div className="space-y-4">
       {/* Toolbar */}
@@ -109,8 +126,8 @@ export function PersonaTable({ personas, role }: Props) {
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <option value="all">All types</option>
-          {PERSONA_TYPES.map(t => (
-            <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+          {personaTypes.map(t => (
+            <option key={t.id} value={t.name}>{t.name}</option>
           ))}
         </select>
         <select
@@ -123,11 +140,18 @@ export function PersonaTable({ personas, role }: Props) {
           <option value="published">Published</option>
           <option value="archived">Archived</option>
         </select>
-        {canEdit && (
-          <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
-            + New persona
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          {canDelete && (
+            <Button variant="outline" size="sm" onClick={() => setManageTypesOpen(true)}>
+              Manage types
+            </Button>
+          )}
+          {canEdit && (
+            <Button onClick={() => setCreateOpen(true)} size="sm">
+              + New persona
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Table */}
@@ -156,7 +180,7 @@ export function PersonaTable({ personas, role }: Props) {
             {filtered.map(p => (
               <TableRow key={p.id}>
                 <TableCell className="font-medium">{p.name}</TableCell>
-                <TableCell className="text-muted-foreground capitalize">{p.type ?? '—'}</TableCell>
+                <TableCell className="text-muted-foreground">{p.type ?? '—'}</TableCell>
                 <TableCell>
                   <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[p.status])}>
                     {p.status.charAt(0).toUpperCase() + p.status.slice(1)}
@@ -195,6 +219,52 @@ export function PersonaTable({ personas, role }: Props) {
         </Table>
       </div>
 
+      {/* Manage Types Dialog */}
+      <Dialog open={manageTypesOpen} onOpenChange={setManageTypesOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Manage persona types</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Types help categorize personas. Changes apply to your organization only.
+          </p>
+          <div className="space-y-2">
+            {personaTypes.length === 0 && (
+              <p className="text-sm text-muted-foreground py-2">No types defined yet.</p>
+            )}
+            {personaTypes.map(t => (
+              <div key={t.id} className="flex items-center justify-between rounded-md border px-3 py-2">
+                <span className="text-sm">{t.name}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => handleDeleteType(t.id)}
+                  className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                >
+                  ×
+                </Button>
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2 pt-2">
+            <Input
+              placeholder="New type name…"
+              value={newTypeName}
+              onChange={e => setNewTypeName(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddType() } }}
+              disabled={isPending}
+            />
+            <Button onClick={handleAddType} disabled={isPending || !newTypeName.trim()} size="sm">
+              Add
+            </Button>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setManageTypesOpen(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
@@ -215,8 +285,8 @@ export function PersonaTable({ personas, role }: Props) {
               <Label>Type</Label>
               <select name="type" defaultValue="" className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
                 <option value="">— None —</option>
-                {PERSONA_TYPES.map(t => (
-                  <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+                {personaTypes.map(t => (
+                  <option key={t.id} value={t.name}>{t.name}</option>
                 ))}
               </select>
             </div>
@@ -265,8 +335,8 @@ export function PersonaTable({ personas, role }: Props) {
               <Label>Type</Label>
               <select name="type" defaultValue={editTarget?.type ?? ''} className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
                 <option value="">— None —</option>
-                {PERSONA_TYPES.map(t => (
-                  <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+                {personaTypes.map(t => (
+                  <option key={t.id} value={t.name}>{t.name}</option>
                 ))}
               </select>
             </div>

--- a/apps/govea/src/db/migrations/0004_cute_hairball.sql
+++ b/apps/govea/src/db/migrations/0004_cute_hairball.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "persona_types" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_org_persona_type" UNIQUE("organization_id","name")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "persona_types" ADD CONSTRAINT "persona_types_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/govea/src/db/migrations/meta/0004_snapshot.json
+++ b/apps/govea/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1619 @@
+{
+  "id": "e1a15a6a-6dc0-4f9f-8181-5660b1f61a63",
+  "prevId": "0078b26f-e26d-4baa-a526-e14f43e520aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'govea'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_parent_id_organizations_id_fk": {
+          "name": "organizations_parent_id_organizations_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.persona_types": {
+      "name": "persona_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_types_organization_id_organizations_id_fk": {
+          "name": "persona_types_organization_id_organizations_id_fk",
+          "tableFrom": "persona_types",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_org_persona_type": {
+          "name": "unique_org_persona_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personas": {
+      "name": "personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personas_organization_id_organizations_id_fk": {
+          "name": "personas_organization_id_organizations_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personas_created_by_users_id_fk": {
+          "name": "personas_created_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personas_updated_by_users_id_fk": {
+          "name": "personas_updated_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capabilities_organization_id_organizations_id_fk": {
+          "name": "capabilities_organization_id_organizations_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capabilities_created_by_users_id_fk": {
+          "name": "capabilities_created_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capabilities_updated_by_users_id_fk": {
+          "name": "capabilities_updated_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_personas": {
+      "name": "capability_personas",
+      "schema": "",
+      "columns": {
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capability_personas_capability_id_capabilities_id_fk": {
+          "name": "capability_personas_capability_id_capabilities_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capability_personas_persona_id_personas_id_fk": {
+          "name": "capability_personas_persona_id_personas_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "personas",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_capabilities": {
+      "name": "application_capabilities",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_capabilities_application_id_applications_id_fk": {
+          "name": "application_capabilities_application_id_applications_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_capabilities_capability_id_capabilities_id_fk": {
+          "name": "application_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosting_model": {
+          "name": "hosting_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "applications_organization_id_organizations_id_fk": {
+          "name": "applications_organization_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_users_id_fk": {
+          "name": "applications_created_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "applications_updated_by_users_id_fk": {
+          "name": "applications_updated_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adrs": {
+      "name": "adrs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consequences": {
+          "name": "consequences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "adr_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adrs_organization_id_organizations_id_fk": {
+          "name": "adrs_organization_id_organizations_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adrs_created_by_users_id_fk": {
+          "name": "adrs_created_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "adrs_updated_by_users_id_fk": {
+          "name": "adrs_updated_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taxonomy_terms": {
+      "name": "taxonomy_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taxonomy_terms_organization_id_organizations_id_fk": {
+          "name": "taxonomy_terms_organization_id_organizations_id_fk",
+          "tableFrom": "taxonomy_terms",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_organization_id_organizations_id_fk": {
+          "name": "audit_log_organization_id_organizations_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_org_links": {
+      "name": "cross_org_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_org_id": {
+          "name": "source_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entity_type": {
+          "name": "source_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_org_id": {
+          "name": "target_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_entity_type": {
+          "name": "target_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "link_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cross_org_links_source_org_id_organizations_id_fk": {
+          "name": "cross_org_links_source_org_id_organizations_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "source_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_org_links_target_org_id_organizations_id_fk": {
+          "name": "cross_org_links_target_org_id_organizations_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "target_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_org_links_created_by_users_id_fk": {
+          "name": "cross_org_links_created_by_users_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_connections": {
+      "name": "org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_org_id": {
+          "name": "from_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_org_id": {
+          "name": "to_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_connections_from_org_id_organizations_id_fk": {
+          "name": "org_connections_from_org_id_organizations_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "from_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_connections_to_org_id_organizations_id_fk": {
+          "name": "org_connections_to_org_id_organizations_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "to_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_connections_created_by_users_id_fk": {
+          "name": "org_connections_created_by_users_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_org_connection": {
+          "name": "unique_org_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "from_org_id",
+            "to_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "org",
+        "connections",
+        "instance"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "contributor",
+        "viewer"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.lifecycle_status": {
+      "name": "lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "sunset",
+        "decommissioned",
+        "planned"
+      ]
+    },
+    "public.adr_status": {
+      "name": "adr_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "accepted",
+        "deprecated",
+        "superseded"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rejected"
+      ]
+    },
+    "public.link_status": {
+      "name": "link_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rejected"
+      ]
+    },
+    "public.link_type": {
+      "name": "link_type",
+      "schema": "public",
+      "values": [
+        "implements",
+        "extends",
+        "maps_to"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775426858345,
       "tag": "0003_tiny_junta",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1775442261128,
+      "tag": "0004_cute_hairball",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/govea/src/db/schema/personas.ts
+++ b/apps/govea/src/db/schema/personas.ts
@@ -1,15 +1,26 @@
-import { pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { pgEnum, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 
 export const workflowStatusEnum = pgEnum('workflow_status', ['draft', 'published', 'archived'])
+
+export const personaTypes = pgTable('persona_types', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+}, (t) => ({
+  uniqueOrgType: unique('unique_org_persona_type').on(t.organizationId, t.name),
+}))
+
+export type PersonaType = typeof personaTypes.$inferSelect
 
 export const personas = pgTable('personas', {
   id: uuid('id').primaryKey().defaultRandom(),
   organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
   description: text('description'),
-  type: text('type'), // citizen, staff, elected official, external partner
+  type: text('type'),
   status: workflowStatusEnum('status').notNull().default('draft'),
   visibility: visibilityEnum('visibility').notNull().default('org'),
   createdBy: uuid('created_by').references(() => users.id),

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -1,7 +1,8 @@
 import { relations } from 'drizzle-orm'
 import { capabilities, capabilityPersonas } from './capabilities'
 import { applications, applicationCapabilities } from './applications'
-import { personas } from './personas'
+import { personas, personaTypes } from './personas'
+import { organizations } from './organizations'
 
 export const capabilitiesRelations = relations(capabilities, ({ many }) => ({
   capabilityPersonas: many(capabilityPersonas),
@@ -20,6 +21,13 @@ export const capabilityPersonasRelations = relations(capabilityPersonas, ({ one 
 
 export const personasRelations = relations(personas, ({ many }) => ({
   capabilityPersonas: many(capabilityPersonas),
+}))
+
+export const personaTypesRelations = relations(personaTypes, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [personaTypes.organizationId],
+    references: [organizations.id],
+  }),
 }))
 
 export const applicationsRelations = relations(applications, ({ many }) => ({

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -8,10 +8,17 @@ export const DEV_USERS = [
   { name: 'Victor Viewer', email: 'victor@govea.dev', role: 'viewer' as const },
 ]
 
+export const DEFAULT_PERSONA_TYPES = [
+  'Citizen',
+  'Staff',
+  'Elected Official',
+  'External Partner',
+]
+
 export const DEV_PERSONAS = [
-  { name: 'Resident', description: 'A member of the public interacting with city services', type: 'citizen' },
-  { name: 'IT Staff', description: 'Internal technology team member', type: 'staff' },
-  { name: 'Department Director', description: 'Senior agency leader responsible for a service area', type: 'staff' },
+  { name: 'Resident', description: 'A member of the public interacting with city services', type: 'Citizen' },
+  { name: 'IT Staff', description: 'Internal technology team member', type: 'Staff' },
+  { name: 'Department Director', description: 'Senior agency leader responsible for a service area', type: 'Staff' },
 ]
 
 export const DEV_CAPABILITIES = [

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -1,7 +1,7 @@
 import { GOV_TAXONOMY } from './gov-taxonomy'
-import { DEV_USERS } from './dev-fixtures'
+import { DEV_USERS, DEFAULT_PERSONA_TYPES } from './dev-fixtures'
 import { db } from '../client'
-import { users, organizations } from '../schema'
+import { users, organizations, personaTypes } from '../schema'
 import bcrypt from 'bcryptjs'
 
 async function seed() {
@@ -36,6 +36,12 @@ async function seed() {
     }
 
     console.log(`Seeded ${DEV_USERS.length} dev users (password: dev-password)`)
+
+    for (const name of DEFAULT_PERSONA_TYPES) {
+      await db.insert(personaTypes).values({ name, organizationId: orgId }).onConflictDoNothing()
+    }
+
+    console.log(`Seeded ${DEFAULT_PERSONA_TYPES.length} default persona types`)
   }
 
   console.log('Seed complete.')

--- a/business-architecture/capabilities/cms/admin-configuration/ac-persona-type-management.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-persona-type-management.md
@@ -1,0 +1,25 @@
+# Capability: Persona Type Management
+
+## What It Does
+The system must allow organization administrators to define and maintain the list of persona types available within their organization. Persona types are used to categorize personas (e.g. Citizen, Staff, Elected Official, External Partner) and drive filtering in the personas UI. Each organization controls its own type list independently.
+
+## Personas
+- **CMS Administrator** — creates, renames, and removes persona types to match the organization's classification needs
+
+## Behaviors
+- Display the current list of persona types scoped to the administrator's organization
+- Allow administrators to add a new type by entering a name (duplicate names within the same org are rejected)
+- Allow administrators to remove a type; existing personas that used the removed type retain the type value as a text label but it no longer appears in the type selector
+- Persona type names are treated as plain text — no enum constraint in the database
+- Default types (Citizen, Staff, Elected Official, External Partner) are seeded at bootstrap for new organizations; administrators may delete them
+- Type list is used in the persona create/edit dialog and the type filter on the personas page
+
+## Rules
+- Only Admins may add or remove persona types — Contributors and Viewers cannot
+- Type names must be unique within an organization; instance-level uniqueness is not required
+- Removing a type does not cascade to update or null personas — personas retain their stored type string
+- No rename operation in v1; to rename, delete the old type and add the new one
+
+## Links
+- Depends on: IAM — Role-Based Access Control
+- Used by: Content Management — Personas


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `PERSONA_TYPES` constant with a `persona_types` table scoped per organization
- Org admins can add and remove types via a **Manage types** button on the Personas page — no code change required
- Type dropdowns in create/edit dialogs and the type filter in the toolbar are all driven from the DB

## Changes
- **Schema**: new `persona_types` table with `unique(organization_id, name)` constraint
- **Migration** `0004_cute_hairball.sql`: creates table + FK to organizations
- **Actions**: `getPersonaTypes`, `createPersonaType`, `deletePersonaType` (admin-only guard)
- **PersonaTable**: accepts `personaTypes` prop; Manage types dialog visible to admins only
- **Seed**: default types (Citizen, Staff, Elected Official, External Partner) inserted on dev bootstrap
- **Business architecture**: `ac-persona-type-management.md` added to admin-configuration

## Test plan
- [ ] Log in as Alice Admin → Personas page → click **Manage types** → add a custom type → confirm it appears in create/edit dropdowns and type filter
- [ ] Add a duplicate type name → confirm it silently deduplicates (onConflictDoNothing)
- [ ] Delete a type → confirm it disappears from dropdowns; existing personas retain their stored type value
- [ ] Log in as Carol Contributor → confirm **Manage types** button is not shown
- [ ] Run `pnpm db:seed` with `DEV=true` on a fresh DB → confirm 4 default types are created

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)