### PR TITLE
feat: add demo docker setup for local and shareable demos

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,40 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.dev
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/govea
+      AUTH_SECRET: demo-secret-not-for-production
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      DEV: "true"
+    volumes:
+      # Mount source for hot reload. node_modules are kept in anonymous
+      # volumes so the container's pre-built install is not overwritten.
+      - .:/app
+      - /app/node_modules
+      - /app/apps/govea/node_modules
+      - /app/packages/core/node_modules
+      - /app/apps/govea/.next
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: govea
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - demo_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  demo_postgres_data:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,32 @@
+FROM node:20-alpine AS base
+RUN corepack enable pnpm
+
+# Install dependencies into the image so node_modules are pre-built.
+# Source is mounted as a volume at runtime, but node_modules are kept
+# in a separate anonymous volume so the container's install is not
+# overwritten by the host mount.
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY apps/govea/package.json ./apps/govea/
+COPY packages/core/package.json ./packages/core/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS dev
+WORKDIR /app
+
+# Copy installed node_modules from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/govea/node_modules ./apps/govea/node_modules
+COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+
+# Copy source — will be overridden by volume mount in docker-compose,
+# but kept here so the image is self-contained if run without volumes.
+COPY . .
+
+COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
+RUN chmod +x /entrypoint.dev.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/entrypoint.dev.sh"]

--- a/docker/entrypoint.dev.sh
+++ b/docker/entrypoint.dev.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo ""
+echo "==> Running database migrations..."
+pnpm --filter govea db:migrate
+
+echo ""
+echo "==> Seeding database..."
+pnpm --filter govea db:seed
+
+echo ""
+echo "==> Starting dev server..."
+exec pnpm --filter govea dev

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
-    "test": "turbo test"
+    "test": "turbo test",
+    "demo:start": "bash scripts/demo-start.sh",
+    "demo:docker": "docker compose -f docker-compose.demo.yml up --build",
+    "demo:stop": "docker compose -f docker-compose.demo.yml down"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/scripts/demo-start.sh
+++ b/scripts/demo-start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# demo-start.sh — Local demo workflow
+#
+# Runs the database in Docker and the Next.js app directly on the host.
+# Use this when you want fast hot reload without fully containerising the app.
+#
+# Prerequisites:
+#   - Docker running
+#   - Node >= 20 and pnpm >= 9 installed
+#   - .env.local present in apps/govea/ (copy from .env.example if needed)
+#
+# Usage:
+#   pnpm demo:start       (from repo root)
+#   bash scripts/demo-start.sh
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo ""
+echo "==> Starting database..."
+docker compose -f docker/docker-compose.dev.yml up -d
+
+echo ""
+echo "==> Waiting for database to be ready..."
+until docker compose -f docker/docker-compose.dev.yml exec -T db pg_isready -U postgres -q 2>/dev/null; do
+  printf "."
+  sleep 1
+done
+echo " ready."
+
+echo ""
+echo "==> Running migrations..."
+pnpm --filter govea db:migrate
+
+echo ""
+echo "==> Seeding database..."
+pnpm --filter govea db:seed
+
+echo ""
+echo "==> Starting dev server at http://localhost:3000"
+echo "    Login: alice@govea.dev / dev-password"
+echo ""
+pnpm --filter govea dev


### PR DESCRIPTION
## Summary

Closes #107. Delivers the demo docker setup originally in the closed PR #97, now as a standalone PR.

Two demo paths:

### Option B — Local (app on host, DB in Docker)
Best for your own demos — fast hot reload, no containerisation overhead.

```bash
pnpm demo:start
# open http://localhost:3000
# login: alice@govea.dev / dev-password
```

Starts the DB container, waits for health, runs migrations, seeds, then launches `next dev`.

### Option C — Fully containerised (shareable)
For sharing with others who don't have Node installed locally.

```bash
pnpm demo:docker
# or: docker compose -f docker-compose.demo.yml up --build
# open http://localhost:3000
```

Builds a dev image with pre-installed dependencies, mounts source as a volume for hot reload, runs migrate + seed on container start.

## Files

| File | Purpose |
|---|---|
| `docker/Dockerfile.dev` | Dev image — Node 20 Alpine, pnpm, deps pre-installed |
| `docker/entrypoint.dev.sh` | Container entrypoint: migrate → seed → `next dev` |
| `docker-compose.demo.yml` | Full stack: app + Postgres with health check and source volume |
| `scripts/demo-start.sh` | Local path: DB in Docker, app on host |
| `package.json` | `demo:start`, `demo:docker`, `demo:stop` shortcuts |

## Test Plan

- [ ] `pnpm demo:start` starts cleanly, app reachable at http://localhost:3000
- [ ] `pnpm demo:docker` builds and starts the full stack
- [ ] Editing a source file triggers hot reload in both paths
- [ ] `pnpm demo:stop` cleanly removes demo containers
- [ ] Re-running either command is safe (idempotent migrate + seed)
- [ ] `alice@govea.dev` / `dev-password` logs in successfully

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)