### PR TITLE
docs: update README with development approach, CI, and capability roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Free. Open source. Runs on-prem or as a hosted service.
 
 ---
 
-
 ## Tech Stack
 
 - **Framework:** Next.js App Router
@@ -22,6 +21,7 @@ Free. Open source. Runs on-prem or as a hosted service.
 - **Search:** embedded/local search in v1 so self-hosted deployments do not require an external search service
 - **Extensibility:** TOGAF and SAFe remain optional overlays, not hard-coded assumptions in the product
 
+---
 
 ## Data Model
 
@@ -37,20 +37,76 @@ Personas -> Capabilities -> Applications
 - Additional core entities include **Architecture Decision Record (ADR)** and **Technology Lifecycle**.
 - v1 is single-organization, but the data model must preserve a path to v2 multi-tenancy by scoping users, roles, content types, and taxonomies to an organization.
 
-## Roadmap
+---
 
-- **Current phase:** active implementation and architecture hardening. The repository now includes a working Next.js application, Drizzle schema and migrations, seeded datasets, admin UI, authentication flows, and Docker-based dev/demo support.
-- **Implemented today:** applications, capabilities, personas, value streams, strategic objectives, initiatives, roadmap views, ADRs, audit history, taxonomy, user management, setup flows, and reusable `@govea/core` primitives.
-- **Current priorities:** close remaining architecture-documentation gaps, expand automated coverage, improve local bootstrap and demo workflows, and continue filling core EA capability areas such as lifecycle, analysis, and integrations.
-- **Near-term direction:** strengthen multi-organization support, improve stakeholder-facing views and detail pages, and keep implementation aligned with persona and capability standards.
-- **Longer-term direction:** ARB review simulation using reviewer personas and broader hosted SaaS deployment options.
-- **Testing principle:** test infrastructure, synthetic data, and restorable test states are part of the development cycle, not an afterthought.
+## Development Approach
+
+This project is developed using the [EasyEA framework](https://github.com/roballred/EasyEA) — a people-centered, lightweight methodology designed for everyday work rather than compliance theater.
+
+All development standards are defined in [`Standards.md`](./Standards.md). The short version:
+
+- **Humans lead.** AI is a capability amplifier, not the decision maker. Humans define intent, review outputs, and own merge decisions.
+- **Persona-first.** Every capability traces back to a real person's pain point or goal. If a feature can't be tied to a persona, it doesn't ship.
+- **Issue-first.** Work begins from a tracked issue with clear scope. Issues reference the relevant persona(s) and capability ID(s).
+- **Pull requests required.** All changes — human or AI-assisted — go through the same branch, review, and merge workflow.
+- **Tests are part of development.** Not an afterthought.
+
+The `business-architecture/` folder is the authoritative source for personas and capabilities. The data model and roadmap flow from there, not from technology choices.
+
+### CI
+
+Every pull request runs:
+- **Type check** — `tsc --noEmit` against `apps/govea/tsconfig.json` (strict mode)
+- **Lint** — ESLint 9 flat config via `eslint-config-next`
+
+Both must pass before merge.
+
+---
+
+## Capability Roadmap
+
+GovEA's capability roadmap is grounded in the [`ea-research/EA-Tools-Market-Research-2026.md`](./ea-research/EA-Tools-Market-Research-2026.md) — a structured analysis of 7 leading EA platforms, 12 practitioner personas, and 45+ capabilities mapped across 8 groups.
+
+Key findings that shape GovEA's direction:
+
+- **EA Adoption & Engagement is the most cited systemic problem across all commercial tools.** No existing tool solves it well. This is a primary differentiator target for GovEA.
+- **Integration is severely underserved.** Gaps in PPM, HR, API management, and process mining force manual work that limits EA's analytical credibility in every tool reviewed.
+- **The mid-market is underserved.** The fastest-growing segment — organisations of 500–2,000 employees building their first EA practice — is largely ignored by tools designed for large enterprises. Government agencies at that scale are the core GovEA audience.
+- **Plain-language outputs are absent.** No tool reviewed produces outputs designed for elected officials or non-technical stakeholders. GovEA treats this as a first-class requirement, not a reporting add-on.
+
+### Capability groups under development
+
+The following 8 groups define GovEA's target capability surface, derived from the market research and filtered through GovEA's personas:
+
+| Group | Description |
+|---|---|
+| Repository & Modelling | Architecture repository, traceability, ADRs, debt tracking |
+| Application & IT Portfolio | Portfolio management, technology lifecycle, rationalisation |
+| Business & Capability Architecture | Capability mapping, strategy alignment, operating model |
+| Planning & Analysis | Value streams, roadmapping, scenario planning, heatmaps |
+| Governance & Compliance | Review processes, regulatory mapping, audit trail |
+| Integration | ITSM, CMDB, DevOps, cloud, and business system connectors |
+| Collaboration & Stakeholder Engagement | Role-based access, stakeholder views, change notifications |
+| Reporting & Documentation | Plain-language outputs, configurable reports, KPI tracking |
+
+Capabilities are defined one at a time through the EasyEA workflow: persona validation → capability definition → ARB review → implementation issues. The research document is a reference source, not an implementation backlog.
+
+---
+
+## Current Status
+
+- **Implemented:** applications, capabilities, personas, value streams, strategic objectives, initiatives, roadmap views, ADRs, audit history, taxonomy, user management, setup flows, multi-org federation scaffolding, and reusable `@govea/core` primitives
+- **Active work:** closing architecture-documentation gaps, expanding automated test coverage, improving local bootstrap and demo workflows
+- **Near-term:** strengthen multi-organization support, improve stakeholder-facing views and detail pages
+- **Longer-term:** ARB review simulation using reviewer personas, broader hosted SaaS deployment options, and progressive capability coverage across the 8 groups above
 
 ---
 
 ## Contributing
 
-GovEA is open source and welcomes contributions. Issues and pull requests are welcome at [github.com/roballred/GovEA](https://github.com/roballred/GovEA).
+GovEA is open source and welcomes contributions. Before opening a pull request, read [`Standards.md`](./Standards.md) — it defines the workflow for both human and AI-assisted contributions.
+
+Issues and pull requests: [github.com/roballred/GovEA](https://github.com/roballred/GovEA)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a **Development Approach** section documenting the EasyEA workflow, Standards.md principles, persona-first design, issue-first development, and CI gates
- Adds a **Capability Roadmap** section with the 8 capability groups derived from the 2026 market research and the key findings shaping GovEA's differentiation (EA adoption gap, integration gaps, mid-market underservice, plain-language outputs)
- Notes the CI gates (typecheck + lint) now active on every PR
- Points contributors to Standards.md before opening a PR
- Keeps the research as a reference pointer — not an implementation backlog

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All links resolve (Standards.md, ea-research doc, EasyEA repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)