### PR TITLE
arb(1,2,4): success criteria, cost rationale, and admin handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,36 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 
 ---
 
+## Cost & Why Not an Existing Tool
+
+GovEA is free and open source. There is no licensing fee. The real cost is staff time — to deploy, configure, and maintain the system. For a self-hosted deployment on existing infrastructure, plan for:
+
+- **Initial setup:** a few hours for a technically capable IT staff member
+- **Ongoing maintenance:** periodic updates, user provisioning, and backup verification — no dedicated admin role required
+- **Hosting:** runs on any server or container platform; no proprietary cloud dependency
+
+### Why not SharePoint, Confluence, or Notion?
+
+Those tools are general-purpose document repositories. They can store EA content, but they cannot enforce the relationships that make EA useful:
+
+- They cannot require that an application links to a capability, or that a capability links to a persona
+- They have no concept of a traceability chain from strategy to people to systems
+- They produce content for whoever created it — not outputs shaped for department directors or elected officials
+- Taxonomy and classification are ad hoc — there is no shared model across the organization
+
+### Why not an existing EA tool (LeanIX, Ardoq, MEGA HOPEX, etc.)?
+
+Commercial EA tools are designed for large enterprise architecture practices. They are expensive, complex, and assume a dedicated EA team with formal training. For state and local government agencies:
+
+- Licensing costs are prohibitive for agencies with no EA budget
+- Tool complexity discourages adoption — EA content stays current only when it is easy to maintain
+- Outputs are designed for architects, not for elected officials or department directors
+- On-prem or air-gapped deployment is difficult or unavailable
+
+GovEA is designed specifically for the agencies commercial tools ignore: 500–2,000 employees, 1–3 person IT team, no EA budget, needing something that works without a consultant.
+
+---
+
 ## Contributing
 
 GovEA is open source and welcomes contributions. Before opening a pull request, read [`Standards.md`](./Standards.md) — it defines the workflow for both human and AI-assisted contributions.

--- a/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
@@ -17,6 +17,27 @@ The system must provide administrators with a complete set of tools to configure
 | Security Settings | [ac-security-settings.md](./ac-security-settings.md) | Password policy, session timeout, and account lockout |
 | Backup & Export | [ac-backup-export.md](./ac-backup-export.md) | Export and import configuration and content |
 
+## Success Criteria
+
+The following outcomes indicate Admin & Configuration is working well for a 1–3 person government IT department 6 months after deployment:
+
+- An administrator can change site settings, configure email, and update security policy without touching a config file or restarting the server
+- When a GovEA update is applied, the administrator can verify the system is healthy using the Admin Dashboard — no CLI or log file access required
+- An administrator can export a full backup of content and configuration, and restore it on a new instance, without developer help
+- If the primary administrator leaves, a replacement can take over all administrative functions using the Admin Dashboard and User Management — no credentials or institutional knowledge are lost because they are documented in the system
+
+## Upgrade & Migration
+
+GovEA follows a migration-based upgrade model. This section defines expectations for how upgrades are applied and what administrators need to know.
+
+| Concern | Approach |
+|---|---|
+| Database migrations | Applied automatically on startup via Drizzle; migrations are idempotent and tracked in `_journal.json` |
+| Rollback | Roll back by restoring the previous Docker image and database backup; migrations are not automatically reversed |
+| Breaking changes | Documented in release notes; migrations that alter existing data are flagged as breaking |
+| Configuration drift | Site settings persist in the database — no manual re-entry required on upgrade |
+| Release notes | Published with each release; link available from the Admin Dashboard once implemented |
+
 ## Rules
 - All Admin & Configuration capabilities are accessible to Admins only
 - Configuration changes must not require a server restart

--- a/business-architecture/capabilities/cms/content-management/content-management.md
+++ b/business-architecture/capabilities/cms/content-management/content-management.md
@@ -19,6 +19,16 @@ The system must provide a complete content management foundation — defining co
 | Content Relationships | [cm-content-relationships.md](./cm-content-relationships.md) | Link content items and enforce GovEA relationship rules |
 | Content Search & Filtering | [cm-content-search-filtering.md](./cm-content-search-filtering.md) | Full-text search and attribute-based filtering |
 
+## Success Criteria
+
+The following outcomes indicate Content Management is working well for a 1–3 person government IT department 6 months after deployment:
+
+- A contributor can create, link, and publish an application record without training — the form is self-explanatory and enforces required relationships before publish
+- A Viewer can tell whether the content they are reading is current — the published date is visible without scrolling or clicking
+- A contributor can find any existing content record using search in under 30 seconds
+- The GovEA traceability rule (Applications → Capabilities → Personas) is never violated in published content — the system blocks or prompts before publish if a required link is missing
+- Taxonomy terms are used consistently — contributors select from existing terms rather than inventing new ones for the same concept
+
 ## Rules
 - Published content is the only content visible to Viewers — workflow state gates all display
 - The core GovEA constraint must be enforced at publish time: Applications must link to Capabilities; Capabilities must link to Personas

--- a/business-architecture/capabilities/cms/frontend-display/frontend-display.md
+++ b/business-architecture/capabilities/cms/frontend-display/frontend-display.md
@@ -19,6 +19,16 @@ The system must present published content to users in a way that is clear, navig
 | Public & Authenticated Views | [fd-public-authenticated-views.md](./fd-public-authenticated-views.md) | Control what requires login vs. what is publicly accessible |
 | Theming | [fd-theming.md](./fd-theming.md) | Theme selection, agency branding, and content rendering customization |
 
+## Success Criteria
+
+The following outcomes indicate Front-end Display is working well for a 1–3 person government IT department 6 months after deployment:
+
+- A department head can answer "what applications support the permitting process?" by navigating from a capability to its linked applications — without asking IT
+- A Viewer who has never used GovEA before can find a specific application record within 2 minutes using search or navigation, without a manual
+- Content reads as plain English to a non-technical audience — no EA jargon appears in labels, headings, or body copy (see [fd-content-display.md](./fd-content-display.md) for the jargon avoidance standard)
+- Published dates are visible on all content so Viewers can assess freshness without contacting the author
+- The front end loads and is fully readable without JavaScript enabled
+
 ## Rules
 - Only published content is ever visible to Viewers — workflow state is the gate
 - Core content must render without JavaScript — progressive enhancement only

--- a/business-architecture/capabilities/cms/iam/iam-first-run-setup.md
+++ b/business-architecture/capabilities/cms/iam/iam-first-run-setup.md
@@ -14,11 +14,34 @@ On first launch, the system must guide the administrator through creating the in
 - Block all non-setup routes until setup is complete
 - Support headless/automated setup via environment variables for Docker and CI deployments
 
+## Administrator Handoff
+
+First-run setup creates the initial Admin account, but it does not address what happens when that administrator leaves. For a 1–3 person government IT shop, staff turnover is a near-certainty within the product's lifetime. The system must not become inaccessible or unmanageable when the original admin departs.
+
+### Handoff behaviors the system must support
+
+- An existing Admin can create additional Admin accounts at any time through User Management — there is no limit on the number of Admin accounts
+- There is no "super admin" or root account that only one person can hold — all Admin accounts are equal
+- The outgoing admin does not need to transfer ownership; the incoming admin is granted full access by being assigned the Admin role
+- If all Admin accounts become inaccessible (e.g. the only admin leaves without creating a successor), a recovery path must exist that does not require database access — documented in the deployment guide
+
+### What the outgoing admin should document
+
+The system cannot enforce this, but the following should be captured before an admin transitions out:
+
+- Which SSO provider is configured and who manages it at the identity provider level
+- Any non-default site settings, feature flags, or email configuration
+- The location of the most recent backup and how to restore it
+- Any active connections to peer organizations (multi-org federation)
+
+> ⚠️ The recovery path for a fully locked-out instance (no accessible Admin account) is a deployment-level concern, not a UI capability. It must be documented in the deployment guide before v1 ships.
+
 ## Rules
 - First-run setup runs exactly once — it cannot be re-triggered after an Admin account exists
 - The initial Admin account created during setup cannot be automatically deactivated
 - Automated setup via environment variables must produce the same result as the UI wizard
+- There is no account hierarchy among Admin users — any Admin can create, edit, or deactivate any other non-Admin user
 
 ## Links
 - Depends on: User Management, Role-Based Access Control, Local Authentication
-- Related: IAM Audit Trail
+- Related: IAM Audit Trail, Admin & Configuration

--- a/business-architecture/capabilities/cms/iam/iam.md
+++ b/business-architecture/capabilities/cms/iam/iam.md
@@ -18,6 +18,17 @@ The system must control who can access it, how they authenticate, and what they 
 | IAM Audit Trail | [iam-audit-trail.md](./iam-audit-trail.md) | Immutable log of all identity and access events |
 | First-Run Setup | [iam-first-run-setup.md](./iam-first-run-setup.md) | Bootstrap initial Admin account on first launch |
 
+## Success Criteria
+
+The following outcomes indicate IAM is working well for a 1–3 person government IT department 6 months after deployment:
+
+- A new staff member can be provisioned with the correct role in under 5 minutes — no developer involvement, no separate ticket
+- A departing staff member's access is revoked the same day IT is notified — one action in the UI, no database access required
+- The administrator can answer "who changed this and when" for any user or role event using the audit log without assistance
+- SSO sign-in works without a separate GovEA password — users authenticate once via the agency identity provider
+- Local authentication remains available if SSO is unavailable — no user is locked out due to an IdP outage
+- A new Admin account can be created by an existing Admin without rerunning first-run setup or touching the database
+
 ## Rules
 - IAM is always active — authentication is required by default; public access to published content is an opt-in configuration controlled by the Admin
 - Local authentication is always available as a fallback, even when SSO is configured


### PR DESCRIPTION
## Summary

Addresses three ARB findings in a single PR — all documentation changes, no code.

### Issue 1 — Success Criteria (Lisa Rodriguez, Business Architect — Severity: Medium)

Added a **Success Criteria** section to all 4 CMS capability group parent files. Each outcome is measurable, traceable to a persona pain point, and usable as an acceptance criterion. Framed for a 1–3 person government IT department 6 months after deployment.

Files: `iam.md`, `content-management.md`, `admin-configuration.md`, `frontend-display.md`

### Issue 2 — Cost Rationale (Emily Johnson, CFO — Severity: Medium)

Added a **Cost & Why Not an Existing Tool** section to `README.md` covering:
- True cost of ownership (hosting, staff time, no licensing fee)
- Direct answer to "why not SharePoint/Confluence/Notion"
- Direct answer to "why not LeanIX/Ardoq/MEGA HOPEX"

### Issue 4 — Admin Handoff & Upgrade Path (Jake Lawson, Veteran Architect — Severity: High)

- Expanded `iam-first-run-setup.md` with an **Administrator Handoff** section: how successor Admins are created, what an outgoing admin should document, and a callout that the locked-out-instance recovery path must be in the deployment guide before v1 ships
- Added **Upgrade & Migration** table to `admin-configuration.md`: migration model, rollback approach, breaking change policy, and release notes location

## Test plan

- [ ] Review success criteria in all 4 group files — are outcomes measurable and traceable to real pain points?
- [ ] Review README cost section — accurate and complete for a procurement conversation?
- [ ] Review handoff section in `iam-first-run-setup.md` — does it cover the staff turnover scenario?
- [ ] Confirm the deployment guide callout in issue 4 is tracked as a follow-on task before v1 ships

Closes #1
Closes #2
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)