### PR TITLE
feat(seed): comprehensive fixture coverage — all enum values, junction tables, and taxonomy

### DIFF
--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -6,7 +6,7 @@
 //   - City of Riverdale (primary dev org) — full EA content, three user roles
 //   - Office of Digital Services (state agency) — second org for multi-org scenario
 //
-// An active org connection between them and a cross-org capability link are
+// An active org connection between them and multiple cross-org capability links are
 // created to exercise the federation/visibility use case.
 
 // ─── Orgs ────────────────────────────────────────────────────────────────────
@@ -50,7 +50,17 @@ export const DEFAULT_TAGS = [
   'multilingual',
 ]
 
+// Tag assignments for specific personas — seeds the personaTags junction table.
+export const DEV_PERSONA_TAGS = [
+  { personaName: 'Resident',             tags: ['mobile-first', 'high-volume', 'low-digital-literacy', 'multilingual'] },
+  { personaName: 'Small Business Owner', tags: ['high-volume', 'multilingual'] },
+  { personaName: 'Field Inspector',      tags: ['mobile-first', 'accessibility'] },
+  { personaName: 'City Council Member',  tags: ['accessibility'] },
+]
+
 // ─── Personas (City of Riverdale) ────────────────────────────────────────────
+// Coverage: status = draft ✓, published ✓, archived ✓
+//           visibility = org ✓, connections ✓, instance ✓
 
 export const DEV_PERSONAS = [
   {
@@ -102,10 +112,19 @@ export const DEV_PERSONAS = [
     status: 'draft' as const,
     visibility: 'connections' as const,
   },
+  // archived + instance — exercises both missing enum values
+  {
+    name: 'Legacy System Operator',
+    description: 'Staff role responsible for operating and maintaining legacy on-premises systems. Role phased out as systems are decommissioned.',
+    type: 'Staff',
+    status: 'archived' as const,
+    visibility: 'instance' as const,
+  },
 ]
 
 // ─── Capabilities (City of Riverdale) ────────────────────────────────────────
-// Each capability maps to one or more persona names from DEV_PERSONAS.
+// Coverage: status = draft ✓, published ✓, archived ✓
+//           visibility = org ✓, connections ✓, instance ✓
 
 export const DEV_CAPABILITIES = [
   {
@@ -172,16 +191,29 @@ export const DEV_CAPABILITIES = [
     visibility: 'connections' as const,
     personas: ['State Agency Liaison', 'IT Staff'],
   },
+  // archived + instance — exercises both missing enum values
+  {
+    name: 'Print & Mail Services',
+    description: 'Printed correspondence and physical mail delivery for city communications. Sunset in favour of digital notifications.',
+    domain: 'Administrative Services',
+    status: 'archived' as const,
+    visibility: 'instance' as const,
+    personas: ['IT Staff'],
+  },
 ]
 
 // ─── Applications (City of Riverdale) ────────────────────────────────────────
-// Each application maps to one or more capability names from DEV_CAPABILITIES.
+// Coverage: lifecycleStatus = active ✓, sunset ✓, decommissioned ✓, planned ✓
+//           hostingModel = saas ✓, on-prem ✓, hybrid ✓
+//           status = published ✓, draft ✓
+//           version field — non-null example on planned app
 
 export const DEV_APPLICATIONS = [
   {
     name: 'Accela',
     description: 'Permitting and licensing platform used by Community Development and Code Enforcement.',
     vendor: 'Accela',
+    version: undefined as string | undefined,
     hostingModel: 'saas',
     lifecycleStatus: 'active' as const,
     status: 'published' as const,
@@ -191,6 +223,7 @@ export const DEV_APPLICATIONS = [
     name: 'Workday',
     description: 'HR and payroll system used enterprise-wide for all city employees.',
     vendor: 'Workday',
+    version: undefined as string | undefined,
     hostingModel: 'saas',
     lifecycleStatus: 'active' as const,
     status: 'published' as const,
@@ -200,6 +233,7 @@ export const DEV_APPLICATIONS = [
     name: 'ArcGIS Online',
     description: 'Cloud GIS platform for mapping, spatial analysis, and field data collection.',
     vendor: 'Esri',
+    version: undefined as string | undefined,
     hostingModel: 'saas',
     lifecycleStatus: 'active' as const,
     status: 'published' as const,
@@ -209,6 +243,7 @@ export const DEV_APPLICATIONS = [
     name: 'OpenGov',
     description: 'Budget transparency and performance management platform used by Finance and department directors.',
     vendor: 'OpenGov',
+    version: undefined as string | undefined,
     hostingModel: 'saas',
     lifecycleStatus: 'active' as const,
     status: 'published' as const,
@@ -218,6 +253,7 @@ export const DEV_APPLICATIONS = [
     name: 'CityWorks',
     description: 'Work order and asset management system for Public Works. On-prem installation, approaching end of vendor support.',
     vendor: 'Trimble',
+    version: undefined as string | undefined,
     hostingModel: 'on-prem',
     lifecycleStatus: 'sunset' as const,
     status: 'published' as const,
@@ -227,6 +263,7 @@ export const DEV_APPLICATIONS = [
     name: 'Microsoft Entra ID',
     description: 'Cloud identity provider used for staff SSO. Residents use a separate local credential store.',
     vendor: 'Microsoft',
+    version: undefined as string | undefined,
     hostingModel: 'saas',
     lifecycleStatus: 'active' as const,
     status: 'published' as const,
@@ -234,16 +271,33 @@ export const DEV_APPLICATIONS = [
   },
   {
     name: 'Legacy Permitting System',
-    description: 'In-house permitting system built in 2008. Being retired in favour of Accela.',
+    description: 'In-house permitting system built in 2008. Retired in favour of Accela.',
     vendor: 'In-house',
+    version: undefined as string | undefined,
     hostingModel: 'on-prem',
     lifecycleStatus: 'decommissioned' as const,
     status: 'published' as const,
     capabilities: ['Online Permitting'],
   },
+  // planned + hybrid + version — covers all three missing field values
+  {
+    name: 'Next-Gen Work Order System',
+    description: 'Cloud-native work order and asset management platform selected to replace CityWorks. Implementation begins Q2 FY2026.',
+    vendor: 'Cityworks Cloud',
+    version: '4.0.0',
+    hostingModel: 'hybrid',
+    lifecycleStatus: 'planned' as const,
+    status: 'draft' as const,
+    capabilities: ['Service Request Management', 'GIS Mapping'],
+  },
 ]
 
 // ─── Strategic Objectives (City of Riverdale) ─────────────────────────────────
+// Coverage: status = draft ✓, published ✓, archived ✓
+//           visibility = org ✓, connections ✓, instance ✓
+//           timeHorizon = multiple values (FY2024, FY2026, FY2027, 3-year)
+//           applications and valueStreams arrays — seed objectiveApplications /
+//           objectiveValueStreams junction tables
 
 export const DEV_OBJECTIVES = [
   {
@@ -252,7 +306,10 @@ export const DEV_OBJECTIVES = [
     successMetric: '80% of permit applications submitted online by end of FY2026',
     timeHorizon: 'FY2026',
     status: 'published' as const,
+    visibility: 'org' as const,
     capabilities: ['Online Permitting', 'Service Request Management', 'Digital Identity & Authentication'],
+    applications: ['Accela', 'Microsoft Entra ID'],
+    valueStreams: ['Permit to Certificate', 'Service Request to Resolution'],
   },
   {
     name: 'Modernise Legacy Infrastructure',
@@ -260,7 +317,10 @@ export const DEV_OBJECTIVES = [
     successMetric: 'Zero active on-prem systems older than 10 years by FY2027',
     timeHorizon: 'FY2027',
     status: 'published' as const,
+    visibility: 'org' as const,
     capabilities: ['GIS Mapping', 'Service Request Management'],
+    applications: ['CityWorks', 'Legacy Permitting System'],
+    valueStreams: ['Permit to Certificate'],
   },
   {
     name: 'Enable Cross-Agency Data Sharing',
@@ -268,11 +328,29 @@ export const DEV_OBJECTIVES = [
     successMetric: 'At least 2 active data exchange agreements with state agencies by end of FY2026',
     timeHorizon: 'FY2026',
     status: 'draft' as const,
+    visibility: 'connections' as const,
     capabilities: ['Cross-Agency Data Sharing', 'Digital Identity & Authentication'],
+    applications: [] as string[],
+    valueStreams: [] as string[],
+  },
+  // archived + instance — exercises both missing enum values
+  {
+    name: 'Migrate to Cloud-First Infrastructure',
+    description: 'Previous strategic priority to move all infrastructure to cloud by FY2024. Superseded by the more targeted Modernise Legacy Infrastructure objective.',
+    successMetric: 'All production workloads cloud-hosted by FY2024',
+    timeHorizon: 'FY2024',
+    status: 'archived' as const,
+    visibility: 'instance' as const,
+    capabilities: ['Digital Identity & Authentication'],
+    applications: [] as string[],
+    valueStreams: [] as string[],
   },
 ]
 
 // ─── Value Streams (City of Riverdale) ───────────────────────────────────────
+// Coverage: status = published ✓, draft ✓
+//           visibility = org ✓, connections ✓
+//           stakeholderPersonas — seeds valueStreamPersonas junction table
 
 export const DEV_VALUE_STREAMS = [
   {
@@ -331,9 +409,35 @@ export const DEV_VALUE_STREAMS = [
       },
     ],
   },
+  // draft + connections — covers missing status and visibility values
+  {
+    name: 'Business Registration',
+    description: 'Journey from a new business registering with the city through to receiving all required approvals to operate.',
+    valueItem: 'Approved business registration enabling legal operation',
+    status: 'draft' as const,
+    visibility: 'connections' as const,
+    stakeholderPersonas: ['Small Business Owner'],
+    stages: [
+      {
+        name: 'Initial Registration',
+        description: 'Business owner submits registration details and initial documentation.',
+        order: 1,
+        capabilities: ['Business License Management', 'Digital Identity & Authentication'],
+      },
+      {
+        name: 'Verification & Compliance',
+        description: 'Staff verify business details and check zoning and compliance requirements.',
+        order: 2,
+        capabilities: ['Business License Management', 'GIS Mapping'],
+      },
+    ],
+  },
 ]
 
 // ─── Initiatives (City of Riverdale) ─────────────────────────────────────────
+// Coverage: status = proposed ✓, active ✓, on-hold ✓, complete ✓, cancelled ✓
+//           capability impact = improve ✓, build ✓, retire ✓
+//           application impact = build ✓, retire ✓, improve ✓, migrate ✓
 
 export const DEV_INITIATIVES = [
   {
@@ -343,12 +447,12 @@ export const DEV_INITIATIVES = [
     startDate: 'Q1 FY2026',
     endDate: 'Q4 FY2026',
     capabilities: [
-      { name: 'Online Permitting',          impact: 'improve' },
+      { name: 'Online Permitting',           impact: 'improve' },
       { name: 'Business License Management', impact: 'improve' },
     ],
     applications: [
-      { name: 'Accela',                    impact: 'build'  },
-      { name: 'Legacy Permitting System',  impact: 'retire' },
+      { name: 'Accela',                   impact: 'build'  },
+      { name: 'Legacy Permitting System', impact: 'retire' },
     ],
     objectives: ['Improve Digital Service Delivery'],
   },
@@ -363,13 +467,66 @@ export const DEV_INITIATIVES = [
       { name: 'GIS Mapping',               impact: 'improve' },
     ],
     applications: [
-      { name: 'CityWorks', impact: 'retire' },
+      { name: 'CityWorks',                  impact: 'retire' },
+      { name: 'Next-Gen Work Order System', impact: 'build'  },
+    ],
+    objectives: ['Modernise Legacy Infrastructure'],
+  },
+  // on-hold — covers missing status; application impact 'improve'
+  {
+    name: 'Cross-Agency Data Exchange Pilot',
+    description: 'Pilot structured data exchange with two state agencies to validate the technical approach before full rollout. Currently on hold pending legal review of data sharing agreements.',
+    status: 'on-hold' as const,
+    startDate: 'Q3 FY2026',
+    endDate: 'Q1 FY2027',
+    capabilities: [
+      { name: 'Cross-Agency Data Sharing',        impact: 'build'   },
+      { name: 'Digital Identity & Authentication', impact: 'improve' },
+    ],
+    applications: [
+      { name: 'Microsoft Entra ID', impact: 'improve' },
+    ],
+    objectives: ['Enable Cross-Agency Data Sharing'],
+  },
+  // complete — covers missing status
+  {
+    name: 'Resident Portal Redesign',
+    description: 'Redesign of the public-facing resident portal to improve mobile accessibility and reduce call volume to the service centre. Completed Q4 FY2025.',
+    status: 'complete' as const,
+    startDate: 'Q1 FY2025',
+    endDate: 'Q4 FY2025',
+    capabilities: [
+      { name: 'Digital Identity & Authentication', impact: 'improve' },
+      { name: 'Service Request Management',        impact: 'improve' },
+    ],
+    applications: [
+      { name: 'Microsoft Entra ID', impact: 'improve' },
+    ],
+    objectives: ['Improve Digital Service Delivery'],
+  },
+  // cancelled — covers missing status; application impact 'migrate'
+  {
+    name: 'ERP Consolidation Evaluation',
+    description: 'Evaluation of enterprise resource planning platforms to consolidate HR, Finance, and procurement. Cancelled Q3 FY2025 due to budget constraints and vendor market reassessment.',
+    status: 'cancelled' as const,
+    startDate: 'Q2 FY2025',
+    endDate: null as string | null,
+    capabilities: [
+      { name: 'HR Self-Service',  impact: 'retire' },
+      { name: 'Budget Reporting', impact: 'retire' },
+    ],
+    applications: [
+      { name: 'Workday',  impact: 'migrate' },
+      { name: 'OpenGov',  impact: 'migrate' },
     ],
     objectives: ['Modernise Legacy Infrastructure'],
   },
 ]
 
 // ─── ADRs (City of Riverdale) ─────────────────────────────────────────────────
+// Coverage: status = accepted ✓, proposed ✓, deprecated ✓, superseded ✓
+//           supersededByNumber — self-reference chain resolved in run.ts
+//           all four junction tables: capabilities, applications, initiatives, objectives
 
 export const DEV_ADRS = [
   {
@@ -379,8 +536,67 @@ export const DEV_ADRS = [
     decision: 'All new application acquisitions will default to SaaS hosting unless a documented security, compliance, or integration requirement mandates on-premises deployment. On-prem exceptions require Director-level approval and an exit plan.',
     consequences: 'Reduces infrastructure maintenance burden and improves vendor-managed update cadence. Increases reliance on internet connectivity and vendor SLAs. Requires updated procurement templates and vendor risk assessment processes.',
     status: 'accepted' as const,
+    supersededByNumber: null as string | null,
     capabilities: ['Digital Identity & Authentication', 'Cross-Agency Data Sharing'],
     applications: ['Accela', 'ArcGIS Online', 'OpenGov'],
+    initiatives: ['Accela Implementation'],
+    objectives: ['Modernise Legacy Infrastructure'],
+  },
+  // proposed — covers missing status
+  {
+    number: 'ADR-002',
+    title: 'Use OAuth 2.0 / OIDC for all resident-facing authentication flows',
+    context: 'The city currently has fragmented authentication across citizen-facing services, with some using legacy username/password forms and others using ad-hoc SSO integrations. This creates security risk and a poor user experience.',
+    decision: 'All resident-facing authentication flows will implement OAuth 2.0 with OIDC. Microsoft Entra ID is the designated identity provider for staff. A separate resident credential store will be maintained for services not requiring SSO.',
+    consequences: 'Improves security posture and enables single sign-on for residents. Increases dependency on Microsoft Entra ID availability. Requires migration of existing legacy authentication implementations.',
+    status: 'proposed' as const,
+    supersededByNumber: null as string | null,
+    capabilities: ['Digital Identity & Authentication'],
+    applications: ['Microsoft Entra ID'],
+    initiatives: ['Cross-Agency Data Exchange Pilot'],
+    objectives: ['Improve Digital Service Delivery'],
+  },
+  // deprecated — covers missing status; no application or initiative links (null examples)
+  {
+    number: 'ADR-003',
+    title: 'Require on-premises deployment for all financial systems',
+    context: 'An earlier security policy required all financial systems to be deployed on-premises to comply with city data residency requirements. Documented as an architectural constraint in the 2019 technology strategy.',
+    decision: 'All financial management and budget systems must be deployed on-premises within city-owned infrastructure.',
+    consequences: 'Provided data residency assurance under the 2019 policy. Created significant infrastructure and maintenance overhead. Superseded by updated cloud security posture and the SaaS-first direction (ADR-001).',
+    status: 'deprecated' as const,
+    supersededByNumber: null as string | null,
+    capabilities: ['Budget Reporting'],
+    applications: [] as string[],
+    initiatives: [] as string[],
+    objectives: [] as string[],
+  },
+  // superseded — covers missing status; supersededByNumber resolved in run.ts
+  {
+    number: 'ADR-004',
+    title: 'Use legacy XML/SOAP gateway for cross-agency data exchange',
+    context: "At the time this decision was made, the city's integration with the state used a legacy XML/SOAP-based API gateway that was the only approved integration pattern for state agency data exchange.",
+    decision: 'All cross-agency data exchange will use the state-provided XML/SOAP gateway and its associated authentication mechanism.',
+    consequences: 'Enabled initial data exchange with the state. Gateway has since been decommissioned by the state. This decision is formally superseded by ADR-005, which adopts REST/JSON with OAuth 2.0.',
+    status: 'superseded' as const,
+    supersededByNumber: 'ADR-005',
+    capabilities: ['Cross-Agency Data Sharing'],
+    applications: [] as string[],
+    initiatives: [] as string[],
+    objectives: [] as string[],
+  },
+  // accepted (second instance) — supersedes ADR-004
+  {
+    number: 'ADR-005',
+    title: 'Adopt REST/JSON APIs with OAuth 2.0 for all cross-agency integrations',
+    context: 'The legacy XML/SOAP gateway (governed by ADR-004) has been decommissioned by the state. New state integration APIs use REST/JSON. The city needs a current integration pattern for all future cross-agency data exchange.',
+    decision: 'All new and migrated cross-agency integrations will use REST/JSON APIs authenticated via OAuth 2.0. API contracts will be documented using OpenAPI specifications and reviewed by the Architecture Review Board.',
+    consequences: 'Aligns with state and industry direction. Reduces integration complexity versus SOAP. Requires updating existing integrations. Supersedes ADR-004.',
+    status: 'accepted' as const,
+    supersededByNumber: null as string | null,
+    capabilities: ['Cross-Agency Data Sharing', 'Digital Identity & Authentication'],
+    applications: ['Microsoft Entra ID'],
+    initiatives: ['Cross-Agency Data Exchange Pilot'],
+    objectives: ['Enable Cross-Agency Data Sharing'],
   },
 ]
 
@@ -444,12 +660,27 @@ export const STATE_APPLICATIONS = [
   },
 ]
 
-// ─── Multi-org connection ─────────────────────────────────────────────────────
-// Describes the cross-org link to create between the two orgs.
-// sourceCapability (City of Riverdale) implements targetCapability (State Org).
+// ─── Multi-org cross-org links ────────────────────────────────────────────────
+// Coverage: linkType = implements ✓, extends ✓, maps_to ✓
+//
+// Note: 'State Grants Management' has 'org' visibility; in runtime federation
+// traversal City of Riverdale cannot follow that link. The row is seeded to
+// exercise the data model regardless of visibility enforcement.
 
-export const DEV_CROSS_ORG_LINK = {
-  sourceCapabilityName: 'Digital Identity & Authentication',
-  targetCapabilityName: 'Statewide Identity Verification',
-  linkType: 'implements' as const,
-}
+export const DEV_CROSS_ORG_LINKS = [
+  {
+    sourceCapabilityName: 'Digital Identity & Authentication',
+    targetCapabilityName: 'Statewide Identity Verification',
+    linkType: 'implements' as const,
+  },
+  {
+    sourceCapabilityName: 'Cross-Agency Data Sharing',
+    targetCapabilityName: 'Open Data Platform',
+    linkType: 'extends' as const,
+  },
+  {
+    sourceCapabilityName: 'Budget Reporting',
+    targetCapabilityName: 'State Grants Management',
+    linkType: 'maps_to' as const,
+  },
+]

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -1,31 +1,38 @@
+import { eq } from 'drizzle-orm'
 import { GOV_TAXONOMY } from './gov-taxonomy'
 import {
   DEV_ORG, STATE_ORG,
   DEV_USERS, STATE_USERS,
   DEFAULT_PERSONA_TYPES, DEFAULT_TAGS,
+  DEV_PERSONA_TAGS,
   DEV_PERSONAS, DEV_CAPABILITIES, DEV_APPLICATIONS,
   DEV_OBJECTIVES, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   STATE_PERSONAS, STATE_CAPABILITIES, STATE_APPLICATIONS,
-  DEV_CROSS_ORG_LINK,
+  DEV_CROSS_ORG_LINKS,
 } from './dev-fixtures'
 import { db } from '../client'
 import {
   users, organizations, personaTypes, tags,
-  personas, capabilities, applications,
+  personas, personaTags, capabilities, applications,
   capabilityPersonas, applicationCapabilities,
-  strategicObjectives, objectiveCapabilities,
-  valueStreams, valueStreamStages, valueStreamStageCapabilities,
-  initiatives, initiativeCapabilities, initiativeObjectives,
-  adrs,
+  strategicObjectives, objectiveCapabilities, objectiveApplications, objectiveValueStreams,
+  valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
+  initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
+  adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
+  taxonomyTerms,
   orgConnections, crossOrgLinks,
 } from '../schema'
 import bcrypt from 'bcryptjs'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
 async function findOrCreateOrg(slug: string, name: string) {
   const existing = await db.query.organizations.findFirst({
-    where: (t, { eq }) => eq(t.slug, slug),
+    where: (t, { eq: e }) => e(t.slug, slug),
   })
   if (existing) return existing.id
   const [org] = await db.insert(organizations).values({ name, slug }).returning()
@@ -36,7 +43,7 @@ async function findOrCreatePersona(orgId: string, name: string, data: {
   description?: string; type?: string; status: 'draft' | 'published' | 'archived'; visibility: 'org' | 'connections' | 'instance'
 }) {
   const existing = await db.query.personas.findFirst({
-    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+    where: (t, { eq: e, and }) => and(e(t.organizationId, orgId), e(t.name, name)),
   })
   if (existing) return existing.id
   const [p] = await db.insert(personas).values({ organizationId: orgId, name, ...data }).returning()
@@ -47,7 +54,7 @@ async function findOrCreateCapability(orgId: string, name: string, data: {
   description?: string; domain?: string; status: 'draft' | 'published' | 'archived'; visibility: 'org' | 'connections' | 'instance'
 }) {
   const existing = await db.query.capabilities.findFirst({
-    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+    where: (t, { eq: e, and }) => and(e(t.organizationId, orgId), e(t.name, name)),
   })
   if (existing) return existing.id
   const [c] = await db.insert(capabilities).values({ organizationId: orgId, name, ...data }).returning()
@@ -55,12 +62,12 @@ async function findOrCreateCapability(orgId: string, name: string, data: {
 }
 
 async function findOrCreateApplication(orgId: string, name: string, data: {
-  description?: string; vendor?: string; hostingModel?: string;
+  description?: string; vendor?: string; version?: string; hostingModel?: string;
   lifecycleStatus: 'active' | 'sunset' | 'decommissioned' | 'planned';
   status: 'draft' | 'published' | 'archived'
 }) {
   const existing = await db.query.applications.findFirst({
-    where: (t, { eq, and }) => and(eq(t.organizationId, orgId), eq(t.name, name)),
+    where: (t, { eq: e, and }) => and(e(t.organizationId, orgId), e(t.name, name)),
   })
   if (existing) return existing.id
   const [a] = await db.insert(applications).values({ organizationId: orgId, name, ...data }).returning()
@@ -70,9 +77,6 @@ async function findOrCreateApplication(orgId: string, name: string, data: {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function seed() {
-  console.log('Seeding government taxonomy...')
-  console.log(`Loaded ${GOV_TAXONOMY.length} top-level domains`)
-
   if (process.env.DEV !== 'true') {
     console.log('Seed complete.')
     process.exit(0)
@@ -92,12 +96,25 @@ async function seed() {
   }
   console.log(`  ✓ ${DEV_USERS.length} users (password: dev-password)`)
 
-  // Persona types & tags
+  // Persona types
   for (const name of DEFAULT_PERSONA_TYPES) {
     await db.insert(personaTypes).values({ name, organizationId: devOrgId }).onConflictDoNothing()
   }
+
+  // Tags — build id map for personaTags
+  const devTagIds: Record<string, string> = {}
   for (const name of DEFAULT_TAGS) {
-    await db.insert(tags).values({ name, organizationId: devOrgId }).onConflictDoNothing()
+    const [tag] = await db.insert(tags).values({ name, organizationId: devOrgId })
+      .onConflictDoNothing()
+      .returning()
+    if (tag) {
+      devTagIds[name] = tag.id
+    } else {
+      const existing = await db.query.tags.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, name)),
+      })
+      if (existing) devTagIds[name] = existing.id
+    }
   }
   console.log(`  ✓ ${DEFAULT_PERSONA_TYPES.length} persona types, ${DEFAULT_TAGS.length} tags`)
 
@@ -110,6 +127,21 @@ async function seed() {
   }
   console.log(`  ✓ ${DEV_PERSONAS.length} personas`)
 
+  // Persona tags — personaTags junction table
+  for (const assignment of DEV_PERSONA_TAGS) {
+    const personaId = devPersonaIds[assignment.personaName]
+    if (!personaId) continue
+    for (const tagName of assignment.tags) {
+      const tagId = devTagIds[tagName]
+      if (!tagId) continue
+      const exists = await db.query.personaTags.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.personaId, personaId), e(t.tagId, tagId)),
+      })
+      if (!exists) await db.insert(personaTags).values({ personaId, tagId })
+    }
+  }
+  console.log(`  ✓ persona tag assignments`)
+
   // Capabilities + persona links
   const devCapabilityIds: Record<string, string> = {}
   for (const c of DEV_CAPABILITIES) {
@@ -121,7 +153,7 @@ async function seed() {
       const personaId = devPersonaIds[personaName]
       if (!personaId) continue
       const exists = await db.query.capabilityPersonas.findFirst({
-        where: (t, { eq, and }) => and(eq(t.capabilityId, capId), eq(t.personaId, personaId)),
+        where: (t, { eq: e, and }) => and(e(t.capabilityId, capId), e(t.personaId, personaId)),
       })
       if (!exists) await db.insert(capabilityPersonas).values({ capabilityId: capId, personaId })
     }
@@ -132,57 +164,63 @@ async function seed() {
   const devApplicationIds: Record<string, string> = {}
   for (const a of DEV_APPLICATIONS) {
     const appId = await findOrCreateApplication(devOrgId, a.name, {
-      description: a.description, vendor: a.vendor, hostingModel: a.hostingModel,
-      lifecycleStatus: a.lifecycleStatus, status: a.status,
+      description: a.description, vendor: a.vendor, version: a.version,
+      hostingModel: a.hostingModel, lifecycleStatus: a.lifecycleStatus, status: a.status,
     })
     devApplicationIds[a.name] = appId
     for (const capName of a.capabilities) {
       const capId = devCapabilityIds[capName]
       if (!capId) continue
       const exists = await db.query.applicationCapabilities.findFirst({
-        where: (t, { eq, and }) => and(eq(t.applicationId, appId), eq(t.capabilityId, capId)),
+        where: (t, { eq: e, and }) => and(e(t.applicationId, appId), e(t.capabilityId, capId)),
       })
       if (!exists) await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capId })
     }
   }
   console.log(`  ✓ ${DEV_APPLICATIONS.length} applications`)
 
-  // Strategic Objectives + capability links
-  const devObjectiveIds: Record<string, string> = {}
-  for (const o of DEV_OBJECTIVES) {
-    const existing = await db.query.strategicObjectives.findFirst({
-      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, o.name)),
+  // Government taxonomy — 10 domains, 5 sub-terms each
+  for (const [domainIdx, domainEntry] of GOV_TAXONOMY.entries()) {
+    const existingDomain = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, domainEntry.domain)),
     })
-    let objId: string
-    if (existing) {
-      objId = existing.id
+    let domainId: string
+    if (existingDomain) {
+      domainId = existingDomain.id
     } else {
-      const [inserted] = await db.insert(strategicObjectives).values({
+      const [inserted] = await db.insert(taxonomyTerms).values({
         organizationId: devOrgId,
-        name: o.name,
-        description: o.description,
-        successMetric: o.successMetric,
-        timeHorizon: o.timeHorizon,
-        status: o.status,
+        name: domainEntry.domain,
+        slug: toSlug(domainEntry.domain),
+        domain: domainEntry.domain,
+        sortOrder: String(domainIdx),
       }).returning()
-      objId = inserted.id
+      domainId = inserted.id
     }
-    devObjectiveIds[o.name] = objId
-    for (const capName of o.capabilities) {
-      const capId = devCapabilityIds[capName]
-      if (!capId) continue
-      const exists = await db.query.objectiveCapabilities.findFirst({
-        where: (t, { eq, and }) => and(eq(t.objectiveId, objId), eq(t.capabilityId, capId)),
+
+    for (const [termIdx, termName] of domainEntry.terms.entries()) {
+      const existingTerm = await db.query.taxonomyTerms.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, termName)),
       })
-      if (!exists) await db.insert(objectiveCapabilities).values({ objectiveId: objId, capabilityId: capId })
+      if (!existingTerm) {
+        await db.insert(taxonomyTerms).values({
+          organizationId: devOrgId,
+          parentId: domainId,
+          name: termName,
+          slug: toSlug(termName),
+          domain: domainEntry.domain,
+          sortOrder: String(termIdx),
+        })
+      }
     }
   }
-  console.log(`  ✓ ${DEV_OBJECTIVES.length} strategic objectives`)
+  console.log(`  ✓ ${GOV_TAXONOMY.length} taxonomy domains with sub-terms`)
 
-  // Value Streams + stages + stage capability links
+  // Value Streams + stages + stage capability links + persona links
+  const devValueStreamIds: Record<string, string> = {}
   for (const vs of DEV_VALUE_STREAMS) {
     const existingVs = await db.query.valueStreams.findFirst({
-      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, vs.name)),
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, vs.name)),
     })
     let vsId: string
     if (existingVs) {
@@ -198,10 +236,22 @@ async function seed() {
       }).returning()
       vsId = inserted.id
     }
+    devValueStreamIds[vs.name] = vsId
 
+    // Stakeholder personas — valueStreamPersonas junction table
+    for (const personaName of vs.stakeholderPersonas) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const exists = await db.query.valueStreamPersonas.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.valueStreamId, vsId), e(t.personaId, personaId)),
+      })
+      if (!exists) await db.insert(valueStreamPersonas).values({ valueStreamId: vsId, personaId })
+    }
+
+    // Stages + stage capability links
     for (const stage of vs.stages) {
       const existingStage = await db.query.valueStreamStages.findFirst({
-        where: (t, { eq, and }) => and(eq(t.valueStreamId, vsId), eq(t.name, stage.name)),
+        where: (t, { eq: e, and }) => and(e(t.valueStreamId, vsId), e(t.name, stage.name)),
       })
       let stageId: string
       if (existingStage) {
@@ -220,18 +270,74 @@ async function seed() {
         const capId = devCapabilityIds[capName]
         if (!capId) continue
         const exists = await db.query.valueStreamStageCapabilities.findFirst({
-          where: (t, { eq, and }) => and(eq(t.stageId, stageId), eq(t.capabilityId, capId)),
+          where: (t, { eq: e, and }) => and(e(t.stageId, stageId), e(t.capabilityId, capId)),
         })
         if (!exists) await db.insert(valueStreamStageCapabilities).values({ stageId, capabilityId: capId })
       }
     }
   }
-  console.log(`  ✓ ${DEV_VALUE_STREAMS.length} value streams with stages`)
+  console.log(`  ✓ ${DEV_VALUE_STREAMS.length} value streams with stages and persona links`)
 
-  // Initiatives + capability/objective links
+  // Strategic Objectives + capability / application / value stream links
+  const devObjectiveIds: Record<string, string> = {}
+  for (const o of DEV_OBJECTIVES) {
+    const existing = await db.query.strategicObjectives.findFirst({
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, o.name)),
+    })
+    let objId: string
+    if (existing) {
+      objId = existing.id
+    } else {
+      const [inserted] = await db.insert(strategicObjectives).values({
+        organizationId: devOrgId,
+        name: o.name,
+        description: o.description,
+        successMetric: o.successMetric,
+        timeHorizon: o.timeHorizon,
+        status: o.status,
+        visibility: o.visibility,
+      }).returning()
+      objId = inserted.id
+    }
+    devObjectiveIds[o.name] = objId
+
+    // objectiveCapabilities
+    for (const capName of o.capabilities) {
+      const capId = devCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.objectiveCapabilities.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.objectiveId, objId), e(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(objectiveCapabilities).values({ objectiveId: objId, capabilityId: capId })
+    }
+
+    // objectiveApplications
+    for (const appName of o.applications) {
+      const appId = devApplicationIds[appName]
+      if (!appId) continue
+      const exists = await db.query.objectiveApplications.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.objectiveId, objId), e(t.applicationId, appId)),
+      })
+      if (!exists) await db.insert(objectiveApplications).values({ objectiveId: objId, applicationId: appId })
+    }
+
+    // objectiveValueStreams
+    for (const vsName of o.valueStreams) {
+      const vsId = devValueStreamIds[vsName]
+      if (!vsId) continue
+      const exists = await db.query.objectiveValueStreams.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.objectiveId, objId), e(t.valueStreamId, vsId)),
+      })
+      if (!exists) await db.insert(objectiveValueStreams).values({ objectiveId: objId, valueStreamId: vsId })
+    }
+  }
+  console.log(`  ✓ ${DEV_OBJECTIVES.length} strategic objectives`)
+
+  // Initiatives + capability / application / objective links
+  const devInitiativeIds: Record<string, string> = {}
   for (const ini of DEV_INITIATIVES) {
     const existingIni = await db.query.initiatives.findFirst({
-      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.name, ini.name)),
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, ini.name)),
     })
     let iniId: string
     if (existingIni) {
@@ -243,38 +349,56 @@ async function seed() {
         description: ini.description,
         status: ini.status,
         startDate: ini.startDate,
-        endDate: ini.endDate,
+        endDate: ini.endDate ?? undefined,
       }).returning()
       iniId = inserted.id
     }
+    devInitiativeIds[ini.name] = iniId
 
+    // initiativeCapabilities
     for (const { name: capName, impact } of ini.capabilities) {
       const capId = devCapabilityIds[capName]
       if (!capId) continue
       const exists = await db.query.initiativeCapabilities.findFirst({
-        where: (t, { eq, and }) => and(eq(t.initiativeId, iniId), eq(t.capabilityId, capId)),
+        where: (t, { eq: e, and }) => and(e(t.initiativeId, iniId), e(t.capabilityId, capId)),
       })
       if (!exists) await db.insert(initiativeCapabilities).values({ initiativeId: iniId, capabilityId: capId, impact })
     }
 
+    // initiativeApplications
+    for (const { name: appName, impact } of ini.applications) {
+      const appId = devApplicationIds[appName]
+      if (!appId) continue
+      const exists = await db.query.initiativeApplications.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.initiativeId, iniId), e(t.applicationId, appId)),
+      })
+      if (!exists) await db.insert(initiativeApplications).values({ initiativeId: iniId, applicationId: appId, impact })
+    }
+
+    // initiativeObjectives
     for (const objName of ini.objectives) {
       const objId = devObjectiveIds[objName]
       if (!objId) continue
       const exists = await db.query.initiativeObjectives.findFirst({
-        where: (t, { eq, and }) => and(eq(t.initiativeId, iniId), eq(t.objectiveId, objId)),
+        where: (t, { eq: e, and }) => and(e(t.initiativeId, iniId), e(t.objectiveId, objId)),
       })
       if (!exists) await db.insert(initiativeObjectives).values({ initiativeId: iniId, objectiveId: objId })
     }
   }
   console.log(`  ✓ ${DEV_INITIATIVES.length} initiatives`)
 
-  // ADRs
+  // ADRs — insert all records first (without supersededBy), then resolve self-references
+  const devAdrIds: Record<string, string> = {}
+
   for (const adr of DEV_ADRS) {
     const existingAdr = await db.query.adrs.findFirst({
-      where: (t, { eq, and }) => and(eq(t.organizationId, devOrgId), eq(t.number, adr.number)),
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.number, adr.number)),
     })
-    if (!existingAdr) {
-      await db.insert(adrs).values({
+    let adrId: string
+    if (existingAdr) {
+      adrId = existingAdr.id
+    } else {
+      const [inserted] = await db.insert(adrs).values({
         organizationId: devOrgId,
         number: adr.number,
         title: adr.title,
@@ -282,10 +406,65 @@ async function seed() {
         decision: adr.decision,
         consequences: adr.consequences,
         status: adr.status,
-      })
+        // supersededBy resolved in second pass below
+      }).returning()
+      adrId = inserted.id
+    }
+    devAdrIds[adr.number] = adrId
+  }
+
+  // Second pass: resolve supersededBy self-references
+  for (const adr of DEV_ADRS) {
+    if (!adr.supersededByNumber) continue
+    const adrId = devAdrIds[adr.number]
+    const supersedingId = devAdrIds[adr.supersededByNumber]
+    if (adrId && supersedingId) {
+      await db.update(adrs).set({ supersededBy: supersedingId }).where(eq(adrs.id, adrId))
     }
   }
-  console.log(`  ✓ ${DEV_ADRS.length} ADRs`)
+
+  // ADR junction tables: capabilities, applications, initiatives, objectives
+  for (const adr of DEV_ADRS) {
+    const adrId = devAdrIds[adr.number]
+    if (!adrId) continue
+
+    for (const capName of adr.capabilities) {
+      const capId = devCapabilityIds[capName]
+      if (!capId) continue
+      const exists = await db.query.adrCapabilities.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.adrId, adrId), e(t.capabilityId, capId)),
+      })
+      if (!exists) await db.insert(adrCapabilities).values({ adrId, capabilityId: capId })
+    }
+
+    for (const appName of adr.applications) {
+      const appId = devApplicationIds[appName]
+      if (!appId) continue
+      const exists = await db.query.adrApplications.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.adrId, adrId), e(t.applicationId, appId)),
+      })
+      if (!exists) await db.insert(adrApplications).values({ adrId, applicationId: appId })
+    }
+
+    for (const iniName of adr.initiatives) {
+      const iniId = devInitiativeIds[iniName]
+      if (!iniId) continue
+      const exists = await db.query.adrInitiatives.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.adrId, adrId), e(t.initiativeId, iniId)),
+      })
+      if (!exists) await db.insert(adrInitiatives).values({ adrId, initiativeId: iniId })
+    }
+
+    for (const objName of adr.objectives) {
+      const objId = devObjectiveIds[objName]
+      if (!objId) continue
+      const exists = await db.query.adrObjectives.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.adrId, adrId), e(t.objectiveId, objId)),
+      })
+      if (!exists) await db.insert(adrObjectives).values({ adrId, objectiveId: objId })
+    }
+  }
+  console.log(`  ✓ ${DEV_ADRS.length} ADRs with junction links and supersededBy chain`)
 
   // ── Org 2: Office of Digital Services ────────────────────────────────────
 
@@ -315,7 +494,7 @@ async function seed() {
       const personaId = statePersonaIds[personaName]
       if (!personaId) continue
       const exists = await db.query.capabilityPersonas.findFirst({
-        where: (t, { eq, and }) => and(eq(t.capabilityId, capId), eq(t.personaId, personaId)),
+        where: (t, { eq: e, and }) => and(e(t.capabilityId, capId), e(t.personaId, personaId)),
       })
       if (!exists) await db.insert(capabilityPersonas).values({ capabilityId: capId, personaId })
     }
@@ -331,30 +510,32 @@ async function seed() {
       const capId = stateCapabilityIds[capName]
       if (!capId) continue
       const exists = await db.query.applicationCapabilities.findFirst({
-        where: (t, { eq, and }) => and(eq(t.applicationId, appId), eq(t.capabilityId, capId)),
+        where: (t, { eq: e, and }) => and(e(t.applicationId, appId), e(t.capabilityId, capId)),
       })
       if (!exists) await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capId })
     }
   }
   console.log(`  ✓ ${STATE_APPLICATIONS.length} applications`)
 
-  // ── Multi-org: connection + cross-org capability link ─────────────────────
+  // ── Multi-org: connection + cross-org capability links ────────────────────
 
   console.log('\n[Multi-org]')
 
   const existingConnection = await db.query.orgConnections.findFirst({
-    where: (t, { eq, and }) => and(eq(t.fromOrgId, devOrgId), eq(t.toOrgId, stateOrgId)),
+    where: (t, { eq: e, and }) => and(e(t.fromOrgId, devOrgId), e(t.toOrgId, stateOrgId)),
   })
   if (!existingConnection) {
     await db.insert(orgConnections).values({ fromOrgId: devOrgId, toOrgId: stateOrgId, status: 'active' })
   }
   console.log('  ✓ Org connection (active): City of Riverdale → Office of Digital Services')
 
-  const sourceCapId = devCapabilityIds[DEV_CROSS_ORG_LINK.sourceCapabilityName]
-  const targetCapId = stateCapabilityIds[DEV_CROSS_ORG_LINK.targetCapabilityName]
-  if (sourceCapId && targetCapId) {
+  for (const link of DEV_CROSS_ORG_LINKS) {
+    const sourceCapId = devCapabilityIds[link.sourceCapabilityName]
+    const targetCapId = stateCapabilityIds[link.targetCapabilityName]
+    if (!sourceCapId || !targetCapId) continue
+
     const existingLink = await db.query.crossOrgLinks.findFirst({
-      where: (t, { eq, and }) => and(eq(t.sourceEntityId, sourceCapId), eq(t.targetEntityId, targetCapId)),
+      where: (t, { eq: e, and }) => and(e(t.sourceEntityId, sourceCapId), e(t.targetEntityId, targetCapId)),
     })
     if (!existingLink) {
       await db.insert(crossOrgLinks).values({
@@ -364,11 +545,11 @@ async function seed() {
         targetOrgId: stateOrgId,
         targetEntityType: 'capability',
         targetEntityId: targetCapId,
-        linkType: DEV_CROSS_ORG_LINK.linkType,
+        linkType: link.linkType,
         status: 'active',
       })
     }
-    console.log(`  ✓ Cross-org link (active): "${DEV_CROSS_ORG_LINK.sourceCapabilityName}" implements "${DEV_CROSS_ORG_LINK.targetCapabilityName}"`)
+    console.log(`  ✓ Cross-org link (${link.linkType}): "${link.sourceCapabilityName}" → "${link.targetCapabilityName}"`)
   }
 
   console.log('\nSeed complete.')


### PR DESCRIPTION
## Summary

Closes #96.

The original issue tracked gaps left after the initial fixture work: taxonomy terms were loaded but never written to the DB, 9 junction tables were never seeded, and only a subset of enum values were exercised. This PR completes all of that.

### Fixtures (`dev-fixtures.ts`)

- **Personas** — adds `archived` status + `instance` visibility example (`Legacy System Operator`); covers all three values of both enums
- **Capabilities** — adds `archived` status + `instance` visibility example (`Print & Mail Services`)
- **Applications** — adds `planned` lifecycle + `hybrid` hosting + non-null `version` example (`Next-Gen Work Order System`); all four `lifecycle_status` values and all three `hostingModel` values now present
- **Objectives** — adds `applications` and `valueStreams` arrays to all entries (feeds new junction tables); adds `archived` + `instance` example (`Migrate to Cloud-First Infrastructure`)
- **Value Streams** — adds `draft` + `connections` example (`Business Registration`); `stakeholderPersonas` now feeds `valueStreamPersonas` junction table
- **Initiatives** — expands from 2 to 5 entries covering all five `initiative_status` values; all four application impact types (`build`, `retire`, `improve`, `migrate`) now present
- **ADRs** — expands from 1 to 5 entries covering all four `adr_status` values; `supersededByNumber` for the ADR-004 → ADR-005 self-reference chain; `initiatives` and `objectives` arrays added to drive all four ADR junction tables
- **Cross-org links** — changed to array; adds `extends` and `maps_to` link types alongside `implements` (all three `link_type` enum values covered)
- **`DEV_PERSONA_TAGS`** — new export mapping tag names to personas, driving `personaTags` junction table

### Seeding (`run.ts`)

- Taxonomy terms **actually inserted** into `taxonomy_terms` (was only logged before) — 10 domains × 5 sub-terms each, with `parentId` hierarchy and `slug` generation
- Seeds 9 previously-unseeded junction tables: `personaTags`, `valueStreamPersonas`, `objectiveApplications`, `objectiveValueStreams`, `initiativeApplications`, `adrCapabilities`, `adrApplications`, `adrInitiatives`, `adrObjectives`
- Two-pass ADR seeding: all ADR rows inserted first, then `supersededBy` self-references resolved in a second pass
- `findOrCreateApplication` helper updated to accept `version` field
- Cross-org link block loops over `DEV_CROSS_ORG_LINKS` array

## Acceptance Criteria

- [x] `pnpm db:seed` (with `DEV=true`) inserts personas, capabilities, and applications with no errors
- [x] Re-running seed does not create duplicate records or junction links (all inserts use `findOrCreate` / `onConflictDoNothing` patterns)
- [x] Each application links to at least one capability
- [x] Each capability links to at least one persona
- [x] All `workflow_status` values seeded: `draft`, `published`, `archived`
- [x] All `lifecycle_status` values seeded: `active`, `sunset`, `decommissioned`, `planned`
- [x] All `initiative_status` values seeded: `proposed`, `active`, `on-hold`, `complete`, `cancelled`
- [x] All `adr_status` values seeded: `accepted`, `proposed`, `deprecated`, `superseded`
- [x] All `visibility` values seeded: `org`, `connections`, `instance`
- [x] All `link_type` values seeded: `implements`, `extends`, `maps_to`
- [x] Taxonomy inserted (not just loaded)
- [x] ADR `supersededBy` self-reference chain seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)