### PR TITLE
feat: relationship panels with inline add/remove on all detail pages

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -29,6 +29,9 @@ export async function getApplication(id: string) {
     with: {
       organization: true,
       applicationCapabilities: { with: { capability: true } },
+      initiativeApplications: { with: { initiative: true } },
+      objectiveApplications: { with: { objective: true } },
+      adrApplications: { with: { adr: true } },
     },
   })
 }

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -29,6 +29,10 @@ export async function getCapability(id: string) {
     with: {
       organization: true,
       capabilityPersonas: { with: { persona: true } },
+      applicationCapabilities: { with: { application: true } },
+      objectiveCapabilities: { with: { objective: true } },
+      initiativeCapabilities: { with: { initiative: true } },
+      adrCapabilities: { with: { adr: true } },
       principleCapabilities: { with: { principle: true } },
     },
   })

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -56,6 +56,7 @@ export async function getInitiative(id: string) {
     with: {
       initiativeCapabilities: { with: { capability: true } },
       initiativeObjectives: { with: { objective: true } },
+      initiativeApplications: { with: { application: true } },
     },
   })
 }

--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -1,0 +1,531 @@
+'use server'
+
+/**
+ * Individual link / unlink actions for every many-to-many junction.
+ *
+ * Each pair follows the same pattern:
+ *   1. Require contributor role
+ *   2. Verify org ownership of the "source" entity
+ *   3. Insert (onConflictDoNothing) or delete the junction row
+ *   4. Revalidate the source entity's detail page
+ */
+
+import { db } from '@/db/client'
+import {
+  capabilities,
+  capabilityPersonas,
+  applications,
+  applicationCapabilities,
+  personas,
+  valueStreams,
+  valueStreamPersonas,
+  strategicObjectives,
+  objectiveCapabilities,
+  objectiveValueStreams,
+  objectiveApplications,
+  initiatives,
+  initiativeCapabilities,
+  initiativeObjectives,
+  initiativeApplications,
+  adrs,
+  adrCapabilities,
+  adrApplications,
+  adrInitiatives,
+  adrObjectives,
+  principles,
+  principleCapabilities,
+  principleAdrs,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { assertOwnership } from '@/lib/federation'
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+async function requireContributor() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!canEdit(session.user)) throw new Error('Forbidden')
+  return session
+}
+
+// ── Capability ↔ Persona ────────────────────────────────────────────────────
+
+export async function linkCapabilityPersona(capabilityId: string, personaId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.insert(capabilityPersonas).values({ capabilityId, personaId }).onConflictDoNothing()
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function unlinkCapabilityPersona(capabilityId: string, personaId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.delete(capabilityPersonas).where(
+    and(eq(capabilityPersonas.capabilityId, capabilityId), eq(capabilityPersonas.personaId, personaId))
+  )
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+// ── Capability ↔ Application ────────────────────────────────────────────────
+
+export async function linkCapabilityApplication(capabilityId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.insert(applicationCapabilities).values({ capabilityId, applicationId }).onConflictDoNothing()
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function unlinkCapabilityApplication(capabilityId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.delete(applicationCapabilities).where(
+    and(eq(applicationCapabilities.capabilityId, capabilityId), eq(applicationCapabilities.applicationId, applicationId))
+  )
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+// ── Capability ↔ Objective ──────────────────────────────────────────────────
+
+export async function linkCapabilityObjective(capabilityId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.insert(objectiveCapabilities).values({ capabilityId, objectiveId }).onConflictDoNothing()
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function unlinkCapabilityObjective(capabilityId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.delete(objectiveCapabilities).where(
+    and(eq(objectiveCapabilities.capabilityId, capabilityId), eq(objectiveCapabilities.objectiveId, objectiveId))
+  )
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+// ── Capability ↔ Initiative ─────────────────────────────────────────────────
+
+export async function linkCapabilityInitiative(capabilityId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.insert(initiativeCapabilities).values({ capabilityId, initiativeId }).onConflictDoNothing()
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function unlinkCapabilityInitiative(capabilityId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.delete(initiativeCapabilities).where(
+    and(eq(initiativeCapabilities.capabilityId, capabilityId), eq(initiativeCapabilities.initiativeId, initiativeId))
+  )
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+// ── Capability ↔ ADR ────────────────────────────────────────────────────────
+
+export async function linkCapabilityAdr(capabilityId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.insert(adrCapabilities).values({ capabilityId, adrId }).onConflictDoNothing()
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function unlinkCapabilityAdr(capabilityId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const cap = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
+  assertOwnership(cap?.organizationId, user.organizationId!)
+  await db.delete(adrCapabilities).where(
+    and(eq(adrCapabilities.capabilityId, capabilityId), eq(adrCapabilities.adrId, adrId))
+  )
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+// ── Application ↔ Capability ────────────────────────────────────────────────
+
+export async function linkApplicationCapability(applicationId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.insert(applicationCapabilities).values({ applicationId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+export async function unlinkApplicationCapability(applicationId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.delete(applicationCapabilities).where(
+    and(eq(applicationCapabilities.applicationId, applicationId), eq(applicationCapabilities.capabilityId, capabilityId))
+  )
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+// ── Application ↔ Objective ─────────────────────────────────────────────────
+
+export async function linkApplicationObjective(applicationId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.insert(objectiveApplications).values({ applicationId, objectiveId }).onConflictDoNothing()
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+export async function unlinkApplicationObjective(applicationId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.delete(objectiveApplications).where(
+    and(eq(objectiveApplications.applicationId, applicationId), eq(objectiveApplications.objectiveId, objectiveId))
+  )
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+// ── Application ↔ Initiative ────────────────────────────────────────────────
+
+export async function linkApplicationInitiative(applicationId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.insert(initiativeApplications).values({ applicationId, initiativeId }).onConflictDoNothing()
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+export async function unlinkApplicationInitiative(applicationId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.delete(initiativeApplications).where(
+    and(eq(initiativeApplications.applicationId, applicationId), eq(initiativeApplications.initiativeId, initiativeId))
+  )
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+// ── Application ↔ ADR ───────────────────────────────────────────────────────
+
+export async function linkApplicationAdr(applicationId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.insert(adrApplications).values({ applicationId, adrId }).onConflictDoNothing()
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+export async function unlinkApplicationAdr(applicationId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
+  assertOwnership(app?.organizationId, user.organizationId!)
+  await db.delete(adrApplications).where(
+    and(eq(adrApplications.applicationId, applicationId), eq(adrApplications.adrId, adrId))
+  )
+  revalidatePath(`/applications/${applicationId}`)
+}
+
+// ── Persona ↔ Capability ────────────────────────────────────────────────────
+
+export async function linkPersonaCapability(personaId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.insert(capabilityPersonas).values({ personaId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/personas/${personaId}`)
+}
+
+export async function unlinkPersonaCapability(personaId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.delete(capabilityPersonas).where(
+    and(eq(capabilityPersonas.personaId, personaId), eq(capabilityPersonas.capabilityId, capabilityId))
+  )
+  revalidatePath(`/personas/${personaId}`)
+}
+
+// ── Persona ↔ Value Stream ──────────────────────────────────────────────────
+
+export async function linkPersonaValueStream(personaId: string, valueStreamId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.insert(valueStreamPersonas).values({ personaId, valueStreamId }).onConflictDoNothing()
+  revalidatePath(`/personas/${personaId}`)
+}
+
+export async function unlinkPersonaValueStream(personaId: string, valueStreamId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.delete(valueStreamPersonas).where(
+    and(eq(valueStreamPersonas.personaId, personaId), eq(valueStreamPersonas.valueStreamId, valueStreamId))
+  )
+  revalidatePath(`/personas/${personaId}`)
+}
+
+// ── Value Stream ↔ Persona ──────────────────────────────────────────────────
+
+export async function linkValueStreamPersona(valueStreamId: string, personaId: string) {
+  const { user } = await requireContributor()
+  const vs = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
+  assertOwnership(vs?.organizationId, user.organizationId!)
+  await db.insert(valueStreamPersonas).values({ valueStreamId, personaId }).onConflictDoNothing()
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+
+export async function unlinkValueStreamPersona(valueStreamId: string, personaId: string) {
+  const { user } = await requireContributor()
+  const vs = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
+  assertOwnership(vs?.organizationId, user.organizationId!)
+  await db.delete(valueStreamPersonas).where(
+    and(eq(valueStreamPersonas.valueStreamId, valueStreamId), eq(valueStreamPersonas.personaId, personaId))
+  )
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+
+// ── Objective ↔ Capability ──────────────────────────────────────────────────
+
+export async function linkObjectiveCapability(objectiveId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.insert(objectiveCapabilities).values({ objectiveId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+export async function unlinkObjectiveCapability(objectiveId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.delete(objectiveCapabilities).where(
+    and(eq(objectiveCapabilities.objectiveId, objectiveId), eq(objectiveCapabilities.capabilityId, capabilityId))
+  )
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+// ── Objective ↔ Value Stream ────────────────────────────────────────────────
+
+export async function linkObjectiveValueStream(objectiveId: string, valueStreamId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.insert(objectiveValueStreams).values({ objectiveId, valueStreamId }).onConflictDoNothing()
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+export async function unlinkObjectiveValueStream(objectiveId: string, valueStreamId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.delete(objectiveValueStreams).where(
+    and(eq(objectiveValueStreams.objectiveId, objectiveId), eq(objectiveValueStreams.valueStreamId, valueStreamId))
+  )
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+// ── Objective ↔ Application ─────────────────────────────────────────────────
+
+export async function linkObjectiveApplication(objectiveId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.insert(objectiveApplications).values({ objectiveId, applicationId }).onConflictDoNothing()
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+export async function unlinkObjectiveApplication(objectiveId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
+  assertOwnership(obj?.organizationId, user.organizationId!)
+  await db.delete(objectiveApplications).where(
+    and(eq(objectiveApplications.objectiveId, objectiveId), eq(objectiveApplications.applicationId, applicationId))
+  )
+  revalidatePath(`/objectives/${objectiveId}`)
+}
+
+// ── Initiative ↔ Capability ─────────────────────────────────────────────────
+
+export async function linkInitiativeCapability(initiativeId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.insert(initiativeCapabilities).values({ initiativeId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+export async function unlinkInitiativeCapability(initiativeId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.delete(initiativeCapabilities).where(
+    and(eq(initiativeCapabilities.initiativeId, initiativeId), eq(initiativeCapabilities.capabilityId, capabilityId))
+  )
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+// ── Initiative ↔ Objective ──────────────────────────────────────────────────
+
+export async function linkInitiativeObjective(initiativeId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.insert(initiativeObjectives).values({ initiativeId, objectiveId }).onConflictDoNothing()
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+export async function unlinkInitiativeObjective(initiativeId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.delete(initiativeObjectives).where(
+    and(eq(initiativeObjectives.initiativeId, initiativeId), eq(initiativeObjectives.objectiveId, objectiveId))
+  )
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+// ── Initiative ↔ Application ────────────────────────────────────────────────
+
+export async function linkInitiativeApplication(initiativeId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.insert(initiativeApplications).values({ initiativeId, applicationId }).onConflictDoNothing()
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+export async function unlinkInitiativeApplication(initiativeId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const init = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+  assertOwnership(init?.organizationId, user.organizationId!)
+  await db.delete(initiativeApplications).where(
+    and(eq(initiativeApplications.initiativeId, initiativeId), eq(initiativeApplications.applicationId, applicationId))
+  )
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
+// ── ADR ↔ Capability ────────────────────────────────────────────────────────
+
+export async function linkAdrCapability(adrId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.insert(adrCapabilities).values({ adrId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+export async function unlinkAdrCapability(adrId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.delete(adrCapabilities).where(
+    and(eq(adrCapabilities.adrId, adrId), eq(adrCapabilities.capabilityId, capabilityId))
+  )
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+// ── ADR ↔ Application ───────────────────────────────────────────────────────
+
+export async function linkAdrApplication(adrId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.insert(adrApplications).values({ adrId, applicationId }).onConflictDoNothing()
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+export async function unlinkAdrApplication(adrId: string, applicationId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.delete(adrApplications).where(
+    and(eq(adrApplications.adrId, adrId), eq(adrApplications.applicationId, applicationId))
+  )
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+// ── ADR ↔ Initiative ────────────────────────────────────────────────────────
+
+export async function linkAdrInitiative(adrId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.insert(adrInitiatives).values({ adrId, initiativeId }).onConflictDoNothing()
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+export async function unlinkAdrInitiative(adrId: string, initiativeId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.delete(adrInitiatives).where(
+    and(eq(adrInitiatives.adrId, adrId), eq(adrInitiatives.initiativeId, initiativeId))
+  )
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+// ── ADR ↔ Objective ─────────────────────────────────────────────────────────
+
+export async function linkAdrObjective(adrId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.insert(adrObjectives).values({ adrId, objectiveId }).onConflictDoNothing()
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+export async function unlinkAdrObjective(adrId: string, objectiveId: string) {
+  const { user } = await requireContributor()
+  const adr = await db.query.adrs.findFirst({ where: eq(adrs.id, adrId) })
+  assertOwnership(adr?.organizationId, user.organizationId!)
+  await db.delete(adrObjectives).where(
+    and(eq(adrObjectives.adrId, adrId), eq(adrObjectives.objectiveId, objectiveId))
+  )
+  revalidatePath(`/adrs/${adrId}`)
+}
+
+// ── Principle ↔ Capability ──────────────────────────────────────────────────
+
+export async function linkPrincipleCapability(principleId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.insert(principleCapabilities).values({ principleId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/principles/${principleId}`)
+}
+
+export async function unlinkPrincipleCapability(principleId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.delete(principleCapabilities).where(
+    and(eq(principleCapabilities.principleId, principleId), eq(principleCapabilities.capabilityId, capabilityId))
+  )
+  revalidatePath(`/principles/${principleId}`)
+}
+
+// ── Principle ↔ ADR ─────────────────────────────────────────────────────────
+
+export async function linkPrincipleAdr(principleId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.insert(principleAdrs).values({ principleId, adrId }).onConflictDoNothing()
+  revalidatePath(`/principles/${principleId}`)
+}
+
+export async function unlinkPrincipleAdr(principleId: string, adrId: string) {
+  const { user } = await requireContributor()
+  const p = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
+  assertOwnership(p?.organizationId, user.organizationId!)
+  await db.delete(principleAdrs).where(
+    and(eq(principleAdrs.principleId, principleId), eq(principleAdrs.adrId, adrId))
+  )
+  revalidatePath(`/principles/${principleId}`)
+}

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -55,6 +55,8 @@ export async function getObjective(id: string) {
     with: {
       objectiveCapabilities: { with: { capability: true } },
       objectiveValueStreams: { with: { valueStream: true } },
+      objectiveApplications: { with: { application: true } },
+      initiativeObjectives: { with: { initiative: true } },
     },
   })
 }

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -139,6 +139,8 @@ export async function getPersona(id: string) {
     with: {
       organization: true,
       personaTags: { with: { tag: true } },
+      capabilityPersonas: { with: { capability: true } },
+      valueStreamPersonas: { with: { valueStream: true } },
     },
   })
 }

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -69,6 +69,8 @@ export async function getValueStream(id: string) {
           },
         },
       },
+      valueStreamPersonas: { with: { persona: true } },
+      objectiveValueStreams: { with: { objective: true } },
     },
   })
 }

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -1,9 +1,20 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getADR } from '@/actions/adrs'
+import { getCapabilities } from '@/actions/capabilities'
+import { getApplications } from '@/actions/applications'
+import { getInitiatives } from '@/actions/initiatives'
+import { getObjectives } from '@/actions/objectives'
+import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { LinkedItemCard } from '@/components/linked-item-card'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkAdrCapability, unlinkAdrCapability,
+  linkAdrApplication, unlinkAdrApplication,
+  linkAdrInitiative, unlinkAdrInitiative,
+  linkAdrObjective, unlinkAdrObjective,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   proposed: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -38,6 +49,27 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
 
   const adr = await getADR(id)
   if (!adr) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allApplications, allInitiatives, allObjectives] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getApplications(orgId),
+        getInitiatives(orgId),
+        getObjectives(orgId),
+      ])
+    : [[], [], [], []]
+
+  const addCapability = linkAdrCapability.bind(null, id)
+  const removeCapability = unlinkAdrCapability.bind(null, id)
+  const addApplication = linkAdrApplication.bind(null, id)
+  const removeApplication = unlinkAdrApplication.bind(null, id)
+  const addInitiative = linkAdrInitiative.bind(null, id)
+  const removeInitiative = unlinkAdrInitiative.bind(null, id)
+  const addObjective = linkAdrObjective.bind(null, id)
+  const removeObjective = unlinkAdrObjective.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -97,76 +129,63 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
 
       <hr />
 
-      {/* Linked items */}
-      {adr.adrCapabilities.length > 0 && (
-        <Section title="Capabilities">
-          <div className="space-y-2">
-            {adr.adrCapabilities.map(({ capability }) => (
-              <LinkedItemCard
-                key={capability.id}
-                href={`/capabilities/${capability.id}`}
-                name={capability.name}
-                meta={capability.domain ?? null}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Capabilities"
+        items={adr.adrCapabilities.map(({ capability }) => ({
+          id: capability.id, name: capability.name,
+          href: `/capabilities/${capability.id}`, meta: capability.domain,
+        }))}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
 
-      {adr.adrApplications.length > 0 && (
-        <Section title="Applications">
-          <div className="space-y-2">
-            {adr.adrApplications.map(({ application }) => (
-              <LinkedItemCard
-                key={application.id}
-                href={`/applications/${application.id}`}
-                name={application.name}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Applications"
+        items={adr.adrApplications.map(({ application }) => ({
+          id: application.id, name: application.name,
+          href: `/applications/${application.id}`,
+        }))}
+        canEdit={editor}
+        available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+        addAction={addApplication}
+        removeAction={removeApplication}
+      />
 
-      {adr.adrInitiatives.length > 0 && (
-        <Section title="Initiatives">
-          <div className="space-y-2">
-            {adr.adrInitiatives.map(({ initiative }) => (
-              <LinkedItemCard
-                key={initiative.id}
-                href={`/initiatives/${initiative.id}`}
-                name={initiative.name}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Initiatives"
+        items={adr.adrInitiatives.map(({ initiative }) => ({
+          id: initiative.id, name: initiative.name,
+          href: `/initiatives/${initiative.id}`, meta: initiative.status,
+        }))}
+        canEdit={editor}
+        available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+        addAction={addInitiative}
+        removeAction={removeInitiative}
+      />
 
-      {adr.adrObjectives.length > 0 && (
-        <Section title="Strategic Objectives">
-          <div className="space-y-2">
-            {adr.adrObjectives.map(({ objective }) => (
-              <LinkedItemCard
-                key={objective.id}
-                href={`/objectives/${objective.id}`}
-                name={objective.name}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Strategic Objectives"
+        items={adr.adrObjectives.map(({ objective }) => ({
+          id: objective.id, name: objective.name,
+          href: `/objectives/${objective.id}`,
+        }))}
+        canEdit={editor}
+        available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+        addAction={addObjective}
+        removeAction={removeObjective}
+      />
 
       {adr.principleAdrs && adr.principleAdrs.length > 0 && (
-        <Section title="Principles">
-          <div className="space-y-2">
-            {adr.principleAdrs.map(({ principle }) => (
-              <LinkedItemCard
-                key={principle.id}
-                href={`/principles/${principle.id}`}
-                name={principle.name}
-              />
-            ))}
-          </div>
-        </Section>
+        <RelationshipPanel
+          title="Principles"
+          items={adr.principleAdrs.map(({ principle }) => ({
+            id: principle.id, name: principle.name,
+            href: `/principles/${principle.id}`,
+          }))}
+          canEdit={false}
+        />
       )}
 
       <div className="text-xs text-muted-foreground pt-4 border-t">

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -1,9 +1,20 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getApplication } from '@/actions/applications'
+import { getCapabilities } from '@/actions/capabilities'
+import { getObjectives } from '@/actions/objectives'
+import { getInitiatives } from '@/actions/initiatives'
+import { getADRs } from '@/actions/adrs'
+import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
-import { LinkedItemCard } from '@/components/linked-item-card'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkApplicationCapability, unlinkApplicationCapability,
+  linkApplicationObjective, unlinkApplicationObjective,
+  linkApplicationInitiative, unlinkApplicationInitiative,
+  linkApplicationAdr, unlinkApplicationAdr,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -25,9 +36,9 @@ const VISIBILITY_LABELS: Record<string, string> = {
 
 const LIFECYCLE_STYLES: Record<string, string> = {
   active: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  deprecated: 'bg-amber-100 text-amber-800 border-amber-200',
+  sunset: 'bg-red-100 text-red-700 border-red-200',
   planned: 'bg-blue-100 text-blue-700 border-blue-200',
-  sunset: 'bg-amber-100 text-amber-800 border-amber-200',
-  decommissioned: 'bg-red-100 text-red-700 border-red-200',
 }
 
 export default async function ApplicationDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -38,6 +49,27 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
   const application = await getApplication(id)
   if (!application) notFound()
 
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allObjectives, allInitiatives, allAdrs] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getObjectives(orgId),
+        getInitiatives(orgId),
+        getADRs(orgId),
+      ])
+    : [[], [], [], []]
+
+  const addCapability = linkApplicationCapability.bind(null, id)
+  const removeCapability = unlinkApplicationCapability.bind(null, id)
+  const addObjective = linkApplicationObjective.bind(null, id)
+  const removeObjective = unlinkApplicationObjective.bind(null, id)
+  const addInitiative = linkApplicationInitiative.bind(null, id)
+  const removeInitiative = unlinkApplicationInitiative.bind(null, id)
+  const addAdr = linkApplicationAdr.bind(null, id)
+  const removeAdr = unlinkApplicationAdr.bind(null, id)
+
   return (
     <div className="space-y-8 max-w-3xl">
       <Link href="/applications" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
@@ -47,9 +79,9 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-2xl font-bold tracking-tight">{application.name}</h1>
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
             {application.lifecycleStatus && (
-              <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LIFECYCLE_STYLES[application.lifecycleStatus])}>
+              <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LIFECYCLE_STYLES[application.lifecycleStatus] ?? 'bg-slate-100 text-slate-600 border-slate-200')}>
                 {application.lifecycleStatus.charAt(0).toUpperCase() + application.lifecycleStatus.slice(1)}
               </span>
             )}
@@ -67,48 +99,80 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
         )}
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
-          <div>
-            <span className="text-muted-foreground">Vendor: </span>
-            {application.vendor
-              ? <span className="font-medium">{application.vendor}</span>
-              : <span className="text-muted-foreground">—</span>
-            }
-          </div>
-          <div>
-            <span className="text-muted-foreground">Version: </span>
-            {application.version
-              ? <span className="font-medium">{application.version}</span>
-              : <span className="text-muted-foreground">—</span>
-            }
-          </div>
-          <div>
-            <span className="text-muted-foreground">Hosting: </span>
-            {application.hostingModel
-              ? <span className="font-medium">{application.hostingModel}</span>
-              : <span className="text-muted-foreground">—</span>
-            }
-          </div>
+          {application.vendor && (
+            <div>
+              <span className="text-muted-foreground">Vendor: </span>
+              <span className="font-medium">{application.vendor}</span>
+            </div>
+          )}
+          {application.version && (
+            <div>
+              <span className="text-muted-foreground">Version: </span>
+              <span className="font-medium">{application.version}</span>
+            </div>
+          )}
+          {application.hostingModel && (
+            <div>
+              <span className="text-muted-foreground">Hosting: </span>
+              <span className="font-medium">{application.hostingModel}</span>
+            </div>
+          )}
         </div>
       </div>
 
       <hr />
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Capabilities</h2>
-        {application.applicationCapabilities.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No capabilities linked to this application.</p>
-        ) : (
-          <div className="space-y-2">
-            {application.applicationCapabilities.map(({ capability }) => (
-              <LinkedItemCard
-                key={capability.id}
-                href={`/capabilities/${capability.id}`}
-                name={capability.name}
-                domain={capability.domain}
-              />
-            ))}
-          </div>
-        )}
+      <RelationshipPanel
+        title="Capabilities"
+        items={application.applicationCapabilities.map(({ capability }) => ({
+          id: capability.id, name: capability.name,
+          href: `/capabilities/${capability.id}`, meta: capability.domain,
+        }))}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
+
+      <RelationshipPanel
+        title="Strategic Objectives"
+        items={application.objectiveApplications.map(({ objective }) => ({
+          id: objective.id, name: objective.name,
+          href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
+        }))}
+        canEdit={editor}
+        available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+        addAction={addObjective}
+        removeAction={removeObjective}
+      />
+
+      <RelationshipPanel
+        title="Initiatives"
+        items={application.initiativeApplications.map(({ initiative }) => ({
+          id: initiative.id, name: initiative.name,
+          href: `/initiatives/${initiative.id}`, meta: initiative.status,
+        }))}
+        canEdit={editor}
+        available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+        addAction={addInitiative}
+        removeAction={removeInitiative}
+      />
+
+      <RelationshipPanel
+        title="Architecture Decision Records"
+        items={application.adrApplications.map(({ adr }) => ({
+          id: adr.id, name: adr.title,
+          href: `/adrs/${adr.id}`,
+          meta: `ADR-${String(adr.number).padStart(3, '0')}`,
+        }))}
+        canEdit={editor}
+        available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+        addAction={addAdr}
+        removeAction={removeAdr}
+      />
+
+      <div className="text-xs text-muted-foreground pt-4 border-t">
+        Created {new Date(application.createdAt).toLocaleDateString()} · Updated {new Date(application.updatedAt).toLocaleDateString()}
       </div>
     </div>
   )

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -1,10 +1,23 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getCapability } from '@/actions/capabilities'
+import { getApplications } from '@/actions/applications'
+import { getObjectives } from '@/actions/objectives'
+import { getInitiatives } from '@/actions/initiatives'
+import { getADRs } from '@/actions/adrs'
+import { getPersonas } from '@/actions/personas'
+import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
-import { LinkedItemCard } from '@/components/linked-item-card'
 import { DomainBadge } from '@/components/domain-badge'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkCapabilityPersona, unlinkCapabilityPersona,
+  linkCapabilityApplication, unlinkCapabilityApplication,
+  linkCapabilityObjective, unlinkCapabilityObjective,
+  linkCapabilityInitiative, unlinkCapabilityInitiative,
+  linkCapabilityAdr, unlinkCapabilityAdr,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -31,6 +44,30 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
 
   const capability = await getCapability(id)
   if (!capability) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs] = editor
+    ? await Promise.all([
+        getPersonas(orgId),
+        getApplications(orgId),
+        getObjectives(orgId),
+        getInitiatives(orgId),
+        getADRs(orgId),
+      ])
+    : [[], [], [], [], []]
+
+  const addPersona = linkCapabilityPersona.bind(null, id)
+  const removePersona = unlinkCapabilityPersona.bind(null, id)
+  const addApplication = linkCapabilityApplication.bind(null, id)
+  const removeApplication = unlinkCapabilityApplication.bind(null, id)
+  const addObjective = linkCapabilityObjective.bind(null, id)
+  const removeObjective = unlinkCapabilityObjective.bind(null, id)
+  const addInitiative = linkCapabilityInitiative.bind(null, id)
+  const removeInitiative = unlinkCapabilityInitiative.bind(null, id)
+  const addAdr = linkCapabilityAdr.bind(null, id)
+  const removeAdr = unlinkCapabilityAdr.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -93,37 +130,82 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
         </div>
       )}
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Personas</h2>
-        {capability.capabilityPersonas.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No personas linked to this capability.</p>
-        ) : (
-          <div className="space-y-2">
-            {capability.capabilityPersonas.map(({ persona }) => (
-              <LinkedItemCard
-                key={persona.id}
-                href={`/personas/${persona.id}`}
-                name={persona.name}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <hr />
 
-      {capability.principleCapabilities && capability.principleCapabilities.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold">Principles</h2>
-          <div className="space-y-2">
-            {capability.principleCapabilities.map(({ principle }) => (
-              <LinkedItemCard
-                key={principle.id}
-                href={`/principles/${principle.id}`}
-                name={principle.name}
-              />
-            ))}
-          </div>
-        </div>
+      <RelationshipPanel
+        title="Personas"
+        items={capability.capabilityPersonas.map(({ persona }) => ({
+          id: persona.id, name: persona.name,
+          href: `/personas/${persona.id}`, meta: persona.type,
+        }))}
+        canEdit={editor}
+        available={allPersonas.map(p => ({ id: p.id, name: p.name }))}
+        addAction={addPersona}
+        removeAction={removePersona}
+      />
+
+      <RelationshipPanel
+        title="Applications"
+        items={capability.applicationCapabilities.map(({ application }) => ({
+          id: application.id, name: application.name,
+          href: `/applications/${application.id}`, meta: application.vendor,
+        }))}
+        canEdit={editor}
+        available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+        addAction={addApplication}
+        removeAction={removeApplication}
+      />
+
+      <RelationshipPanel
+        title="Strategic Objectives"
+        items={capability.objectiveCapabilities.map(({ objective }) => ({
+          id: objective.id, name: objective.name,
+          href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
+        }))}
+        canEdit={editor}
+        available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+        addAction={addObjective}
+        removeAction={removeObjective}
+      />
+
+      <RelationshipPanel
+        title="Initiatives"
+        items={capability.initiativeCapabilities.map(({ initiative }) => ({
+          id: initiative.id, name: initiative.name,
+          href: `/initiatives/${initiative.id}`, meta: initiative.status,
+        }))}
+        canEdit={editor}
+        available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+        addAction={addInitiative}
+        removeAction={removeInitiative}
+      />
+
+      <RelationshipPanel
+        title="Architecture Decision Records"
+        items={capability.adrCapabilities.map(({ adr }) => ({
+          id: adr.id, name: adr.title,
+          href: `/adrs/${adr.id}`,
+          meta: `ADR-${String(adr.number).padStart(3, '0')}`,
+        }))}
+        canEdit={editor}
+        available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+        addAction={addAdr}
+        removeAction={removeAdr}
+      />
+
+      {capability.principleCapabilities.length > 0 && (
+        <RelationshipPanel
+          title="Principles"
+          items={capability.principleCapabilities.map(({ principle }) => ({
+            id: principle.id, name: principle.name, href: `/principles/${principle.id}`,
+          }))}
+          canEdit={false}
+        />
       )}
+
+      <div className="text-xs text-muted-foreground pt-4 border-t">
+        Created {new Date(capability.createdAt).toLocaleDateString()} · Updated {new Date(capability.updatedAt).toLocaleDateString()}
+      </div>
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -1,9 +1,19 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getInitiative } from '@/actions/initiatives'
+import { getCapabilities } from '@/actions/capabilities'
+import { getObjectives } from '@/actions/objectives'
+import { getApplications } from '@/actions/applications'
+import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { LinkedItemCard } from '@/components/linked-item-card'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import type { RelationshipItem } from '@/components/relationship-panel'
+import {
+  linkInitiativeCapability, unlinkInitiativeCapability,
+  linkInitiativeObjective, unlinkInitiativeObjective,
+  linkInitiativeApplication, unlinkInitiativeApplication,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   proposed: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -14,17 +24,15 @@ const STATUS_STYLES: Record<string, string> = {
 }
 
 const STATUS_LABELS: Record<string, string> = {
-  proposed: 'Proposed',
-  active: 'Active',
-  'on-hold': 'On Hold',
-  complete: 'Complete',
-  cancelled: 'Cancelled',
+  proposed: 'Proposed', active: 'Active', 'on-hold': 'On Hold',
+  complete: 'Complete', cancelled: 'Cancelled',
 }
 
 const IMPACT_STYLES: Record<string, string> = {
   build: 'bg-emerald-50 text-emerald-700 border-emerald-200',
   improve: 'bg-blue-50 text-blue-700 border-blue-200',
   retire: 'bg-red-50 text-red-700 border-red-200',
+  migrate: 'bg-amber-50 text-amber-700 border-amber-200',
 }
 
 const VISIBILITY_STYLES: Record<string, string> = {
@@ -34,9 +42,7 @@ const VISIBILITY_STYLES: Record<string, string> = {
 }
 
 const VISIBILITY_LABELS: Record<string, string> = {
-  org: 'Org only',
-  connections: 'Connected orgs',
-  instance: 'Instance-wide',
+  org: 'Org only', connections: 'Connected orgs', instance: 'Instance-wide',
 }
 
 export default async function InitiativeDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -46,6 +52,44 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
 
   const initiative = await getInitiative(id)
   if (!initiative) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allObjectives, allApplications] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getObjectives(orgId),
+        getApplications(orgId),
+      ])
+    : [[], [], []]
+
+  const addCapability = linkInitiativeCapability.bind(null, id)
+  const removeCapability = unlinkInitiativeCapability.bind(null, id)
+  const addObjective = linkInitiativeObjective.bind(null, id)
+  const removeObjective = unlinkInitiativeObjective.bind(null, id)
+  const addApplication = linkInitiativeApplication.bind(null, id)
+  const removeApplication = unlinkInitiativeApplication.bind(null, id)
+
+  const capabilityItems: RelationshipItem[] = initiative.initiativeCapabilities.map(({ capability, impact }) => ({
+    id: capability.id, name: capability.name,
+    href: `/capabilities/${capability.id}`, meta: capability.domain,
+    badge: impact ? (
+      <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium', IMPACT_STYLES[impact] ?? 'bg-slate-100 text-slate-600 border-slate-200')}>
+        {impact}
+      </span>
+    ) : undefined,
+  }))
+
+  const applicationItems: RelationshipItem[] = initiative.initiativeApplications.map(({ application, impact }) => ({
+    id: application.id, name: application.name,
+    href: `/applications/${application.id}`, meta: application.vendor,
+    badge: impact ? (
+      <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium', IMPACT_STYLES[impact] ?? 'bg-slate-100 text-slate-600 border-slate-200')}>
+        {impact}
+      </span>
+    ) : undefined,
+  }))
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -80,46 +124,35 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
 
       <hr />
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Capabilities</h2>
-        {initiative.initiativeCapabilities.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No capabilities linked.</p>
-        ) : (
-          <div className="space-y-2">
-            {initiative.initiativeCapabilities.map(({ capability, impact }) => (
-              <LinkedItemCard
-                key={capability.id}
-                href={`/capabilities/${capability.id}`}
-                name={capability.name}
-                meta={capability.domain}
-                badge={impact ? (
-                  <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium', IMPACT_STYLES[impact] ?? 'bg-slate-100 text-slate-600 border-slate-200')}>
-                    {impact}
-                  </span>
-                ) : undefined}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <RelationshipPanel
+        title="Capabilities"
+        items={capabilityItems}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Strategic Objectives</h2>
-        {initiative.initiativeObjectives.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No strategic objectives linked.</p>
-        ) : (
-          <div className="space-y-2">
-            {initiative.initiativeObjectives.map(({ objective }) => (
-              <LinkedItemCard
-                key={objective.id}
-                href={`/objectives/${objective.id}`}
-                name={objective.name}
-                meta={objective.timeHorizon}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <RelationshipPanel
+        title="Strategic Objectives"
+        items={initiative.initiativeObjectives.map(({ objective }) => ({
+          id: objective.id, name: objective.name,
+          href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
+        }))}
+        canEdit={editor}
+        available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+        addAction={addObjective}
+        removeAction={removeObjective}
+      />
+
+      <RelationshipPanel
+        title="Applications"
+        items={applicationItems}
+        canEdit={editor}
+        available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+        addAction={addApplication}
+        removeAction={removeApplication}
+      />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">
         Created {new Date(initiative.createdAt).toLocaleDateString()} · Updated {new Date(initiative.updatedAt).toLocaleDateString()}

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -1,9 +1,18 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getObjective } from '@/actions/objectives'
+import { getCapabilities } from '@/actions/capabilities'
+import { getValueStreams } from '@/actions/value-streams'
+import { getApplications } from '@/actions/applications'
+import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { LinkedItemCard } from '@/components/linked-item-card'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkObjectiveCapability, unlinkObjectiveCapability,
+  linkObjectiveValueStream, unlinkObjectiveValueStream,
+  linkObjectiveApplication, unlinkObjectiveApplication,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -28,8 +37,26 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
   const session = await auth()
   if (!session?.user) redirect('/login')
 
-  const obj = await getObjective(id)
-  if (!obj) notFound()
+  const objective = await getObjective(id)
+  if (!objective) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allValueStreams, allApplications] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getValueStreams(orgId),
+        getApplications(orgId),
+      ])
+    : [[], [], []]
+
+  const addCapability = linkObjectiveCapability.bind(null, id)
+  const removeCapability = unlinkObjectiveCapability.bind(null, id)
+  const addValueStream = linkObjectiveValueStream.bind(null, id)
+  const removeValueStream = unlinkObjectiveValueStream.bind(null, id)
+  const addApplication = linkObjectiveApplication.bind(null, id)
+  const removeApplication = unlinkObjectiveApplication.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -39,77 +66,86 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold tracking-tight">{obj.name}</h1>
+          <h1 className="text-2xl font-bold tracking-tight">{objective.name}</h1>
           <div className="flex items-center gap-2 shrink-0">
-            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[obj.status])}>
-              {obj.status.charAt(0).toUpperCase() + obj.status.slice(1)}
+            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[objective.status])}>
+              {objective.status.charAt(0).toUpperCase() + objective.status.slice(1)}
             </span>
-            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', VISIBILITY_STYLES[obj.visibility])}>
-              {VISIBILITY_LABELS[obj.visibility]}
+            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', VISIBILITY_STYLES[objective.visibility])}>
+              {VISIBILITY_LABELS[objective.visibility]}
             </span>
           </div>
         </div>
 
-        {obj.description && (
-          <p className="text-muted-foreground">{obj.description}</p>
+        {objective.description && (
+          <p className="text-muted-foreground">{objective.description}</p>
         )}
 
-        <div className="grid grid-cols-2 gap-4 pt-1 text-sm">
-          <div className="space-y-0.5">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Success Metric</p>
-            <p>{obj.successMetric || <span className="text-muted-foreground">—</span>}</p>
-          </div>
-          <div className="space-y-0.5">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Time Horizon</p>
-            <p>{obj.timeHorizon || <span className="text-muted-foreground">—</span>}</p>
-          </div>
+        <div className="flex flex-wrap gap-6 text-sm pt-1">
+          {objective.successMetric && (
+            <div>
+              <span className="text-muted-foreground">Success metric: </span>
+              <span className="font-medium">{objective.successMetric}</span>
+            </div>
+          )}
+          {objective.timeHorizon && (
+            <div>
+              <span className="text-muted-foreground">Time horizon: </span>
+              <span className="font-medium">{objective.timeHorizon}</span>
+            </div>
+          )}
         </div>
       </div>
 
       <hr />
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Value Streams</h2>
-        {obj.objectiveValueStreams.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No value streams linked.</p>
-        ) : (
-          <div className="space-y-2">
-            {obj.objectiveValueStreams.map(({ valueStream }) => (
-              <LinkedItemCard
-                key={valueStream.id}
-                href={`/value-streams/${valueStream.id}`}
-                name={valueStream.name}
-                badge={
-                  <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[valueStream.status])}>
-                    {valueStream.status.charAt(0).toUpperCase() + valueStream.status.slice(1)}
-                  </span>
-                }
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <RelationshipPanel
+        title="Capabilities"
+        items={objective.objectiveCapabilities.map(({ capability }) => ({
+          id: capability.id, name: capability.name,
+          href: `/capabilities/${capability.id}`, meta: capability.domain,
+        }))}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
 
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Capabilities</h2>
-        {obj.objectiveCapabilities.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No capabilities linked.</p>
-        ) : (
-          <div className="space-y-2">
-            {obj.objectiveCapabilities.map(({ capability }) => (
-              <LinkedItemCard
-                key={capability.id}
-                href={`/capabilities/${capability.id}`}
-                name={capability.name}
-                meta={capability.domain}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <RelationshipPanel
+        title="Value Streams"
+        items={objective.objectiveValueStreams.map(({ valueStream }) => ({
+          id: valueStream.id, name: valueStream.name,
+          href: `/value-streams/${valueStream.id}`,
+        }))}
+        canEdit={editor}
+        available={allValueStreams.map(vs => ({ id: vs.id, name: vs.name }))}
+        addAction={addValueStream}
+        removeAction={removeValueStream}
+      />
+
+      <RelationshipPanel
+        title="Applications"
+        items={objective.objectiveApplications.map(({ application }) => ({
+          id: application.id, name: application.name,
+          href: `/applications/${application.id}`, meta: application.vendor,
+        }))}
+        canEdit={editor}
+        available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+        addAction={addApplication}
+        removeAction={removeApplication}
+      />
+
+      <RelationshipPanel
+        title="Initiatives"
+        items={objective.initiativeObjectives.map(({ initiative }) => ({
+          id: initiative.id, name: initiative.name,
+          href: `/initiatives/${initiative.id}`, meta: initiative.status,
+        }))}
+        canEdit={false}
+      />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">
-        Created {new Date(obj.createdAt).toLocaleDateString()} · Updated {new Date(obj.updatedAt).toLocaleDateString()}
+        Created {new Date(objective.createdAt).toLocaleDateString()} · Updated {new Date(objective.updatedAt).toLocaleDateString()}
       </div>
     </div>
   )

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -1,8 +1,17 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
-import { getPersona } from '@/actions/personas'
+import { getPersona, getPersonaTypes, getTags } from '@/actions/personas'
+import { getCapabilities } from '@/actions/capabilities'
+import { getValueStreams } from '@/actions/value-streams'
+import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import { PersonaEditButton } from '@/components/persona-edit-button'
+import {
+  linkPersonaCapability, unlinkPersonaCapability,
+  linkPersonaValueStream, unlinkPersonaValueStream,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -29,6 +38,23 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
 
   const persona = await getPersona(id)
   if (!persona) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allValueStreams, personaTypes, allTags] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getValueStreams(orgId),
+        getPersonaTypes(orgId),
+        getTags(orgId),
+      ])
+    : [[], [], [], []]
+
+  const addCapability = linkPersonaCapability.bind(null, id)
+  const removeCapability = unlinkPersonaCapability.bind(null, id)
+  const addValueStream = linkPersonaValueStream.bind(null, id)
+  const removeValueStream = unlinkPersonaValueStream.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -64,6 +90,22 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
         </div>
       </div>
 
+      {editor && (
+        <PersonaEditButton
+          personaId={id}
+          initial={{
+            name: persona.name,
+            description: persona.description,
+            type: persona.type,
+            status: persona.status,
+            visibility: persona.visibility,
+            tagIds: persona.personaTags.map(pt => pt.tag.id),
+          }}
+          personaTypes={personaTypes}
+          tags={allTags}
+        />
+      )}
+
       <hr />
 
       <div className="space-y-3">
@@ -82,6 +124,34 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
             ))}
           </div>
         )}
+      </div>
+
+      <RelationshipPanel
+        title="Capabilities"
+        items={persona.capabilityPersonas.map(({ capability }) => ({
+          id: capability.id, name: capability.name,
+          href: `/capabilities/${capability.id}`, meta: capability.domain,
+        }))}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
+
+      <RelationshipPanel
+        title="Value Streams"
+        items={persona.valueStreamPersonas.map(({ valueStream }) => ({
+          id: valueStream.id, name: valueStream.name,
+          href: `/value-streams/${valueStream.id}`,
+        }))}
+        canEdit={editor}
+        available={allValueStreams.map(vs => ({ id: vs.id, name: vs.name }))}
+        addAction={addValueStream}
+        removeAction={removeValueStream}
+      />
+
+      <div className="text-xs text-muted-foreground pt-4 border-t">
+        Created {new Date(persona.createdAt).toLocaleDateString()} · Updated {new Date(persona.updatedAt).toLocaleDateString()}
       </div>
     </div>
   )

--- a/apps/govea/src/app/(admin)/principles/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/[id]/page.tsx
@@ -1,9 +1,16 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getPrinciple } from '@/actions/principles'
+import { getCapabilities } from '@/actions/capabilities'
+import { getADRs } from '@/actions/adrs'
+import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
-import { LinkedItemCard } from '@/components/linked-item-card'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkPrincipleCapability, unlinkPrincipleCapability,
+  linkPrincipleAdr, unlinkPrincipleAdr,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -30,6 +37,21 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
 
   const principle = await getPrinciple(id)
   if (!principle) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+
+  const [allCapabilities, allAdrs] = editor
+    ? await Promise.all([
+        getCapabilities(orgId),
+        getADRs(orgId),
+      ])
+    : [[], []]
+
+  const addCapability = linkPrincipleCapability.bind(null, id)
+  const removeCapability = unlinkPrincipleCapability.bind(null, id)
+  const addAdr = linkPrincipleAdr.bind(null, id)
+  const removeAdr = unlinkPrincipleAdr.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -76,37 +98,32 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
         )}
       </div>
 
-      {(principle.principleCapabilities.length > 0 || principle.principleAdrs.length > 0) && <hr />}
+      <hr />
 
-      {principle.principleCapabilities.length > 0 && (
-        <Section title="Capabilities">
-          <div className="space-y-2">
-            {principle.principleCapabilities.map(({ capability }) => (
-              <LinkedItemCard
-                key={capability.id}
-                href={`/capabilities/${capability.id}`}
-                name={capability.name}
-                meta={capability.domain ?? null}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Capabilities"
+        items={principle.principleCapabilities.map(({ capability }) => ({
+          id: capability.id, name: capability.name,
+          href: `/capabilities/${capability.id}`, meta: capability.domain,
+        }))}
+        canEdit={editor}
+        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        addAction={addCapability}
+        removeAction={removeCapability}
+      />
 
-      {principle.principleAdrs.length > 0 && (
-        <Section title="Architecture Decision Records">
-          <div className="space-y-2">
-            {principle.principleAdrs.map(({ adr }) => (
-              <LinkedItemCard
-                key={adr.id}
-                href={`/adrs/${adr.id}`}
-                name={adr.title}
-                meta={adr.number}
-              />
-            ))}
-          </div>
-        </Section>
-      )}
+      <RelationshipPanel
+        title="Architecture Decision Records"
+        items={principle.principleAdrs.map(({ adr }) => ({
+          id: adr.id, name: adr.title,
+          href: `/adrs/${adr.id}`,
+          meta: `ADR-${String(adr.number).padStart(3, '0')}`,
+        }))}
+        canEdit={editor}
+        available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+        addAction={addAdr}
+        removeAction={removeAdr}
+      />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">
         Created {new Date(principle.createdAt).toLocaleDateString()} · Updated {new Date(principle.updatedAt).toLocaleDateString()}

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -2,9 +2,15 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getValueStream } from '@/actions/value-streams'
 import { getCapabilities } from '@/actions/capabilities'
+import { getPersonas } from '@/actions/personas'
+import { canEdit } from '@/lib/rbac'
 import { StageManager } from './stage-manager'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import {
+  linkValueStreamPersona, unlinkValueStreamPersona,
+} from '@/actions/links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -29,16 +35,19 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
   const session = await auth()
   if (!session?.user) redirect('/login')
 
-  const role = session.user.role
+  const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
-  const canEdit = role === 'admin' || role === 'contributor'
 
-  const [vs, capabilityList] = await Promise.all([
+  const [vs, capabilityList, allPersonas] = await Promise.all([
     getValueStream(id),
     getCapabilities(orgId),
+    editor ? getPersonas(orgId) : Promise.resolve([]),
   ])
 
   if (!vs) notFound()
+
+  const addPersona = linkValueStreamPersona.bind(null, id)
+  const removePersona = unlinkValueStreamPersona.bind(null, id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -91,7 +100,7 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
           </span>
         </div>
 
-        {vs.stages.length === 0 && !canEdit && (
+        {vs.stages.length === 0 && !editor && (
           <p className="text-sm text-muted-foreground py-4">No stages have been defined for this value stream yet.</p>
         )}
 
@@ -128,13 +137,38 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
         )}
 
         {/* Stage manager for editors */}
-        {canEdit && (
+        {editor && (
           <StageManager
             valueStreamId={vs.id}
             stages={vs.stages}
             capabilities={capabilityList}
           />
         )}
+      </div>
+
+      <RelationshipPanel
+        title="Personas"
+        items={vs.valueStreamPersonas.map(({ persona }) => ({
+          id: persona.id, name: persona.name,
+          href: `/personas/${persona.id}`,
+        }))}
+        canEdit={editor}
+        available={allPersonas.map(p => ({ id: p.id, name: p.name }))}
+        addAction={addPersona}
+        removeAction={removePersona}
+      />
+
+      <RelationshipPanel
+        title="Strategic Objectives"
+        items={vs.objectiveValueStreams.map(({ objective }) => ({
+          id: objective.id, name: objective.name,
+          href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
+        }))}
+        canEdit={false}
+      />
+
+      <div className="text-xs text-muted-foreground pt-4 border-t">
+        Created {new Date(vs.createdAt).toLocaleDateString()} · Updated {new Date(vs.updatedAt).toLocaleDateString()}
       </div>
     </div>
   )

--- a/apps/govea/src/components/persona-edit-button.tsx
+++ b/apps/govea/src/components/persona-edit-button.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { PersonaEditForm } from '@/components/persona-edit-form'
+
+interface PersonaEditSectionProps {
+  personaId: string
+  initial: {
+    name: string
+    description: string | null
+    type: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    tagIds: string[]
+  }
+  personaTypes: { id: string; name: string }[]
+  tags: { id: string; name: string }[]
+}
+
+/**
+ * Renders an "Edit" button. When clicked, expands an inline edit form.
+ * Designed to sit as a standalone section between the header and the divider.
+ */
+export function PersonaEditButton({ personaId, initial, personaTypes, tags }: PersonaEditSectionProps) {
+  const [editing, setEditing] = useState(false)
+
+  if (editing) {
+    return (
+      <PersonaEditForm
+        personaId={personaId}
+        initial={initial}
+        personaTypes={personaTypes}
+        tags={tags}
+        onCancel={() => setEditing(false)}
+      />
+    )
+  }
+
+  return (
+    <div className="flex justify-end">
+      <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+        Edit persona
+      </Button>
+    </div>
+  )
+}

--- a/apps/govea/src/components/persona-edit-form.tsx
+++ b/apps/govea/src/components/persona-edit-form.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useTransition, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { editPersona } from '@/actions/personas'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+interface PersonaType {
+  id: string
+  name: string
+}
+
+interface Tag {
+  id: string
+  name: string
+}
+
+interface PersonaEditFormProps {
+  personaId: string
+  initial: {
+    name: string
+    description: string | null
+    type: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    tagIds: string[]
+  }
+  personaTypes: PersonaType[]
+  tags: Tag[]
+  onCancel: () => void
+}
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'archived', label: 'Archived' },
+]
+
+const VISIBILITY_OPTIONS = [
+  { value: 'org', label: 'Org only' },
+  { value: 'connections', label: 'Connected orgs' },
+  { value: 'instance', label: 'Instance-wide' },
+]
+
+export function PersonaEditForm({
+  personaId,
+  initial,
+  personaTypes,
+  tags,
+  onCancel,
+}: PersonaEditFormProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    const formData = new FormData(e.currentTarget)
+    startTransition(async () => {
+      try {
+        await editPersona(personaId, formData)
+        router.refresh()
+        onCancel()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Save failed')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border bg-card p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Edit Persona</h3>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor="pe-name">Name</Label>
+          <Input id="pe-name" name="name" defaultValue={initial.name} required />
+        </div>
+
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor="pe-description">Description</Label>
+          <Textarea
+            id="pe-description"
+            name="description"
+            defaultValue={initial.description ?? ''}
+            rows={3}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="pe-type">Type</Label>
+          <select
+            id="pe-type"
+            name="type"
+            defaultValue={initial.type ?? ''}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <option value="">— No type —</option>
+            {personaTypes.map(pt => (
+              <option key={pt.id} value={pt.name}>{pt.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="pe-status">Status</Label>
+          <select
+            id="pe-status"
+            name="status"
+            defaultValue={initial.status}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {STATUS_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="pe-visibility">Visibility</Label>
+          <select
+            id="pe-visibility"
+            name="visibility"
+            defaultValue={initial.visibility}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {VISIBILITY_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {tags.length > 0 && (
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label>Tags</Label>
+            <div className="flex flex-wrap gap-2">
+              {tags.map(tag => (
+                <label key={tag.id} className="flex items-center gap-1.5 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    name="tagIds"
+                    value={tag.id}
+                    defaultChecked={initial.tagIds.includes(tag.id)}
+                    className="rounded border-input"
+                  />
+                  <span className="text-sm">{tag.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={isPending}>
+          {isPending ? 'Saving…' : 'Save changes'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/apps/govea/src/components/relationship-panel.tsx
+++ b/apps/govea/src/components/relationship-panel.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useOptimistic, useTransition, useState, useId } from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+export interface RelationshipItem {
+  id: string
+  name: string
+  href: string
+  meta?: string | null
+  badge?: React.ReactNode
+}
+
+export interface RelationshipOption {
+  id: string
+  name: string
+}
+
+interface RelationshipPanelProps {
+  title: string
+  items: RelationshipItem[]
+  emptyMessage?: string
+  /** Contributor+ only — when false, add/remove controls are hidden */
+  canEdit: boolean
+  /** Items available to add (caller should already exclude already-linked ones) */
+  available?: RelationshipOption[]
+  /**
+   * Bound server action: (targetId: string) => Promise<void>
+   * Pass as `myAction.bind(null, entityId)` from the server component.
+   */
+  addAction?: (targetId: string) => Promise<void>
+  removeAction?: (targetId: string) => Promise<void>
+}
+
+export function RelationshipPanel({
+  title,
+  items: initialItems,
+  emptyMessage,
+  canEdit,
+  available = [],
+  addAction,
+  removeAction,
+}: RelationshipPanelProps) {
+  const selectId = useId()
+  const empty = emptyMessage ?? `No ${title.toLowerCase()} linked.`
+
+  const [items, applyOptimistic] = useOptimistic(
+    initialItems,
+    (state: RelationshipItem[], action: { type: 'add'; item: RelationshipItem } | { type: 'remove'; id: string }) => {
+      if (action.type === 'remove') return state.filter(i => i.id !== action.id)
+      if (action.type === 'add') return [...state, action.item]
+      return state
+    }
+  )
+
+  const [isPending, startTransition] = useTransition()
+  const [selectedId, setSelectedId] = useState('')
+  const [showAdd, setShowAdd] = useState(false)
+
+  const linkedIds = new Set(items.map(i => i.id))
+  const unlinked = available.filter(o => !linkedIds.has(o.id))
+
+  function handleRemove(id: string, _name: string) {
+    if (!removeAction) return
+    startTransition(async () => {
+      applyOptimistic({ type: 'remove', id })
+      await removeAction(id)
+    })
+  }
+
+  function handleAdd() {
+    if (!addAction || !selectedId) return
+    const option = available.find(o => o.id === selectedId)
+    if (!option) return
+    const newItem: RelationshipItem = { id: option.id, name: option.name, href: '#' }
+    startTransition(async () => {
+      applyOptimistic({ type: 'add', item: newItem })
+      setSelectedId('')
+      setShowAdd(false)
+      await addAction(selectedId)
+    })
+  }
+
+  const showAddButton = canEdit && addAction && unlinked.length > 0
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between min-h-[1.75rem]">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {showAddButton && (
+          <button
+            type="button"
+            onClick={() => setShowAdd(v => !v)}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            {showAdd ? 'Cancel' : '+ Add'}
+          </button>
+        )}
+      </div>
+
+      {showAdd && unlinked.length > 0 && (
+        <div className="flex gap-2 items-center">
+          <label htmlFor={selectId} className="sr-only">
+            Select {title.toLowerCase()} to link
+          </label>
+          <select
+            id={selectId}
+            value={selectedId}
+            onChange={e => setSelectedId(e.target.value)}
+            className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <option value="">Select {title.toLowerCase()}…</option>
+            {unlinked.map(o => (
+              <option key={o.id} value={o.id}>{o.name}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!selectedId || isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50 hover:bg-primary/90 transition-colors"
+          >
+            Link
+          </button>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{empty}</p>
+      ) : (
+        <div className={cn('space-y-2', isPending && 'opacity-60')}>
+          {items.map(item => (
+            <div key={item.id} className="flex items-center gap-2 group">
+              <Link
+                href={item.href}
+                className="flex-1 flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:bg-muted/50 transition-colors"
+              >
+                <span className="font-medium text-sm">{item.name}</span>
+                {(item.meta || item.badge) && (
+                  <div className="flex items-center gap-2">
+                    {item.meta && <span className="text-xs text-muted-foreground">{item.meta}</span>}
+                    {item.badge}
+                  </div>
+                )}
+              </Link>
+              {canEdit && removeAction && (
+                <button
+                  type="button"
+                  onClick={() => handleRemove(item.id, item.name)}
+                  disabled={isPending}
+                  aria-label={`Unlink ${item.name}`}
+                  className="shrink-0 rounded-md p-1.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-destructive/10 transition-all disabled:opacity-30"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/components/ui/textarea.tsx
+++ b/apps/govea/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
Closes #102, #90

## Summary

- **`RelationshipPanel` component** — client component with `useOptimistic` + `useTransition` for instant add/remove feedback and group-hover unlink controls
- **`links.ts` server actions** — 30 individual link/unlink actions covering every many-to-many junction (capabilities, personas, applications, objectives, initiatives, value streams, ADRs, principles), each with ownership check + `revalidatePath`
- **All 8 entity detail pages rewritten** — capabilities, personas, applications, objectives, initiatives, value streams, ADRs, principles — now show live relationship panels that Contributor+ users can edit inline
- **Persona inline editing** (`#90`) — `PersonaEditButton` + `PersonaEditForm` client components; toggling "Edit persona" expands a full inline form between the header and the content divider
- **`Textarea` UI component** — added missing shadcn-style textarea to match project's input component

## What Contributors can now do on every detail page
- See all linked entities with navigation links and metadata (domain, vendor, status, etc.)
- Add a relationship via a dropdown → Link button (optimistic — appears instantly)
- Remove a relationship via hover-reveal ✕ button (optimistic — disappears instantly)
- Edit persona name, description, type, status, visibility, and tags inline without leaving the page

## Test plan
- [ ] Log in as Contributor — verify add/remove controls appear on capability, persona, application, objective, initiative, value stream, ADR, and principle detail pages
- [ ] Log in as Viewer — verify all panels are read-only (no add/remove controls)
- [ ] Add a relationship — confirm it appears immediately and persists on refresh
- [ ] Remove a relationship — confirm it disappears immediately and persists on refresh
- [ ] Edit a persona inline — confirm form opens, saves, and updates the displayed values
- [ ] Verify Principles panel on capabilities page is always read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)