### PR TITLE
feat(azure): Container Apps deployment for dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Dependencies — installed inside the image by Dockerfile
+node_modules
+**/node_modules
+
+# Next.js build output
+.next
+**/.next
+
+# Test output
+playwright-report
+test-results
+
+# Local env files
+.env*.local
+.env
+
+# Git
+.git
+.gitignore
+
+# Dev tooling
+.turbo
+coverage
+
+# Docker files (not needed inside the image)
+docker-compose*.yml

--- a/apps/govea/next.config.ts
+++ b/apps/govea/next.config.ts
@@ -1,9 +1,22 @@
 import type { NextConfig } from 'next'
 
+const allowedOrigins = ['localhost:3000']
+
+// When deployed to Azure (or any remote host), NEXT_PUBLIC_APP_URL carries the
+// full origin. Extract just the host so server actions are not blocked by the
+// CSRF origin check.
+if (process.env.NEXT_PUBLIC_APP_URL) {
+  try {
+    allowedOrigins.push(new URL(process.env.NEXT_PUBLIC_APP_URL).host)
+  } catch {
+    // malformed URL — skip
+  }
+}
+
 const nextConfig: NextConfig = {
   experimental: {
     serverActions: {
-      allowedOrigins: ['localhost:3000'],
+      allowedOrigins,
     },
   },
 }

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -25,7 +25,8 @@ COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 COPY . .
 
 COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
-RUN chmod +x /entrypoint.dev.sh
+COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh
+RUN chmod +x /entrypoint.dev.sh /entrypoint.azure-dev.sh
 
 EXPOSE 3000
 

--- a/docker/entrypoint.azure-dev.sh
+++ b/docker/entrypoint.azure-dev.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Azure Container Apps entrypoint.
+# Waits for the Postgres sidecar (localhost:5432) before migrating + seeding,
+# then starts the Next.js dev server.
+set -e
+
+echo ""
+echo "==> Waiting for Postgres..."
+until node -e "
+  const n = require('net');
+  const s = n.createConnection(5432, 'localhost');
+  s.on('connect', () => { s.destroy(); process.exit(0); });
+  s.on('error',   () => process.exit(1));
+" 2>/dev/null; do
+  sleep 2
+done
+echo "    Postgres is ready."
+
+echo ""
+echo "==> Running database migrations..."
+pnpm --filter govea db:migrate
+
+echo ""
+echo "==> Seeding database..."
+pnpm --filter govea db:seed
+
+echo ""
+echo "==> Starting dev server..."
+exec pnpm --filter govea dev

--- a/scripts/azure-dev.sh
+++ b/scripts/azure-dev.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# scripts/azure-dev.sh — GovEA Azure dev environment
+#
+# Usage: ./scripts/azure-dev.sh <command>
+#
+#   deploy   One-time setup: creates all Azure resources and does first deploy
+#   update   Rebuild image, push, and roll out a new revision (no downtime)
+#   start    Scale up to 1 replica (resume after stop)
+#   stop     Scale to 0 replicas — no compute charges while stopped
+#   logs     Stream live app logs
+#   url      Print the app URL
+#   status   Show current replica/image state
+#   destroy  Delete all Azure resources (confirmation required)
+#
+# Prerequisites:
+#   - az CLI installed and authenticated (az login)
+#   - Docker daemon running
+#   - Run from repo root
+
+set -euo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+RG="govea-dev-rg"
+LOCATION="eastus"
+ACR="goveadevacr"
+ACA_ENV="govea-dev-env"
+ACA_APP="govea-dev"
+IMAGE="${ACR}.azurecr.io/govea-dev:latest"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+log()  { echo ""; echo "==> $*"; }
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+require_deploy() {
+  az containerapp show --name "$ACA_APP" --resource-group "$RG" \
+    --query name -o tsv &>/dev/null \
+    || die "App not deployed. Run: ./scripts/azure-dev.sh deploy"
+}
+
+acr_password() {
+  az acr credential show --name "$ACR" --query "passwords[0].value" -o tsv
+}
+
+app_url() {
+  local fqdn
+  fqdn=$(az containerapp show --name "$ACA_APP" --resource-group "$RG" \
+    --query "properties.configuration.ingress.fqdn" -o tsv 2>/dev/null || true)
+  [[ -n "$fqdn" ]] && echo "https://${fqdn}" || echo "(not deployed)"
+}
+
+# Derive a stable 32-char secret from the subscription ID so it survives
+# updates. Override by setting GOVEA_AUTH_SECRET before running.
+auth_secret() {
+  if [[ -n "${GOVEA_AUTH_SECRET:-}" ]]; then
+    echo "$GOVEA_AUTH_SECRET"
+  else
+    az account show --query id -o tsv | shasum -a 256 | cut -c1-32
+  fi
+}
+
+build_and_push() {
+  # Build and push in Azure using ACR Tasks — no local Docker push needed.
+  # The image lands directly in ACR and build output is streamed live.
+  log "Building image in Azure (az acr build)..."
+  az acr build \
+    --registry "$ACR" \
+    --image govea-dev:latest \
+    --file docker/Dockerfile.dev \
+    .
+}
+
+# Create or update the Container App.
+# $1 = app_url (for NEXT_PUBLIC_APP_URL and allowedOrigins)
+deploy_containerapp() {
+  local app_url="$1"
+  local acr_pass
+  acr_pass=$(acr_password)
+  local secret
+  secret=$(auth_secret)
+
+  if az containerapp show --name "$ACA_APP" --resource-group "$RG" &>/dev/null; then
+    # Already exists — just update the image
+    az containerapp update \
+      --name "$ACA_APP" \
+      --resource-group "$RG" \
+      --image "$IMAGE" \
+      --output none
+  else
+    # First deploy: create app + add postgres sidecar
+    az containerapp create \
+      --name "$ACA_APP" \
+      --resource-group "$RG" \
+      --environment "$ACA_ENV" \
+      --image "$IMAGE" \
+      --registry-server "${ACR}.azurecr.io" \
+      --registry-username "$ACR" \
+      --registry-password "$acr_pass" \
+      --command "/entrypoint.azure-dev.sh" \
+      --cpu 1.0 \
+      --memory 2Gi \
+      --env-vars \
+        "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/govea" \
+        "AUTH_SECRET=${secret}" \
+        "NEXT_PUBLIC_APP_URL=${app_url}" \
+        "DEV=true" \
+        "NODE_ENV=development" \
+      --ingress external \
+      --target-port 3000 \
+      --min-replicas 1 \
+      --max-replicas 1 \
+      --output none
+
+    # Add postgres as a sidecar (shares localhost with the app container)
+    az containerapp update \
+      --name "$ACA_APP" \
+      --resource-group "$RG" \
+      --container-name postgres \
+      --image postgres:16-alpine \
+      --set-env-vars "POSTGRES_DB=govea" "POSTGRES_USER=postgres" "POSTGRES_PASSWORD=postgres" \
+      --cpu 0.5 \
+      --memory 1Gi \
+      --output none
+  fi
+}
+
+# ── Commands ───────────────────────────────────────────────────────────────────
+
+cmd_deploy() {
+  log "Creating resource group (${RG})..."
+  az group create --name "$RG" --location "$LOCATION" --output none
+
+  log "Creating Azure Container Registry (${ACR}, Basic tier)..."
+  az acr create \
+    --resource-group "$RG" \
+    --name "$ACR" \
+    --sku Basic \
+    --admin-enabled true \
+    --output none
+
+  build_and_push
+
+  log "Creating Container Apps environment (${ACA_ENV})..."
+  az containerapp env create \
+    --name "$ACA_ENV" \
+    --resource-group "$RG" \
+    --location "$LOCATION" \
+    --output none
+
+  # The environment's defaultDomain lets us calculate the FQDN before the
+  # app exists, so NEXT_PUBLIC_APP_URL is correct from first boot.
+  local env_domain
+  env_domain=$(az containerapp env show \
+    --name "$ACA_ENV" \
+    --resource-group "$RG" \
+    --query "properties.defaultDomain" -o tsv)
+  local first_app_url="https://${ACA_APP}.${env_domain}"
+
+  log "Deploying Container App..."
+  deploy_containerapp "$first_app_url"
+
+  echo ""
+  echo "✓ Deployed!"
+  echo "  URL : ${first_app_url}"
+  echo ""
+  echo "  The app is starting up — allow ~60 s for Postgres, migrations,"
+  echo "  and seed data on first boot."
+  echo ""
+  echo "  To stream logs:  ./scripts/azure-dev.sh logs"
+  echo "  To stop billing: ./scripts/azure-dev.sh stop"
+}
+
+cmd_update() {
+  require_deploy
+  build_and_push
+
+  log "Rolling out new revision..."
+  az containerapp update \
+    --name "$ACA_APP" \
+    --resource-group "$RG" \
+    --container-name "$ACA_APP" \
+    --image "$IMAGE" \
+    --output none
+
+  echo ""
+  echo "✓ New revision is live."
+  echo "  URL: $(app_url)"
+}
+
+cmd_start() {
+  require_deploy
+  log "Scaling up..."
+  az containerapp update \
+    --name "$ACA_APP" \
+    --resource-group "$RG" \
+    --min-replicas 1 \
+    --max-replicas 1 \
+    --output none
+  echo "✓ Started: $(app_url)"
+}
+
+cmd_stop() {
+  require_deploy
+  log "Scaling to 0 replicas (no compute charges while stopped)..."
+  az containerapp update \
+    --name "$ACA_APP" \
+    --resource-group "$RG" \
+    --min-replicas 0 \
+    --max-replicas 0 \
+    --output none
+  echo "✓ Stopped."
+}
+
+cmd_logs() {
+  require_deploy
+  az containerapp logs show \
+    --name "$ACA_APP" \
+    --resource-group "$RG" \
+    --container app \
+    --follow \
+    --tail 50
+}
+
+cmd_url() {
+  require_deploy
+  app_url
+}
+
+cmd_status() {
+  az containerapp show \
+    --name "$ACA_APP" \
+    --resource-group "$RG" \
+    --query "{
+      url: properties.configuration.ingress.fqdn,
+      image: properties.template.containers[0].image,
+      minReplicas: properties.template.scale.minReplicas,
+      maxReplicas: properties.template.scale.maxReplicas
+    }" \
+    -o table 2>/dev/null \
+    || echo "Not deployed. Run: ./scripts/azure-dev.sh deploy"
+}
+
+cmd_destroy() {
+  echo "This will permanently delete the resource group '${RG}' and"
+  echo "ALL resources inside it (ACR, Container Apps, images, etc.)."
+  echo ""
+  read -r -p "Type the resource group name to confirm: " confirm
+  [[ "$confirm" == "$RG" ]] || die "Aborted."
+
+  log "Deleting resource group ${RG}..."
+  az group delete --name "$RG" --yes --no-wait
+  echo "✓ Deletion queued (runs in background in Azure)."
+}
+
+# ── Entrypoint ─────────────────────────────────────────────────────────────────
+case "${1:-help}" in
+  deploy)   cmd_deploy   ;;
+  update)   cmd_update   ;;
+  start)    cmd_start    ;;
+  stop)     cmd_stop     ;;
+  logs)     cmd_logs     ;;
+  url)      cmd_url      ;;
+  status)   cmd_status   ;;
+  destroy)  cmd_destroy  ;;
+  help|*)
+    cat <<'HELP'
+Usage: ./scripts/azure-dev.sh <command>
+
+  deploy   One-time setup and first deploy
+  update   Rebuild image and roll out new revision (no downtime)
+  start    Resume the app (scale to 1 replica)
+  stop     Pause the app (scale to 0 — no compute charges)
+  logs     Stream live logs
+  url      Print the app URL
+  status   Show current image / replica state
+  destroy  Delete all Azure resources (permanent)
+
+Cost notes:
+  Container Apps consumption plan — no charge when stopped (min-replicas=0).
+  ACR Basic tier is ~$5/month regardless of usage.
+  Set GOVEA_AUTH_SECRET env var to pin the auth secret across redeploys.
+HELP
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds everything needed to deploy and manage GovEA in Azure Container Apps (dev/demo tier).

- **`scripts/azure-dev.sh`** — single management script with subcommands: `deploy` (one-time setup), `update` (rebuild + roll out), `start`/`stop` (scale 0↔1 for cost control), `logs`, `url`, `status`, `destroy`. Uses `az acr build` so no local Docker daemon is required for pushes.
- **`docker/entrypoint.azure-dev.sh`** — Azure-specific entrypoint: waits for the Postgres sidecar on localhost:5432, then runs `db:migrate`, `db:seed`, and starts the Next.js dev server.
- **`docker/Dockerfile.dev`** — copies both entrypoints into the image so either can be used as the container command.
- **`.dockerignore`** — excludes `node_modules`, `.next`, `.git`, and dev tooling to keep the build context lean.
- **`apps/govea/next.config.ts`** — adds `NEXT_PUBLIC_APP_URL` as an allowed server-action origin; without this, server actions fail the CSRF origin check when called from the Azure hostname.

## Architecture notes

The app and Postgres run as sidecars in the same Container App replica, sharing `localhost`. This avoids needing a separate managed database for a dev/demo environment. The `entrypoint.azure-dev.sh` polls port 5432 before proceeding, so startup order doesn't matter.

## Test plan

- [ ] `./scripts/azure-dev.sh deploy` — creates RG, ACR, env, and app; prints URL
- [ ] App loads at the printed URL and sign-in works
- [ ] `./scripts/azure-dev.sh stop` → `status` shows minReplicas=0
- [ ] `./scripts/azure-dev.sh start` → app comes back up
- [ ] `./scripts/azure-dev.sh update` — rebuilds and rolls out without downtime
- [ ] `./scripts/azure-dev.sh destroy` — prompts for RG name, then deletes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)