### PR TITLE
docs: add portfolio management capability group

### DIFF
--- a/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
@@ -1,0 +1,45 @@
+# Capability: Application Portfolio
+
+## What It Does
+The system must allow contributors to maintain a structured inventory of the organization's applications, capturing lifecycle status, hosting model, vendor, version, and links to the business capabilities each application supports.
+
+## Personas
+- **CMS Contributor** — creates, edits, and publishes application records
+- **CMS Administrator** — has all Contributor permissions; can delete records
+- **Content Viewer** — reads published application records through the front-end portfolio view
+
+## Behaviors
+- Create an application record with: name, description, vendor, version, hosting model, lifecycle status, workflow status, and visibility
+- Link an application to one or more business capabilities (required — at least one link must exist)
+- Edit all fields on an existing application record
+- Delete an application record (Admin only)
+- View all applications in a table, sortable by name
+- Filter applications by lifecycle status, hosting model, and owning department on the front-end portfolio view
+
+## Lifecycle Status Values
+| Status | Meaning |
+|---|---|
+| `active` | Application is in active use |
+| `planned` | Application is approved or under procurement; not yet live |
+| `sunset` | Application is being phased out; a replacement exists or is in progress |
+| `decommissioned` | Application has been retired and is no longer in use |
+
+## Hosting Model Values
+Free-text field. Recommended values: `on-prem`, `saas`, `hybrid`, `cloud-hosted`.
+
+## Rules
+- Every application must be linked to at least one capability — enforced at the application layer
+- Deletion is Admin-only
+- All create, edit, and delete actions are written to the audit log
+- Visibility defaults to `org`; Contributors can set to `connections` or `instance`
+- Only published applications appear in front-end portfolio views
+
+## Implementation Status
+Fully implemented in v1:
+- Schema: `applications` table, `application_capabilities` junction table (`apps/govea/src/db/schema/applications.ts`)
+- Server actions: create, edit, delete, get (`apps/govea/src/actions/applications.ts`)
+- Admin UI: list view, detail view, create/edit forms (`apps/govea/src/app/(admin)/applications/`)
+
+## Links
+- Depends on: Capability Map, IAM — Role-Based Access Control, Content Management — Content Workflow
+- Related: Frontend Display — Portfolio Views, Planning — Initiatives

--- a/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
+++ b/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
@@ -1,0 +1,46 @@
+# Capability: Architecture Decision Records
+
+## What It Does
+The system must allow contributors to record, track, and supersede architecture decisions so the organization has a durable, navigable log of why significant technical choices were made. ADRs use the standard lightweight format: context, decision, consequences.
+
+## Personas
+- **CMS Contributor** — creates and maintains ADR records
+- **CMS Administrator** — has all Contributor permissions; can delete records
+- **Content Viewer** — reads published ADRs through the front-end ADR list view
+- **Department Director** — reads significant decisions to understand technical direction and constraints
+
+## Behaviors
+- Create an ADR with: number (e.g. ADR-001), title, context, decision, consequences, status, and visibility
+- Edit all fields on an existing ADR
+- Mark an ADR as superseded and link it to the ADR that replaces it
+- Delete an ADR (Admin only)
+- View all ADRs in a list with status prominently displayed
+- Filter ADRs by status and affected capability on the front-end view
+- Navigate from an ADR to the ADR that supersedes it (and vice versa)
+
+## Status Values
+| Status | Meaning |
+|---|---|
+| `proposed` | Decision is under review and not yet accepted |
+| `accepted` | Decision is current and in effect |
+| `deprecated` | Decision is no longer relevant but has not been replaced |
+| `superseded` | Decision has been replaced by a newer ADR; `supersededBy` links to the replacement |
+
+## Rules
+- ADR numbers are manually assigned by contributors — the system does not auto-increment them in v1
+- `supersededBy` references another ADR record in the same organization; the field is optional
+- Deletion is Admin-only
+- All create, edit, and delete actions are written to the audit log
+- Visibility defaults to `org`
+- Only published ADRs appear in front-end portfolio views
+
+## Implementation Status
+Partially implemented in v1:
+- Schema: `adrs` table with full field set including `superseded_by` (`apps/govea/src/db/schema/adrs.ts`)
+- Admin UI: list view exists (`apps/govea/src/app/(admin)/adrs/page.tsx`)
+- **Not yet implemented:** create/edit forms, detail view, delete action, server actions
+- Front-end portfolio view references ADR list but depends on published ADR records existing
+
+## Links
+- Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow
+- Related: Capability Map, Frontend Display — Portfolio Views

--- a/business-architecture/capabilities/cms/portfolio/po-capability-map.md
+++ b/business-architecture/capabilities/cms/portfolio/po-capability-map.md
@@ -1,0 +1,40 @@
+# Capability: Capability Map
+
+## What It Does
+The system must allow contributors to define and maintain the organization's business capabilities — the things the organization does, independent of how they are implemented. Capabilities are organized by domain and linked to the applications that support them and the personas that depend on them.
+
+## Personas
+- **CMS Contributor** — creates, edits, and publishes capability records
+- **CMS Administrator** — has all Contributor permissions; can delete records
+- **Content Viewer** — reads published capabilities through the front-end capability map view
+- **Department Director** — uses the capability map to understand what the organization does and where technology supports it
+
+## Behaviors
+- Create a capability with: name, description, domain, workflow status, and visibility
+- Link a capability to one or more personas
+- Edit all fields on an existing capability record
+- Delete a capability record (Admin only)
+- View all capabilities in a table, sortable by name
+- Filter capabilities by domain on the front-end capability map view
+- Navigate from a capability to its linked applications and personas
+
+## Domain
+Free-text field used to group capabilities into top-level areas (e.g., "Citizen Services", "Finance", "HR", "IT"). Domain values are not controlled by a taxonomy in v1 — contributors enter them manually.
+
+## Rules
+- Capabilities are the anchor entity in the EasyEA methodology — applications link to capabilities, and capabilities link to personas
+- Deleting a capability removes all `application_capabilities` and `capability_personas` junction records via cascade
+- Deletion is Admin-only
+- All create, edit, and delete actions are written to the audit log
+- Visibility defaults to `org`
+- Only published capabilities appear in front-end views
+
+## Implementation Status
+Fully implemented in v1:
+- Schema: `capabilities` table, `capability_personas` junction table (`apps/govea/src/db/schema/capabilities.ts`)
+- Server actions: create, edit, delete, get (`apps/govea/src/actions/capabilities.ts`)
+- Admin UI: list view, detail view, create/edit forms (`apps/govea/src/app/(admin)/capabilities/`)
+
+## Links
+- Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow
+- Related: Application Portfolio, Frontend Display — Portfolio Views, Personas

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -1,0 +1,27 @@
+# Capability Group: Portfolio Management
+
+## What It Does
+The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, and architecture decisions. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
+
+## Personas
+- **CMS Contributor** — creates and maintains portfolio records
+- **CMS Administrator** — has all Contributor permissions; manages visibility and lifecycle
+- **Content Viewer** — reads published portfolio content through front-end views
+- **Department Director** — reads portfolio views to inform investment and planning decisions
+
+## Sub-Capabilities
+
+| Capability | File | Description |
+|---|---|---|
+| Application Portfolio | [po-application-portfolio.md](./po-application-portfolio.md) | Manage applications with lifecycle status and capability links |
+| Capability Map | [po-capability-map.md](./po-capability-map.md) | Define business capabilities organized by domain, linked to applications and personas |
+| Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
+
+## Rules
+- Portfolio records follow the standard content workflow: draft → published → archived
+- Only published records are visible to Content Viewers and Department Directors
+- Every application must link to at least one capability — this is a data integrity rule enforced at the application layer
+- Visibility controls (org / connections / instance) apply to all portfolio record types
+
+## Links
+- Related: Frontend Display — Portfolio Views, Planning, Content Management


### PR DESCRIPTION
## Summary

- Adds `portfolio/` capability group with parent doc and three sub-capability docs
- Documents what is already built (Application Portfolio, Capability Map) and what is partially built (ADRs — schema + list view, no forms yet)
- Closes the gap identified in the EA tools research: portfolio capabilities existed in code with no corresponding business architecture docs

## Capabilities documented

| File | Status |
|---|---|
| `portfolio.md` | New — parent group |
| `po-application-portfolio.md` | Fully implemented in v1 |
| `po-capability-map.md` | Fully implemented in v1 |
| `po-architecture-decisions.md` | Partially implemented — schema and list view only |

## Test plan

- [ ] Review capability docs for accuracy against schema files (`applications.ts`, `capabilities.ts`, `adrs.ts`)
- [ ] Verify implementation status sections match actual admin UI routes
- [ ] Confirm ADR partial implementation note is accurate before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)