### PR TITLE
feat(settings): sync dark mode when selecting org theme

### DIFF
--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -3,9 +3,7 @@ import { redirect } from 'next/navigation'
 import { db } from '@/db/client'
 import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
-import { themes } from '@/lib/themes'
-import { updateOrgTheme } from '@/actions/settings'
-import { cn } from '@/lib/utils'
+import { ThemeSelector } from '@/components/theme-selector'
 
 export default async function SettingsPage() {
   const session = await auth()
@@ -31,72 +29,7 @@ export default async function SettingsPage() {
           <h2 className="text-base font-semibold">Appearance</h2>
           <p className="text-sm text-muted-foreground mt-0.5">Choose a theme for your organization.</p>
         </div>
-
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {themes.map(theme => {
-            const isActive = theme.id === activeTheme
-            return (
-              <form key={theme.id} action={async () => {
-                'use server'
-                await updateOrgTheme(theme.id)
-                redirect('/settings')
-              }}>
-                <button
-                  type="submit"
-                  className={cn(
-                    'w-full text-left rounded-lg border-2 overflow-hidden transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-                    isActive ? 'border-primary shadow-sm' : 'border-transparent hover:border-border'
-                  )}
-                >
-                  {/* Preview */}
-                  <div className="h-24 flex flex-col">
-                    {/* Header strip */}
-                    <div
-                      className="h-8 flex items-center px-3 gap-1.5"
-                      style={{ backgroundColor: theme.previewColors.header }}
-                    >
-                      <div className="w-2 h-2 rounded-full opacity-60" style={{ backgroundColor: theme.previewColors.primary }} />
-                      <div className="h-1.5 w-12 rounded-full opacity-40" style={{ backgroundColor: theme.previewColors.primary }} />
-                      <div className="ml-auto h-1.5 w-8 rounded-full opacity-30" style={{ backgroundColor: theme.previewColors.primary }} />
-                    </div>
-                    {/* Body */}
-                    <div
-                      className="flex-1 p-2 flex gap-1.5 items-start"
-                      style={{ backgroundColor: theme.previewColors.background }}
-                    >
-                      <div className="flex flex-col gap-1 flex-1">
-                        <div className="h-1.5 w-16 rounded-full bg-current opacity-20" />
-                        <div className="h-2.5 w-full rounded bg-white border border-current/10" />
-                        <div className="h-2.5 w-full rounded bg-white border border-current/10" />
-                      </div>
-                      <div
-                        className="h-5 w-12 rounded text-[8px] font-bold flex items-center justify-center text-white flex-shrink-0"
-                        style={{ backgroundColor: theme.previewColors.primary }}
-                      >
-                        Save
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Label */}
-                  <div className="px-3 py-2.5 bg-card border-t border-border flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-foreground">{theme.name}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">{theme.description}</p>
-                    </div>
-                    {isActive && (
-                      <div className="h-5 w-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-2">
-                        <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                        </svg>
-                      </div>
-                    )}
-                  </div>
-                </button>
-              </form>
-            )
-          })}
-        </div>
+        <ThemeSelector activeTheme={activeTheme} />
       </section>
     </div>
   )

--- a/apps/govea/src/components/theme-selector.tsx
+++ b/apps/govea/src/components/theme-selector.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useTransition } from 'react'
+import { themes } from '@/lib/themes'
+import { updateOrgTheme } from '@/actions/settings'
+import { cn } from '@/lib/utils'
+
+export function ThemeSelector({ activeTheme }: { activeTheme: string }) {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+
+  function handleSelect(themeId: string) {
+    const theme = themes.find(t => t.id === themeId)
+    if (!theme) return
+
+    document.documentElement.classList.toggle('dark', theme.darkMode)
+    localStorage.setItem('govea-dark-mode', theme.darkMode ? 'dark' : 'light')
+
+    startTransition(async () => {
+      await updateOrgTheme(themeId)
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className={cn('grid gap-4 sm:grid-cols-2 lg:grid-cols-3', pending && 'opacity-60 pointer-events-none')}>
+      {themes.map(theme => {
+        const isActive = theme.id === activeTheme
+        return (
+          <button
+            key={theme.id}
+            type="button"
+            onClick={() => handleSelect(theme.id)}
+            className={cn(
+              'w-full text-left rounded-lg border-2 overflow-hidden transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+              isActive ? 'border-primary shadow-sm' : 'border-transparent hover:border-border'
+            )}
+          >
+            {/* Preview */}
+            <div className="h-24 flex flex-col">
+              <div
+                className="h-8 flex items-center px-3 gap-1.5"
+                style={{ backgroundColor: theme.previewColors.header }}
+              >
+                <div className="w-2 h-2 rounded-full opacity-60" style={{ backgroundColor: theme.previewColors.primary }} />
+                <div className="h-1.5 w-12 rounded-full opacity-40" style={{ backgroundColor: theme.previewColors.primary }} />
+                <div className="ml-auto h-1.5 w-8 rounded-full opacity-30" style={{ backgroundColor: theme.previewColors.primary }} />
+              </div>
+              <div
+                className="flex-1 p-2 flex gap-1.5 items-start"
+                style={{ backgroundColor: theme.previewColors.background }}
+              >
+                <div className="flex flex-col gap-1 flex-1">
+                  <div className="h-1.5 w-16 rounded-full bg-current opacity-20" />
+                  <div className="h-2.5 w-full rounded bg-white border border-current/10" />
+                  <div className="h-2.5 w-full rounded bg-white border border-current/10" />
+                </div>
+                <div
+                  className="h-5 w-12 rounded text-[8px] font-bold flex items-center justify-center text-white flex-shrink-0"
+                  style={{ backgroundColor: theme.previewColors.primary }}
+                >
+                  Save
+                </div>
+              </div>
+            </div>
+
+            {/* Label */}
+            <div className="px-3 py-2.5 bg-card border-t border-border flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-foreground">{theme.name}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{theme.description}</p>
+              </div>
+              {isActive && (
+                <div className="h-5 w-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 ml-2">
+                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+              )}
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/govea/src/lib/themes.ts
+++ b/apps/govea/src/lib/themes.ts
@@ -4,6 +4,7 @@ export interface ThemeDefinition {
   id: ThemeId
   name: string
   description: string
+  darkMode: boolean
   previewColors: {
     header: string   // hex for preview swatch
     primary: string
@@ -17,6 +18,7 @@ export const themes: ThemeDefinition[] = [
     id: 'govea',
     name: 'GovEA',
     description: 'Clean, professional blue. WCAG AA compliant.',
+    darkMode: false,
     previewColors: {
       header: '#152c5c',
       primary: '#1a4fba',
@@ -52,6 +54,7 @@ export const themes: ThemeDefinition[] = [
     id: 'servicenow',
     name: 'ServiceNow',
     description: 'Dark header with purple accents. Familiar to ServiceNow users.',
+    darkMode: true,
     previewColors: {
       header: '#1c2433',
       primary: '#6b3fa0',


### PR DESCRIPTION
## Summary

- Adds `darkMode: boolean` to `ThemeDefinition` — `govea: false`, `servicenow: true`
- Extracts theme selection into a new `ThemeSelector` client component that immediately toggles `.dark` on `<html>` and updates `localStorage` on click
- Settings page simplified to pass `activeTheme` to `ThemeSelector`

## Test plan

- [ ] Navigate to Settings → Appearance
- [ ] Click ServiceNow — page switches to dark mode immediately
- [ ] Click GovEA — page returns to light mode immediately
- [ ] Reload after each selection — correct mode persists via `localStorage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)