### PR TITLE
arb(3): flag CMS personas as assumed and define plain-language standard

### DIFF
--- a/business-architecture/capabilities/cms/frontend-display/fd-content-display.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-content-display.md
@@ -15,6 +15,23 @@ The system must render published content items in a clear, readable layout that 
 - Display taxonomy tags with links to filtered views of the same term
 - Show related content items with links to navigate to them
 
+## Plain-Language Standard
+
+Content displayed to Viewers must avoid EA jargon — specifically terms that assume familiarity with enterprise architecture practice and have no plain-language equivalent apparent from context. Terms to avoid in labels, headings, and descriptive copy:
+
+| Avoid | Use instead |
+|---|---|
+| Capability | Business capability, or just the capability name |
+| Persona | Who this serves, or the role name |
+| ADR / Architecture Decision Record | Decision record, or Technology decision |
+| Traceability | How this connects to… |
+| Lifecycle status | Status (Active / Retiring / Planned) |
+| Decommissioned | Retired |
+| Value stream | How we deliver… / Service process |
+| Taxonomy | Category / Topic |
+
+This list is provisional. It should be validated against real users — specifically the Content Viewer persona — before front-end copy is finalized.
+
 ## Rules
 - Only published content is ever rendered for Viewers — draft and archived content returns a 404
 - Field labels and content must not expose internal system identifiers or technical metadata

--- a/business-architecture/personas/cms-administrator.md
+++ b/business-architecture/personas/cms-administrator.md
@@ -1,5 +1,7 @@
 # Persona: CMS Administrator
 
+**Validation Status: Assumed** — drafted without direct user research. Pain points and goals are plausible but generic. Must not drive implementation beyond what is already built until validated through interviews with real government IT administrators in a state or local government context (1–3 person IT shop).
+
 ## Role Type
 Internal — Back-end administrator
 

--- a/business-architecture/personas/cms-viewer.md
+++ b/business-architecture/personas/cms-viewer.md
@@ -1,5 +1,7 @@
 # Persona: Content Viewer
 
+**Validation Status: Assumed** — drafted without direct user research. Goals and pain points reflect plausible friction for non-technical government stakeholders but have not been confirmed through interviews with real department heads, elected officials, or budget staff. Must not drive front-end display decisions beyond what is already built until validated.
+
 ## Role Type
 Internal / External — Front-end information consumer
 


### PR DESCRIPTION
## Summary

Addresses ARB finding #3 (Alex Chen, Human-Centered Designer — Severity: High).

- Flag `cms-administrator.md` and `cms-viewer.md` as **Validation Status: Assumed** — consistent with the pattern used for EA personas
- Add a plain-language jargon avoidance table to `fd-content-display.md` — specifies which EA terms to avoid in front-end copy and what to use instead

## What this does not do

It does not conduct the user research. The finding calls for at least one interview with a real government IT staff member before driving further implementation. That work is still outstanding and tracked in #3.

## Test plan

- [ ] Review validation status wording on both persona files matches the pattern in `enterprise-architect.md`
- [ ] Review the jargon table in `fd-content-display.md` for accuracy and completeness
- [ ] Confirm issue #3 is closed by this PR

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)