### PR TITLE
feat(business-arch): define Repository & Modelling capability group

### DIFF
--- a/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
+++ b/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
@@ -1,0 +1,45 @@
+# Capability Group: Repository & Modelling
+
+The system must maintain a reliable, navigable, and self-auditing store of all architecture objects — capabilities, applications, personas, decisions, and technology — and surface the relationships, gaps, and accumulated debt within that store so that architects and decision-makers can trust what they see.
+
+## Personas
+
+- **Enterprise Architect (Central IT)** — needs confidence that the repository reflects reality and can show the impact of a change before it happens
+- **Agency EA Coordinator** — needs to maintain their portion of the repository without central IT involvement and see where their agency's architecture has gaps
+- **Department Director** — needs a traceable path from their department's strategy down to the specific applications and people affected
+
+> ⚠️ Enterprise Architect and Agency EA Coordinator are **Assumed** personas. Capabilities in this group carry elevated implementation risk until those personas are validated through direct user research.
+
+## Sub-Capabilities
+
+| Capability | File | Status | Description |
+|---|---|---|---|
+| End-to-End Traceability | [rm-end-to-end-traceability.md](./rm-end-to-end-traceability.md) | Not implemented | Cross-layer impact analysis from strategic goals through capabilities to applications |
+| Architecture Debt Tracking | [rm-architecture-debt.md](./rm-architecture-debt.md) | Not implemented | Surface and track decisions and conditions that constrain future options |
+| Repository Completeness | [rm-repository-completeness.md](./rm-repository-completeness.md) | Partially implemented | Signals and dashboards showing where the EA object store has gaps |
+
+## Capabilities Covered Elsewhere
+
+The following market research capabilities in this group are substantively addressed by existing GovEA capability definitions and do not require separate definitions here:
+
+| Market Capability | Covered By |
+|---|---|
+| Architecture Repository | `cm-content-versioning`, `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `iam-audit-trail` |
+| Architecture Decision Records | `po-architecture-decisions` |
+
+## Out of Scope
+
+| Market Capability | Rationale |
+|---|---|
+| Multi-Framework Modelling (ArchiMate, BPMN, UML, SysML, Zachman) | GovEA uses plain-language descriptions and enforced relationship chains, not formal modelling notations. Adding notation frameworks would increase complexity without serving the state and local government audience, where most EA practitioners are not modelling-certified. |
+| Meta-Model Customisation | The GovEA meta-model (Organization → Personas, Capabilities, Applications, ADRs, Technology) is fixed in v1. Custom content types are available via `cm-content-types` for extensions. Full meta-model modification is deferred beyond v1. |
+
+## Deferred
+
+| Market Capability | Rationale |
+|---|---|
+| Knowledge Graph Exploration | Graph-based navigation to surface unexpected dependencies has value but no directly validated pain point in state and local government EA at v1 scale. Deferred to v2 pending persona validation and repository size warranting graph tooling. |
+
+## Design Principle
+
+Trust is the foundation of this capability group. An architecture repository that nobody believes is worse than no repository at all. Every capability in this group exists to increase trust: traceability shows the chain is real, debt tracking makes the gaps honest, and completeness signals tell users exactly what to rely on and what to take with caution.

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -1,0 +1,40 @@
+# Capability: Architecture Debt Tracking
+
+## What It Does
+
+The system must allow architects to identify, record, and track conditions in the architecture that constrain future options — applications past their supported lifecycle, capabilities with no enabling technology, outdated decisions that have never been revisited, and deliberate shortcuts taken without a documented plan to resolve them.
+
+Debt that is named and tracked is manageable. Debt that is invisible becomes the reason EA outputs stop being trusted.
+
+## Personas
+
+- **Enterprise Architect (Central IT)** — needs to surface and communicate architectural debt to leadership in plain language; currently has no mechanism to separate "what we know is a problem" from "what we haven't looked at yet"; this conflation erodes trust in EA outputs
+- **Agency EA Coordinator** — needs to document known debt in their agency's architecture without it looking like an indictment; debt is normal; the discipline is in tracking it honestly and having a plan
+
+> ⚠️ Enterprise Architect and Agency EA Coordinator are **Assumed** personas. The behaviors below reflect their stated pain points and goals as currently understood. Validation through direct user research is required before implementation begins.
+
+## Behaviors
+
+- Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, and optional target resolution date
+- Debt types: `lifecycle-risk` (application approaching or past vendor support end), `capability-gap` (capability with no supporting application), `decision-drift` (ADR superseded by practice without formal revision), `known-shortcut` (deliberate technical or architectural compromise), `unreviewed` (object not updated in more than N months)
+- Mark an application, capability, or ADR as carrying known debt directly from its edit form — without requiring a separate debt item to be created
+- View all debt items for the organization on a single screen, filterable by type, severity, and status
+- Link a debt item to an initiative as the resolution path
+- Track debt item status: `open`, `in-progress` (linked to an active initiative), `resolved`, `accepted` (acknowledged, no resolution planned, with a documented rationale)
+- Surface open debt count on the admin dashboard alongside repository completeness metrics
+- Auto-flag applications where the lifecycle status is `end-of-life` or where technology records indicate an end-of-support date has passed
+
+## Rules
+
+- Debt items belong to an organization and follow the standard content workflow: draft → published → archived
+- Only published debt items are visible to Viewer-role users — this is intentional; organizations control what they publish about their own architecture challenges
+- `accepted` debt items require a written rationale; the system must not allow acceptance without documentation
+- Auto-flagged debt (lifecycle-based) appears in a separate "system-detected" queue, distinct from human-created debt items; the distinction must be visible
+- Resolving a debt item requires linking it to an initiative or explicitly marking it `accepted` with rationale; it cannot be closed without one or the other
+- Debt items must be linked to at least one architecture object; unattached debt items are not permitted
+
+## Links
+
+- Depends on: `po-application-portfolio`, `po-capability-map`, `po-architecture-decisions`, `pl-initiatives`
+- Related: `rm-repository-completeness`, `rm-end-to-end-traceability`
+- Personas served: Enterprise Architect, Agency EA Coordinator

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -33,8 +33,25 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 - Resolving a debt item requires linking it to an initiative or explicitly marking it `accepted` with rationale; it cannot be closed without one or the other
 - Debt items must be linked to at least one architecture object; unattached debt items are not permitted
 
+## Federation Behavior
+
+Debt items are always owned by the organization that creates them. Federation does not change ownership.
+
+**Creating debt against cross-org linked objects:** An agency may create a debt item linked to a cross-org object they can see (e.g., "we've linked to the enterprise Licensing capability but have no application implementing it — that gap is our debt to close"). The debt item belongs to the agency, not to the org whose capability is referenced. The referenced cross-org object appears in the debt item's linked objects list as a read-only reference.
+
+**Visibility of debt items across org boundaries:** Debt items follow `mo-content-visibility` exactly. Default visibility is `org` — debt is private to the creating organization. An agency may choose to share debt items at `connections` or `instance` visibility, making them visible to connected orgs or the full instance. This is always an explicit opt-in by the agency.
+
+**What Enterprise Architects see:**
+- Debt items they created on enterprise-owned content (at any visibility)
+- Debt items from other orgs that those orgs have shared at `connections` or `instance` visibility
+- They do not see `org`-visibility debt from agencies, even if that debt references enterprise capabilities they own
+
+**Design principle:** An Enterprise Architect cannot use debt tracking as a surveillance mechanism to discover problems in agencies that have not chosen to share them. The federation model is a professional network, not an audit trail. If agencies know that linking to an enterprise capability automatically exposes their debt to central IT, they will not link — and the entire federation model fails.
+
+**Auto-flagged debt and cross-org objects:** The system-detected debt queue (lifecycle-based flags) only fires against objects the org owns. An agency is never auto-flagged for debt conditions in a cross-org linked object that belongs to another org.
+
 ## Links
 
-- Depends on: `po-application-portfolio`, `po-capability-map`, `po-architecture-decisions`, `pl-initiatives`
+- Depends on: `po-application-portfolio`, `po-capability-map`, `po-architecture-decisions`, `pl-initiatives`, `mo-content-visibility`, `mo-cross-org-linking`
 - Related: `rm-repository-completeness`, `rm-end-to-end-traceability`
 - Personas served: Enterprise Architect, Agency EA Coordinator

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -28,14 +28,32 @@ The system must allow any user to follow a chain of relationships across the ful
 - Cross-agency traceability is available only to Enterprise Architect role and only where federation connections have been established and content is marked as `connections` or `instance` visibility
 - Broken chain indicators are visible to Contributors and Admins; they do not surface to Viewers (Viewers only see published, complete content)
 
+## Federation Behavior
+
+Traversal respects content visibility at every hop. A relationship link is only followed if the user is permitted to see the target object under `mo-content-visibility` rules. No traversal path can expose content that the user could not already reach through normal navigation.
+
+**Within-org traversal (all roles):** Follow all relationship links within the owning organization. No restrictions beyond standard role-based access.
+
+**Outbound cross-org traversal (all roles):** When a local object has an approved cross-org link (via `mo-cross-org-linking`) pointing to content in another org, the impact panel follows that link if the target content is visible to the current user — i.e., the target is marked `connections` (and a connection exists) or `instance`. This is not a special case: it is simply traversal following a relationship the user can already see.
+
+**Inbound cross-org traversal (Enterprise Architect only):** When traversing from an enterprise-owned object, the impact panel shows other orgs' objects that have linked to it — but only if those objects are visible at `connections` or `instance` visibility. An agency's `org`-visibility content is never reachable from outside that org, even if a cross-org link exists. This is the mechanism behind the "cross-agency view" behavior.
+
+**Broken chain indicators across org boundaries:** Broken chain indicators are calculated within the owning org only. The Enterprise Architect does not see broken chains in agency repositories via the traceability view — only in their own org. Cross-agency gaps surface through the cross-agency view (redundancy and rationalisation signals), not as broken chain alerts.
+
+**What Enterprise Architects do NOT see via traversal:**
+- Agency content marked `org` visibility, even if a cross-org link exists
+- Draft content from any org other than their own
+- Broken chains or completeness gaps in other orgs' internal repositories
+
 ## Implementation Notes
 
 - The core chain (Personas → Capabilities → Applications) is already enforced in the data model and publish workflow
 - What is not yet implemented: reverse traversal UI, impact panel, broken chain indicators, cross-agency views
 - Technology layer (infrastructure, platforms) is a natural extension of this chain but is not in scope until the Technology Lifecycle capability set is defined
+- The traversal visibility gate must be validated with a security test matrix covering all role × visibility combinations before the impact panel ships (see ARB finding #129)
 
 ## Links
 
-- Depends on: `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `mo-content-visibility`
+- Depends on: `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `mo-content-visibility`, `mo-cross-org-linking`, `mo-org-connections`
 - Related: `rm-repository-completeness`, `pl-strategic-objectives`, `pl-initiatives`, `pl-roadmap`
 - Personas served: Enterprise Architect, Agency EA Coordinator, Department Director

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -1,0 +1,41 @@
+# Capability: End-to-End Traceability
+
+## What It Does
+
+The system must allow any user to follow a chain of relationships across the full architecture — from strategic objectives through capabilities to applications and technology — in either direction, and must surface where those chains are broken or incomplete.
+
+## Personas
+
+- **Enterprise Architect (Central IT)** — needs to see the full impact of a proposed change or decommission before it happens; wants to identify which agencies have redundant applications serving the same capability
+- **Agency EA Coordinator** — needs to demonstrate that their agency's technology investments are grounded in real capability needs; needs to see which capabilities have no supporting applications (gaps), not just which applications exist
+- **Department Director** — needs a single navigable view showing how their department's strategy connects down to the specific applications and people their teams depend on; currently this information is scattered across tools and requires architect interpretation
+
+> ⚠️ Enterprise Architect and Agency EA Coordinator are **Assumed** personas. Traceability behaviors below reflect persona goals and pain points as currently understood and must be validated before implementation.
+
+## Behaviors
+
+- From any strategic objective, navigate to linked initiatives, then to the capabilities those initiatives affect, then to the applications supporting each capability
+- From any application, navigate upward to linked capabilities, then to the personas those capabilities serve, then to any strategic objectives or initiatives connected to those capabilities
+- From any persona, see the full set of capabilities defined for them and the applications enabling each capability
+- Impact panel: select any object and see all directly and indirectly connected objects, grouped by type (objectives, capabilities, applications, personas, ADRs)
+- Broken chain indicator: surface objects where a required link is missing — applications with no capability, capabilities with no application, capabilities with no persona, personas with no capability
+- Cross-agency view (Enterprise Architect only): across connected organizations, show which capabilities are served by multiple independent applications — potential rationalisation signals
+
+## Rules
+
+- The core chain constraint (every Application links to a Capability; every Capability links to a Persona) is enforced at publish time and cannot be bypassed
+- Traceability navigation is read-only — no editing occurs within the trace view
+- Cross-agency traceability is available only to Enterprise Architect role and only where federation connections have been established and content is marked as `connections` or `instance` visibility
+- Broken chain indicators are visible to Contributors and Admins; they do not surface to Viewers (Viewers only see published, complete content)
+
+## Implementation Notes
+
+- The core chain (Personas → Capabilities → Applications) is already enforced in the data model and publish workflow
+- What is not yet implemented: reverse traversal UI, impact panel, broken chain indicators, cross-agency views
+- Technology layer (infrastructure, platforms) is a natural extension of this chain but is not in scope until the Technology Lifecycle capability set is defined
+
+## Links
+
+- Depends on: `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `mo-content-visibility`
+- Related: `rm-repository-completeness`, `pl-strategic-objectives`, `pl-initiatives`, `pl-roadmap`
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -1,0 +1,45 @@
+# Capability: Repository Completeness
+
+## What It Does
+
+The system must continuously signal the health and completeness of the EA object store — showing architects and administrators exactly what is missing, what is stale, and what level of confidence a viewer should place in the repository at any point in time.
+
+A repository where everything appears equally authoritative — regardless of whether it was updated last week or three years ago — is a repository people stop trusting. Completeness signals turn the unknown unknowns into known gaps.
+
+## Personas
+
+- **Enterprise Architect (Central IT)** — needs to report the state of the enterprise capability map with honesty; a completeness view allows them to say "we have 80% of capabilities mapped to at least one application" rather than making claims that can be challenged; currently has no mechanism to produce this picture without manual audit
+- **Agency EA Coordinator** — needs to know which parts of their agency's architecture are genuinely documented and which are placeholder content; completeness signals guide where to focus maintenance effort
+- **CMS Administrator** — needs a single operational view showing repository health alongside system health; currently the admin dashboard shows system status but not content quality
+
+## Behaviors
+
+- Display a completeness dashboard showing, for each object type (Capabilities, Applications, Personas, ADRs, Initiatives, Objectives):
+  - Total count
+  - % published (visible to Viewers)
+  - % with all required relationships complete (e.g., Capabilities linked to at least one Application and one Persona)
+  - % updated within a configurable staleness window (default: 12 months)
+- Drill down from any completeness metric to the specific objects that are incomplete, unpublished, or stale — clickable list, not just a percentage
+- Show a trend line for each metric over time so that progress (or regression) is visible
+- Surface a "completeness score" per capability domain — which areas of the architecture are well-maintained and which are gaps
+- Allow the Admin to configure the staleness threshold (default 12 months; configurable to 3, 6, 12, or 24 months)
+- Publish a read-only completeness summary to Viewers — showing high-level scores without exposing the drill-down list of incomplete objects (the gap list is internal; the score is publishable)
+
+## Rules
+
+- Completeness metrics are calculated at the organization level; cross-org completeness is not exposed across federation boundaries
+- The published completeness summary (visible to Viewers) must show only aggregate scores, not the list of incomplete objects — incomplete drafts should not be surfaced to readers
+- Staleness is calculated from the last-modified date of the published version, not the draft; updating a draft does not reset the staleness clock until published
+- An object with no published version does not contribute to completeness scores — it simply does not exist from the repository's perspective
+
+## Implementation Notes
+
+- The admin dashboard (`ac-admin-dashboard`) already surfaces system health and basic content counts; this capability extends it with EA-specific completeness signals
+- Completeness calculations require joining across object types and their relationship tables — performance implications should be evaluated before implementation
+- The trend line feature requires storing historical completeness snapshots; decide before implementation whether these are computed at query time or stored at a scheduled interval
+
+## Links
+
+- Depends on: `ac-admin-dashboard`, `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`
+- Related: `rm-architecture-debt`, `rm-end-to-end-traceability`
+- Personas served: Enterprise Architect, Agency EA Coordinator, CMS Administrator


### PR DESCRIPTION
## Summary

Defines the Repository & Modelling capability group — the first of 8 groups from the 2026 market research — filtered through GovEA's personas and design principles.

### New sub-capability definitions

| ID | Capability | Status |
|---|---|---|
| `rm-end-to-end-traceability` | Cross-layer impact analysis from strategic goals → capabilities → applications, with reverse traversal and broken chain indicators | Not implemented |
| `rm-architecture-debt` | Surface and track lifecycle risk, capability gaps, decision drift, and deliberate shortcuts; link debt items to resolution initiatives | Not implemented |
| `rm-repository-completeness` | Completeness dashboard with per-object-type metrics, staleness indicators, drill-down lists, and publishable summary scores | Partially implemented |

### Disposition of all 7 market capabilities in this group

| Market Capability | Disposition |
|---|---|
| Architecture Repository | Covered by `cm-content-versioning`, `po-*`, `iam-audit-trail` |
| Multi-Framework Modelling | Out of scope — plain-language is GovEA's differentiator |
| Meta-Model Customisation | Deferred beyond v1; covered by `cm-content-types` |
| End-to-End Traceability | Defined — `rm-end-to-end-traceability` |
| Architecture Decision Records | Covered by `po-architecture-decisions` |
| Architecture Debt Tracking | Defined — `rm-architecture-debt` |
| Knowledge Graph Exploration | Deferred to v2 — no validated pain point at v1 scale |

### Important caveat

Enterprise Architect and Agency EA Coordinator are **Assumed** personas. All three new sub-capabilities depend on them. Implementation work in this group carries elevated risk until those personas are validated through direct user research. This is flagged in each capability file and in the group parent.

### Next steps (not part of this PR)

- [ ] ARB review of this capability group before opening implementation issues
- [ ] Persona validation interviews for Enterprise Architect and Agency EA Coordinator
- [ ] Implementation issues after ARB review is complete

## Test plan
- [ ] Capability files follow established format (What It Does, Personas, Behaviors, Rules, Links)
- [ ] All persona references trace to defined personas in `business-architecture/personas/`
- [ ] All capability ID references in Links sections exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)