### PR TITLE
docs: add capabilities.md and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,9 @@ Both must pass before merge.
 
 ---
 
-## Capability Roadmap
+## Capabilities
 
-GovEA's capability roadmap is grounded in the [`ea-research/EA-Tools-Market-Research-2026.md`](./ea-research/EA-Tools-Market-Research-2026.md) — a structured analysis of 7 leading EA platforms, 12 practitioner personas, and 45+ capabilities mapped across 8 groups.
-
-Key findings that shape GovEA's direction:
-
-- **EA Adoption & Engagement is the most cited systemic problem across all commercial tools.** No existing tool solves it well. This is a primary differentiator target for GovEA.
-- **Integration is severely underserved.** Gaps in PPM, HR, API management, and process mining force manual work that limits EA's analytical credibility in every tool reviewed.
-- **The mid-market is underserved.** The fastest-growing segment — organisations of 500–2,000 employees building their first EA practice — is largely ignored by tools designed for large enterprises. Government agencies at that scale are the core GovEA audience.
-- **Plain-language outputs are absent.** No tool reviewed produces outputs designed for elected officials or non-technical stakeholders. GovEA treats this as a first-class requirement, not a reporting add-on.
-
-### Capability groups under development
-
-The following 8 groups define GovEA's target capability surface, derived from the market research and filtered through GovEA's personas:
+GovEA's capability surface spans 8 groups, each driven by validated government EA practitioner personas:
 
 | Group | Description |
 |---|---|
@@ -89,16 +78,40 @@ The following 8 groups define GovEA's target capability surface, derived from th
 | Collaboration & Stakeholder Engagement | Role-based access, stakeholder views, change notifications |
 | Reporting & Documentation | Plain-language outputs, configurable reports, KPI tracking |
 
-Capabilities are defined one at a time through the EasyEA workflow: persona validation → capability definition → ARB review → implementation issues. The research document is a reference source, not an implementation backlog.
+For the full capability inventory — including implementation status — see [`capabilities.md`](./capabilities.md).
+
+Capabilities are defined one at a time through the EasyEA workflow: persona validation → capability definition → ARB review → implementation issues.
 
 ---
 
 ## Current Status
 
-- **Implemented:** applications, capabilities, personas, value streams, strategic objectives, initiatives, roadmap views, ADRs, audit history, taxonomy, user management, setup flows, multi-org federation scaffolding, and reusable `@govea/core` primitives
-- **Active work:** closing architecture-documentation gaps, expanding automated test coverage, improving local bootstrap and demo workflows
-- **Near-term:** strengthen multi-organization support, improve stakeholder-facing views and detail pages
-- **Longer-term:** ARB review simulation using reviewer personas, broader hosted SaaS deployment options, and progressive capability coverage across the 8 groups above
+**Implemented:**
+- Full CRUD for the core EA object model: applications, capabilities, personas, value streams, strategic objectives, initiatives, ADRs
+- Mission-first traceability: Personas → Capabilities → Applications enforced at the application layer
+- Roadmap view — initiatives and objectives visualized on a timeline
+- Audit trail — immutable before/after log of all changes
+- Taxonomy — hierarchical org-scoped classification for all content
+- Identity & access management — SSO via Microsoft Entra ID (OIDC), local auth fallback, Admin/Contributor/Viewer roles
+- User management and first-run setup flow
+- Multi-org federation scaffolding — connection requests, visibility levels, cross-org linking
+- Reusable `@govea/core` package — RBAC, audit, taxonomy, workflow, content type, and recipe primitives
+- E2E smoke test coverage across all routes × roles (Playwright)
+
+**Active work:**
+- Expanding automated test coverage
+- Improving local bootstrap and demo workflows
+
+**Near-term:**
+- Stakeholder-facing views and plain-language detail pages
+- Repository completeness signals and gap detection
+- Stronger multi-organization support
+
+**Longer-term:**
+- End-to-end traceability and architecture debt tracking
+- ARB review simulation using reviewer personas
+- Broader hosted SaaS deployment options
+- Progressive coverage across remaining capability groups
 
 ---
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -1,0 +1,194 @@
+# GovEA Capabilities
+
+This document describes GovEA's implemented and planned capabilities, organized by group. It is the authoritative summary of what the product does and where it is headed.
+
+Capability definitions live in [`business-architecture/capabilities/`](./business-architecture/capabilities/). That folder is the authoritative source — this document summarizes it.
+
+---
+
+## Capability Groups
+
+| # | Group | Status |
+|---|---|---|
+| 1 | [Identity & Access Management](#1-identity--access-management) | Implemented |
+| 2 | [Content Management](#2-content-management) | Partially implemented |
+| 3 | [Portfolio Management](#3-portfolio-management) | Implemented |
+| 4 | [Planning & Roadmap](#4-planning--roadmap) | Implemented |
+| 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
+| 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
+| 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Scaffolded |
+| 8 | [Repository & Modelling](#8-repository--modelling) | Partially implemented |
+
+---
+
+## 1. Identity & Access Management
+
+Controls authentication, authorization, and all identity events.
+
+| Capability | Status | Description |
+|---|---|---|
+| User Management | Implemented | Create, edit, deactivate, and assign roles to user accounts |
+| Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions |
+| SSO Authentication | Implemented | Microsoft Entra ID sign-in via OpenID Connect (OIDC) |
+| Local Authentication | Implemented | Email and password login; always available as SSO fallback |
+| IAM Audit Trail | Implemented | Immutable log of all identity and access events |
+| First-Run Setup | Implemented | Bootstrap the initial Admin account on first launch |
+| API Auth Decision | Implemented | Auth strategy for API routes (session-based, not token-based in v1) |
+
+**Roles:**
+
+| Role | Access |
+|---|---|
+| Admin | Full access — users, org settings, all content |
+| Contributor | Create and edit EA content — no user management, no delete |
+| Viewer | Read-only, published content only |
+
+SSO users default to Viewer. Admins promote as needed.
+
+---
+
+## 2. Content Management
+
+Foundational content authoring and lifecycle capabilities shared across all EA content types.
+
+| Capability | Status | Description |
+|---|---|---|
+| Content Authoring | Implemented | Create, edit, and save content items |
+| Content Workflow | Implemented | Draft → Published → Archived lifecycle; Viewer-gated on Published |
+| Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for categorizing all content |
+| Content Relationships | Implemented | Link content items; enforce GovEA traceability rules at publish time |
+| Content Search & Filtering | Implemented | Embedded full-text search; no external search service required |
+| Content Types | Partially implemented | Configurable schemas for content; v1 types are fixed in the data model |
+| Content Versioning | Not implemented | Change history, diffs, and version restore |
+
+**Traceability rule:** Applications must link to at least one Capability. Capabilities must link to at least one Persona. This constraint is enforced at the application layer.
+
+---
+
+## 3. Portfolio Management
+
+The structured inventory of the organization's architecture objects.
+
+| Capability | Status | Description |
+|---|---|---|
+| Application Portfolio | Implemented | Manage applications with lifecycle status, capability links, and metadata |
+| Capability Map | Implemented | Define business capabilities organized by domain; linked to applications and personas |
+| Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
+| Architecture Decision Records (ADRs) | Implemented | Record, track, supersede, and link architecture decisions to capabilities, applications, initiatives, and objectives |
+| Value Streams | Implemented | Define value streams with ordered stages; link to capabilities and personas |
+
+**Data model relationships:**
+
+```
+Personas → Capabilities → Applications
+Strategic Objectives → Capabilities, Value Streams, Applications
+Initiatives → Capabilities, Objectives, Applications
+ADRs → Capabilities, Applications, Initiatives, Objectives
+```
+
+---
+
+## 4. Planning & Roadmap
+
+Strategic direction, change initiatives, and timeline visualization.
+
+| Capability | Status | Description |
+|---|---|---|
+| Strategic Objectives | Implemented | Define and track business goals; link to capabilities and value streams |
+| Initiatives | Implemented | Track change programmes; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
+| Roadmap View | Implemented | Visualize initiatives and objectives on a governed timeline |
+
+**Design principle:** Planning capabilities are a lens on existing architecture content. Strategic objectives trace to capabilities. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
+
+---
+
+## 5. Frontend Display
+
+How content is presented to authenticated users and, optionally, the public.
+
+| Capability | Status | Description |
+|---|---|---|
+| Navigation | Implemented | App shell with role-aware sidebar navigation |
+| Portfolio Views | Implemented | List and detail pages for all EA entity types |
+| Relationship Navigation | Implemented | Navigate between linked entities (capability ↔ application ↔ persona) |
+| Value Stream Display | Implemented | Visualize value stream stages with linked capabilities |
+| Content Display | Implemented | Detail pages with status badges, metadata, and linked records |
+| Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
+| Responsive Layout | Partially implemented | Desktop-first; mobile not a v1 priority |
+| Theming | Not implemented | Organization-branded themes |
+
+---
+
+## 6. Admin Configuration
+
+Organization-level settings and administrative tools.
+
+| Capability | Status | Description |
+|---|---|---|
+| Organization Settings | Implemented | Org name, branding, and configuration |
+| Persona Type Management | Implemented | Create and manage persona type categories |
+| Persona Tags | Implemented | Tag-based classification for personas |
+| Admin Dashboard | Partially implemented | Summary stats and navigation for admins |
+| Feature Management | Not implemented | Enable/disable optional product features per org |
+| Email Configuration | Not implemented | SMTP setup for notifications and password reset |
+| Backup & Export | Not implemented | Data export and backup tooling |
+| Security Settings | Not implemented | Session timeouts, password policy, IP restrictions |
+
+---
+
+## 7. Multi-Organization Federation
+
+Allows organizations to connect, share content, and link local EA artifacts to enterprise-wide counterparts while preserving each org's autonomy.
+
+| Capability | Status | Description |
+|---|---|---|
+| Org Connections | Scaffolded | Establish and manage connections between organizations |
+| Content Visibility | Scaffolded | Control which content is visible at org / connections / instance level |
+| Cross-Org Linking | Scaffolded | Link local capabilities and personas to enterprise counterparts |
+| Cross-Org Link Approval | Scaffolded | Review and approve or reject incoming cross-org link requests |
+
+**Visibility levels:**
+
+| Level | Visible to |
+|---|---|
+| `org` | This organization only |
+| `connections` | This org and all directly connected orgs |
+| `instance` | All orgs on the same GovEA instance |
+
+**Design principle:** Single-org installs work identically without federation UI or complexity. Federation is opt-in from the agency side — no org can be forced into a connection. Content ownership never transfers across org boundaries.
+
+---
+
+## 8. Repository & Modelling
+
+Reliability, navigability, and self-auditing of the architecture store.
+
+| Capability | Status | Description |
+|---|---|---|
+| Audit Trail | Implemented | Immutable log of all create/update/delete events with before/after JSON |
+| Repository Completeness | Partially implemented | Signals showing where the EA object store has gaps |
+| End-to-End Traceability | Not implemented | Cross-layer impact analysis from strategic goals through capabilities to applications |
+| Architecture Debt Tracking | Not implemented | Surface and track decisions and conditions that constrain future options |
+
+**Out of scope for v1:**
+- Multi-framework modelling (ArchiMate, BPMN, UML) — GovEA uses enforced relationship chains and plain-language descriptions, not formal notation
+- Meta-model customization — the GovEA meta-model is fixed in v1; custom content types extend it without changing the core
+
+---
+
+## Capability Target Surface
+
+GovEA's long-term capability surface spans 8 groups, each defined through the EasyEA workflow: persona validation → capability definition → ARB review → implementation issues.
+
+| Group | Near-term priorities |
+|---|---|
+| Repository & Modelling | End-to-end traceability, architecture debt tracking |
+| Application & IT Portfolio | Technology lifecycle tracking, rationalization views |
+| Business & Capability Architecture | Capability heat maps, operating model views |
+| Planning & Analysis | Scenario planning, value stream analytics |
+| Governance & Compliance | ARB review workflow, regulatory mapping |
+| Integration | ITSM/CMDB connectors, DevOps pipeline links |
+| Collaboration & Stakeholder Engagement | Change notifications, stakeholder-facing plain-language views |
+| Reporting & Documentation | Configurable reports, KPI tracking, elected-official summaries |
+
+Capabilities are added one at a time as personas are validated and pain points confirmed. The roadmap is driven by real government EA practitioner needs, not feature parity with commercial tools.


### PR DESCRIPTION
## Summary

- Add `capabilities.md` — full inventory of all 8 capability groups with sub-capabilities and implementation status (Implemented / Partially implemented / Scaffolded / Not implemented)
- Update README `Capabilities` section — remove reference to the market research PDF, link to `capabilities.md` for the detailed inventory
- Rewrite `Current Status` to accurately reflect what is built, including E2E test coverage and `@govea/core`

## Test plan

- [ ] Review `capabilities.md` for accuracy against implemented routes and schema
- [ ] Review README for accuracy and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)