### PR TITLE
design: resolve ARB findings #129, #130, #131 (repository-modelling)

### DIFF
--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -17,11 +17,17 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 
 - Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, and optional target resolution date
 - Debt types: `lifecycle-risk` (application approaching or past vendor support end), `capability-gap` (capability with no supporting application), `decision-drift` (ADR superseded by practice without formal revision), `known-shortcut` (deliberate technical or architectural compromise), `unreviewed` (object not updated in more than N months)
+- Severity tiers (defined once here; used by this capability and referenced by `rm-end-to-end-traceability` and `rm-repository-completeness`):
+  - `critical` — immediate operational or security risk: an application past end-of-life in active use with no remediation plan; a published capability with zero linked personas
+  - `high` — significant constraint on future options: application approaching end-of-life, ADR that contradicts current practice without a formal revision
+  - `medium` — known gap without immediate risk: weak application coverage for a capability, a deliberate shortcut without a resolution timeline
+  - `low` — documentation debt: outdated descriptions, missing optional relationships, stale content with no active delivery impact
 - Mark an application, capability, or ADR as carrying known debt directly from its edit form — without requiring a separate debt item to be created
 - View all debt items for the organization on a single screen, filterable by type, severity, and status
 - Link a debt item to an initiative as the resolution path
 - Track debt item status: `open`, `in-progress` (linked to an active initiative), `resolved`, `accepted` (acknowledged, no resolution planned, with a documented rationale)
 - Surface open debt count on the admin dashboard alongside repository completeness metrics
+- Surface a **unified priority signal summary** on the admin dashboard: a single ranked list combining open debt items, broken chain indicators (from `rm-end-to-end-traceability`), and staleness warnings (from `rm-repository-completeness`), sorted by severity tier (`critical` first, then `high`, `medium`, `low`). This replaces three separate signal lists — architects see one prioritised action queue, not three panels to check separately
 - Auto-flag applications where the lifecycle status is `end-of-life` or where technology records indicate an end-of-support date has passed
 
 ## Rules
@@ -31,6 +37,7 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 - `accepted` debt items require a written rationale; the system must not allow acceptance without documentation
 - Auto-flagged debt (lifecycle-based) appears in a separate "system-detected" queue, distinct from human-created debt items; the distinction must be visible
 - Resolving a debt item requires linking it to an initiative or explicitly marking it `accepted` with rationale; it cannot be closed without one or the other
+- When a user attempts to publish an architecture object that has one or more linked `critical` or `high` severity debt items in `open` status, the system must display a warning and require explicit acknowledgment before publishing proceeds — the publish action is not blocked, but the acknowledgment is mandatory and logged in the audit trail; this prevents silent publication of high-risk content without removing the architect's ability to communicate context alongside known problems
 - Debt items must be linked to at least one architecture object; unattached debt items are not permitted
 
 ## Federation Behavior

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -18,7 +18,12 @@ The system must allow any user to follow a chain of relationships across the ful
 - From any application, navigate upward to linked capabilities, then to the personas those capabilities serve, then to any strategic objectives or initiatives connected to those capabilities
 - From any persona, see the full set of capabilities defined for them and the applications enabling each capability
 - Impact panel: select any object and see all directly and indirectly connected objects, grouped by type (objectives, capabilities, applications, personas, ADRs)
-- Broken chain indicator: surface objects where a required link is missing — applications with no capability, capabilities with no application, capabilities with no persona, personas with no capability
+- Broken chain indicator: surface objects where a required link is missing, with severity assigned by type:
+  - `critical` — published application with no linked capability (active governance gap)
+  - `high` — capability with no linked application (no evidence of delivery)
+  - `medium` — capability with no linked persona (justification chain incomplete)
+  - `low` — persona with no linked capability (documentation gap, not a delivery gap)
+- Broken chain indicators feed into the unified priority signal summary on the admin dashboard (see `rm-architecture-debt` for the unified view definition)
 - Cross-agency view (Enterprise Architect only): across connected organizations, show which capabilities are served by multiple independent applications — potential rationalisation signals
 
 ## Rules
@@ -27,6 +32,8 @@ The system must allow any user to follow a chain of relationships across the ful
 - Traceability navigation is read-only — no editing occurs within the trace view
 - Cross-agency traceability is available only to Enterprise Architect role and only where federation connections have been established and content is marked as `connections` or `instance` visibility
 - Broken chain indicators are visible to Contributors and Admins; they do not surface to Viewers (Viewers only see published, complete content)
+- Draft objects are excluded from impact panel traversal results for Viewer-role users — any object without a published version is treated as non-existent in traversal, regardless of relationship links
+- The traversal visibility gate described in the Federation Behavior section is a pre-ship security requirement; the impact panel must not ship until a security test matrix covering all role × visibility × federation-state combinations has been completed and reviewed by a human
 
 ## Federation Behavior
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -23,14 +23,24 @@ A repository where everything appears equally authoritative — regardless of wh
 - Show a trend line for each metric over time so that progress (or regression) is visible
 - Surface a "completeness score" per capability domain — which areas of the architecture are well-maintained and which are gaps
 - Allow the Admin to configure the staleness threshold (default 12 months; configurable to 3, 6, 12, or 24 months)
-- Publish a read-only completeness summary to Viewers — showing high-level scores without exposing the drill-down list of incomplete objects (the gap list is internal; the score is publishable)
+- Allow the Admin to set a **completeness target** per capability domain (e.g., "80% of capabilities linked to at least one application"); the dashboard shows RAG progress toward each target rather than a raw score in isolation — green ≥ target, amber within 15 points below target, red more than 15 points below
+- Surface a **"most-needed actions" list** — the top 5 specific objects whose update would most improve the overall completeness score, shown only to Contributors and Admins; this gives architects a concrete starting point rather than a wall of signals to triage. Staleness warnings from this list also feed into the unified priority signal summary on the admin dashboard (see `rm-architecture-debt` for the unified view definition)
+- **Completeness publication** (opt-in, off by default):
+  - Admin explicitly enables completeness publication in org settings; it is off by default
+  - A configurable publication threshold must be set before enabling publication (default 50%; configurable 25–100%); the summary is suppressed automatically if the overall score drops below the threshold
+  - The published view shows **plain-language status labels** by default, not raw percentages: `actively maintained` (≥75%), `under development` (40–74%), `getting started` (<40%); admins may optionally enable raw percentage display for authenticated viewers
+  - An optional **admin-authored narrative field** allows admins to contextualise the label in plain language (example: "We launched our EA practice in January — this score reflects a practice in its first year, not an architecture in disrepair"); this narrative appears alongside the label in the published view
+  - Separate publication controls for authenticated internal viewers and unauthenticated (public) audiences; by default only authenticated users may see the completeness summary
 
 ## Rules
 
 - Completeness metrics are calculated at the organization level; cross-org completeness is not exposed across federation boundaries
-- The published completeness summary (visible to Viewers) must show only aggregate scores, not the list of incomplete objects — incomplete drafts should not be surfaced to readers
+- The published completeness summary (visible to Viewers) must show only the plain-language label and optional narrative — the drill-down list of incomplete objects is never published; incomplete drafts must not be surfaced to readers
 - Staleness is calculated from the last-modified date of the published version, not the draft; updating a draft does not reset the staleness clock until published
 - An object with no published version does not contribute to completeness scores — it simply does not exist from the repository's perspective
+- Completeness publication is opt-in and off by default; enabling it requires an explicit admin action and a publication threshold to be configured
+- Unauthenticated (public) audiences never see completeness summaries unless the admin explicitly enables public visibility as a separate step from enabling authenticated-viewer publication; the two controls are independent
+- If the completeness score falls below the configured publication threshold after publication has been enabled, the summary is automatically suppressed until the score recovers; Admins are notified when this occurs
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Summary

Pre-implementation design work on the Repository & Modelling capability group. Resolves all three high-severity ARB findings before any code is written against these capabilities.

- **#129 (Omar Singh — Security):** Added two explicit Rules to `rm-end-to-end-traceability` — draft objects are excluded from Viewer-role traversal regardless of relationship links; the impact panel carries a pre-ship security-test-matrix gate. The Federation Behavior section that addressed the traversal scoping concern already existed; these rules formalise what was implied.

- **#130 (Jake Lawson — Veteran Architect):** Severity tiers (`critical` / `high` / `medium` / `low`) defined once in `rm-architecture-debt` with plain-language definitions. Broken chain indicators in `rm-end-to-end-traceability` now carry per-type severity (published app with no capability = `critical`; capability with no persona = `medium`, etc.). Unified priority signal summary added to the admin dashboard — one ranked list across debt, broken chains, and staleness rather than three separate panels. Completeness target + RAG status added to `rm-repository-completeness`. Warn-and-acknowledge rule added for publishing objects with open `critical`/`high` debt (not a hard block).

- **#131 (Thomas Reed — Central IT Director):** Completeness publication is now opt-in, off by default, gated by a configurable threshold (default 50%). Published view shows plain-language labels (`actively maintained` / `under development` / `getting started`) not raw percentages. Optional admin narrative field. Independent controls for authenticated and unauthenticated audiences.

## Files changed

- `business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md`
- `business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md`
- `business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md`

## Test plan

- [ ] Read each file end-to-end and confirm no internal contradictions
- [ ] Verify the severity tier definitions in `rm-architecture-debt` are referenced correctly from the other two files
- [ ] Confirm the warn-and-acknowledge rule wording is clear enough to drive a UI spec
- [ ] Confirm the plain-language label thresholds (75% / 40%) are acceptable or adjust before implementation
- [ ] Close issues #129, #130, #131 on merge

Closes #129
Closes #130
Closes #131

Capability: rm-end-to-end-traceability, rm-architecture-debt, rm-repository-completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)