### PR TITLE
arb(8,9): data retention, user data governance, and data classification

### DIFF
--- a/business-architecture/capabilities/cms/admin-configuration/ac-admin-dashboard.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-admin-dashboard.md
@@ -13,6 +13,7 @@ The system must provide administrators with an at-a-glance overview of system he
 - Show user account summary — total users, active users, users by role
 - Display lifecycle risk summary — Applications in aging, sunset, or decommissioned status
 - Show system status — database connectivity, last backup timestamp
+- Display content completeness summary — percentage of published content items with all recommended fields populated, broken down by content type
 
 ## Rules
 - Dashboard data reflects real-time state — no stale cache

--- a/business-architecture/capabilities/cms/content-management/cm-content-types.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-types.md
@@ -15,6 +15,22 @@ The system must allow administrators to define and configure the structure of co
 - Enable or disable workflow and audit trail per content type
 - Preview the content type form before publishing the schema
 
+## Data Classification Field
+
+All content types should support an optional **sensitivity classification** field. This is not a full access control system — it is a signal field that surfaces the data sensitivity question before content is published.
+
+Recommended values:
+
+| Value | Meaning |
+|---|---|
+| Public | Suitable for public-facing display; no sensitivity concerns |
+| Internal | For internal agency use; not for public release |
+| Restricted | Sensitive content; review before sharing outside the team |
+
+- Classification is set by the contributor at authoring time; it defaults to Internal if not set
+- Classification does not gate access in v1 — that is a v2 concern — but it must be visible to Admins and surfaced in the Admin Dashboard
+- Agencies with specific data classification standards (e.g. CUI, FOUO) should map those to these three values rather than extending the field in v1
+
 ## Rules
 - Content type changes must not destroy existing content — removing a field hides it, it does not delete stored data
 - At least one field must be designated as the display title for each content type

--- a/business-architecture/capabilities/cms/content-management/cm-content-versioning.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-versioning.md
@@ -13,10 +13,24 @@ The system must retain a complete history of changes to every content item so th
 - Restore a previous version (creates a new version — does not overwrite history)
 - Display the current version number on the content item
 
+## Retention Policy
+
+Retaining every version of every content item indefinitely creates unbounded storage growth. GovEA applies a configurable retention policy per content type.
+
+| Setting | Default | Notes |
+|---|---|---|
+| Retention mode | Keep last N versions | Simplest to reason about; alternative: keep versions within X months |
+| Default N | 25 versions | Sufficient for normal editorial workflows without runaway storage |
+| On limit reached | Oldest versions pruned | Pruning is automatic; the current published version is never pruned |
+
+- The retention policy is configurable per content type by an Admin
+- The currently published version and the version immediately preceding it are always retained regardless of the retention limit
+- Pruned versions are permanently deleted — export or download before they are pruned if long-term version history is required
+
 ## Rules
-- Version history is append-only — versions cannot be deleted individually
+- Version history is append-only — versions cannot be deleted individually by users
 - Restoring a previous version creates a new version rather than rolling back
-- All versions are retained for the life of the content item
+- The currently published and immediately preceding versions are never automatically pruned
 - Version history is visible to Admins and Contributors; not visible to Viewers
 
 ## Links

--- a/business-architecture/capabilities/cms/content-management/content-management.md
+++ b/business-architecture/capabilities/cms/content-management/content-management.md
@@ -24,5 +24,9 @@ The system must provide a complete content management foundation — defining co
 - The core GovEA constraint must be enforced at publish time: Applications must link to Capabilities; Capabilities must link to Personas
 - All content changes are versioned and auditable
 
+## Deferred to v2
+
+**Content quality / completeness monitoring** — a dedicated capability covering completeness scoring, quality flags, and trend reporting across the repository is deferred to v2. The Admin Dashboard surfaces a basic completeness summary in v1 (percentage of published items with all recommended fields populated), which is sufficient for early adopters. Full quality monitoring requires a larger repository to be meaningful and validated user need beyond what v1 personas confirm.
+
 ## Links
 - Depends on: IAM

--- a/business-architecture/capabilities/cms/iam/iam-audit-trail.md
+++ b/business-architecture/capabilities/cms/iam/iam-audit-trail.md
@@ -13,9 +13,22 @@ The system must log all identity and access management events so that administra
 - Display the audit log in the admin UI with filtering by event type, user, and date range
 - Export the audit log as CSV
 
+## Retention Policy
+
+Audit logs are subject to government records retention requirements. The defaults below are designed to align with common state and local government retention schedules for IT system access logs.
+
+| Setting | Default | Recommended maximum | On expiry |
+|---|---|---|---|
+| Retention period | 12 months | 7 years | Entries are permanently deleted |
+
+- The 12-month default aligns with a common minimum for government IT access logs; agencies with longer statutory requirements must increase this in Site Settings
+- The 7-year recommended maximum reflects typical government records schedules for administrative system logs; beyond this, storage cost and query performance degrade without corresponding compliance benefit
+- No automated archival to external storage is provided in v1 — Admins must export via CSV before the retention window expires if long-term records are required
+- Admins are responsible for confirming their configured period meets their agency's records retention schedule
+
 ## Rules
 - Audit log entries are immutable — no user including Admin can edit or delete them through the application
-- Logs must be retained for a configurable period (default: 12 months)
+- Logs must be retained for a configurable period (default: 12 months, recommended maximum: 7 years)
 - Failed login attempts must be logged including the email address used
 
 ## Log Integrity

--- a/business-architecture/personas/cms-administrator.md
+++ b/business-architecture/personas/cms-administrator.md
@@ -25,6 +25,23 @@ The CMS Administrator is the person responsible for setting up, configuring, and
 ## Critical Insight
 The CMS Administrator is not a developer and should never need to be. If administrative functions require code changes or CLI access, the system has failed this persona. Every configuration action they need to perform must be available through the UI, and every access decision must be auditable.
 
+## Data Stored About This Persona
+
+GovEA stores the following personal data about CMS Administrator accounts:
+
+| Data | Purpose | Retention |
+|---|---|---|
+| Full name | Display in audit log and UI | Retained for the life of the account |
+| Email address | Authentication, notifications, audit log | Retained for the life of the account |
+| Hashed password | Local authentication (if not SSO-only) | Retained until account is deleted |
+| Role assignment | Access control | Retained for the life of the account |
+| Login timestamps | Audit trail | Subject to audit log retention policy (default: 12 months) |
+| Action history | Audit trail — records all content and IAM changes | Subject to audit log retention policy |
+
+**Authority:** Data is collected under the agency's IT system administration authority. No data is shared with third parties. No data is used for purposes other than operating the system.
+
+**Access and deletion:** An Admin can deactivate their own account or have another Admin do so. Deactivation prevents login but does not delete audit trail entries — those are immutable by design. To fully remove personal data, a database-level deletion is required; this is a manual process documented in the deployment guide.
+
 ## Relevant Capabilities
 - Back-end content administration
 - User and role management

--- a/business-architecture/personas/cms-viewer.md
+++ b/business-architecture/personas/cms-viewer.md
@@ -25,6 +25,25 @@ The Content Viewer is anyone who needs to read and navigate published content bu
 ## Critical Insight
 The Content Viewer will not come back if the first experience is confusing or the content feels out of date. Trust is built through clear navigation, visible publish dates, and outputs written for a general audience. SSO must work transparently — any login friction is a reason to go back to email and spreadsheets.
 
+## Data Stored About This Persona
+
+GovEA stores the following personal data about Content Viewer accounts:
+
+| Data | Purpose | Retention |
+|---|---|---|
+| Full name | Display in UI and session | Retained for the life of the account |
+| Email address | Authentication | Retained for the life of the account |
+| Role assignment | Access control (Viewer) | Retained for the life of the account |
+| Login timestamps | Audit trail | Subject to audit log retention policy (default: 12 months) |
+
+**SSO users:** For users who authenticate via Microsoft Entra ID SSO, GovEA does not store a password. Name and email are provided by the identity provider at login and stored locally for display and audit purposes.
+
+**No content interaction data is stored:** GovEA does not track which content items a Viewer reads, how long they spend on a page, or what they search for.
+
+**Authority:** Data is collected under the agency's IT system administration authority. No data is shared with third parties.
+
+**Access and deletion:** An Admin can deactivate a Viewer account. Deactivation prevents login but does not delete audit trail entries. Full account data deletion requires a database-level operation documented in the deployment guide.
+
 ## Relevant Capabilities
 - Front-end content display and navigation
 - Search and filtering


### PR DESCRIPTION
## Summary

Addresses two ARB findings — all documentation changes, no code.

### Issue 8 — Data retention & user data governance (Maya Patel, Data Privacy Architect — Severity: High)

**Audit trail retention** (`iam-audit-trail.md`):
- Added Retention Policy section with 12-month default and rationale (aligns with common government IT access log schedules)
- Documented 7-year recommended maximum with reasoning
- Defined purge-on-expiry behaviour and Admin responsibility for confirming their agency's schedule

**Content version retention** (`cm-content-versioning.md`):
- Added Retention Policy section — keep-last-N model (default: 25 versions), auto-prune oldest, published and preceding versions always retained

**User data governance** (`cms-administrator.md`, `cms-viewer.md`):
- Added Data Stored section to both persona files listing every piece of personal data collected, purpose, retention period, authority, and deletion path
- Notes that SSO users have no stored password; Content Viewers have no content interaction tracking

### Issue 9 — Data classification & content quality (Grace Holloway, Data & Analytics Architect — Severity: Medium)

- `cm-content-types.md`: added Data Classification Field section — optional Public/Internal/Restricted signal field with guidance for agencies using CUI/FOUO classifications
- `ac-admin-dashboard.md`: added content completeness summary behaviour to the dashboard
- `content-management.md`: explicitly deferred full content quality/completeness monitoring to v2 with rationale

## Test plan

- [ ] Review retention policy defaults — do the 12-month and 7-year figures hold up against common government records schedules?
- [ ] Review Data Stored tables in both persona files — anything missing or incorrect?
- [ ] Review data classification field design — is Public/Internal/Restricted the right default taxonomy?
- [ ] Confirm content quality deferral rationale is sound

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)