### PR TITLE
feat: add State Admin dev login shortcut to login page

### DIFF
--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -73,9 +73,10 @@ export default async function LoginPage({
               <Separator />
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-2">Dev shortcuts</p>
               {([
-                { label: 'Sign in as Admin', email: 'alice@govea.dev', cls: 'bg-violet-50 text-violet-800 border-violet-200 hover:bg-violet-100' },
-                { label: 'Sign in as Contributor', email: 'carol@govea.dev', cls: 'bg-emerald-50 text-emerald-800 border-emerald-200 hover:bg-emerald-100' },
-                { label: 'Sign in as Viewer', email: 'victor@govea.dev', cls: 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100' },
+                { label: 'Sign in as Admin',       email: 'alice@govea.dev',     cls: 'bg-violet-50 text-violet-800 border-violet-200 hover:bg-violet-100' },
+                { label: 'Sign in as Contributor', email: 'carol@govea.dev',     cls: 'bg-emerald-50 text-emerald-800 border-emerald-200 hover:bg-emerald-100' },
+                { label: 'Sign in as Viewer',      email: 'victor@govea.dev',    cls: 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100' },
+                { label: 'Sign in as State Admin', email: 'sam@state.govea.dev', cls: 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100' },
               ] as const).map(({ label, email, cls }) => (
                 <form key={email} action={devSignIn}>
                   <input type="hidden" name="email" value={email} />


### PR DESCRIPTION
## Summary

Closes #109. Adds a fourth dev shortcut for `sam@state.govea.dev` (Office of Digital Services admin) so the multi-org federation use case can be tested without typing credentials.

Styled in amber to visually distinguish the state org from the City of Riverdale shortcuts:

| Button | Org | Colour |
|---|---|---|
| Sign in as Admin | City of Riverdale | Violet |
| Sign in as Contributor | City of Riverdale | Emerald |
| Sign in as Viewer | City of Riverdale | Slate |
| Sign in as State Admin | Office of Digital Services | Amber |

Only visible when `NODE_ENV === 'development'`.

## Test Plan

- [ ] "Sign in as State Admin" button appears on the login page in dev mode
- [ ] Clicking it signs in as sam@state.govea.dev without typing credentials
- [ ] Button does not appear in production builds
- [ ] Existing shortcuts unaffected

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)