### PR TITLE
docs: add capability documentation for Principles and Glossary

### DIFF
--- a/business-architecture/capabilities/cms/portfolio/po-glossary.md
+++ b/business-architecture/capabilities/cms/portfolio/po-glossary.md
@@ -1,0 +1,52 @@
+# Capability: Glossary
+
+## What It Does
+The system must allow contributors to maintain a shared terminology reference for the organization's EA repository. The glossary gives architects, contributors, and non-technical stakeholders a common language — reducing ambiguity across capability maps, ADRs, principles, and planning content.
+
+## Personas
+- **CMS Contributor** — creates, edits, and publishes glossary terms
+- **CMS Administrator** — has all Contributor permissions; can delete records
+- **Content Viewer** — reads published terms to understand EA vocabulary
+- **Department Director** — references the glossary to interpret EA content without needing specialist training
+
+## Behaviors
+- Create a glossary term with: term, definition, domain, notes, status, and visibility
+- Optionally attach one or more source definitions from authoritative references (e.g. TOGAF, NIST, ISO) with source name, URL, and verbatim definition
+- Mark one source definition as the active definition — populates `definitionSource` and `definitionSourceUrl` on the term
+- Edit all fields on an existing term
+- Delete a term (Admin only)
+- View all terms in a list, filterable by domain and status
+
+## Fields
+
+| Field | Purpose |
+|---|---|
+| `term` | The word or phrase being defined |
+| `definition` | The organization's working definition |
+| `definitionSource` | Name of the authoritative source for the active definition (optional) |
+| `definitionSourceUrl` | URL to the source document (optional) |
+| `domain` | Free-text grouping — e.g. "Enterprise Architecture", "Security", "Planning" |
+| `notes` | Additional context, usage guidance, or disambiguation notes |
+| `status` | Standard workflow state: draft / published / archived |
+| `visibility` | Scope: org / connections / instance |
+
+## Source Definitions
+Each term can carry multiple reference definitions from external standards bodies. This supports organizations that want to show both the authoritative definition from a source (e.g. NIST) and their own adapted working definition. Source records are stored in the `glossary_term_sources` table and linked to the parent term.
+
+## Rules
+- A term must belong to an organization
+- `definition` is required; source definitions are optional
+- Deletion is Admin-only
+- All create, edit, and delete actions are written to the audit log
+- Visibility defaults to `org`
+- Only published terms are visible to Content Viewers
+
+## Implementation Status
+Implemented in v1:
+- Schema: `glossary_terms` table, `glossary_term_sources` table (`apps/govea/src/db/schema/glossary.ts`)
+- Server actions: create, edit, delete, get (`apps/govea/src/actions/glossary.ts`)
+- Admin UI: list view, detail view, create/edit forms (`apps/govea/src/app/(admin)/glossary/`)
+
+## Links
+- Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow
+- Related: Capability Map, Principles, Portfolio Management

--- a/business-architecture/capabilities/cms/portfolio/po-principles.md
+++ b/business-architecture/capabilities/cms/portfolio/po-principles.md
@@ -1,0 +1,47 @@
+# Capability: Principles
+
+## What It Does
+The system must allow contributors to capture and maintain the architecture principles that guide design decisions across the organization. Principles articulate the values and rules that constrain how the organization builds and changes its EA — giving decision-makers a stable reference point when evaluating options and trade-offs.
+
+## Personas
+- **CMS Contributor** — creates, edits, and publishes principle records
+- **CMS Administrator** — has all Contributor permissions; can delete records
+- **Content Viewer** — reads published principles through the front-end view
+- **Department Director** — references principles to understand the rules of the road before initiating change
+
+## Behaviors
+- Create a principle with: name (short label), title (full principle statement), description (one-sentence summary), rationale, implications, status, and visibility
+- Edit all fields on an existing principle record
+- Link a principle to one or more capabilities it governs
+- Link a principle to one or more ADRs that apply or express it
+- Delete a principle record (Admin only)
+- View all principles in a list with status and linked records visible
+
+## Fields
+
+| Field | Purpose |
+|---|---|
+| `name` | Short display label — e.g. "SaaS First" |
+| `title` | Full principle statement — e.g. "Prefer SaaS solutions before building custom" |
+| `description` | One-sentence summary for scannable lists |
+| `rationale` | Why this principle exists — the reasoning behind the rule |
+| `implications` | What following this principle means in practice |
+| `status` | Standard workflow state: draft / published / archived |
+| `visibility` | Scope: org / connections / instance |
+
+## Rules
+- A principle must belong to an organization
+- Deletion is Admin-only
+- All create, edit, and delete actions are written to the audit log
+- Visibility defaults to `org`
+- Only published principles are visible to Content Viewers
+
+## Implementation Status
+Implemented in v1:
+- Schema: `principles` table, `principle_capabilities` and `principle_adrs` junction tables (`apps/govea/src/db/schema/principles.ts`)
+- Server actions: create, edit, delete, get (`apps/govea/src/actions/principles.ts`)
+- Admin UI: list view, detail view, create/edit forms (`apps/govea/src/app/(admin)/principles/`)
+
+## Links
+- Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow
+- Related: Architecture Decision Records, Capability Map

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -16,6 +16,8 @@ The system must allow contributors to maintain a structured inventory of the org
 | Application Portfolio | [po-application-portfolio.md](./po-application-portfolio.md) | Manage applications with lifecycle status and capability links |
 | Capability Map | [po-capability-map.md](./po-capability-map.md) | Define business capabilities organized by domain, linked to applications and personas |
 | Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
+| Principles | [po-principles.md](./po-principles.md) | Capture architecture principles and link them to capabilities and decisions |
+| Glossary | [po-glossary.md](./po-glossary.md) | Maintain shared terminology to support consistent EA language across the repository |
 
 ## Rules
 - Portfolio records follow the standard content workflow: draft → published → archived


### PR DESCRIPTION
## Summary

- Adds `po-principles.md` — full capability doc covering fields, behaviors, rules, and implementation status for Principles
- Adds `po-glossary.md` — same treatment for Glossary, including the source definitions feature
- Updates `portfolio.md` to link to both new files, replacing the N/A placeholders from PR #166

## Testing
Documentation-only changes — no testing required.

Closes #167