### PR TITLE
feat: expand dev fixtures with richer data, second org, and multi-org scenario

### DIFF
--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -1,12 +1,39 @@
 // Synthetic data for development and testing.
 // All dev users use the password 'dev-password' (hashed at seed time).
 // Dev login shortcuts on the login page bypass password entry in development.
+//
+// Two organizations are seeded:
+//   - City of Riverdale (primary dev org) — full EA content, three user roles
+//   - Office of Digital Services (state agency) — second org for multi-org scenario
+//
+// An active org connection between them and a cross-org capability link are
+// created to exercise the federation/visibility use case.
+
+// ─── Orgs ────────────────────────────────────────────────────────────────────
+
+export const DEV_ORG = {
+  name: 'City of Riverdale',
+  slug: 'city-of-riverdale',
+}
+
+export const STATE_ORG = {
+  name: 'Office of Digital Services',
+  slug: 'office-of-digital-services',
+}
+
+// ─── Users ───────────────────────────────────────────────────────────────────
 
 export const DEV_USERS = [
-  { name: 'Alice Admin', email: 'alice@govea.dev', role: 'admin' as const },
-  { name: 'Carol Contributor', email: 'carol@govea.dev', role: 'contributor' as const },
-  { name: 'Victor Viewer', email: 'victor@govea.dev', role: 'viewer' as const },
+  { name: 'Alice Admin',       email: 'alice@govea.dev',       role: 'admin'       as const },
+  { name: 'Carol Contributor', email: 'carol@govea.dev',       role: 'contributor' as const },
+  { name: 'Victor Viewer',     email: 'victor@govea.dev',      role: 'viewer'      as const },
 ]
+
+export const STATE_USERS = [
+  { name: 'Sam StateAdmin',    email: 'sam@state.govea.dev',   role: 'admin'       as const },
+]
+
+// ─── Persona types & tags (shared defaults) ──────────────────────────────────
 
 export const DEFAULT_PERSONA_TYPES = [
   'Citizen',
@@ -23,20 +50,406 @@ export const DEFAULT_TAGS = [
   'multilingual',
 ]
 
+// ─── Personas (City of Riverdale) ────────────────────────────────────────────
+
 export const DEV_PERSONAS = [
-  { name: 'Resident', description: 'A member of the public interacting with city services', type: 'Citizen' },
-  { name: 'IT Staff', description: 'Internal technology team member', type: 'Staff' },
-  { name: 'Department Director', description: 'Senior agency leader responsible for a service area', type: 'Staff' },
+  {
+    name: 'Resident',
+    description: 'A member of the public interacting with city services online or in person. Primary user of public-facing digital services.',
+    type: 'Citizen',
+    status: 'published' as const,
+    visibility: 'org' as const,
+  },
+  {
+    name: 'Small Business Owner',
+    description: 'Local business operator who interacts with the city for permits, licenses, and inspections. High value, time-sensitive needs.',
+    type: 'External Partner',
+    status: 'published' as const,
+    visibility: 'org' as const,
+  },
+  {
+    name: 'IT Staff',
+    description: 'Internal technology team member responsible for maintaining and supporting city systems.',
+    type: 'Staff',
+    status: 'published' as const,
+    visibility: 'org' as const,
+  },
+  {
+    name: 'Department Director',
+    description: 'Senior agency leader accountable for a service area and its technology investment. Needs budget and performance visibility.',
+    type: 'Staff',
+    status: 'published' as const,
+    visibility: 'org' as const,
+  },
+  {
+    name: 'Field Inspector',
+    description: 'City employee conducting inspections in the field, typically on a mobile device with intermittent connectivity.',
+    type: 'Staff',
+    status: 'published' as const,
+    visibility: 'org' as const,
+  },
+  {
+    name: 'City Council Member',
+    description: 'Elected official who needs plain-language visibility into technology investment and service performance.',
+    type: 'Elected Official',
+    status: 'published' as const,
+    visibility: 'connections' as const,
+  },
+  {
+    name: 'State Agency Liaison',
+    description: 'Representative from a state agency who exchanges data and coordinates shared services with the city.',
+    type: 'External Partner',
+    status: 'draft' as const,
+    visibility: 'connections' as const,
+  },
 ]
+
+// ─── Capabilities (City of Riverdale) ────────────────────────────────────────
+// Each capability maps to one or more persona names from DEV_PERSONAS.
 
 export const DEV_CAPABILITIES = [
-  { name: 'Online Permitting', description: 'Submit and track permit applications online', domain: 'Community Development' },
-  { name: 'HR Self-Service', description: 'Employee access to HR functions', domain: 'Legislative & Executive' },
-  { name: 'GIS Mapping', description: 'Geographic information services for staff and public', domain: 'Information Technology' },
+  {
+    name: 'Online Permitting',
+    description: 'Residents and businesses submit, pay for, and track permit applications without visiting a counter.',
+    domain: 'Community Development',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Resident', 'Small Business Owner', 'Field Inspector'],
+  },
+  {
+    name: 'Business License Management',
+    description: 'Issue, renew, and revoke business licenses. Notify owners of expiry and compliance requirements.',
+    domain: 'Community Development',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Small Business Owner'],
+  },
+  {
+    name: 'HR Self-Service',
+    description: 'Employees view pay stubs, request leave, update personal information, and access benefits.',
+    domain: 'Legislative & Executive',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['IT Staff'],
+  },
+  {
+    name: 'GIS Mapping',
+    description: 'Geographic information services supporting public-facing maps, field data collection, and internal spatial analysis.',
+    domain: 'Information Technology',
+    status: 'published' as const,
+    visibility: 'connections' as const,
+    personas: ['IT Staff', 'Field Inspector'],
+  },
+  {
+    name: 'Budget Reporting',
+    description: 'Directors and elected officials access real-time budget vs. actuals and forecast dashboards.',
+    domain: 'Finance & Budget',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Department Director', 'City Council Member'],
+  },
+  {
+    name: 'Service Request Management',
+    description: 'Residents submit and track non-emergency service requests such as pothole repairs, graffiti removal, and missed pickups.',
+    domain: 'Public Works',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Resident'],
+  },
+  {
+    name: 'Digital Identity & Authentication',
+    description: 'Unified login for residents and staff across city digital services. Supports local accounts and optional SSO.',
+    domain: 'Information Technology',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Resident', 'Small Business Owner', 'IT Staff'],
+  },
+  {
+    name: 'Cross-Agency Data Sharing',
+    description: 'Structured data exchange between the city and state agencies via secure APIs and agreed data standards.',
+    domain: 'Information Technology',
+    status: 'draft' as const,
+    visibility: 'connections' as const,
+    personas: ['State Agency Liaison', 'IT Staff'],
+  },
 ]
 
+// ─── Applications (City of Riverdale) ────────────────────────────────────────
+// Each application maps to one or more capability names from DEV_CAPABILITIES.
+
 export const DEV_APPLICATIONS = [
-  { name: 'Accela', description: 'Permitting and licensing platform', vendor: 'Accela', hostingModel: 'saas' },
-  { name: 'Workday', description: 'HR and payroll system', vendor: 'Workday', hostingModel: 'saas' },
-  { name: 'ArcGIS Online', description: 'Cloud GIS platform', vendor: 'Esri', hostingModel: 'saas' },
+  {
+    name: 'Accela',
+    description: 'Permitting and licensing platform used by Community Development and Code Enforcement.',
+    vendor: 'Accela',
+    hostingModel: 'saas',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['Online Permitting', 'Business License Management'],
+  },
+  {
+    name: 'Workday',
+    description: 'HR and payroll system used enterprise-wide for all city employees.',
+    vendor: 'Workday',
+    hostingModel: 'saas',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['HR Self-Service'],
+  },
+  {
+    name: 'ArcGIS Online',
+    description: 'Cloud GIS platform for mapping, spatial analysis, and field data collection.',
+    vendor: 'Esri',
+    hostingModel: 'saas',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['GIS Mapping', 'Online Permitting'],
+  },
+  {
+    name: 'OpenGov',
+    description: 'Budget transparency and performance management platform used by Finance and department directors.',
+    vendor: 'OpenGov',
+    hostingModel: 'saas',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['Budget Reporting'],
+  },
+  {
+    name: 'CityWorks',
+    description: 'Work order and asset management system for Public Works. On-prem installation, approaching end of vendor support.',
+    vendor: 'Trimble',
+    hostingModel: 'on-prem',
+    lifecycleStatus: 'sunset' as const,
+    status: 'published' as const,
+    capabilities: ['Service Request Management', 'GIS Mapping'],
+  },
+  {
+    name: 'Microsoft Entra ID',
+    description: 'Cloud identity provider used for staff SSO. Residents use a separate local credential store.',
+    vendor: 'Microsoft',
+    hostingModel: 'saas',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['Digital Identity & Authentication'],
+  },
+  {
+    name: 'Legacy Permitting System',
+    description: 'In-house permitting system built in 2008. Being retired in favour of Accela.',
+    vendor: 'In-house',
+    hostingModel: 'on-prem',
+    lifecycleStatus: 'decommissioned' as const,
+    status: 'published' as const,
+    capabilities: ['Online Permitting'],
+  },
 ]
+
+// ─── Strategic Objectives (City of Riverdale) ─────────────────────────────────
+
+export const DEV_OBJECTIVES = [
+  {
+    name: 'Improve Digital Service Delivery',
+    description: 'Make city services faster and easier to access online, reducing in-person visits and processing times.',
+    successMetric: '80% of permit applications submitted online by end of FY2026',
+    timeHorizon: 'FY2026',
+    status: 'published' as const,
+    capabilities: ['Online Permitting', 'Service Request Management', 'Digital Identity & Authentication'],
+  },
+  {
+    name: 'Modernise Legacy Infrastructure',
+    description: 'Replace end-of-life on-prem systems with cloud-based alternatives to reduce operational risk and maintenance cost.',
+    successMetric: 'Zero active on-prem systems older than 10 years by FY2027',
+    timeHorizon: 'FY2027',
+    status: 'published' as const,
+    capabilities: ['GIS Mapping', 'Service Request Management'],
+  },
+  {
+    name: 'Enable Cross-Agency Data Sharing',
+    description: 'Establish secure, standards-based data exchange with state agencies to reduce duplicate data entry and improve service coordination.',
+    successMetric: 'At least 2 active data exchange agreements with state agencies by end of FY2026',
+    timeHorizon: 'FY2026',
+    status: 'draft' as const,
+    capabilities: ['Cross-Agency Data Sharing', 'Digital Identity & Authentication'],
+  },
+]
+
+// ─── Value Streams (City of Riverdale) ───────────────────────────────────────
+
+export const DEV_VALUE_STREAMS = [
+  {
+    name: 'Permit to Certificate',
+    description: 'End-to-end journey from a resident or business submitting a permit application through to receiving their certificate of approval.',
+    valueItem: 'Permit certificate enabling legal operation or construction',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    stakeholderPersonas: ['Resident', 'Small Business Owner'],
+    stages: [
+      {
+        name: 'Application Submission',
+        description: 'Applicant submits permit request with required documents and fees.',
+        order: 1,
+        capabilities: ['Online Permitting', 'Digital Identity & Authentication'],
+      },
+      {
+        name: 'Review & Inspection',
+        description: 'Staff review application, schedule and conduct site inspection if required.',
+        order: 2,
+        capabilities: ['Online Permitting', 'GIS Mapping'],
+      },
+      {
+        name: 'Approval & Issuance',
+        description: 'Approved permit is issued and applicant notified.',
+        order: 3,
+        capabilities: ['Online Permitting', 'Business License Management'],
+      },
+    ],
+  },
+  {
+    name: 'Service Request to Resolution',
+    description: 'Journey from a resident reporting a non-emergency issue through to resolution and confirmation.',
+    valueItem: 'Resolved public works issue with confirmation to the resident',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    stakeholderPersonas: ['Resident'],
+    stages: [
+      {
+        name: 'Request Submission',
+        description: 'Resident submits request via web, mobile, or phone.',
+        order: 1,
+        capabilities: ['Service Request Management'],
+      },
+      {
+        name: 'Assignment & Dispatch',
+        description: 'Request is triaged, assigned to a crew, and dispatched.',
+        order: 2,
+        capabilities: ['Service Request Management', 'GIS Mapping'],
+      },
+      {
+        name: 'Resolution & Closure',
+        description: 'Work is completed and resident is notified of resolution.',
+        order: 3,
+        capabilities: ['Service Request Management'],
+      },
+    ],
+  },
+]
+
+// ─── Initiatives (City of Riverdale) ─────────────────────────────────────────
+
+export const DEV_INITIATIVES = [
+  {
+    name: 'Accela Implementation',
+    description: 'Implement Accela as the new permitting and licensing platform, replacing the legacy in-house system.',
+    status: 'active' as const,
+    startDate: 'Q1 FY2026',
+    endDate: 'Q4 FY2026',
+    capabilities: [
+      { name: 'Online Permitting',          impact: 'improve' },
+      { name: 'Business License Management', impact: 'improve' },
+    ],
+    applications: [
+      { name: 'Accela',                    impact: 'build'  },
+      { name: 'Legacy Permitting System',  impact: 'retire' },
+    ],
+    objectives: ['Improve Digital Service Delivery'],
+  },
+  {
+    name: 'CityWorks Replacement',
+    description: 'Evaluate and replace CityWorks with a modern cloud-based work order and asset management system.',
+    status: 'proposed' as const,
+    startDate: 'Q2 FY2026',
+    endDate: 'Q2 FY2027',
+    capabilities: [
+      { name: 'Service Request Management', impact: 'improve' },
+      { name: 'GIS Mapping',               impact: 'improve' },
+    ],
+    applications: [
+      { name: 'CityWorks', impact: 'retire' },
+    ],
+    objectives: ['Modernise Legacy Infrastructure'],
+  },
+]
+
+// ─── ADRs (City of Riverdale) ─────────────────────────────────────────────────
+
+export const DEV_ADRS = [
+  {
+    number: 'ADR-001',
+    title: 'Adopt SaaS-first hosting for new application acquisitions',
+    context: 'The city operates several aging on-premises systems that require dedicated infrastructure, patching, and specialist staff. Two systems (CityWorks, Legacy Permitting) are approaching end of vendor support.',
+    decision: 'All new application acquisitions will default to SaaS hosting unless a documented security, compliance, or integration requirement mandates on-premises deployment. On-prem exceptions require Director-level approval and an exit plan.',
+    consequences: 'Reduces infrastructure maintenance burden and improves vendor-managed update cadence. Increases reliance on internet connectivity and vendor SLAs. Requires updated procurement templates and vendor risk assessment processes.',
+    status: 'accepted' as const,
+    capabilities: ['Digital Identity & Authentication', 'Cross-Agency Data Sharing'],
+    applications: ['Accela', 'ArcGIS Online', 'OpenGov'],
+  },
+]
+
+// ─── State Org Fixtures ───────────────────────────────────────────────────────
+
+export const STATE_PERSONAS = [
+  {
+    name: 'Local Government Partner',
+    description: 'Representative from a city or county agency that exchanges data or shares services with the state.',
+    type: 'External Partner',
+    status: 'published' as const,
+    visibility: 'connections' as const,
+  },
+]
+
+export const STATE_CAPABILITIES = [
+  {
+    name: 'Statewide Identity Verification',
+    description: 'State-managed identity verification service available to local government agencies for resident authentication.',
+    domain: 'Information Technology',
+    status: 'published' as const,
+    visibility: 'connections' as const,
+    personas: ['Local Government Partner'],
+  },
+  {
+    name: 'Open Data Platform',
+    description: 'Centralised platform for publishing and consuming government datasets in open, machine-readable formats.',
+    domain: 'Information Technology',
+    status: 'published' as const,
+    visibility: 'connections' as const,
+    personas: ['Local Government Partner'],
+  },
+  {
+    name: 'State Grants Management',
+    description: 'System for local agencies to apply for, track, and report on state grants.',
+    domain: 'Finance & Budget',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    personas: ['Local Government Partner'],
+  },
+]
+
+export const STATE_APPLICATIONS = [
+  {
+    name: 'State Identity Hub',
+    description: 'Statewide identity and authentication broker for government services.',
+    vendor: 'State OIT',
+    hostingModel: 'on-prem',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['Statewide Identity Verification'],
+  },
+  {
+    name: 'CKAN Open Data Portal',
+    description: 'Open source data portal used for the state open data platform.',
+    vendor: 'Open Knowledge Foundation',
+    hostingModel: 'on-prem',
+    lifecycleStatus: 'active' as const,
+    status: 'published' as const,
+    capabilities: ['Open Data Platform'],
+  },
+]
+
+// ─── Multi-org connection ─────────────────────────────────────────────────────
+// Describes the cross-org link to create between the two orgs.
+// sourceCapability (City of Riverdale) implements targetCapability (State Org).
+
+export const DEV_CROSS_ORG_LINK = {
+  sourceCapabilityName: 'Digital Identity & Authentication',
+  targetCapabilityName: 'Statewide Identity Verification',
+  linkType: 'implements' as const,
+}

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -1,54 +1,378 @@
 import { GOV_TAXONOMY } from './gov-taxonomy'
-import { DEV_USERS, DEFAULT_PERSONA_TYPES, DEFAULT_TAGS } from './dev-fixtures'
+import {
+  DEV_ORG, STATE_ORG,
+  DEV_USERS, STATE_USERS,
+  DEFAULT_PERSONA_TYPES, DEFAULT_TAGS,
+  DEV_PERSONAS, DEV_CAPABILITIES, DEV_APPLICATIONS,
+  DEV_OBJECTIVES, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
+  STATE_PERSONAS, STATE_CAPABILITIES, STATE_APPLICATIONS,
+  DEV_CROSS_ORG_LINK,
+} from './dev-fixtures'
 import { db } from '../client'
-import { users, organizations, personaTypes, tags } from '../schema'
+import {
+  users, organizations, personaTypes, tags,
+  personas, capabilities, applications,
+  capabilityPersonas, applicationCapabilities,
+  strategicObjectives, objectiveCapabilities,
+  valueStreams, valueStreamStages, valueStreamStageCapabilities,
+  initiatives, initiativeCapabilities, initiativeObjectives,
+  adrs,
+  orgConnections, crossOrgLinks,
+} from '../schema'
 import bcrypt from 'bcryptjs'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function findOrCreateOrg(slug: string, name: string) {
+  const existing = await db.query.organizations.findFirst({
+    where: (t, { eq }) => eq(t.slug, slug),
+  })
+  if (existing) return existing.id
+  const [org] = await db.insert(organizations).values({ name, slug }).returning()
+  return org.id
+}
+
+async function findOrCreatePersona(orgId: string, name: string, data: {
+  description?: string; type?: string; status: 'draft' | 'published' | 'archived'; visibility: 'org' | 'connections' | 'instance'
+}) {
+  const existing = await db.query.personas.findFirst({
+    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+  })
+  if (existing) return existing.id
+  const [p] = await db.insert(personas).values({ organizationId: orgId, name, ...data }).returning()
+  return p.id
+}
+
+async function findOrCreateCapability(orgId: string, name: string, data: {
+  description?: string; domain?: string; status: 'draft' | 'published' | 'archived'; visibility: 'org' | 'connections' | 'instance'
+}) {
+  const existing = await db.query.capabilities.findFirst({
+    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+  })
+  if (existing) return existing.id
+  const [c] = await db.insert(capabilities).values({ organizationId: orgId, name, ...data }).returning()
+  return c.id
+}
+
+async function findOrCreateApplication(orgId: string, name: string, data: {
+  description?: string; vendor?: string; hostingModel?: string;
+  lifecycleStatus: 'active' | 'sunset' | 'decommissioned' | 'planned';
+  status: 'draft' | 'published' | 'archived'
+}) {
+  const existing = await db.query.applications.findFirst({
+    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+  })
+  if (existing) return existing.id
+  const [a] = await db.insert(applications).values({ organizationId: orgId, name, ...data }).returning()
+  return a.id
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function seed() {
   console.log('Seeding government taxonomy...')
   console.log(`Loaded ${GOV_TAXONOMY.length} top-level domains`)
 
-  if (process.env.DEV === 'true') {
-    console.log('Loading dev fixtures...')
-
-    let existing = await db.query.organizations.findFirst()
-    let orgId: string
-
-    if (existing) {
-      orgId = existing.id
-    } else {
-      const [org] = await db.insert(organizations).values({
-        name: 'Dev Organization',
-        slug: 'dev-org',
-      }).returning()
-      orgId = org.id
-    }
-
-    const passwordHash = await bcrypt.hash('dev-password', 12)
-
-    for (const u of DEV_USERS) {
-      await db.insert(users).values({
-        ...u,
-        passwordHash,
-        organizationId: orgId,
-        isActive: 'true',
-      }).onConflictDoNothing()
-    }
-
-    console.log(`Seeded ${DEV_USERS.length} dev users (password: dev-password)`)
-
-    for (const name of DEFAULT_PERSONA_TYPES) {
-      await db.insert(personaTypes).values({ name, organizationId: orgId }).onConflictDoNothing()
-    }
-    console.log(`Seeded ${DEFAULT_PERSONA_TYPES.length} default persona types`)
-
-    for (const name of DEFAULT_TAGS) {
-      await db.insert(tags).values({ name, organizationId: orgId }).onConflictDoNothing()
-    }
-    console.log(`Seeded ${DEFAULT_TAGS.length} default tags`)
+  if (process.env.DEV !== 'true') {
+    console.log('Seed complete.')
+    process.exit(0)
   }
 
-  console.log('Seed complete.')
+  console.log('\nLoading dev fixtures...')
+  const passwordHash = await bcrypt.hash('dev-password', 12)
+
+  // ── Org 1: City of Riverdale ─────────────────────────────────────────────
+
+  console.log('\n[Org 1] City of Riverdale')
+  const devOrgId = await findOrCreateOrg(DEV_ORG.slug, DEV_ORG.name)
+
+  // Users
+  for (const u of DEV_USERS) {
+    await db.insert(users).values({ ...u, passwordHash, organizationId: devOrgId, isActive: 'true' }).onConflictDoNothing()
+  }
+  console.log(`  ✓ ${DEV_USERS.length} users (password: dev-password)`)
+
+  // Persona types & tags
+  for (const name of DEFAULT_PERSONA_TYPES) {
+    await db.insert(personaTypes).values({ name, organizationId: devOrgId }).onConflictDoNothing()
+  }
+  for (const name of DEFAULT_TAGS) {
+    await db.insert(tags).values({ name, organizationId: devOrgId }).onConflictDoNothing()
+  }
+  console.log(`  ✓ ${DEFAULT_PERSONA_TYPES.length} persona types, ${DEFAULT_TAGS.length} tags`)
+
+  // Personas
+  const devPersonaIds: Record<string, string> = {}
+  for (const p of DEV_PERSONAS) {
+    devPersonaIds[p.name] = await findOrCreatePersona(devOrgId, p.name, {
+      description: p.description, type: p.type, status: p.status, visibility: p.visibility,
+    })
+  }
+  console.log(`  ✓ ${DEV_PERSONAS.length} personas`)
+
+  // Capabilities + persona links
+  const devCapabilityIds: Record<string, string> = {}
+  for (const c of DEV_CAPABILITIES) {
+    const capId = await findOrCreateCapability(devOrgId, c.name, {
+      description: c.description, domain: c.domain, status: c.status, visibility: c.visibility,
+    })
+    devCapabilityIds[c.name] = capId
+    for (const personaName of c.personas) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const exists = await db.query.capabilityPersonas.findFirst({
+        where: (t, { eq, and }) => and(eq(t.capabilityId, capId), eq(t.personaId, personaId)),
+      })
+      if (!exists) await db.insert(capabilityPersonas).values({ capabilityId: capId, personaId })
+    }
+  }
+  console.log(`  ✓ ${DEV_CAPABILITIES.length} capabilities`)
+
+  // Applications + capability links
+  const devApplicationIds: Record<string, string> = {}
+  for (const a of DEV_APPLICATIONS) {
+    const appId = await findOrCreateApplication(devOrgId, a.name, {
+      description: a.description, vendor: a.vendor, hostingModel: a.hostingModel,
+      lifecycleStatus: a.lifecycleStatus, status: a.status,
+    })
+    devApplicationIds[a.name] = appId
+    for (const capName of a.capabilities) {
+      const capId = devCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.applicationCapabilities.findFirst({
+        where: (t, { eq, and }) => and(eq(t.applicationId, appId), eq(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capId })
+    }
+  }
+  console.log(`  ✓ ${DEV_APPLICATIONS.length} applications`)
+
+  // Strategic Objectives + capability links
+  const devObjectiveIds: Record<string, string> = {}
+  for (const o of DEV_OBJECTIVES) {
+    const existing = await db.query.strategicObjectives.findFirst({
+      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, o.name)),
+    })
+    let objId: string
+    if (existing) {
+      objId = existing.id
+    } else {
+      const [inserted] = await db.insert(strategicObjectives).values({
+        organizationId: devOrgId,
+        name: o.name,
+        description: o.description,
+        successMetric: o.successMetric,
+        timeHorizon: o.timeHorizon,
+        status: o.status,
+      }).returning()
+      objId = inserted.id
+    }
+    devObjectiveIds[o.name] = objId
+    for (const capName of o.capabilities) {
+      const capId = devCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.objectiveCapabilities.findFirst({
+        where: (t, { eq, and }) => and(eq(t.objectiveId, objId), eq(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(objectiveCapabilities).values({ objectiveId: objId, capabilityId: capId })
+    }
+  }
+  console.log(`  ✓ ${DEV_OBJECTIVES.length} strategic objectives`)
+
+  // Value Streams + stages + stage capability links
+  for (const vs of DEV_VALUE_STREAMS) {
+    const existingVs = await db.query.valueStreams.findFirst({
+      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, vs.name)),
+    })
+    let vsId: string
+    if (existingVs) {
+      vsId = existingVs.id
+    } else {
+      const [inserted] = await db.insert(valueStreams).values({
+        organizationId: devOrgId,
+        name: vs.name,
+        description: vs.description,
+        valueItem: vs.valueItem,
+        status: vs.status,
+        visibility: vs.visibility,
+        stakeholderPersonaId: devPersonaIds[vs.stakeholderPersonas[0]] ?? null,
+      }).returning()
+      vsId = inserted.id
+    }
+
+    for (const stage of vs.stages) {
+      const existingStage = await db.query.valueStreamStages.findFirst({
+        where: (t, { eq, and }) => and(eq(t.valueStreamId, vsId), eq(t.name, stage.name)),
+      })
+      let stageId: string
+      if (existingStage) {
+        stageId = existingStage.id
+      } else {
+        const [insertedStage] = await db.insert(valueStreamStages).values({
+          valueStreamId: vsId,
+          name: stage.name,
+          description: stage.description,
+          order: stage.order,
+        }).returning()
+        stageId = insertedStage.id
+      }
+
+      for (const capName of stage.capabilities) {
+        const capId = devCapabilityIds[capName]
+        if (!capId) continue
+        const exists = await db.query.valueStreamStageCapabilities.findFirst({
+          where: (t, { eq, and }) => and(eq(t.stageId, stageId), eq(t.capabilityId, capId)),
+        })
+        if (!exists) await db.insert(valueStreamStageCapabilities).values({ stageId, capabilityId: capId })
+      }
+    }
+  }
+  console.log(`  ✓ ${DEV_VALUE_STREAMS.length} value streams with stages`)
+
+  // Initiatives + capability/objective links
+  for (const ini of DEV_INITIATIVES) {
+    const existingIni = await db.query.initiatives.findFirst({
+      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, ini.name)),
+    })
+    let iniId: string
+    if (existingIni) {
+      iniId = existingIni.id
+    } else {
+      const [inserted] = await db.insert(initiatives).values({
+        organizationId: devOrgId,
+        name: ini.name,
+        description: ini.description,
+        status: ini.status,
+        startDate: ini.startDate,
+        endDate: ini.endDate,
+      }).returning()
+      iniId = inserted.id
+    }
+
+    for (const { name: capName, impact } of ini.capabilities) {
+      const capId = devCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.initiativeCapabilities.findFirst({
+        where: (t, { eq, and }) => and(eq(t.initiativeId, iniId), eq(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(initiativeCapabilities).values({ initiativeId: iniId, capabilityId: capId, impact })
+    }
+
+    for (const objName of ini.objectives) {
+      const objId = devObjectiveIds[objName]
+      if (!objId) continue
+      const exists = await db.query.initiativeObjectives.findFirst({
+        where: (t, { eq, and }) => and(eq(t.initiativeId, iniId), eq(t.objectiveId, objId)),
+      })
+      if (!exists) await db.insert(initiativeObjectives).values({ initiativeId: iniId, objectiveId: objId })
+    }
+  }
+  console.log(`  ✓ ${DEV_INITIATIVES.length} initiatives`)
+
+  // ADRs
+  for (const adr of DEV_ADRS) {
+    const existingAdr = await db.query.adrs.findFirst({
+      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.number, adr.number)),
+    })
+    if (!existingAdr) {
+      await db.insert(adrs).values({
+        organizationId: devOrgId,
+        number: adr.number,
+        title: adr.title,
+        context: adr.context,
+        decision: adr.decision,
+        consequences: adr.consequences,
+        status: adr.status,
+      })
+    }
+  }
+  console.log(`  ✓ ${DEV_ADRS.length} ADRs`)
+
+  // ── Org 2: Office of Digital Services ────────────────────────────────────
+
+  console.log('\n[Org 2] Office of Digital Services')
+  const stateOrgId = await findOrCreateOrg(STATE_ORG.slug, STATE_ORG.name)
+
+  for (const u of STATE_USERS) {
+    await db.insert(users).values({ ...u, passwordHash, organizationId: stateOrgId, isActive: 'true' }).onConflictDoNothing()
+  }
+  console.log(`  ✓ ${STATE_USERS.length} users (password: dev-password)`)
+
+  const statePersonaIds: Record<string, string> = {}
+  for (const p of STATE_PERSONAS) {
+    statePersonaIds[p.name] = await findOrCreatePersona(stateOrgId, p.name, {
+      description: p.description, type: p.type, status: p.status, visibility: p.visibility,
+    })
+  }
+  console.log(`  ✓ ${STATE_PERSONAS.length} personas`)
+
+  const stateCapabilityIds: Record<string, string> = {}
+  for (const c of STATE_CAPABILITIES) {
+    const capId = await findOrCreateCapability(stateOrgId, c.name, {
+      description: c.description, domain: c.domain, status: c.status, visibility: c.visibility,
+    })
+    stateCapabilityIds[c.name] = capId
+    for (const personaName of c.personas) {
+      const personaId = statePersonaIds[personaName]
+      if (!personaId) continue
+      const exists = await db.query.capabilityPersonas.findFirst({
+        where: (t, { eq, and }) => and(eq(t.capabilityId, capId), eq(t.personaId, personaId)),
+      })
+      if (!exists) await db.insert(capabilityPersonas).values({ capabilityId: capId, personaId })
+    }
+  }
+  console.log(`  ✓ ${STATE_CAPABILITIES.length} capabilities`)
+
+  for (const a of STATE_APPLICATIONS) {
+    const appId = await findOrCreateApplication(stateOrgId, a.name, {
+      description: a.description, vendor: a.vendor, hostingModel: a.hostingModel,
+      lifecycleStatus: a.lifecycleStatus, status: a.status,
+    })
+    for (const capName of a.capabilities) {
+      const capId = stateCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.applicationCapabilities.findFirst({
+        where: (t, { eq, and }) => and(eq(t.applicationId, appId), eq(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capId })
+    }
+  }
+  console.log(`  ✓ ${STATE_APPLICATIONS.length} applications`)
+
+  // ── Multi-org: connection + cross-org capability link ─────────────────────
+
+  console.log('\n[Multi-org]')
+
+  const existingConnection = await db.query.orgConnections.findFirst({
+    where: (t, { eq, and }) => and(eq(t.fromOrgId, devOrgId), eq(t.toOrgId, stateOrgId)),
+  })
+  if (!existingConnection) {
+    await db.insert(orgConnections).values({ fromOrgId: devOrgId, toOrgId: stateOrgId, status: 'active' })
+  }
+  console.log('  ✓ Org connection (active): City of Riverdale → Office of Digital Services')
+
+  const sourceCapId = devCapabilityIds[DEV_CROSS_ORG_LINK.sourceCapabilityName]
+  const targetCapId = stateCapabilityIds[DEV_CROSS_ORG_LINK.targetCapabilityName]
+  if (sourceCapId && targetCapId) {
+    const existingLink = await db.query.crossOrgLinks.findFirst({
+      where: (t, { eq, and }) => and(eq(t.sourceEntityId, sourceCapId), eq(t.targetEntityId, targetCapId)),
+    })
+    if (!existingLink) {
+      await db.insert(crossOrgLinks).values({
+        sourceOrgId: devOrgId,
+        sourceEntityType: 'capability',
+        sourceEntityId: sourceCapId,
+        targetOrgId: stateOrgId,
+        targetEntityType: 'capability',
+        targetEntityId: targetCapId,
+        linkType: DEV_CROSS_ORG_LINK.linkType,
+        status: 'active',
+      })
+    }
+    console.log(`  ✓ Cross-org link (active): "${DEV_CROSS_ORG_LINK.sourceCapabilityName}" implements "${DEV_CROSS_ORG_LINK.targetCapabilityName}"`)
+  }
+
+  console.log('\nSeed complete.')
   process.exit(0)
 }
 


### PR DESCRIPTION
## Summary

Closes #105. Replaces minimal dev fixtures with a realistic, fully-linked dataset across two organizations and exercises the multi-org federation use case.

## City of Riverdale (primary dev org)

| Entity | Count | Notes |
|---|---|---|
| Users | 3 | alice (admin), carol (contributor), victor (viewer) |
| Personas | 7 | Citizen, Staff, Elected Official, External Partner types; mixed `org`/`connections` visibility |
| Capabilities | 8 | Full persona links; includes `connections`-visible cap for cross-org demo |
| Applications | 7 | Active, sunset, decommissioned lifecycle states; varied hosting models |
| Strategic Objectives | 3 | Linked to capabilities |
| Value Streams | 2 | Multi-stage with capability links per stage |
| Initiatives | 2 | Active + proposed; linked to capabilities and objectives |
| ADRs | 1 | ADR-001, accepted |

## Office of Digital Services (state agency — second org)

| Entity | Count |
|---|---|
| Users | 1 (sam@state.govea.dev, admin) |
| Personas | 1 |
| Capabilities | 3 |
| Applications | 2 |

## Multi-org scenario

- Active org connection: City of Riverdale → Office of Digital Services
- Active cross-org capability link: "Digital Identity & Authentication" `implements` "Statewide Identity Verification"
- Content at `connections` visibility to exercise the federation display

## Test Plan

- [ ] `pnpm db:seed` with `DEV=true` completes without errors on a fresh DB
- [ ] Re-running seed is idempotent — no duplicates
- [ ] Both orgs appear in the DB with correct slugs
- [ ] `sam@state.govea.dev` can log in with `dev-password`
- [ ] Cross-org link exists between the two capability IDs
- [ ] Org connection status is `active`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)