### PR TITLE
docs: correct capability maturity across product docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,24 +88,29 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 
 **Implemented:**
 - Full CRUD for the core EA object model: applications, capabilities, personas, value streams, strategic objectives, initiatives, ADRs
+- Supporting reference content for principles and glossary terms
 - Mission-first traceability: Personas → Capabilities → Applications enforced at the application layer
-- Roadmap view — initiatives and objectives visualized on a timeline
+- Live dashboard for EA practitioners with repository activity and coverage signals
+- Roadmap view — initiatives and objectives visualized through planning-status columns
 - Audit trail — immutable before/after log of all changes
 - Taxonomy — hierarchical org-scoped classification for all content
 - Identity & access management — SSO via Microsoft Entra ID (OIDC), local auth fallback, Admin/Contributor/Viewer roles
 - User management and first-run setup flow
-- Multi-org federation scaffolding — connection requests, visibility levels, cross-org linking
+- Prototype multi-org federation — connection requests, visibility levels, shared content, cross-org linking
 - Reusable `@govea/core` package — RBAC, audit, taxonomy, workflow, content type, and recipe primitives
 - E2E smoke test coverage across all routes × roles (Playwright)
+- Containerized local development plus Azure Container Apps dev deployment support
 
 **Active work:**
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
+- Aligning product documentation with actual feature maturity
 
 **Near-term:**
 - Stakeholder-facing views and plain-language detail pages
 - Repository completeness signals and gap detection
 - Stronger multi-organization support
+- Repository-wide search and consistent workflow behavior across all entity types
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
@@ -1,7 +1,7 @@
 # Capability: Admin & Configuration
 
 ## What It Does
-The system must provide administrators with a complete set of tools to configure, monitor, and maintain the site — from initial setup through ongoing operations — without requiring code changes or server access.
+The system must provide administrators with the tools needed to configure, monitor, and maintain the site without requiring code changes or server access. In the current product this is an early admin toolkit rather than a complete operations surface.
 
 ## Personas
 - **CMS Administrator** — the sole user of this capability group; configures and maintains the system on behalf of the organization
@@ -21,9 +21,8 @@ The system must provide administrators with a complete set of tools to configure
 
 The following outcomes indicate Admin & Configuration is working well for a 1–3 person government IT department 6 months after deployment:
 
-- An administrator can change site settings, configure email, and update security policy without touching a config file or restarting the server
+- An administrator can manage the currently supported settings and admin surfaces without touching a config file or restarting the server
 - When a GovEA update is applied, the administrator can verify the system is healthy using the Admin Dashboard — no CLI or log file access required
-- An administrator can export a full backup of content and configuration, and restore it on a new instance, without developer help
 - If the primary administrator leaves, a replacement can take over all administrative functions using the Admin Dashboard and User Management — no credentials or institutional knowledge are lost because they are documented in the system
 
 ## Upgrade & Migration
@@ -42,6 +41,10 @@ GovEA follows a migration-based upgrade model. This section defines expectations
 - All Admin & Configuration capabilities are accessible to Admins only
 - Configuration changes must not require a server restart
 - No Admin & Configuration function should require CLI or database access
+
+## Current Scope
+- Implemented today: admin dashboard, user management, audit visibility, taxonomy and persona metadata management, org connections, and theme selection
+- Future work: broader site settings, feature toggles, email configuration, backup/export, and security policy controls
 
 ## Links
 - Depends on: IAM

--- a/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
@@ -1,26 +1,25 @@
 # Capability: Content Search & Filtering
 
 ## What It Does
-The system must allow users to find content items quickly across the repository by searching on text and filtering by type, taxonomy, workflow state, and other attributes.
+The system must allow users to find content items quickly using list-level filtering, taxonomy context, and search where it exists today. A single repository-wide full-text search experience remains future work.
 
 ## Personas
 - **CMS Administrator** — searches across all content to manage the repository
 - **Content Viewer** — searches and filters to find published content relevant to their question
 
 ## Behaviors
-- Full-text search across all published content (Viewers) or all content (Admins and Contributors)
+- List-level filtering and search within the current screen
 - Filter content by content type
 - Filter content by taxonomy term
 - Filter content by workflow state (Admins and Contributors only)
 - Filter content by owning department or organization
-- Sort results by relevance, name, or last modified date
-- Display search results with content type, title, and workflow state
+- Display filtered results with content type, title, and workflow state where those fields are available
 
 ## Rules
 - Viewers can only search and filter published content — draft and archived content is never returned in their results
-- Search must work without an external search service in v1 — embedded/local search only
+- Repository-wide search must work without an external search service in v1 when it is added
 - Filters are additive — multiple filters narrow results
-- Empty search with filters applied returns all content matching the filters
+- Empty filters return all content matching the current screen and role context
 
 ## Links
 - Depends on: Content Authoring, Content Workflow, Taxonomy Management

--- a/business-architecture/capabilities/cms/content-management/cm-content-workflow.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-workflow.md
@@ -1,14 +1,14 @@
 # Capability: Content Workflow
 
 ## What It Does
-The system must manage the lifecycle state of each content item through a defined workflow. Content moves through states in a controlled sequence and only published content is visible to Viewers.
+The system must manage the lifecycle state of each content item through a defined workflow. For the core repository content model, content moves through Draft → Published → Archived and only published content is visible to Viewers. Planning entities currently use planning-specific lifecycle states.
 
 ## Personas
 - **CMS Administrator** — manages content state; can move content to any state
 - **Content Viewer** — sees only published content; workflow state is invisible to them
 
 ## Behaviors
-- Track each content item through three states: Draft → Published → Archived
+- Track core content items through three states: Draft → Published → Archived
 - Allow Contributors to move content from Draft to Published
 - Allow Contributors to move published content back to Draft for editing
 - Allow Admins to archive published content
@@ -24,7 +24,7 @@ The system must manage the lifecycle state of each content item through a define
 | Archived | Retired — hidden from Viewers; preserved for history and audit |
 
 ## Rules
-- Content cannot skip states — Draft must precede Published; Published must precede Archived
+- Core content cannot skip states — Draft must precede Published; Published must precede Archived
 - Archived content cannot be edited — it must be moved back to Draft first
 - Deleting a content item is separate from archiving — archive first, delete only when certain
 

--- a/business-architecture/capabilities/cms/content-management/content-management.md
+++ b/business-architecture/capabilities/cms/content-management/content-management.md
@@ -1,7 +1,7 @@
 # Capability: Content Management
 
 ## What It Does
-The system must provide a complete content management foundation — defining content structure, authoring content items, managing their lifecycle, organizing them with taxonomy, linking them together, and enabling users to find what they need.
+The system must provide a complete content management foundation — defining content structure, authoring content items, managing their lifecycle, organizing them with taxonomy, linking them together, and enabling users to find what they need. In the current product, core authoring and relationships are strong, while repository-wide search and fully consistent workflow behavior are still maturing.
 
 ## Personas
 - **CMS Administrator** — manages all content management functions; defines structure, authors and publishes content
@@ -25,14 +25,14 @@ The following outcomes indicate Content Management is working well for a 1–3 p
 
 - A contributor can create, link, and publish an application record without training — the form is self-explanatory and enforces required relationships before publish
 - A Viewer can tell whether the content they are reading is current — the published date is visible without scrolling or clicking
-- A contributor can find any existing content record using search in under 30 seconds
+- A contributor can find any existing content record using the current filters, taxonomy, and navigation in under 30 seconds
 - The GovEA traceability rule (Applications → Capabilities → Personas) is never violated in published content — the system blocks or prompts before publish if a required link is missing
 - Taxonomy terms are used consistently — contributors select from existing terms rather than inventing new ones for the same concept
 
 ## Rules
-- Published content is the only content visible to Viewers — workflow state gates all display
+- Published content is the only content visible to Viewers for the core content model — workflow state gates those displays
 - The core GovEA constraint must be enforced at publish time: Applications must link to Capabilities; Capabilities must link to Personas
-- All content changes are versioned and auditable
+- All content changes are auditable today; full version history and restore are future work
 
 ## Deferred to v2
 

--- a/business-architecture/capabilities/cms/frontend-display/fd-theming.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-theming.md
@@ -1,34 +1,26 @@
 # Capability: Theming
 
 ## What It Does
-The system must allow administrators to control the visual presentation of the front-end and admin interface through themes — without writing code for routine customization. Agencies should be able to align the tool with their branding standards.
+The system must allow administrators to control the visual presentation of the product through supported themes without writing code for routine customization. Agencies should be able to align the tool with their branding standards within the boundaries of the shipped theme set.
 
 ## Personas
 - **CMS Administrator** — selects and configures themes; applies agency branding
 - **Content Viewer** — experiences the themed front-end; expects a consistent, professional appearance
 
 ## Behaviors
-- Select an active front-end theme from available installed themes
-- Select an active admin theme independently of the front-end theme
-- Configure basic theme settings from the admin UI — primary color, font, logo placement
+- Select an active theme from the available supported theme set
 - Preview a theme before activating it
-- Bundle and serve CSS and JavaScript assets efficiently — no manual asset pipeline management
-- Support Liquid and Markdown templates for content rendering customization
-- Allow placement configuration — control where content parts and fields render on a page without code
+- Apply the selected theme without redeploying the application
 
 ## Rules
 - GovEA ships with a default theme that meets accessibility standards (WCAG 2.1 AA minimum)
 - Theme changes take effect immediately without a restart
-- Custom theme development is supported but not required — the default theme must be fully functional out of the box
-- Theme customization via the admin UI is limited to safe options — arbitrary CSS injection is not exposed to Contributors
+- Theme customization via the admin UI is limited to supported theme selection — arbitrary CSS injection is not exposed to Contributors
 - Only Admins can manage themes
 
-## OrchardCore Reference
-- `OrchardCore.Themes` — theme management and switching
-- `OrchardCore.Resources` — centralized script and stylesheet declaration
-- `OrchardCore.Placements` — shape placement configuration
-- `OrchardCore.Liquid` — Liquid template engine for content rendering
-- `OrchardCore.Shortcodes` — shortcode processing in content
+## Current Scope
+- Predefined theme selection is implemented
+- Separate front-end/admin themes, arbitrary branding controls, and template-level rendering customization are future work
 
 ## Links
 - Depends on: Admin & Configuration — Site Settings, IAM — Role-Based Access Control

--- a/business-architecture/capabilities/cms/frontend-display/frontend-display.md
+++ b/business-architecture/capabilities/cms/frontend-display/frontend-display.md
@@ -1,7 +1,7 @@
 # Capability: Front-end Display
 
 ## What It Does
-The system must present published content to users in a way that is clear, navigable, and useful without EA training — on any device, with or without a login depending on agency configuration.
+The system must present EA content to users in a way that is clear, navigable, and useful without EA training. The authenticated experience is substantial today; optional public unauthenticated publishing remains future work.
 
 ## Personas
 - **Content Viewer** — the primary user of all front-end display capabilities; expects to find information quickly and trust that it is current

--- a/business-architecture/capabilities/cms/multi-org/multi-org.md
+++ b/business-architecture/capabilities/cms/multi-org/multi-org.md
@@ -1,7 +1,7 @@
 # Capability: Multi-Organization Federation
 
 ## What It Does
-The system must allow multiple organizations to connect with each other, share appropriate content across organizational boundaries, and link local EA artifacts to enterprise-wide counterparts — while preserving each organization's autonomy and keeping single-org installs simple.
+The system must allow multiple organizations to connect with each other, share appropriate content across organizational boundaries, and link local EA artifacts to enterprise-wide counterparts — while preserving each organization's autonomy and keeping single-org installs simple. In the current product this is a prototype capability: the core model and shared-read behaviors exist, while approval and hardening workflows remain in progress.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — publishes enterprise capabilities and personas at instance level; sees aggregated view of agency adoption across connected orgs

--- a/business-architecture/capabilities/cms/planning/pl-initiatives.md
+++ b/business-architecture/capabilities/cms/planning/pl-initiatives.md
@@ -16,12 +16,11 @@ The system must allow organizations to document change programmes (initiatives, 
 - View which initiatives are advancing a given objective
 - View which initiatives affect a given capability
 - Track initiative status through its lifecycle (proposed, active, on-hold, complete, cancelled)
-- Publish initiatives so they are visible to Viewer-role users
+- Display initiatives in roadmap and planning views using their planning status and dates
 
 ## Rules
 - An initiative must belong to an organization
-- Initiatives follow the standard content workflow: draft → published → archived
-- Only published initiatives are visible to Viewer-role users
+- Initiatives follow the planning lifecycle documented here: proposed, active, on-hold, complete, cancelled
 - An initiative with no linked capabilities is architecturally incomplete — this should surface as a completeness signal in the admin dashboard
 - Impact labels on capability links are optional but recommended; they communicate whether the initiative is building new capability or changing existing capability
 

--- a/business-architecture/capabilities/cms/planning/pl-roadmap.md
+++ b/business-architecture/capabilities/cms/planning/pl-roadmap.md
@@ -1,7 +1,7 @@
 # Capability: Roadmap
 
 ## What It Does
-The system must provide a timeline view of initiatives and their relationship to strategic objectives, allowing stakeholders to see what is planned, what is underway, and what has been delivered — and how these changes connect to the capability portfolio.
+The system must provide a roadmap view of initiatives and their relationship to strategic objectives, allowing stakeholders to see what is planned, what is underway, and what has been delivered — and how these changes connect to the capability portfolio.
 
 The roadmap is a view over existing planning content, not a standalone data store. It renders what is already captured in initiatives and objectives as a governed, readable timeline.
 
@@ -11,21 +11,20 @@ The roadmap is a view over existing planning content, not a standalone data stor
 - **Department Director** — primary consumer; reads the roadmap to understand what is changing and when, without needing to navigate the full architecture repository
 
 ## Behaviors
-- Display initiatives on a timeline grouped by status (proposed, active, complete)
+- Display initiatives grouped by planning status
 - Show the strategic objectives each initiative advances
 - Show the capabilities each initiative affects, with impact label
 - Filter the roadmap by status, capability, or objective
 - Display start and end dates where available; display "TBD" or "ongoing" where dates are not set
-- Render the roadmap from published content only — draft and archived initiatives do not appear to Viewers
+- Render the roadmap directly from initiative records and their planning metadata
 
 ## Rules
-- The roadmap does not have its own data — it is a rendered view of published initiatives with planning metadata
-- Only published initiatives appear in the roadmap view for Viewer-role users
+- The roadmap does not have its own data — it is a rendered view of initiatives with planning metadata
 - Initiatives without start/end dates appear in a "Unscheduled" section rather than being hidden
 - The roadmap is read-only; editing is done through the initiatives management interface
 
 ## Implementation Status
-- **v1:** Basic roadmap view implemented. Displays published initiatives grouped by status with objective and capability links. Date-based timeline rendering is deferred to a future iteration.
+- **v1:** Basic roadmap view implemented. Displays initiatives grouped by planning status with objective and capability links. Richer date-based timeline rendering is deferred to a future iteration.
 
 ## Links
 - Depends on: Initiatives, Strategic Objectives, Capabilities

--- a/business-architecture/capabilities/cms/planning/planning.md
+++ b/business-architecture/capabilities/cms/planning/planning.md
@@ -1,6 +1,6 @@
 # Capability Group: Planning
 
-The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio on a timeline.
+The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio. In the current product this is a strong early-v1 capability, but its workflow model is intentionally different from the core content workflow.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — publishes enterprise-wide objectives and tracks capability alignment across agencies

--- a/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
+++ b/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
@@ -35,11 +35,13 @@ The system must allow contributors to record, track, and supersede architecture 
 - Only published ADRs appear in front-end portfolio views
 
 ## Implementation Status
-Partially implemented in v1:
-- Schema: `adrs` table with full field set including `superseded_by` (`apps/govea/src/db/schema/adrs.ts`)
-- Admin UI: list view exists (`apps/govea/src/app/(admin)/adrs/page.tsx`)
-- **Not yet implemented:** create/edit forms, detail view, delete action, server actions
-- Front-end portfolio view references ADR list but depends on published ADR records existing
+Implemented in early v1:
+- Schema and server actions support the full ADR lifecycle, including supersession links
+- Admin UI includes list, detail, create, edit, and delete flows
+- ADRs can link to capabilities, applications, initiatives, and objectives
+
+Remaining gaps:
+- richer ADR analytics and debt-oriented reporting are still future work
 
 ## Links
 - Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -1,7 +1,7 @@
 # Capability Group: Portfolio Management
 
 ## What It Does
-The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, and architecture decisions. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
+The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, architecture decisions, and supporting reference content. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
 
 ## Personas
 - **CMS Contributor** — creates and maintains portfolio records
@@ -16,12 +16,15 @@ The system must allow contributors to maintain a structured inventory of the org
 | Application Portfolio | [po-application-portfolio.md](./po-application-portfolio.md) | Manage applications with lifecycle status and capability links |
 | Capability Map | [po-capability-map.md](./po-capability-map.md) | Define business capabilities organized by domain, linked to applications and personas |
 | Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
+| Principles | N/A | Implemented in the product as linked reference content; detailed capability documentation still to be added |
+| Glossary | N/A | Implemented in the product as shared terminology; detailed capability documentation still to be added |
 
 ## Rules
 - Portfolio records follow the standard content workflow: draft → published → archived
 - Only published records are visible to Content Viewers and Department Directors
 - Every application must link to at least one capability — this is a data integrity rule enforced at the application layer
 - Visibility controls (org / connections / instance) apply to all portfolio record types
+- Detailed capability documentation for Principles and Glossary should be added so the architecture inventory matches the shipped product
 
 ## Links
 - Related: Frontend Display — Portfolio Views, Planning, Content Management

--- a/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
+++ b/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
@@ -1,6 +1,6 @@
 # Capability Group: Repository & Modelling
 
-The system must maintain a reliable, navigable, and self-auditing store of all architecture objects — capabilities, applications, personas, decisions, and technology — and surface the relationships, gaps, and accumulated debt within that store so that architects and decision-makers can trust what they see.
+The system must maintain a reliable, navigable, and self-auditing store of all architecture objects — capabilities, applications, personas, decisions, and technology — and surface the relationships, gaps, and accumulated debt within that store so that architects and decision-makers can trust what they see. In the current product, most of this group remains roadmap work beyond the existing audit trail and early coverage signals.
 
 ## Personas
 
@@ -16,7 +16,7 @@ The system must maintain a reliable, navigable, and self-auditing store of all a
 |---|---|---|---|
 | End-to-End Traceability | [rm-end-to-end-traceability.md](./rm-end-to-end-traceability.md) | Not implemented | Cross-layer impact analysis from strategic goals through capabilities to applications |
 | Architecture Debt Tracking | [rm-architecture-debt.md](./rm-architecture-debt.md) | Not implemented | Surface and track decisions and conditions that constrain future options |
-| Repository Completeness | [rm-repository-completeness.md](./rm-repository-completeness.md) | Partially implemented | Signals and dashboards showing where the EA object store has gaps |
+| Repository Completeness | [rm-repository-completeness.md](./rm-repository-completeness.md) | Scaffolded | Early signals and dashboards showing where the EA object store has gaps |
 
 ## Capabilities Covered Elsewhere
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -16,8 +16,8 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 | 4 | [Planning & Roadmap](#4-planning--roadmap) | Implemented |
 | 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
 | 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
-| 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Scaffolded |
-| 8 | [Repository & Modelling](#8-repository--modelling) | Partially implemented |
+| 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Prototype |
+| 8 | [Repository & Modelling](#8-repository--modelling) | Scaffolded |
 
 ---
 
@@ -54,10 +54,10 @@ Foundational content authoring and lifecycle capabilities shared across all EA c
 | Capability | Status | Description |
 |---|---|---|
 | Content Authoring | Implemented | Create, edit, and save content items |
-| Content Workflow | Implemented | Draft → Published → Archived lifecycle; Viewer-gated on Published |
+| Content Workflow | Partially implemented | Draft → Published → Archived is established for core content types, but planning entities still use their own lifecycle states |
 | Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for categorizing all content |
 | Content Relationships | Implemented | Link content items; enforce GovEA traceability rules at publish time |
-| Content Search & Filtering | Implemented | Embedded full-text search; no external search service required |
+| Content Search & Filtering | Partially implemented | Per-entity filtering and taxonomy-driven browsing exist; repository-wide search is still future work |
 | Content Types | Partially implemented | Configurable schemas for content; v1 types are fixed in the data model |
 | Content Versioning | Not implemented | Change history, diffs, and version restore |
 
@@ -72,9 +72,11 @@ The structured inventory of the organization's architecture objects.
 | Capability | Status | Description |
 |---|---|---|
 | Application Portfolio | Implemented | Manage applications with lifecycle status, capability links, and metadata |
-| Capability Map | Implemented | Define business capabilities organized by domain; linked to applications and personas |
+| Capability Map | Implemented | Define business capabilities organized by domain; linked to applications, personas, principles, and decisions |
 | Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
 | Architecture Decision Records (ADRs) | Implemented | Record, track, supersede, and link architecture decisions to capabilities, applications, initiatives, and objectives |
+| Principles | Implemented | Capture architecture principles and link them to capabilities and decisions |
+| Glossary | Implemented | Maintain shared terminology to support consistent EA language across the repository |
 | Value Streams | Implemented | Define value streams with ordered stages; link to capabilities and personas |
 
 **Data model relationships:**
@@ -84,6 +86,8 @@ Personas → Capabilities → Applications
 Strategic Objectives → Capabilities, Value Streams, Applications
 Initiatives → Capabilities, Objectives, Applications
 ADRs → Capabilities, Applications, Initiatives, Objectives
+Principles → Capabilities, ADRs
+Glossary → Shared reference terms across all content
 ```
 
 ---
@@ -96,7 +100,7 @@ Strategic direction, change initiatives, and timeline visualization.
 |---|---|---|
 | Strategic Objectives | Implemented | Define and track business goals; link to capabilities and value streams |
 | Initiatives | Implemented | Track change programmes; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
-| Roadmap View | Implemented | Visualize initiatives and objectives on a governed timeline |
+| Roadmap View | Implemented | Visualize initiatives grouped by planning status with linked objectives and capability context |
 
 **Design principle:** Planning capabilities are a lens on existing architecture content. Strategic objectives trace to capabilities. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
 
@@ -115,7 +119,7 @@ How content is presented to authenticated users and, optionally, the public.
 | Content Display | Implemented | Detail pages with status badges, metadata, and linked records |
 | Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
 | Responsive Layout | Partially implemented | Desktop-first; mobile not a v1 priority |
-| Theming | Not implemented | Organization-branded themes |
+| Theming | Implemented | Organization-selected predefined themes applied through settings |
 
 ---
 
@@ -125,10 +129,10 @@ Organization-level settings and administrative tools.
 
 | Capability | Status | Description |
 |---|---|---|
-| Organization Settings | Implemented | Org name, branding, and configuration |
+| Organization Settings | Partially implemented | Theme selection is available today; broader org settings remain future work |
 | Persona Type Management | Implemented | Create and manage persona type categories |
 | Persona Tags | Implemented | Tag-based classification for personas |
-| Admin Dashboard | Partially implemented | Summary stats and navigation for admins |
+| Admin Dashboard | Implemented | Live practitioner dashboard with repository activity, coverage signals, and navigation shortcuts |
 | Feature Management | Not implemented | Enable/disable optional product features per org |
 | Email Configuration | Not implemented | SMTP setup for notifications and password reset |
 | Backup & Export | Not implemented | Data export and backup tooling |
@@ -142,9 +146,9 @@ Allows organizations to connect, share content, and link local EA artifacts to e
 
 | Capability | Status | Description |
 |---|---|---|
-| Org Connections | Scaffolded | Establish and manage connections between organizations |
-| Content Visibility | Scaffolded | Control which content is visible at org / connections / instance level |
-| Cross-Org Linking | Scaffolded | Link local capabilities and personas to enterprise counterparts |
+| Org Connections | Prototype | Establish and manage connections between organizations |
+| Content Visibility | Prototype | Control which content is visible at org / connections / instance level |
+| Cross-Org Linking | Prototype | Link local capabilities and personas to enterprise counterparts |
 | Cross-Org Link Approval | Scaffolded | Review and approve or reject incoming cross-org link requests |
 
 **Visibility levels:**
@@ -166,7 +170,7 @@ Reliability, navigability, and self-auditing of the architecture store.
 | Capability | Status | Description |
 |---|---|---|
 | Audit Trail | Implemented | Immutable log of all create/update/delete events with before/after JSON |
-| Repository Completeness | Partially implemented | Signals showing where the EA object store has gaps |
+| Repository Completeness | Scaffolded | Early coverage signals exist, but this is not yet a dedicated repository-quality workflow |
 | End-to-End Traceability | Not implemented | Cross-layer impact analysis from strategic goals through capabilities to applications |
 | Architecture Debt Tracking | Not implemented | Surface and track decisions and conditions that constrain future options |
 


### PR DESCRIPTION
## Summary
- align `capabilities.md` and `README.md` with the product's actual maturity
- update supporting capability docs for ADRs, planning workflow, theming, admin configuration, federation, and repository modelling
- acknowledge shipped product areas that recent PRs added, including principles, glossary, dashboarding, and deployment support

## Testing
- not run (documentation-only changes)

Closes #165