### PR TITLE
feat: dev toolbar with test dataset presets

### DIFF
--- a/apps/govea/src/actions/dev.ts
+++ b/apps/govea/src/actions/dev.ts
@@ -1,0 +1,128 @@
+'use server'
+
+import { db } from '@/db/client'
+import {
+  personas, capabilities, applications, tags, personaTypes,
+  personaTags, capabilityPersonas, applicationCapabilities,
+} from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { redirect } from 'next/navigation'
+import { TEST_DATASETS } from '@/db/seeds/test-datasets'
+
+export async function resetToDataset(datasetKey: string) {
+  if (process.env.NODE_ENV !== 'development') {
+    throw new Error('Dataset reset is only available in development mode')
+  }
+
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user as any)) throw new Error('Admin required')
+
+  const orgId = (session.user as any).organizationId as string
+  const dataset = TEST_DATASETS[datasetKey]
+  if (!dataset) throw new Error(`Unknown dataset: ${datasetKey}`)
+
+  // ── Wipe org content (junction tables cascade automatically) ──────────────
+  await db.delete(applications).where(eq(applications.organizationId, orgId))
+  await db.delete(capabilities).where(eq(capabilities.organizationId, orgId))
+  await db.delete(personas).where(eq(personas.organizationId, orgId))
+  await db.delete(tags).where(eq(tags.organizationId, orgId))
+  await db.delete(personaTypes).where(eq(personaTypes.organizationId, orgId))
+
+  // ── Insert persona types ──────────────────────────────────────────────────
+  const typeRows = dataset.personaTypes.length > 0
+    ? await db.insert(personaTypes)
+        .values(dataset.personaTypes.map(name => ({ name, organizationId: orgId })))
+        .onConflictDoNothing()
+        .returning()
+    : []
+
+  // ── Insert tags ───────────────────────────────────────────────────────────
+  const tagRows = dataset.tags.length > 0
+    ? await db.insert(tags)
+        .values(dataset.tags.map(name => ({ name, organizationId: orgId })))
+        .onConflictDoNothing()
+        .returning()
+    : []
+
+  const tagByName = Object.fromEntries(tagRows.map(t => [t.name, t.id]))
+
+  if (dataset.personas.length === 0) return
+
+  // ── Insert personas ───────────────────────────────────────────────────────
+  const personaRows = await db.insert(personas)
+    .values(dataset.personas.map(p => ({
+      name: p.name,
+      description: p.description,
+      type: p.type || null,
+      status: p.status,
+      organizationId: orgId,
+    })))
+    .returning()
+
+  const personaByName = Object.fromEntries(personaRows.map(p => [p.name, p.id]))
+
+  // Insert persona → tag junctions
+  const personaTagRows = dataset.personas.flatMap(p =>
+    p.tags
+      .filter(t => tagByName[t])
+      .map(t => ({ personaId: personaByName[p.name], tagId: tagByName[t] }))
+  )
+  if (personaTagRows.length > 0) {
+    await db.insert(personaTags).values(personaTagRows)
+  }
+
+  if (dataset.capabilities.length === 0) return
+
+  // ── Insert capabilities ───────────────────────────────────────────────────
+  const capabilityRows = await db.insert(capabilities)
+    .values(dataset.capabilities.map(c => ({
+      name: c.name,
+      description: c.description,
+      domain: c.domain,
+      status: c.status,
+      organizationId: orgId,
+    })))
+    .returning()
+
+  const capabilityByName = Object.fromEntries(capabilityRows.map(c => [c.name, c.id]))
+
+  // Insert capability → persona junctions
+  const capPersonaRows = dataset.capabilities.flatMap(c =>
+    c.personas
+      .filter(p => personaByName[p])
+      .map(p => ({ capabilityId: capabilityByName[c.name], personaId: personaByName[p] }))
+  )
+  if (capPersonaRows.length > 0) {
+    await db.insert(capabilityPersonas).values(capPersonaRows)
+  }
+
+  if (dataset.applications.length === 0) return
+
+  // ── Insert applications ───────────────────────────────────────────────────
+  const applicationRows = await db.insert(applications)
+    .values(dataset.applications.map(a => ({
+      name: a.name,
+      description: a.description,
+      vendor: a.vendor,
+      hostingModel: a.hostingModel,
+      lifecycleStatus: a.lifecycleStatus,
+      status: a.status,
+      organizationId: orgId,
+    })))
+    .returning()
+
+  const applicationByName = Object.fromEntries(applicationRows.map(a => [a.name, a.id]))
+
+  // Insert application → capability junctions
+  const appCapRows = dataset.applications.flatMap(a =>
+    a.capabilities
+      .filter(c => capabilityByName[c])
+      .map(c => ({ applicationId: applicationByName[a.name], capabilityId: capabilityByName[c] }))
+  )
+  if (appCapRows.length > 0) {
+    await db.insert(applicationCapabilities).values(appCapRows)
+  }
+}

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -8,6 +8,7 @@ import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { getTheme, themeToStyleString } from '@/lib/themes'
 import type { Role } from '@/lib/rbac'
+import { DevToolbar } from '@/components/dev-toolbar'
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
@@ -97,7 +98,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           </div>
         </div>
       </header>
-      <main className="p-6">{children}</main>
+      <main className={cn('p-6', process.env.NODE_ENV === 'development' && 'pb-16')}>{children}</main>
+      {process.env.NODE_ENV === 'development' && <DevToolbar />}
     </div>
   )
 }

--- a/apps/govea/src/components/dev-toolbar.tsx
+++ b/apps/govea/src/components/dev-toolbar.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { resetToDataset } from '@/actions/dev'
+import { useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+const DATASETS = [
+  { key: 'blank',     label: 'Blank',     description: 'Empty content, default types & tags' },
+  { key: 'starter',   label: 'Starter',   description: '3 personas · 3 capabilities · 3 apps' },
+  { key: 'city-demo', label: 'City Demo', description: '6 personas · 8 capabilities · 5 apps' },
+]
+
+export function DevToolbar() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [lastLoaded, setLastLoaded] = useState<string | null>(null)
+  const [confirmKey, setConfirmKey] = useState<string | null>(null)
+
+  function requestReset(key: string) {
+    setConfirmKey(key)
+  }
+
+  function cancelReset() {
+    setConfirmKey(null)
+  }
+
+  function confirmReset() {
+    if (!confirmKey) return
+    const key = confirmKey
+    setConfirmKey(null)
+    startTransition(async () => {
+      await resetToDataset(key)
+      setLastLoaded(key)
+      router.refresh()
+    })
+  }
+
+  const confirmDataset = DATASETS.find(d => d.key === confirmKey)
+
+  return (
+    <>
+      {/* Confirm overlay */}
+      {confirmKey && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-background border rounded-lg shadow-lg p-6 max-w-sm w-full mx-4 space-y-4">
+            <div className="space-y-1">
+              <p className="font-semibold text-sm">Load dataset: {confirmDataset?.label}?</p>
+              <p className="text-xs text-muted-foreground">
+                This will <strong>delete all content</strong> for your org (personas, capabilities, applications, tags, types) and replace it with the preset.
+              </p>
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={cancelReset}
+                className="rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmReset}
+                className="rounded-md bg-destructive text-destructive-foreground px-3 py-1.5 text-xs font-medium hover:bg-destructive/90 transition-colors"
+              >
+                Yes, reset data
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toolbar */}
+      <div className="fixed bottom-0 left-0 right-0 z-40 border-t bg-yellow-50 border-yellow-200">
+        <div className="flex items-center gap-3 px-4 py-2">
+          {/* Dev badge */}
+          <span className="inline-flex items-center gap-1 rounded-md border border-yellow-300 bg-yellow-100 px-2 py-0.5 text-xs font-semibold text-yellow-800 shrink-0">
+            <span className="h-1.5 w-1.5 rounded-full bg-yellow-500" />
+            DEV
+          </span>
+
+          <span className="text-xs text-yellow-700 font-medium shrink-0">Test data:</span>
+
+          <div className="flex items-center gap-2">
+            {DATASETS.map(d => (
+              <button
+                key={d.key}
+                onClick={() => requestReset(d.key)}
+                disabled={isPending}
+                title={d.description}
+                className={cn(
+                  'rounded-md border px-3 py-1 text-xs font-medium transition-colors',
+                  lastLoaded === d.key
+                    ? 'border-yellow-500 bg-yellow-200 text-yellow-900'
+                    : 'border-yellow-300 bg-white text-yellow-800 hover:bg-yellow-100',
+                  isPending && 'opacity-50 cursor-not-allowed'
+                )}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+
+          {isPending && (
+            <span className="text-xs text-yellow-600 animate-pulse">Resetting…</span>
+          )}
+
+          {lastLoaded && !isPending && (
+            <span className="text-xs text-yellow-600">
+              Loaded: <strong>{DATASETS.find(d => d.key === lastLoaded)?.label}</strong>
+            </span>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/govea/src/db/seeds/test-datasets.ts
+++ b/apps/govea/src/db/seeds/test-datasets.ts
@@ -1,0 +1,306 @@
+// Test and demo dataset presets.
+// Used by the dev toolbar to reset org content to a known state.
+// Each dataset defines personas, capabilities, applications, tags,
+// persona types, and the linkages between them.
+
+export type DatasetPersona = {
+  name: string
+  description: string
+  type: string
+  status: 'draft' | 'published' | 'archived'
+  tags: string[]
+}
+
+export type DatasetCapability = {
+  name: string
+  description: string
+  domain: string
+  status: 'draft' | 'published' | 'archived'
+  personas: string[] // persona names
+}
+
+export type DatasetApplication = {
+  name: string
+  description: string
+  vendor: string
+  hostingModel: 'saas' | 'on-prem' | 'hybrid'
+  lifecycleStatus: 'active' | 'planned' | 'sunset' | 'decommissioned'
+  status: 'draft' | 'published' | 'archived'
+  capabilities: string[] // capability names
+}
+
+export type Dataset = {
+  label: string
+  description: string
+  personaTypes: string[]
+  tags: string[]
+  personas: DatasetPersona[]
+  capabilities: DatasetCapability[]
+  applications: DatasetApplication[]
+}
+
+// ── Dataset 1: Blank ──────────────────────────────────────────────────────────
+// Empty content — tests empty states and creation flows.
+// Restores default persona types and tags.
+
+export const DATASET_BLANK: Dataset = {
+  label: 'Blank',
+  description: 'Empty — default types and tags only',
+  personaTypes: ['Citizen', 'Staff', 'Elected Official', 'External Partner'],
+  tags: ['mobile-first', 'accessibility', 'high-volume', 'low-digital-literacy', 'multilingual'],
+  personas: [],
+  capabilities: [],
+  applications: [],
+}
+
+// ── Dataset 2: Starter ────────────────────────────────────────────────────────
+// Small city baseline — 3 personas, 3 capabilities, 3 applications.
+// Good for testing basic CRUD and linkage flows.
+
+export const DATASET_STARTER: Dataset = {
+  label: 'Starter',
+  description: '3 personas · 3 capabilities · 3 applications',
+  personaTypes: ['Citizen', 'Staff', 'Elected Official', 'External Partner'],
+  tags: ['mobile-first', 'accessibility', 'high-volume', 'low-digital-literacy', 'multilingual'],
+  personas: [
+    {
+      name: 'Resident',
+      description: 'A member of the public interacting with city services online or in person.',
+      type: 'Citizen',
+      status: 'published',
+      tags: ['high-volume', 'mobile-first'],
+    },
+    {
+      name: 'IT Staff',
+      description: 'Internal technology team member who administers systems and supports staff.',
+      type: 'Staff',
+      status: 'published',
+      tags: ['accessibility'],
+    },
+    {
+      name: 'Department Director',
+      description: 'Senior agency leader responsible for a service area and its budget.',
+      type: 'Staff',
+      status: 'published',
+      tags: [],
+    },
+  ],
+  capabilities: [
+    {
+      name: 'Online Permitting',
+      description: 'Submit and track permit applications online without visiting a counter.',
+      domain: 'Community Development',
+      status: 'published',
+      personas: ['Resident'],
+    },
+    {
+      name: 'HR Self-Service',
+      description: 'Employee access to payroll, benefits, and HR forms without HR staff involvement.',
+      domain: 'Legislative & Executive',
+      status: 'published',
+      personas: ['IT Staff', 'Department Director'],
+    },
+    {
+      name: 'GIS Mapping',
+      description: 'Geographic information services for staff planning and public-facing maps.',
+      domain: 'Information Technology',
+      status: 'published',
+      personas: ['IT Staff'],
+    },
+  ],
+  applications: [
+    {
+      name: 'Accela',
+      description: 'Permitting and licensing platform for Community Development.',
+      vendor: 'Accela',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['Online Permitting'],
+    },
+    {
+      name: 'Workday',
+      description: 'HR and payroll system for all city employees.',
+      vendor: 'Workday',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['HR Self-Service'],
+    },
+    {
+      name: 'ArcGIS Online',
+      description: 'Cloud GIS platform for map authoring and public viewer apps.',
+      vendor: 'Esri',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['GIS Mapping'],
+    },
+  ],
+}
+
+// ── Dataset 3: City Demo ──────────────────────────────────────────────────────
+// Full-featured demo — 6 personas, 8 capabilities, 5 applications.
+// Shows off type badges, tags, filters, multi-select, lifecycle states.
+
+export const DATASET_CITY_DEMO: Dataset = {
+  label: 'City Demo',
+  description: '6 personas · 8 capabilities · 5 applications',
+  personaTypes: ['Citizen', 'Staff', 'Elected Official', 'External Partner'],
+  tags: ['mobile-first', 'accessibility', 'high-volume', 'low-digital-literacy', 'multilingual'],
+  personas: [
+    {
+      name: 'Resident',
+      description: 'A member of the public who accesses city services online, by phone, or in person. Often low digital literacy; primary consumer of public-facing services.',
+      type: 'Citizen',
+      status: 'published',
+      tags: ['high-volume', 'mobile-first', 'low-digital-literacy'],
+    },
+    {
+      name: 'Business Owner',
+      description: 'Local business owner who needs permits, licenses, and inspections to operate. Interacts with multiple departments; time-sensitive needs.',
+      type: 'External Partner',
+      status: 'published',
+      tags: ['mobile-first', 'high-volume'],
+    },
+    {
+      name: 'City Council Member',
+      description: 'Elected official who reviews budget proposals, approves ordinances, and needs high-level portfolio visibility without technical detail.',
+      type: 'Elected Official',
+      status: 'published',
+      tags: [],
+    },
+    {
+      name: 'IT Administrator',
+      description: 'Manages infrastructure, user accounts, and system integrations. Primary internal technology contact for departments.',
+      type: 'Staff',
+      status: 'published',
+      tags: ['accessibility'],
+    },
+    {
+      name: 'Department Director',
+      description: 'Senior agency leader accountable for service delivery and budget. Needs visibility into application portfolio and upcoming lifecycle risks.',
+      type: 'Staff',
+      status: 'published',
+      tags: [],
+    },
+    {
+      name: 'Grant Coordinator',
+      description: 'Staff member who manages federal and state grant applications and reporting. Needs multilingual document support and records access.',
+      type: 'Staff',
+      status: 'draft',
+      tags: ['multilingual', 'accessibility'],
+    },
+  ],
+  capabilities: [
+    {
+      name: 'Online Permitting',
+      description: 'Citizens and businesses submit, track, and pay for permit applications without visiting a counter.',
+      domain: 'Community Development',
+      status: 'published',
+      personas: ['Resident', 'Business Owner'],
+    },
+    {
+      name: 'Business License Management',
+      description: 'Issuance, renewal, and inspection scheduling for business operating licenses.',
+      domain: 'Community Development',
+      status: 'published',
+      personas: ['Business Owner'],
+    },
+    {
+      name: 'HR Self-Service',
+      description: 'Employee access to payroll, benefits elections, time-off requests, and HR forms.',
+      domain: 'Legislative & Executive',
+      status: 'published',
+      personas: ['IT Administrator', 'Department Director', 'Grant Coordinator'],
+    },
+    {
+      name: 'Budget Management',
+      description: 'Departmental budget planning, tracking, and reporting for finance and elected oversight.',
+      domain: 'Legislative & Executive',
+      status: 'published',
+      personas: ['City Council Member', 'Department Director'],
+    },
+    {
+      name: 'GIS Mapping',
+      description: 'Authoritative geographic data for internal planning and public-facing map applications.',
+      domain: 'Information Technology',
+      status: 'published',
+      personas: ['IT Administrator'],
+    },
+    {
+      name: 'Cybersecurity Monitoring',
+      description: 'Continuous threat detection, alerting, and incident response across city infrastructure.',
+      domain: 'Information Technology',
+      status: 'published',
+      personas: ['IT Administrator'],
+    },
+    {
+      name: '311 Resident Services',
+      description: 'Omnichannel intake (web, phone, app) for non-emergency service requests and status tracking.',
+      domain: 'Public Safety',
+      status: 'published',
+      personas: ['Resident'],
+    },
+    {
+      name: 'Records Management',
+      description: 'Retention, retrieval, and disposition of official city records including grant documentation.',
+      domain: 'Administration & Operations',
+      status: 'draft',
+      personas: ['Grant Coordinator', 'Department Director'],
+    },
+  ],
+  applications: [
+    {
+      name: 'Accela',
+      description: 'Permitting and licensing platform handling permits, business licenses, and inspections.',
+      vendor: 'Accela',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['Online Permitting', 'Business License Management'],
+    },
+    {
+      name: 'Workday',
+      description: 'HR, payroll, and financial management platform for city employees.',
+      vendor: 'Workday',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['HR Self-Service', 'Budget Management'],
+    },
+    {
+      name: 'ArcGIS Online',
+      description: 'Cloud GIS platform for authoritative map publishing and spatial analysis.',
+      vendor: 'Esri',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['GIS Mapping'],
+    },
+    {
+      name: 'CrowdStrike Falcon',
+      description: 'Cloud-native endpoint detection and response platform for cybersecurity monitoring.',
+      vendor: 'CrowdStrike',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      status: 'published',
+      capabilities: ['Cybersecurity Monitoring'],
+    },
+    {
+      name: 'OpenText Livelink',
+      description: 'Legacy on-premise document and records management system. Sunset in progress.',
+      vendor: 'OpenText',
+      hostingModel: 'on-prem',
+      lifecycleStatus: 'sunset',
+      status: 'published',
+      capabilities: ['Records Management'],
+    },
+  ],
+}
+
+export const TEST_DATASETS: Record<string, Dataset> = {
+  blank: DATASET_BLANK,
+  starter: DATASET_STARTER,
+  'city-demo': DATASET_CITY_DEMO,
+}


### PR DESCRIPTION
## Summary
- Adds a yellow fixed toolbar at the bottom of every admin page, visible only in `NODE_ENV=development`
- Three preset dataset buttons reset all org content to a known state with one click (+ confirm step)
- Toolbar highlights the last-loaded dataset and shows "Resetting…" while the action runs

## Datasets

| Name | Content |
|------|---------|
| **Blank** | Empty — default persona types and tags only. Tests empty states. |
| **Starter** | 3 personas, 3 capabilities, 3 applications with basic linkages. |
| **City Demo** | 6 personas (with types + tags), 8 capabilities across 4 domains, 5 applications (incl. sunset + draft). Full linkage chain. |

## Changes
- **`test-datasets.ts`** — typed dataset definitions; all linkages expressed by name, resolved to IDs at reset time
- **`actions/dev.ts`** — `resetToDataset(key)` server action: guards `NODE_ENV` + `isAdmin`; wipes org content (cascade handles junctions); reinserts in order: types → tags → personas → persona_tags → capabilities → cap_personas → applications → app_capabilities
- **`DevToolbar`** — `'use client'` fixed bottom bar; confirm overlay before destructive reset; highlights last-loaded dataset
- **`layout.tsx`** — conditionally renders `<DevToolbar />` and adds `pb-16` in dev only

## Test plan
- [ ] In dev: toolbar visible at bottom of every admin page
- [ ] Click **City Demo** → confirm dialog appears → confirm → page refreshes with full dataset
- [ ] Navigate to Personas → 6 rows with badges; Capabilities → 8 rows; Applications → 5 rows (1 sunset)
- [ ] Click **Blank** → all content wiped; empty state messages shown on all pages
- [ ] Click **Starter** → 3 rows each
- [ ] Last-loaded button is highlighted after reset
- [ ] Build for production (`NODE_ENV=production`) → toolbar not rendered

Depends on #50 (tags)
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)