### PR TITLE
fix: broken ADR self-referential relation and dropped column in seed

### DIFF
--- a/apps/govea/src/db/schema/adrs.ts
+++ b/apps/govea/src/db/schema/adrs.ts
@@ -1,4 +1,4 @@
-import { pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { type AnyPgColumn, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 import { capabilities } from './capabilities'
@@ -18,7 +18,7 @@ export const adrs = pgTable('adrs', {
   consequences: text('consequences'),
   status: adrStatusEnum('status').notNull().default('proposed'),
   visibility: visibilityEnum('visibility').notNull().default('org'),
-  supersededBy: uuid('superseded_by').references((): any => adrs.id, { onDelete: 'set null' }),
+  supersededBy: uuid('superseded_by').references((): AnyPgColumn => adrs.id, { onDelete: 'set null' }),
   createdBy: uuid('created_by').references(() => users.id),
   updatedBy: uuid('updated_by').references(() => users.id),
   createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -226,9 +226,14 @@ export const adrsRelations = relations(adrs, ({ one, many }) => ({
     fields: [adrs.organizationId],
     references: [organizations.id],
   }),
+  // Self-referential: the ADR this one was superseded by
   supersededByAdr: one(adrs, {
     fields: [adrs.supersededBy],
     references: [adrs.id],
+    relationName: 'adr_supersession',
+  }),
+  // Self-referential: ADRs that this one supersedes (both sides required by Drizzle)
+  supersedes: many(adrs, {
     relationName: 'adr_supersession',
   }),
   adrCapabilities: many(adrCapabilities),

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -195,7 +195,6 @@ async function seed() {
         valueItem: vs.valueItem,
         status: vs.status,
         visibility: vs.visibility,
-        stakeholderPersonaId: devPersonaIds[vs.stakeholderPersonas[0]] ?? null,
       }).returning()
       vsId = inserted.id
     }


### PR DESCRIPTION
## Problem

App throws on startup:
```
TypeError: Cannot read properties of undefined (reading 'referencedTable')
```

Three bugs introduced across PRs #104 and #106.

## Fixes

**1. `adrs.ts` — wrong type on self-referential FK**
`references((): any => adrs.id)` → `references((): AnyPgColumn => adrs.id)`, consistent with `organizations.ts`.

**2. `relations.ts` — missing `many` side of self-referential ADR relation**
Drizzle requires both sides of a named relation. `supersededByAdr: one(adrs, { relationName: 'adr_supersession' })` had no matching `many(adrs, { relationName: 'adr_supersession' })`. Drizzle tried to resolve `referencedTable` on the undefined counterpart and threw. Added `supersedes: many(adrs, { relationName: 'adr_supersession' })`.

**3. `seeds/run.ts` — reference to dropped column `stakeholderPersonaId`**
Migration 0010 (PR #101) dropped this column from `value_streams`. The expanded seed in PR #106 still tried to insert it. Removed the reference.

## Test Plan

- [x] App starts without TypeError (verified locally)
- [ ] `pnpm db:seed` completes without errors
- [ ] No TypeScript errors on `tsc --noEmit`

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)