### PR TITLE
feat: org-level module toggles

### DIFF
--- a/apps/govea/src/actions/settings.ts
+++ b/apps/govea/src/actions/settings.ts
@@ -7,7 +7,9 @@ import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { themes } from '@/lib/themes'
+import { MODULE_DEFS, type ModuleKey } from '@/lib/modules'
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 
 export async function updateOrgTheme(themeId: string) {
   const session = await auth()
@@ -37,4 +39,44 @@ export async function updateOrgTheme(themeId: string) {
     before: { theme: before?.theme },
     after: { theme: themeId },
   })
+
+  revalidatePath('/', 'layout')
+}
+
+/**
+ * Toggles a single module on or off for the current org.
+ * Absent key = on, so we only store explicit `false` values.
+ */
+export async function setModuleEnabled(key: ModuleKey, enabled: boolean) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+
+  // Validate key against known modules
+  if (!MODULE_DEFS.find(m => m.key === key)) throw new Error('Unknown module')
+
+  const orgId = session.user.organizationId!
+
+  const org = await db.query.organizations.findFirst({
+    where: eq(organizations.id, orgId),
+  })
+
+  const before = org?.enabledModules ?? {}
+  const after = { ...before, [key]: enabled }
+
+  await db.update(organizations)
+    .set({ enabledModules: after, updatedAt: new Date() })
+    .where(eq(organizations.id, orgId))
+
+  await writeAuditLog({
+    action: 'settings.module_toggled',
+    entityType: 'organization',
+    entityId: orgId,
+    userId: session.user.id,
+    organizationId: orgId,
+    before: { [key]: before[key] ?? true },
+    after: { [key]: enabled },
+  })
+
+  revalidatePath('/', 'layout')
 }

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -21,8 +21,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   const role = session.user.role
 
-  // Load org theme
+  // Load org settings (theme + enabled modules)
   let themeStyle = ''
+  let enabledModules: Record<string, boolean> = {}
   if (session.user.organizationId) {
     const org = await db.query.organizations.findFirst({
       where: eq(organizations.id, session.user.organizationId),
@@ -30,6 +31,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     if (org) {
       const theme = getTheme(org.theme)
       themeStyle = themeToStyleString(theme)
+      enabledModules = org.enabledModules ?? {}
     }
   }
 
@@ -57,6 +59,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       roleBadgeClass={ROLE_BADGE_CLASS[role]}
       themeStyle={themeStyle}
       isDev={process.env.NODE_ENV === 'development'}
+      enabledModules={enabledModules}
       signOutSlot={signOutSlot}
     >
       {children}

--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -4,6 +4,7 @@ import { db } from '@/db/client'
 import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { ThemeSelector } from '@/components/theme-selector'
+import { ModuleToggles } from '@/components/module-toggles'
 
 export default async function SettingsPage() {
   const session = await auth()
@@ -16,9 +17,10 @@ export default async function SettingsPage() {
     : null
 
   const activeTheme = org?.theme ?? 'govea'
+  const enabledModules = org?.enabledModules ?? {}
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 max-w-2xl">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
         <p className="text-muted-foreground mt-1">Organization configuration and preferences.</p>
@@ -30,6 +32,19 @@ export default async function SettingsPage() {
           <p className="text-sm text-muted-foreground mt-0.5">Choose a theme for your organization.</p>
         </div>
         <ThemeSelector activeTheme={activeTheme} />
+      </section>
+
+      <hr />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Modules</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Disable modules your organization does not use. Hidden modules are removed from navigation
+            — no data is deleted and you can re-enable them at any time.
+          </p>
+        </div>
+        <ModuleToggles initialModules={enabledModules} />
       </section>
     </div>
   )

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -1,53 +1,54 @@
 'use client'
 
 import { useState, useEffect, type ReactNode } from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { DevToolbar } from '@/components/dev-toolbar'
 import { DarkModeToggle } from '@/components/dark-mode-toggle'
+import { isModuleEnabled, moduleForPath } from '@/lib/modules'
 
 // ── Nav structure ─────────────────────────────────────────────────────────────
 
-type NavItem = { href: string; label: string }
+type NavItem = { href: string; label: string; moduleKey?: string }
 type NavGroup = { label: string; items: NavItem[]; adminOnly?: boolean }
 
 const NAV_GROUPS: NavGroup[] = [
   {
     label: 'Business Architecture',
     items: [
-      { href: '/personas', label: 'Personas' },
-      { href: '/value-streams', label: 'Value Streams' },
-      { href: '/capabilities', label: 'Capabilities' },
-      { href: '/glossary', label: 'Glossary' },
+      { href: '/personas',      label: 'Personas',      moduleKey: 'personas' },
+      { href: '/value-streams', label: 'Value Streams',  moduleKey: 'value-streams' },
+      { href: '/capabilities',  label: 'Capabilities',   moduleKey: 'capabilities' },
+      { href: '/glossary',      label: 'Glossary',       moduleKey: 'glossary' },
     ],
   },
   {
     label: 'Portfolio',
     items: [
-      { href: '/applications', label: 'Applications' },
-      { href: '/adrs', label: 'Decisions' },
-      { href: '/principles', label: 'Principles' },
+      { href: '/applications', label: 'Applications', moduleKey: 'applications' },
+      { href: '/adrs',         label: 'Decisions',    moduleKey: 'adrs' },
+      { href: '/principles',   label: 'Principles',   moduleKey: 'principles' },
     ],
   },
   {
     label: 'Strategy',
     items: [
-      { href: '/objectives', label: 'Objectives' },
-      { href: '/initiatives', label: 'Initiatives' },
-      { href: '/roadmap', label: 'Roadmap' },
+      { href: '/objectives',  label: 'Objectives',  moduleKey: 'objectives' },
+      { href: '/initiatives', label: 'Initiatives', moduleKey: 'initiatives' },
+      { href: '/roadmap',     label: 'Roadmap',     moduleKey: 'roadmap' },
     ],
   },
   {
     label: 'Configuration',
     adminOnly: true,
     items: [
-      { href: '/taxonomy', label: 'Taxonomy' },
-      { href: '/users', label: 'Users' },
+      { href: '/taxonomy',    label: 'Taxonomy' },
+      { href: '/users',       label: 'Users' },
       { href: '/connections', label: 'Connections' },
-      { href: '/audit', label: 'Audit Log' },
-      { href: '/settings', label: 'Settings' },
+      { href: '/audit',       label: 'Audit Log' },
+      { href: '/settings',    label: 'Settings' },
     ],
   },
 ]
@@ -57,10 +58,12 @@ const NAV_GROUPS: NavGroup[] = [
 function SidebarContent({
   role,
   pathname,
+  enabledModules,
   onClose,
 }: {
   role: Role
   pathname: string
+  enabledModules: Record<string, boolean>
   onClose?: () => void
 }) {
   const isAdmin = role === 'admin'
@@ -82,33 +85,39 @@ function SidebarContent({
       </Link>
 
       <div className="mt-2 space-y-4">
-        {NAV_GROUPS.filter(g => !g.adminOnly || isAdmin).map(group => (
-          <div key={group.label}>
-            <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-white/40 select-none">
-              {group.label}
-            </p>
-            <div className="mt-0.5 space-y-0.5">
-              {group.items.map(item => {
-                const active = pathname === item.href || pathname.startsWith(item.href + '/')
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={onClose}
-                    className={cn(
-                      'block rounded-md px-3 py-2 text-sm transition-colors',
-                      active
-                        ? 'bg-white/15 text-white font-medium'
-                        : 'text-white/70 hover:bg-white/10 hover:text-white'
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                )
-              })}
+        {NAV_GROUPS.filter(g => !g.adminOnly || isAdmin).map(group => {
+          const visibleItems = group.items.filter(
+            item => !item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])
+          )
+          if (visibleItems.length === 0) return null
+          return (
+            <div key={group.label}>
+              <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-white/40 select-none">
+                {group.label}
+              </p>
+              <div className="mt-0.5 space-y-0.5">
+                {visibleItems.map(item => {
+                  const active = pathname === item.href || pathname.startsWith(item.href + '/')
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={onClose}
+                      className={cn(
+                        'block rounded-md px-3 py-2 text-sm transition-colors',
+                        active
+                          ? 'bg-white/15 text-white font-medium'
+                          : 'text-white/70 hover:bg-white/10 hover:text-white'
+                      )}
+                    >
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </nav>
   )
@@ -122,6 +131,7 @@ interface AppShellProps {
   roleBadgeClass: string
   themeStyle: string
   isDev: boolean
+  enabledModules: Record<string, boolean>
   signOutSlot: ReactNode
   children: ReactNode
 }
@@ -132,10 +142,12 @@ export function AppShell({
   roleBadgeClass,
   themeStyle,
   isDev,
+  enabledModules,
   signOutSlot,
   children,
 }: AppShellProps) {
   const pathname = usePathname()
+  const router = useRouter()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [prevPathname, setPrevPathname] = useState(pathname)
 
@@ -146,6 +158,14 @@ export function AppShell({
       setSidebarOpen(false)
     }
   }
+
+  // Redirect to dashboard if the current route's module has been disabled
+  useEffect(() => {
+    const mod = moduleForPath(pathname)
+    if (mod && !isModuleEnabled(enabledModules, mod.key)) {
+      router.replace('/dashboard')
+    }
+  }, [pathname, enabledModules, router])
 
   // Prevent body scroll when mobile sidebar is open
   useEffect(() => {
@@ -181,7 +201,7 @@ export function AppShell({
             GovEA
           </Link>
         </div>
-        <SidebarContent role={role} pathname={pathname} />
+        <SidebarContent role={role} pathname={pathname} enabledModules={enabledModules} />
       </aside>
 
       {/* ── Mobile overlay backdrop ── */}
@@ -218,7 +238,7 @@ export function AppShell({
             </svg>
           </button>
         </div>
-        <SidebarContent role={role} pathname={pathname} onClose={() => setSidebarOpen(false)} />
+        <SidebarContent role={role} pathname={pathname} enabledModules={enabledModules} onClose={() => setSidebarOpen(false)} />
       </aside>
 
       {/* ── Main content area ── */}

--- a/apps/govea/src/components/module-toggles.tsx
+++ b/apps/govea/src/components/module-toggles.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { MODULE_DEFS, isModuleEnabled, type ModuleGroup, type ModuleKey } from '@/lib/modules'
+import { setModuleEnabled } from '@/actions/settings'
+import { cn } from '@/lib/utils'
+
+interface ModuleTogglesProps {
+  initialModules: Record<string, boolean>
+}
+
+const GROUPS: ModuleGroup[] = ['Business Architecture', 'Portfolio', 'Strategy']
+
+export function ModuleToggles({ initialModules }: ModuleTogglesProps) {
+  const [modules, setModules] = useState(initialModules)
+  const [isPending, startTransition] = useTransition()
+
+  function toggle(key: ModuleKey) {
+    const next = !isModuleEnabled(modules, key)
+    // Optimistic update
+    setModules(prev => ({ ...prev, [key]: next }))
+    startTransition(async () => {
+      await setModuleEnabled(key, next)
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      {GROUPS.map(group => (
+        <div key={group} className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {group}
+          </p>
+          <div className="space-y-1.5">
+            {MODULE_DEFS.filter(m => m.group === group).map(mod => {
+              const enabled = isModuleEnabled(modules, mod.key)
+              return (
+                <div
+                  key={mod.key}
+                  className="flex items-center justify-between rounded-lg border bg-card px-4 py-3"
+                >
+                  <span className="text-sm font-medium">{mod.label}</span>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={enabled}
+                    aria-label={`${enabled ? 'Disable' : 'Enable'} ${mod.label}`}
+                    disabled={isPending}
+                    onClick={() => toggle(mod.key)}
+                    className={cn(
+                      'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-150',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                      'disabled:cursor-not-allowed disabled:opacity-60',
+                      enabled ? 'bg-primary' : 'bg-input',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform duration-150',
+                        enabled ? 'translate-x-4' : 'translate-x-0',
+                      )}
+                    />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+      {isPending && (
+        <p className="text-xs text-muted-foreground">Saving…</p>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/db/migrations/0015_quiet_silver_surfer.sql
+++ b/apps/govea/src/db/migrations/0015_quiet_silver_surfer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ADD COLUMN "enabled_modules" jsonb DEFAULT '{}' NOT NULL;

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776009322938,
       "tag": "0014_broad_scarlet_witch",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0015_quiet_silver_surfer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -1,4 +1,4 @@
-import { type AnyPgColumn, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { type AnyPgColumn, jsonb, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 export const visibilityEnum = pgEnum('visibility', ['org', 'connections', 'instance'])
 
@@ -7,6 +7,7 @@ export const organizations = pgTable('organizations', {
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
   theme: text('theme').notNull().default('govea'),
+  enabledModules: jsonb('enabled_modules').$type<Record<string, boolean>>().notNull().default({}),
   parentId: uuid('parent_id').references((): AnyPgColumn => organizations.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/apps/govea/src/lib/modules.ts
+++ b/apps/govea/src/lib/modules.ts
@@ -1,0 +1,63 @@
+/**
+ * Org-level module definitions.
+ *
+ * Absent key in `enabledModules` → module is ON.
+ * Only explicitly set `false` values disable a module, so new modules
+ * are visible to all orgs automatically without backfilling rows.
+ */
+
+export type ModuleKey =
+  | 'personas'
+  | 'value-streams'
+  | 'capabilities'
+  | 'glossary'
+  | 'applications'
+  | 'adrs'
+  | 'principles'
+  | 'objectives'
+  | 'initiatives'
+  | 'roadmap'
+
+export type ModuleGroup = 'Business Architecture' | 'Portfolio' | 'Strategy'
+
+export interface ModuleDef {
+  key: ModuleKey
+  label: string
+  /** The route prefix this module owns — used for nav filtering and route guarding. */
+  href: string
+  group: ModuleGroup
+}
+
+export const MODULE_DEFS: ModuleDef[] = [
+  // Business Architecture
+  { key: 'personas',      label: 'Personas',           href: '/personas',      group: 'Business Architecture' },
+  { key: 'value-streams', label: 'Value Streams',       href: '/value-streams', group: 'Business Architecture' },
+  { key: 'capabilities',  label: 'Capabilities',        href: '/capabilities',  group: 'Business Architecture' },
+  { key: 'glossary',      label: 'Glossary',            href: '/glossary',      group: 'Business Architecture' },
+  // Portfolio
+  { key: 'applications',  label: 'Applications',        href: '/applications',  group: 'Portfolio' },
+  { key: 'adrs',          label: 'Decisions (ADRs)',    href: '/adrs',          group: 'Portfolio' },
+  { key: 'principles',    label: 'Principles',          href: '/principles',    group: 'Portfolio' },
+  // Strategy
+  { key: 'objectives',    label: 'Objectives',          href: '/objectives',    group: 'Strategy' },
+  { key: 'initiatives',   label: 'Initiatives',         href: '/initiatives',   group: 'Strategy' },
+  { key: 'roadmap',       label: 'Roadmap',             href: '/roadmap',       group: 'Strategy' },
+]
+
+/** Returns true when a module is enabled. Absent key defaults to true. */
+export function isModuleEnabled(
+  enabledModules: Record<string, boolean>,
+  key: ModuleKey,
+): boolean {
+  return enabledModules[key] !== false
+}
+
+/**
+ * Returns the ModuleDef whose href prefix matches the given pathname,
+ * or undefined if the pathname doesn't belong to any module.
+ */
+export function moduleForPath(pathname: string): ModuleDef | undefined {
+  return MODULE_DEFS.find(
+    m => pathname === m.href || pathname.startsWith(m.href + '/'),
+  )
+}


### PR DESCRIPTION
Closes #164

## Summary

- **Admin-only toggle UI** in Settings → Modules: a grouped list of switch controls covering all 10 modules (Business Architecture / Portfolio / Strategy). Each toggle saves immediately with optimistic UI — no page reload needed.
- **Nav filtering**: disabled modules are removed from the sidebar instantly after the layout revalidates. Both desktop and mobile sidebars respect the setting.
- **Route guard**: if a user navigates directly to a disabled module's URL (e.g. `/adrs`), `AppShell` detects it via `usePathname` and calls `router.replace('/dashboard')`.
- **Data-safe**: the column stores only explicit `false` values. Absent key = enabled, so existing orgs and new modules both default to fully visible without any backfill.
- **Audit log**: every toggle change records a `settings.module_toggled` entry with before/after state.

## What was changed

| File | Change |
|---|---|
| `db/schema/organizations.ts` | Added `enabled_modules jsonb` column |
| `db/migrations/0015_quiet_silver_surfer.sql` | Migration: `ALTER TABLE organizations ADD COLUMN` |
| `lib/modules.ts` | New — single source of truth for module keys, labels, hrefs, and groups |
| `actions/settings.ts` | Added `setModuleEnabled` server action |
| `components/module-toggles.tsx` | New — client toggle UI with `useTransition` + optimistic state |
| `components/app-shell.tsx` | Accepts `enabledModules`, filters nav, redirects on disabled routes |
| `app/(admin)/layout.tsx` | Reads `enabledModules` from org, passes to `AppShell` |
| `app/(admin)/settings/page.tsx` | Adds Modules section below Appearance |

## Test plan
- [ ] Log in as Admin — navigate to Settings, verify Modules section appears with toggle switches for all 10 modules
- [ ] Disable a module (e.g. Principles) — confirm it disappears from the sidebar immediately
- [ ] Navigate directly to the disabled route (`/principles`) — confirm redirect to `/dashboard`
- [ ] Re-enable the module — confirm it reappears in the sidebar
- [ ] Log in as Contributor — confirm Settings page is not accessible (admin-only route)
- [ ] Disable a module and log in as Viewer — confirm the module is hidden for them too
- [ ] Verify audit log records each toggle change

🤖 Generated with [Claude Code](https://claude.com/claude-code)