### PR TITLE
test: server-action integration tests + CI job (#117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,50 @@ jobs:
       - name: Production build
         run: pnpm --filter govea build
 
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: [typecheck, lint]
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: govea
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/govea
+      AUTH_SECRET: ci-integration-secret-not-for-production
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run database migrations
+        run: pnpm --filter govea db:migrate
+
+      - name: Run integration tests
+        run: pnpm --filter govea test:integration
+
   smoke:
     name: E2E smoke tests
     runs-on: ubuntu-latest

--- a/apps/govea/tests/integration/README.md
+++ b/apps/govea/tests/integration/README.md
@@ -1,0 +1,128 @@
+# Integration Tests
+
+Server-action integration tests that call the real write path against a live
+PostgreSQL database. These tests verify role enforcement, cross-org boundaries,
+audit logging, and DB-level correctness that TypeScript alone cannot catch.
+
+## What's Covered
+
+| Suite | File | Tests |
+|---|---|---|
+| Capabilities | `capabilities.test.ts` | create/edit/delete with role checks; audit log before/after snapshots |
+| Users | `users.test.ts` | createUser org scoping; role promotion/demotion; last-admin guard; audit logging |
+| Settings | `settings.test.ts` | module toggle (absent-key semantics, audit); theme update; role enforcement |
+| Cross-org | `cross-org.test.ts` | `assertOwnership` blocks cross-org edits and deletes; `updateUserRole` WHERE-scoped no-op |
+
+48 tests total. Runtime: ~3–4 seconds.
+
+## Prerequisites
+
+A running PostgreSQL instance at `localhost:5432` with:
+
+```
+database: govea
+user:     postgres
+password: postgres
+```
+
+The easiest way to run one locally is with Podman (or Docker):
+
+```bash
+podman machine start                   # if not already running
+podman run -d \
+  --name govea-postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=govea \
+  -p 5432:5432 \
+  --restart unless-stopped \
+  docker.io/postgres:16-alpine
+```
+
+Then apply migrations once (re-run any time the schema changes):
+
+```bash
+cd apps/govea
+pnpm db:migrate
+```
+
+## Running the Tests
+
+From `apps/govea`:
+
+```bash
+# Single run
+pnpm test:integration
+
+# Watch mode (re-runs on file change)
+pnpm test:integration:watch
+```
+
+`DATABASE_URL` is loaded from `.env.local` automatically by the test setup file.
+It does not need to be in the environment before you run the command.
+
+## How Test Isolation Works
+
+Each test suite creates its own org with a unique UUID slug, creates users
+inside it, and tears the whole org down in `afterAll`. Because every foreign
+key in the schema cascades on delete, a single `DELETE FROM organizations WHERE
+id = $1` removes all data created by that suite.
+
+```
+beforeAll  → createTestOrg()       ← fresh org, isolated from every other suite
+             createTestUser(...)   ← users scoped to that org
+afterAll   → cleanupOrg(orgId)     ← deletes org + all cascade data
+```
+
+Test suites that run in the same process share the database but never share
+org data, so they can safely run concurrently within a single Vitest fork.
+
+## Auth Mocking
+
+Server actions call `auth()` from `@/lib/auth`. Tests mock this at the module
+level using `vi.hoisted`:
+
+```typescript
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+// In a test:
+mockAuth.mockResolvedValue(makeSession(admin))
+await createCapability(formData)
+```
+
+`makeSession(user)` builds the same shape that NextAuth returns in production,
+so the actions behave exactly as they would with a real session.
+
+## Next.js Mocks
+
+`setup.ts` mocks three Next.js APIs that server actions import:
+
+| Mock | Behavior |
+|---|---|
+| `next/navigation` — `redirect` | throws `Error('REDIRECT:<url>')` so tests can assert on it |
+| `next/navigation` — `notFound` | throws `Error('NOT_FOUND')` |
+| `next/cache` — `revalidatePath` | no-op |
+| `next/headers` — `cookies/headers` | stub returning null/empty |
+
+This lets tests call server actions directly without a running Next.js server.
+
+## Helper Reference (`helpers/db.ts`)
+
+| Function | Purpose |
+|---|---|
+| `createTestOrg()` | Insert org with unique slug, return `{ id, name, slug }` |
+| `createTestUser(orgId, role)` | Insert user with bcrypt password hash |
+| `cleanupOrg(orgId)` | Delete org (cascades all child data) |
+| `makeSession(user)` | Build NextAuth session shape |
+| `findOrg(id)` | Direct DB read for assertions |
+| `findUser(id)` | Direct DB read for assertions |
+| `getAuditLogs(orgId, action?)` | All audit rows for org, sorted by `createdAt ASC` |
+| `getAuditLogsForEntity(entityId)` | Audit rows for a specific entity |
+| `getCapabilitiesForOrg(orgId)` | All capabilities for org |
+| `insertCapability(orgId, name)` | Direct DB insert (used in cross-org setup) |
+
+## CI
+
+The CI workflow (`.github/workflows/ci.yml`) spins up a `postgres:16` service
+container, applies migrations, and runs `pnpm test:integration` on every push.

--- a/apps/govea/tests/integration/capabilities.test.ts
+++ b/apps/govea/tests/integration/capabilities.test.ts
@@ -11,7 +11,7 @@ import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vites
 import { createCapability, editCapability, deleteCapability } from '@/actions/capabilities'
 import { db } from '@/db/client'
 import { capabilities } from '@/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import {
   createTestOrg, createTestUser, cleanupOrg,
   makeSession, getCapabilitiesForOrg, getAuditLogsForEntity,
@@ -150,7 +150,7 @@ describe('capabilities actions', () => {
       const logs = await getAuditLogsForEntity(capId)
       // Find by known after value — avoids timestamp-ordering ambiguity
       const entry = logs.find(
-        l => l.action === 'capability.edit' && (l.after as any)?.name === 'After State',
+        l => l.action === 'capability.edit' && (l.after as Record<string, unknown>)?.name === 'After State',
       )
       expect(entry).toBeDefined()
       expect(entry!.before).toMatchObject({ name: 'Before State', status: 'draft' })

--- a/apps/govea/tests/integration/settings.test.ts
+++ b/apps/govea/tests/integration/settings.test.ts
@@ -93,7 +93,7 @@ describe('settings / setModuleEnabled', () => {
     const org = await findOrg(orgId)
     expect(org?.enabledModules?.['glossary']).toBeUndefined()
 
-    const before = await getAuditLogs(orgId, 'settings.module_toggled')
+    const _before = await getAuditLogs(orgId, 'settings.module_toggled')
     await setModuleEnabled('glossary', false)
     const after = await getAuditLogs(orgId, 'settings.module_toggled')
 

--- a/apps/govea/tests/integration/users.test.ts
+++ b/apps/govea/tests/integration/users.test.ts
@@ -157,7 +157,7 @@ describe('user management actions', () => {
       await updateUserRole(viewer.id, 'contributor')
 
       const logs = await getAuditLogs(orgId, 'user.role_changed')
-      const entry = logs.find(l => l.entityId === viewer.id && (l.after as any)?.role === 'contributor')
+      const entry = logs.find(l => l.entityId === viewer.id && (l.after as Record<string, unknown>)?.role === 'contributor')
       expect(entry).toBeDefined()
       expect(entry!.before).toMatchObject({ role: 'viewer' })
       expect(entry!.after).toMatchObject({ role: 'contributor' })


### PR DESCRIPTION
## Summary

Closes #117.

- **48 DB-backed integration tests** covering the primary write paths: capabilities, users, settings, and cross-org boundary enforcement
- **Vitest** runs server actions directly (no browser), importing them against a real Postgres instance
- **Test isolation**: each suite creates a unique org via factory helpers and cascade-deletes it in `afterAll` — no shared state between suites
- **CI job**: `integration` workflow step spins up `postgres:16-alpine`, runs migrations, and runs `pnpm test:integration` on every push and PR

## What the tests verify

| Area | Checks |
|---|---|
| Role enforcement | contributor/admin/viewer/unauthenticated on every mutation |
| Cross-org | `assertOwnership` blocks edits/deletes on another org's content |
| Audit logging | `before`/`after` snapshots on create, edit, delete, role change, module toggle |
| Last-admin guard | `deactivateUser` throws when the org would be left with no admin |
| Org scoping | `createUser` always places new users in the caller's org |

## Test plan

- [x] `pnpm test:integration` → 48/48 passing locally against Podman Postgres
- [x] CI workflow job added — will run on this PR
- [x] README documents local setup, test isolation strategy, auth mocking, and helper API

## Capabilities

Capability: iam-user-management
Capability: iam-audit-trail
Capability: iam-role-based-access-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)