### PR TITLE
feat: taxonomy as first-class UX layer — domain badges, filters, dashboard

### DIFF
--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -104,6 +104,7 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
                 key={capability.id}
                 href={`/capabilities/${capability.id}`}
                 name={capability.name}
+                domain={capability.domain}
               />
             ))}
           </div>

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -15,11 +15,12 @@ import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 
 type ApplicationRow = Pick<Application, 'id' | 'name' | 'description' | 'vendor' | 'version' | 'hostingModel' | 'lifecycleStatus' | 'status' | 'visibility' | 'createdAt' | 'organizationId'> & {
   organization: { id: string; name: string } | null
-  applicationCapabilities: { capability: Pick<Capability, 'id' | 'name'> }[]
+  applicationCapabilities: { capability: Pick<Capability, 'id' | 'name' | 'domain'> }[]
 }
 
 interface Props {
@@ -61,11 +62,21 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
   const [search, setSearch] = useState('')
   const [lifecycleFilter, setLifecycleFilter] = useState('all')
   const [statusFilter, setStatusFilter] = useState('all')
+  const [domainFilter, setDomainFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
 
   const orgOptions = Array.from(new Map(
     applications.map(a => [a.organizationId, a.organization?.name ?? 'Unknown'])
   ).entries())
+
+  // Domains are derived from linked capabilities — an app is "in" a domain via its capabilities
+  const domainOptions = Array.from(
+    new Set(
+      applications
+        .flatMap(a => a.applicationCapabilities.map(ac => ac.capability.domain))
+        .filter(Boolean)
+    )
+  ).sort() as string[]
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ApplicationRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ApplicationRow | null>(null)
@@ -79,8 +90,9 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
     const matchSearch = !search || a.name.toLowerCase().includes(search.toLowerCase())
     const matchLifecycle = lifecycleFilter === 'all' || a.lifecycleStatus === lifecycleFilter
     const matchStatus = statusFilter === 'all' || a.status === statusFilter
+    const matchDomain = domainFilter === 'all' || a.applicationCapabilities.some(ac => ac.capability.domain === domainFilter)
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? a.organizationId === currentOrgId : a.organizationId === orgFilter)
-    return matchSearch && matchLifecycle && matchStatus && matchOrg
+    return matchSearch && matchLifecycle && matchStatus && matchDomain && matchOrg
   })
 
   async function handleCreate(formData: FormData) {
@@ -141,6 +153,16 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           <option value="published">Published</option>
           <option value="archived">Archived</option>
         </select>
+        {domainOptions.length > 0 && (
+          <select
+            value={domainFilter}
+            onChange={e => setDomainFilter(e.target.value)}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All domains</option>
+            {domainOptions.map(d => <option key={d} value={d}>{d}</option>)}
+          </select>
+        )}
         {orgOptions.length > 1 && (
           <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
             <option value="all">All organizations</option>
@@ -164,6 +186,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Vendor</TableHead>
+              <TableHead>Domains</TableHead>
               <TableHead>Capabilities</TableHead>
               <TableHead>Lifecycle</TableHead>
               <TableHead>Status</TableHead>
@@ -174,7 +197,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           <TableBody>
             {filtered.length === 0 && (
               <TableRow>
-                <TableCell colSpan={canEdit ? 7 : 6} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={canEdit ? 8 : 7} className="text-center text-muted-foreground py-8">
                   {applications.length === 0
                     ? 'No applications yet. Add one to get started.'
                     : 'No applications match the current filters.'}
@@ -196,6 +219,18 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
                   </div>
                 </TableCell>
                 <TableCell className="text-muted-foreground">{a.vendor ?? '—'}</TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {(() => {
+                      const uniqueDomains = Array.from(
+                        new Set(a.applicationCapabilities.map(ac => ac.capability.domain).filter(Boolean))
+                      ) as string[]
+                      return uniqueDomains.length === 0
+                        ? <span className="text-muted-foreground text-sm">—</span>
+                        : uniqueDomains.map(d => <DomainBadge key={d} domain={d} />)
+                    })()}
+                  </div>
+                </TableCell>
                 <TableCell>
                   <div className="flex flex-wrap gap-1">
                     {a.applicationCapabilities.length === 0

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getCapability } from '@/actions/capabilities'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { LinkedItemCard } from '@/components/linked-item-card'
+import { DomainBadge } from '@/components/domain-badge'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -54,14 +55,11 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
           <p className="text-muted-foreground">{capability.description}</p>
         )}
 
-        <div className="flex flex-wrap gap-6 text-sm pt-1">
-          <div>
-            <span className="text-muted-foreground">Domain: </span>
-            {capability.domain
-              ? <span className="font-medium">{capability.domain}</span>
-              : <span className="text-muted-foreground">—</span>
-            }
-          </div>
+        <div className="flex flex-wrap gap-3 pt-1">
+          {capability.domain
+            ? <DomainBadge domain={capability.domain} />
+            : <span className="text-sm text-muted-foreground">No domain assigned</span>
+          }
         </div>
       </div>
 

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -15,6 +15,7 @@ import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 
 type CapabilityRow = Pick<Capability, 'id' | 'name' | 'description' | 'domain' | 'behaviors' | 'rules' | 'status' | 'visibility' | 'createdAt' | 'organizationId'> & {
@@ -53,11 +54,16 @@ export function CapabilityTable({ capabilities, personas, role, currentOrgId }: 
 
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('all')
+  const [domainFilter, setDomainFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
 
   const orgOptions = Array.from(new Map(
     capabilities.map(c => [c.organizationId, c.organization?.name ?? 'Unknown'])
   ).entries())
+
+  const domainOptions = Array.from(
+    new Set(capabilities.map(c => c.domain).filter(Boolean))
+  ).sort() as string[]
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<CapabilityRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<CapabilityRow | null>(null)
@@ -70,8 +76,9 @@ export function CapabilityTable({ capabilities, personas, role, currentOrgId }: 
   const filtered = capabilities.filter(c => {
     const matchSearch = !search || c.name.toLowerCase().includes(search.toLowerCase())
     const matchStatus = statusFilter === 'all' || c.status === statusFilter
+    const matchDomain = domainFilter === 'all' || c.domain === domainFilter
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? c.organizationId === currentOrgId : c.organizationId === orgFilter)
-    return matchSearch && matchStatus && matchOrg
+    return matchSearch && matchStatus && matchDomain && matchOrg
   })
 
   async function handleCreate(formData: FormData) {
@@ -121,6 +128,16 @@ export function CapabilityTable({ capabilities, personas, role, currentOrgId }: 
           <option value="published">Published</option>
           <option value="archived">Archived</option>
         </select>
+        {domainOptions.length > 0 && (
+          <select
+            value={domainFilter}
+            onChange={e => setDomainFilter(e.target.value)}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All domains</option>
+            {domainOptions.map(d => <option key={d} value={d}>{d}</option>)}
+          </select>
+        )}
         {orgOptions.length > 1 && (
           <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
             <option value="all">All organizations</option>
@@ -174,7 +191,7 @@ export function CapabilityTable({ capabilities, personas, role, currentOrgId }: 
                     )}
                   </div>
                 </TableCell>
-                <TableCell className="text-muted-foreground">{c.domain ?? '—'}</TableCell>
+                <TableCell>{c.domain ? <DomainBadge domain={c.domain} /> : <span className="text-muted-foreground">—</span>}</TableCell>
                 <TableCell>
                   <div className="flex flex-wrap gap-1">
                     {c.capabilityPersonas.length === 0

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -6,8 +6,9 @@ import {
   strategicObjectives, valueStreams, principles, glossaryTerms,
   auditLog, users,
 } from '@/db/schema'
-import { count, eq, desc } from 'drizzle-orm'
+import { count, eq, desc, asc } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DomainBadge } from '@/components/domain-badge'
 import Link from 'next/link'
 
 function pivotCounts(rows: { status: string; count: number | string }[]) {
@@ -50,6 +51,7 @@ export default async function DashboardPage() {
     personaRows, capabilityRows, applicationRows, adrRows,
     initiativeRows, objectiveRows, valueStreamRows, principleRows, glossaryRows,
     recentActivity,
+    capsByDomain,
   ] = await Promise.all([
     db.select({ status: personas.status,           count: count() }).from(personas)           .where(eq(personas.organizationId,           orgId)).groupBy(personas.status),
     db.select({ status: capabilities.status,       count: count() }).from(capabilities)       .where(eq(capabilities.organizationId,       orgId)).groupBy(capabilities.status),
@@ -67,6 +69,12 @@ export default async function DashboardPage() {
       .where(eq(auditLog.organizationId, orgId))
       .orderBy(desc(auditLog.createdAt))
       .limit(10),
+    db
+      .select({ domain: capabilities.domain, count: count() })
+      .from(capabilities)
+      .where(eq(capabilities.organizationId, orgId))
+      .groupBy(capabilities.domain)
+      .orderBy(asc(capabilities.domain)),
   ])
 
   const stats = {
@@ -119,6 +127,32 @@ export default async function DashboardPage() {
           })}
         </div>
       </div>
+
+      {/* Capabilities by Domain */}
+      {capsByDomain.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Capabilities by Domain</p>
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex flex-wrap gap-3">
+                {capsByDomain.map(row => (
+                  <Link
+                    key={row.domain ?? '__none__'}
+                    href={`/capabilities${row.domain ? `?domain=${encodeURIComponent(row.domain)}` : ''}`}
+                    className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2 hover:bg-muted/50 transition-colors"
+                  >
+                    {row.domain
+                      ? <DomainBadge domain={row.domain} />
+                      : <span className="text-xs text-muted-foreground">Uncategorized</span>
+                    }
+                    <span className="text-sm font-semibold">{Number(row.count)}</span>
+                  </Link>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
 
       <div className="grid gap-6 md:grid-cols-2">
         {/* Needs Attention */}

--- a/apps/govea/src/components/domain-badge.tsx
+++ b/apps/govea/src/components/domain-badge.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils'
+
+// Ten-color palette — domain gets a consistent color by string hash,
+// so any free-text domain value maps to the same color every time.
+const PALETTE = [
+  'bg-blue-100 text-blue-800 border-blue-200',
+  'bg-emerald-100 text-emerald-800 border-emerald-200',
+  'bg-violet-100 text-violet-800 border-violet-200',
+  'bg-amber-100 text-amber-800 border-amber-200',
+  'bg-rose-100 text-rose-800 border-rose-200',
+  'bg-cyan-100 text-cyan-800 border-cyan-200',
+  'bg-orange-100 text-orange-800 border-orange-200',
+  'bg-teal-100 text-teal-800 border-teal-200',
+  'bg-indigo-100 text-indigo-800 border-indigo-200',
+  'bg-pink-100 text-pink-800 border-pink-200',
+]
+
+function hashDomain(domain: string): number {
+  let h = 0
+  for (const c of domain) h = (h * 31 + c.charCodeAt(0)) & 0xffffffff
+  return Math.abs(h) % PALETTE.length
+}
+
+export function DomainBadge({ domain }: { domain?: string | null }) {
+  if (!domain) return null
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+      PALETTE[hashDomain(domain)],
+    )}>
+      {domain}
+    </span>
+  )
+}

--- a/apps/govea/src/components/linked-item-card.tsx
+++ b/apps/govea/src/components/linked-item-card.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { DomainBadge } from '@/components/domain-badge'
 
 /**
  * Consistent card-row for linked EA items on detail pages.
@@ -8,11 +9,13 @@ export function LinkedItemCard({
   href,
   name,
   meta,
+  domain,
   badge,
 }: {
   href: string
   name: string
   meta?: string | null
+  domain?: string | null
   badge?: React.ReactNode
 }) {
   return (
@@ -21,9 +24,10 @@ export function LinkedItemCard({
       className="flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:bg-muted/50 transition-colors"
     >
       <span className="font-medium text-sm">{name}</span>
-      {(meta || badge) && (
+      {(meta || domain || badge) && (
         <div className="flex items-center gap-2">
           {meta && <span className="text-xs text-muted-foreground">{meta}</span>}
+          {domain && <DomainBadge domain={domain} />}
           {badge}
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes #156 — moves taxonomy from hidden infrastructure to a visible navigation and reporting layer.

## What's in this PR

### New: `DomainBadge` component
Hash-based 10-color palette assigns a consistent, distinct color to any free-text domain name. No hardcoding required — works across all government domain values and any org-specific domains contributors add.

### Capabilities list
- **Domain filter** added to the toolbar (same pattern as glossary) — browse by government domain, not just by name or status
- **Domain column** now renders colored `DomainBadge` instead of muted plain text

### Capability detail page
- Domain rendered as a prominent `DomainBadge` instead of a `Domain: text` label

### Applications list
- **Domains column** added — shows unique domains derived from linked capabilities, as colored badges
- **Domain filter** — filters applications by any linked capability's domain (the right model since apps don't have their own domain field)

### Application detail page
- Each linked capability card now shows its domain badge inline via `LinkedItemCard`

### Dashboard
- **Capabilities by Domain** section added — clickable chips showing capability count per domain, positioned between the coverage grid and the detail cards
- Section is hidden when no capabilities with domains exist (graceful for fresh installs)

### `LinkedItemCard`
- New optional `domain` prop renders a `DomainBadge` alongside linked items — enables domain context to propagate through all relationship navigation

## What's not in this PR (tracked in #156 for future iterations)
- Domain filters on objectives, initiatives, value streams (requires deriving domain through linked capabilities server-side)
- Domain-grouped summaries for applications and other entities on the dashboard
- Taxonomy-driven analytics / heatmaps (Priority 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)