### PR TITLE
feat: planning capability group and Department Director persona (#67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ npm-debug.log*
 .vscode
 .idea
 *.swp
+
+# Temporary research and working files
+ea-research/

--- a/business-architecture/capabilities/cms/planning/pl-initiatives.md
+++ b/business-architecture/capabilities/cms/planning/pl-initiatives.md
@@ -1,0 +1,31 @@
+# Capability: Initiatives
+
+## What It Does
+The system must allow organizations to document change programmes (initiatives, projects, programmes), link them to the capabilities they affect and the objectives they advance, and track their status and timeline. This makes the connection between investment decisions and the architecture they change explicit and visible.
+
+## Personas
+- **Enterprise Architect (Central IT)** — tracks enterprise-level programmes and their impact on the enterprise capability portfolio
+- **Agency EA Coordinator** — maintains the agency's initiative register and links each initiative to the capabilities it builds, changes, or retires
+- **Department Director** — views the initiative portfolio to understand what is underway, what capabilities are being built, and how initiatives connect to strategic objectives
+
+## Behaviors
+- Create an initiative with name, description, status, start date, end date, and organization
+- Link an initiative to one or more capabilities with an impact label (builds, enhances, retires, depends-on)
+- Link an initiative to one or more strategic objectives
+- View which capabilities an initiative affects and in what way
+- View which initiatives are advancing a given objective
+- View which initiatives affect a given capability
+- Track initiative status through its lifecycle (proposed, active, on-hold, complete, cancelled)
+- Publish initiatives so they are visible to Viewer-role users
+
+## Rules
+- An initiative must belong to an organization
+- Initiatives follow the standard content workflow: draft → published → archived
+- Only published initiatives are visible to Viewer-role users
+- An initiative with no linked capabilities is architecturally incomplete — this should surface as a completeness signal in the admin dashboard
+- Impact labels on capability links are optional but recommended; they communicate whether the initiative is building new capability or changing existing capability
+
+## Links
+- Depends on: Content Management — Content Workflow, Content Relationships
+- Related: Strategic Objectives, Capabilities, Roadmap
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director

--- a/business-architecture/capabilities/cms/planning/pl-roadmap.md
+++ b/business-architecture/capabilities/cms/planning/pl-roadmap.md
@@ -1,0 +1,33 @@
+# Capability: Roadmap
+
+## What It Does
+The system must provide a timeline view of initiatives and their relationship to strategic objectives, allowing stakeholders to see what is planned, what is underway, and what has been delivered — and how these changes connect to the capability portfolio.
+
+The roadmap is a view over existing planning content, not a standalone data store. It renders what is already captured in initiatives and objectives as a governed, readable timeline.
+
+## Personas
+- **Enterprise Architect (Central IT)** — reviews the enterprise initiative timeline and identifies sequencing conflicts or gaps in capability coverage
+- **Agency EA Coordinator** — uses the roadmap to communicate the agency's transformation trajectory to leadership and peer agencies
+- **Department Director** — primary consumer; reads the roadmap to understand what is changing and when, without needing to navigate the full architecture repository
+
+## Behaviors
+- Display initiatives on a timeline grouped by status (proposed, active, complete)
+- Show the strategic objectives each initiative advances
+- Show the capabilities each initiative affects, with impact label
+- Filter the roadmap by status, capability, or objective
+- Display start and end dates where available; display "TBD" or "ongoing" where dates are not set
+- Render the roadmap from published content only — draft and archived initiatives do not appear to Viewers
+
+## Rules
+- The roadmap does not have its own data — it is a rendered view of published initiatives with planning metadata
+- Only published initiatives appear in the roadmap view for Viewer-role users
+- Initiatives without start/end dates appear in a "Unscheduled" section rather than being hidden
+- The roadmap is read-only; editing is done through the initiatives management interface
+
+## Implementation Status
+- **v1:** Basic roadmap view implemented. Displays published initiatives grouped by status with objective and capability links. Date-based timeline rendering is deferred to a future iteration.
+
+## Links
+- Depends on: Initiatives, Strategic Objectives, Capabilities
+- Related: Portfolio Views, Front-End Display
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director

--- a/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
+++ b/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
@@ -1,0 +1,30 @@
+# Capability: Strategic Objectives
+
+## What It Does
+The system must allow organizations to define strategic business objectives, link them to the capabilities and value streams that deliver on them, and track their status over time. This closes the gap between stated strategy and the architecture that enables it.
+
+## Personas
+- **Enterprise Architect (Central IT)** — defines enterprise-level objectives and links them to enterprise capabilities
+- **Agency EA Coordinator** — maintains agency-level objectives tied to the agency's capability portfolio
+- **Department Director** — views how strategic objectives connect to current capabilities and investment priorities; does not author
+
+## Behaviors
+- Create a strategic objective with name, description, success metric, time horizon, and status
+- Link a strategic objective to one or more capabilities
+- Link a strategic objective to one or more value streams
+- View which capabilities and value streams support a given objective
+- View which objectives a given capability or value stream contributes to
+- Track objective status through a defined lifecycle (draft, active, achieved, on-hold, cancelled)
+- Publish objectives so they are visible to non-admin users
+
+## Rules
+- A strategic objective must belong to an organization
+- Strategic objectives follow the standard content workflow: draft → published → archived
+- Only published objectives are visible to Viewer-role users
+- An objective's success metric is optional but strongly encouraged — objectives without measurable outcomes are flagged as incomplete in the admin dashboard
+- Linking to capabilities and value streams is optional but recommended; unlinked objectives are architecturally orphaned and should surface as a completeness signal
+
+## Links
+- Depends on: Content Management — Content Workflow, Content Relationships
+- Related: Capabilities, Value Streams, Initiatives, Roadmap
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director

--- a/business-architecture/capabilities/cms/planning/planning.md
+++ b/business-architecture/capabilities/cms/planning/planning.md
@@ -1,0 +1,19 @@
+# Capability Group: Planning
+
+The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio on a timeline.
+
+## Personas
+- **Enterprise Architect (Central IT)** — publishes enterprise-wide objectives and tracks capability alignment across agencies
+- **Agency EA Coordinator** — maintains the agency's strategic objectives and links them to capabilities and value streams
+- **Department Director** — consumes planning outputs to understand how technology investments connect to strategic priorities
+
+## Sub-Capabilities
+
+| Capability | File | Description |
+|---|---|---|
+| Strategic Objectives | [pl-strategic-objectives.md](./pl-strategic-objectives.md) | Define and track business goals; link to capabilities and value streams |
+| Initiatives | [pl-initiatives.md](./pl-initiatives.md) | Track change programmes; link to capabilities and objectives with impact |
+| Roadmap | [pl-roadmap.md](./pl-roadmap.md) | Visualize initiatives and objectives on a governed timeline |
+
+## Design Principle
+Planning capabilities are a lens on existing architecture content — they do not exist in isolation. Strategic objectives trace to capabilities and value streams. Initiatives trace to objectives and capabilities. The roadmap visualizes initiative timelines against the architecture they affect. Nothing in this capability group is meaningful unless the underlying capability and persona content is maintained.

--- a/business-architecture/personas/department-director.md
+++ b/business-architecture/personas/department-director.md
@@ -1,0 +1,38 @@
+# Persona: Department Director
+
+**Validation Status: Assumed** — drafted using market research and the government EA context. Must not drive implementation until validated through interviews with real department heads or deputy directors in a state or local government context.
+
+## Role Type
+Internal — Senior Department Leadership
+
+## Who They Are
+The Department Director is a senior government leader responsible for a specific department or agency (e.g., Director of Public Works, Deputy Director of Health Services, IT Director for a line agency). They are responsible for programme delivery, budget decisions, and technology investment within their remit. They are not architects — they have no interest in EA methodology — but they depend on EA outputs to make well-informed decisions about what to build, buy, or stop.
+
+In government, this role often includes budget officers, deputy directors, and senior programme managers who sit between operational staff and elected leadership. They are the primary audience for EA's value but are rarely the primary user of EA tools.
+
+## Goals
+- Understand what technology their department depends on and which systems are at risk of failure or decommission
+- Get a clear view of how current investments connect to stated strategic objectives
+- See what initiatives are underway and what capability gaps remain
+- Find authoritative answers to questions like "what systems support permitting?" without routing through IT
+- Engage with architecture reviews and planning without wading through framework jargon
+- Present credible, plain-language views of the department's technology posture to elected officials, budget committees, or auditors
+
+## Pain Points
+- EA outputs are designed for architects, not decision-makers — dense diagrams, framework language, and incomplete data they cannot act on
+- Information is scattered across tools, spreadsheets, and documents that are never current
+- No single place to see how the department's applications connect to its capabilities and strategic priorities
+- When they ask IT a question, the answer either takes too long or comes back as a presentation rather than a direct answer
+- Architecture reviews feel like compliance gates, not support for their decision-making
+- They have no way to track whether strategic objectives are actually supported by the current technology portfolio
+
+## Critical Insight
+The Department Director will only engage with GovEA if the outputs require no training to read and the content is visibly current. A published date on every piece of content matters more than comprehensive coverage. Plain language that connects technology to mission outcomes is more valuable than architectural accuracy. If they have to ask the EA team to interpret an output, the tool has already failed this persona.
+
+## Relevant Capabilities
+- Front-end content display and navigation
+- Portfolio views (capability map, application portfolio, persona directory)
+- Strategic objectives and initiative tracking
+- Roadmap views
+- Relationship navigation (what applications support which capabilities)
+- Plain-language content presentation


### PR DESCRIPTION
## Summary

Adds missing business architecture artifacts for planning features already implemented in the codebase (strategic objectives, initiatives, roadmap views introduced in #57 and #58).

### New persona: Department Director

The senior government leader who consumes EA outputs to make investment and programme decisions — a department head, deputy director, or senior programme manager. Equivalent to the "Business Stakeholder" pattern documented across EA tool market research. Status: **Assumed** (needs validation).

This persona was already referenced in existing capability documents (dev-fixtures seed data) without a formal definition file. It closes that gap and gives the front-end display and planning capabilities a clearly defined consumer persona.

### New capability group: Planning

Framed as a lens over existing architecture content — planning artifacts are only meaningful when the underlying capability and persona content is maintained.

| File | Description |
|---|---|
| `planning.md` | Parent group; design principle |
| `pl-strategic-objectives.md` | Define objectives, link to capabilities/value streams, track status |
| `pl-initiatives.md` | Document change programmes, link to objectives/capabilities with impact labels |
| `pl-roadmap.md` | Read-only timeline view over published initiatives; clarifies roadmap is a rendered view, not a data store |

### .gitignore

Added `ea-research/` to exclude the temporary research folder from version control.

Closes #67

## Test plan

- [ ] Review Department Director persona — confirm it accurately represents a real government stakeholder type
- [ ] Review planning capability files — confirm behaviors and rules match the implemented schema and UI
- [ ] Confirm `ea-research/` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)