### PR TITLE
fix: SSO session invalidation, audit log integrity, API auth scope (#6)

### DIFF
--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -15,7 +15,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     sessionsTable: sessions as any,
     verificationTokensTable: verificationTokens as any,
   }),
-  session: { strategy: 'jwt' },
+  session: { strategy: 'jwt', maxAge: 60 * 60 * 24 }, // 24h
   providers: [
     ...(process.env.AUTH_MICROSOFT_ENTRA_ID_ID
       ? [MicrosoftEntraID({
@@ -67,9 +67,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
+        // Fresh sign-in — populate token from user object
         token.id = user.id
         token.role = (user as any).role
         token.organizationId = (user as any).organizationId
+        return token
+      }
+      // Subsequent requests — verify user is still active
+      if (token.id) {
+        const dbUser = await db.query.users.findFirst({
+          where: eq(users.id, token.id as string),
+        })
+        if (!dbUser || dbUser.isActive !== 'true') return null
       }
       return token
     },

--- a/business-architecture/capabilities/cms/iam/iam-api-auth-decision.md
+++ b/business-architecture/capabilities/cms/iam/iam-api-auth-decision.md
@@ -1,0 +1,33 @@
+# Architecture Decision: API Authentication Scope (v1)
+
+## Decision
+
+GovEA v1 exposes no external API surface. API authentication is out of scope for v1.
+
+## Context
+
+An ARB review (issue #6) flagged that API authentication references existed in OrchardCore capability references but no explicit decision had been documented about whether GovEA v1 would include an external API.
+
+## Rationale
+
+All data access in v1 is through:
+- Next.js server actions (server-side, session-protected)
+- The admin UI (session-protected)
+- The `api/auth/[...nextauth]` route (NextAuth internal — not a public API)
+
+There are no REST endpoints, GraphQL endpoints, or token-based API consumers in v1. The primary personas (CMS Administrator, Agency EA Coordinator, Content Viewer) all interact through the browser UI. No integration use case requiring a machine-readable API has been identified for v1.
+
+## Consequences
+
+- No API key management, bearer token issuance, or OAuth client credential flow is needed in v1
+- If a public or partner API is added in v2, authentication must be designed at that time (API keys, OAuth 2.0 client credentials, or similar)
+- This decision should be revisited if data export or integration requirements surface during persona validation
+
+## Status
+
+Accepted — v1 scope
+
+## Related
+
+- ARB finding: roballred/GovEA#6
+- Affected personas: Enterprise Architect (Central IT), Agency EA Coordinator

--- a/business-architecture/capabilities/cms/iam/iam-audit-trail.md
+++ b/business-architecture/capabilities/cms/iam/iam-audit-trail.md
@@ -14,9 +14,17 @@ The system must log all identity and access management events so that administra
 - Export the audit log as CSV
 
 ## Rules
-- Audit log entries are immutable — no user including Admin can edit or delete them
+- Audit log entries are immutable — no user including Admin can edit or delete them through the application
 - Logs must be retained for a configurable period (default: 12 months)
 - Failed login attempts must be logged including the email address used
+
+## Log Integrity
+
+Application-level enforcement: no delete or update path exists for audit log entries in the application code. The UI provides read-only access.
+
+Operational requirement: the database role used by the application must be granted INSERT-only on the `audit_log` table — no UPDATE or DELETE. This is a deployment configuration requirement, not enforced by the schema. See deployment documentation for setup instructions.
+
+Acknowledged limitation: an operator with direct superuser database access can bypass application-level controls. This is accepted in v1. Mitigation options for future consideration include append-only cloud storage exports and WAL-based tamper detection.
 
 ## Links
 - Depends on: User Management, Local Authentication, SSO Authentication

--- a/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
+++ b/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
@@ -21,6 +21,13 @@ The system must allow users to sign in using their agency's identity provider vi
 - If an SSO user is deactivated in the identity provider, their next login attempt must fail
 - Only one SSO provider is supported in v1
 
+## Session Invalidation
+
+- Sessions are validated on every request — a deactivated GovEA user is blocked immediately on their next request, regardless of session age
+- Sessions expire after 24 hours and require re-authentication
+- **Important:** Deactivating a user in the identity provider (e.g. Entra ID) alone does not immediately revoke their active GovEA session. Admins must also deactivate the user in GovEA for immediate effect. IdP-only deactivation is caught at the next login attempt (within 24h at latest due to session expiry)
+- SCIM-based real-time provisioning sync is out of scope for v1
+
 ## Links
 - Depends on: User Management, Role-Based Access Control
 - Related: Local Authentication, IAM Audit Trail


### PR DESCRIPTION
## Summary

Resolves three security gaps identified in ARB finding #6.

### 1. Session invalidation

- Added `isActive` DB check to the `jwt` callback in `auth.ts` — on every authenticated request, the user's active status is verified against the database. A deactivated user is blocked immediately on their next request (token returns `null`, middleware redirects to login)
- Set `maxAge: 60 * 60 * 24` (24h) on JWT sessions — was previously unbounded (30-day NextAuth default)
- **Known limitation:** Deactivating a user in Entra ID alone does not immediately revoke their GovEA session. Admins must also deactivate in GovEA for immediate effect. IdP-only deactivation is caught within 24h (session expiry) or on next login attempt. Documented in `iam-sso-authentication.md`.

### 2. Audit log integrity

Updated `iam-audit-trail.md` with an explicit integrity section:
- Application code has no delete/update path for audit entries (enforced)
- Deployment must configure an INSERT-only database role for the application user (operational requirement)
- Superuser bypass acknowledged as an accepted v1 limitation with future mitigation options noted

### 3. API authentication scope

Created `iam-api-auth-decision.md` documenting that v1 has no external API surface. All data access is through Next.js server actions and the admin UI. API authentication is explicitly deferred to v2.

Closes #6

## Test plan

- [ ] Sign in as a user, deactivate them in the admin UI — verify next request redirects to login
- [ ] Verify session expires after 24 hours
- [ ] Confirm audit log entries cannot be deleted through the UI
- [ ] Confirm no API endpoints exist beyond `/api/auth/[...nextauth]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)