### PR TITLE
fix: remove stakeholderPersona references dropped in migration 0010

### DIFF
--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -29,7 +29,6 @@ export async function getValueStreams(organizationId: string) {
     where: (vs, { eq }) => eq(vs.organizationId, organizationId),
     orderBy: (vs, { asc }) => [asc(vs.name)],
     with: {
-      stakeholderPersona: true,
       stages: {
         orderBy: (s, { asc }) => [asc(s.order)],
         with: {
@@ -46,7 +45,6 @@ export async function getValueStream(id: string) {
   return db.query.valueStreams.findFirst({
     where: (vs, { eq }) => eq(vs.id, id),
     with: {
-      stakeholderPersona: true,
       stages: {
         orderBy: (s, { asc }) => [asc(s.order)],
         with: {
@@ -65,7 +63,6 @@ export async function createValueStream(formData: FormData) {
 
   const name = formData.get('name') as string
   const description = (formData.get('description') as string) || null
-  const stakeholderPersonaId = (formData.get('stakeholderPersonaId') as string) || null
   const valueItem = (formData.get('valueItem') as string) || null
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
@@ -73,7 +70,6 @@ export async function createValueStream(formData: FormData) {
   const [vs] = await db.insert(valueStreams).values({
     name,
     description,
-    stakeholderPersonaId,
     valueItem,
     status,
     visibility,
@@ -98,7 +94,6 @@ export async function editValueStream(valueStreamId: string, formData: FormData)
 
   const name = formData.get('name') as string
   const description = (formData.get('description') as string) || null
-  const stakeholderPersonaId = (formData.get('stakeholderPersonaId') as string) || null
   const valueItem = (formData.get('valueItem') as string) || null
   const status = formData.get('status') as 'draft' | 'published' | 'archived'
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
@@ -108,7 +103,6 @@ export async function editValueStream(valueStreamId: string, formData: FormData)
   await db.update(valueStreams).set({
     name,
     description,
-    stakeholderPersonaId,
     valueItem,
     status,
     visibility,

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -67,13 +67,6 @@ export default async function ValueStreamDetailPage({ params }: { params: { id: 
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
           <div>
-            <span className="text-muted-foreground">Stakeholder: </span>
-            {vs.stakeholderPersona
-              ? <span className="font-medium">{vs.stakeholderPersona.name}</span>
-              : <span className="text-muted-foreground">—</span>
-            }
-          </div>
-          <div>
             <span className="text-muted-foreground">Value delivered: </span>
             {vs.valueItem
               ? <span className="font-medium">{vs.valueItem}</span>

--- a/apps/govea/src/app/(admin)/value-streams/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/page.tsx
@@ -1,7 +1,6 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getValueStreams } from '@/actions/value-streams'
-import { getPersonas } from '@/actions/personas'
 import { ValueStreamTable } from './value-stream-table'
 import type { Role } from '@/lib/rbac'
 
@@ -12,10 +11,7 @@ export default async function ValueStreamsPage() {
   const orgId = (session.user as any).organizationId as string
   const role = (session.user as any).role as Role
 
-  const [valueStreamList, personaList] = await Promise.all([
-    getValueStreams(orgId),
-    getPersonas(orgId),
-  ])
+  const valueStreamList = await getValueStreams(orgId)
 
   return (
     <div className="space-y-6">
@@ -25,7 +21,7 @@ export default async function ValueStreamsPage() {
           End-to-end sequences of stages that deliver measurable outcomes to your stakeholders.
         </p>
       </div>
-      <ValueStreamTable valueStreams={valueStreamList} personas={personaList} role={role} />
+      <ValueStreamTable valueStreams={valueStreamList} role={role} />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { createValueStream, editValueStream, deleteValueStream } from '@/actions/value-streams'
-import type { ValueStream, Persona } from '@/db/schema'
+import type { ValueStream } from '@/db/schema'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
@@ -18,13 +18,11 @@ import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 
 type ValueStreamRow = ValueStream & {
-  stakeholderPersona: Persona | null
   stages: { id: string }[]
 }
 
 interface Props {
   valueStreams: ValueStreamRow[]
-  personas: Persona[]
   role: Role
 }
 
@@ -46,7 +44,7 @@ const VISIBILITY_LABELS: Record<string, string> = {
   instance: 'Instance-wide',
 }
 
-export function ValueStreamTable({ valueStreams, personas, role }: Props) {
+export function ValueStreamTable({ valueStreams, role }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
@@ -115,7 +113,6 @@ export function ValueStreamTable({ valueStreams, personas, role }: Props) {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
-              <TableHead>Stakeholder</TableHead>
               <TableHead>Stages</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Visibility</TableHead>
@@ -125,7 +122,7 @@ export function ValueStreamTable({ valueStreams, personas, role }: Props) {
           <TableBody>
             {filtered.length === 0 && (
               <TableRow>
-                <TableCell colSpan={canEdit ? 6 : 5} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={canEdit ? 5 : 4} className="text-center text-muted-foreground py-8">
                   {valueStreams.length === 0
                     ? 'No value streams yet. Add one to get started.'
                     : 'No value streams match the current filters.'}
@@ -138,9 +135,6 @@ export function ValueStreamTable({ valueStreams, personas, role }: Props) {
                   <Link href={`/value-streams/${vs.id}`} className="hover:underline">
                     {vs.name}
                   </Link>
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {vs.stakeholderPersona?.name ?? '—'}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {vs.stages.length}
@@ -191,14 +185,6 @@ export function ValueStreamTable({ valueStreams, personas, role }: Props) {
               <textarea name="description" rows={2}
                 className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
             </div>
-            <div className="space-y-1.5">
-              <Label>Stakeholder persona</Label>
-              <select name="stakeholderPersonaId" defaultValue=""
-                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
-                <option value="">— None —</option>
-                {personas.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-              </select>
-            </div>
             <FormField label="Value delivered" name="valueItem" placeholder="What is delivered to the stakeholder?" />
             <div className="space-y-1.5">
               <Label>Status</Label>
@@ -236,14 +222,6 @@ export function ValueStreamTable({ valueStreams, personas, role }: Props) {
               <Label>Description</Label>
               <textarea name="description" rows={2} defaultValue={editTarget?.description ?? ''}
                 className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Stakeholder persona</Label>
-              <select name="stakeholderPersonaId" defaultValue={editTarget?.stakeholderPersonaId ?? ''}
-                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
-                <option value="">— None —</option>
-                {personas.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-              </select>
             </div>
             <FormField label="Value delivered" name="valueItem" defaultValue={editTarget?.valueItem ?? ''} />
             <div className="space-y-1.5">


### PR DESCRIPTION
## Summary

- Removes `stakeholderPersona` from `with:` clauses in `getValueStreams` and `getValueStream` — the relation no longer exists after migration 0010 dropped `stakeholder_persona_id` from `value_streams`
- Removes `stakeholderPersonaId` from `createValueStream` and `editValueStream` insert/update payloads
- Removes the Stakeholder column, `Persona` type import, and both `stakeholderPersonaId` form fields from `value-stream-table.tsx`
- Removes the stakeholder display block from the value stream detail page
- Removes the now-unused `getPersonas` call from `value-streams/page.tsx`

This was the root cause of the `Cannot read properties of undefined (reading 'referencedTable')` TypeError on the Value Streams page. Drizzle throws this when a `with:` clause references a relation name that is not registered in `relations.ts`.

Closes #111

## Test plan

- [ ] Navigate to `/value-streams` — page loads without TypeError
- [ ] Navigate to `/value-streams/[id]` — detail page loads without TypeError
- [ ] Create a new value stream — succeeds without DB error
- [ ] Edit a value stream — succeeds without DB error

🤖 Generated with [Claude Code](https://claude.com/claude-code)