### PR TITLE
fix: enforce cross-org write protection across all content mutations

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -5,7 +5,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -132,6 +132,7 @@ export async function editADR(id: string, formData: FormData) {
   const objectiveIds = formData.getAll('objectiveIds') as string[]
 
   const before = await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(adrs).set({
     number,
@@ -168,6 +169,7 @@ export async function deleteADR(id: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(adrs).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
 

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { applications, applicationCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -117,6 +117,7 @@ export async function editApplication(applicationId: string, formData: FormData)
   const capabilityIds = formData.getAll('capabilityIds') as string[]
 
   const before = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(applications).set({
     name,
@@ -155,6 +156,7 @@ export async function deleteApplication(applicationId: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(applications).where(
     and(eq(applications.id, applicationId), eq(applications.organizationId, orgId))

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { capabilities, capabilityPersonas } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -115,6 +115,7 @@ export async function editCapability(capabilityId: string, formData: FormData) {
   const personaIds = formData.getAll('personaIds') as string[]
 
   const before = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(capabilities).set({
     name,
@@ -152,6 +153,7 @@ export async function deleteCapability(capabilityId: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(capabilities).where(
     and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId))

--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { glossaryTerms, glossaryTermSources } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -113,6 +113,7 @@ export async function editGlossaryTerm(termId: string, formData: FormData) {
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
 
   const before = await db.query.glossaryTerms.findFirst({ where: eq(glossaryTerms.id, termId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(glossaryTerms).set({
     term, definition, definitionSource, definitionSourceUrl,
@@ -149,6 +150,7 @@ export async function deleteGlossaryTerm(termId: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.glossaryTerms.findFirst({ where: eq(glossaryTerms.id, termId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(glossaryTerms).where(
     and(eq(glossaryTerms.id, termId), eq(glossaryTerms.organizationId, orgId))

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -5,7 +5,7 @@ import {
   initiatives, initiativeCapabilities, initiativeObjectives,
 } from '@/db/schema'
 import { eq } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -93,6 +93,10 @@ export async function createInitiative(formData: FormData) {
 
 export async function editInitiative(id: string, formData: FormData) {
   const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const existing = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
+  assertOwnership(existing?.organizationId, orgId)
 
   const userId = session.user.id
 
@@ -125,7 +129,12 @@ export async function editInitiative(id: string, formData: FormData) {
 }
 
 export async function deleteInitiative(id: string) {
-  await requireAdmin()
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const existing = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
+  assertOwnership(existing?.organizationId, orgId)
+
   await db.delete(initiatives).where(eq(initiatives.id, id))
 }
 

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -112,6 +112,7 @@ export async function editObjective(objectiveId: string, formData: FormData) {
   const before = await db.query.strategicObjectives.findFirst({
     where: eq(strategicObjectives.id, objectiveId),
   })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(strategicObjectives).set({
     name, description, successMetric, timeHorizon, status, visibility,
@@ -147,6 +148,7 @@ export async function deleteObjective(objectiveId: string) {
   const before = await db.query.strategicObjectives.findFirst({
     where: eq(strategicObjectives.id, objectiveId),
   })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(strategicObjectives).where(
     and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId))

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { personas, personaTypes, personaTags, tags } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -220,6 +220,7 @@ export async function editPersona(personaId: string, formData: FormData) {
   const tagIds = formData.getAll('tagIds') as string[]
 
   const before = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(personas).set({
     name,
@@ -255,6 +256,7 @@ export async function deletePersona(personaId: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(personas).where(
     and(eq(personas.id, personaId), eq(personas.organizationId, orgId))

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { principles, principleAdrs, principleCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -115,6 +115,7 @@ export async function editPrinciple(principleId: string, formData: FormData) {
   const capabilityIds = formData.getAll('capabilityIds') as string[]
 
   const before = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.update(principles).set({
     name, description, title, rationale, implications, status, visibility,
@@ -142,6 +143,7 @@ export async function deletePrinciple(principleId: string) {
   const orgId = session.user.organizationId!
 
   const before = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(principles).where(
     and(eq(principles.id, principleId), eq(principles.organizationId, orgId))

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -183,8 +183,19 @@ export async function addStage(valueStreamId: string, name: string, description:
   })
 }
 
+async function requireStageOwnership(stageId: string, orgId: string) {
+  const stage = await db.query.valueStreamStages.findFirst({
+    where: eq(valueStreamStages.id, stageId),
+    with: { valueStream: true },
+  })
+  if (!stage) throw new Error('Stage not found')
+  assertOwnership(stage.valueStream.organizationId, orgId)
+  return stage
+}
+
 export async function editStage(stageId: string, name: string, description: string) {
-  await requireContributor()
+  const session = await requireContributor()
+  await requireStageOwnership(stageId, session.user.organizationId!)
 
   await db.update(valueStreamStages).set({
     name: name.trim(),
@@ -193,20 +204,23 @@ export async function editStage(stageId: string, name: string, description: stri
 }
 
 export async function deleteStage(stageId: string) {
-  await requireContributor()
+  const session = await requireContributor()
+  await requireStageOwnership(stageId, session.user.organizationId!)
   await db.delete(valueStreamStages).where(eq(valueStreamStages.id, stageId))
 }
 
 export async function moveStage(stageId: string, direction: 'up' | 'down') {
-  await requireContributor()
+  const session = await requireContributor()
 
   const stage = await db.query.valueStreamStages.findFirst({
     where: eq(valueStreamStages.id, stageId),
+    with: { valueStream: true },
   })
   if (!stage) return
+  assertOwnership(stage.valueStream.organizationId, session.user.organizationId!)
 
   const siblings = await db.query.valueStreamStages.findMany({
-    where: eq(valueStreamStages.valueStreamId, stage.valueStreamId),
+    where: eq(valueStreamStages.valueStreamId, stage.valueStream.id),
     orderBy: (s, { asc }) => [asc(s.order)],
   })
 
@@ -228,14 +242,16 @@ export async function moveStage(stageId: string, direction: 'up' | 'down') {
 // ── Stage Capabilities ────────────────────────────────────────────────────────
 
 export async function addCapabilityToStage(stageId: string, capabilityId: string) {
-  await requireContributor()
+  const session = await requireContributor()
+  await requireStageOwnership(stageId, session.user.organizationId!)
   await db.insert(valueStreamStageCapabilities)
     .values({ stageId, capabilityId })
     .onConflictDoNothing()
 }
 
 export async function removeCapabilityFromStage(stageId: string, capabilityId: string) {
-  await requireContributor()
+  const session = await requireContributor()
+  await requireStageOwnership(stageId, session.user.organizationId!)
   await db.delete(valueStreamStageCapabilities).where(
     and(
       eq(valueStreamStageCapabilities.stageId, stageId),

--- a/apps/govea/src/lib/federation.ts
+++ b/apps/govea/src/lib/federation.ts
@@ -11,3 +11,17 @@ export async function getConnectedOrgIds(organizationId: string): Promise<string
     c.fromOrgId === organizationId ? c.toOrgId : c.fromOrgId
   )
 }
+
+/**
+ * Asserts that the entity's owning org matches the calling user's org.
+ * Throws if the entity is missing or owned by a different organization.
+ * Call this before any mutation to enforce cross-org write protection.
+ */
+export function assertOwnership(
+  entityOrgId: string | null | undefined,
+  callerOrgId: string,
+): void {
+  if (!entityOrgId || entityOrgId !== callerOrgId) {
+    throw new Error('Forbidden: content owned by another organization')
+  }
+}

--- a/business-architecture/capabilities/cms/multi-org/mo-content-visibility.md
+++ b/business-architecture/capabilities/cms/multi-org/mo-content-visibility.md
@@ -19,11 +19,29 @@ The system must allow contributors and admins to control how broadly a persona, 
 - Never allow a user in org B to edit content owned by org A, regardless of visibility level
 - When a connection is removed, `connections`-visibility content from the removed org disappears from the user's view immediately
 
+## Access Matrix
+
+| Action | Owning org | Connected org (`connections`) | Any org (`instance`) |
+|---|---|---|---|
+| Read | ✅ | ✅ | ✅ |
+| Create cross-org link request | — | ✅ | ✅ |
+| Edit content | ✅ | ❌ | ❌ |
+| Delete content | ✅ (Admin) | ❌ | ❌ |
+| Change visibility | ✅ (Contributor+) | ❌ | ❌ |
+| Archive content | ✅ (Admin) | ❌ | ❌ |
+
+Content ownership never transfers across org boundaries. Sharing content at a broader visibility level does not grant any write access to other organizations.
+
 ## Rules
 - Default visibility for all new content is `org` — sharing is always an explicit opt-in
 - Read access to cross-org content does not imply write or delete access
+- Only the owning organization may edit, archive, or delete its content
 - Visibility changes are logged in the audit trail
 - `instance` visibility is appropriate for enterprise reference artifacts, not agency-internal content
+
+## Implementation Status
+- Visibility levels (`org`, `connections`, `instance`) are enforced on all read queries via `getConnectedOrgIds` in `federation.ts`
+- Write protection is enforced in all content mutation server actions via `assertOwnership` in `federation.ts` — throws before any DB write if the calling user's org does not own the content
 
 ## Links
 - Depends on: Org Connections (for `connections` level), IAM — Role-Based Access Control

--- a/business-architecture/capabilities/cms/multi-org/mo-cross-org-linking.md
+++ b/business-architecture/capabilities/cms/multi-org/mo-cross-org-linking.md
@@ -26,6 +26,7 @@ The system must allow an agency to link one of its own capabilities or personas 
 
 ## Rules
 - Cross-org links are directional: the initiating org owns the link; the target org approves or rejects it
+- **Approval does not grant write access.** An approved cross-org link gives the target org read attribution (the inbound link appears on their content item) — it does not allow the target org to edit, delete, or archive the source org's content
 - A link does not grant the target org any access to the source org's content beyond what visibility settings already allow
 - Deleting a local content item removes all cross-org links originating from it
 - If the target content item is deleted or its visibility is reduced so the source org can no longer see it, the link is automatically invalidated and both orgs are notified


### PR DESCRIPTION
## Summary

Closes #144 — ARB finding: cross-org write protection not enforced.

Adds `assertOwnership()` to `federation.ts` and calls it in every server action before any DB mutation. Two critical gaps fixed:

- **`initiatives.ts`** — `editInitiative` and `deleteInitiative` had zero org check; any authenticated contributor could edit or delete any org's initiatives
- **Value stream stage actions** — `editStage`, `deleteStage`, `moveStage`, `addCapabilityToStage`, `removeCapabilityFromStage` had no check that the parent value stream belonged to the calling user's org

**All other edit actions** (capabilities, applications, personas, ADRs, objectives, principles, glossary) had an org check in the WHERE clause but junction table deletes/re-inserts would still run on a WHERE miss — a silent data corruption path. `assertOwnership` now throws explicitly before any write.

## Changes

| File | What changed |
|---|---|
| `src/lib/federation.ts` | Added `assertOwnership(entityOrgId, callerOrgId)` — throws if mismatch |
| `src/actions/initiatives.ts` | Added ownership check to `editInitiative` and `deleteInitiative` |
| `src/actions/value-streams.ts` | Added `requireStageOwnership` helper; applied to all stage mutation actions |
| All other action files | `assertOwnership` called on `before` fetch before any junction mutations |
| `mo-content-visibility.md` | Added explicit read/write access matrix and implementation status |
| `mo-cross-org-linking.md` | Clarified that link approval does not confer write access |

## Testing
- TypeScript check passes clean (`tsc --noEmit`)
- E2E test coverage for cross-org write attempts is tracked separately per the ARB finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)