### PR TITLE
feat: move persona type and tag management to taxonomy

### DIFF
--- a/apps/govea/src/actions/dev.ts
+++ b/apps/govea/src/actions/dev.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import {
-  personas, capabilities, applications, tags, personaTypes,
+  personas, capabilities, applications, taxonomyTerms,
   personaTags, capabilityPersonas, applicationCapabilities,
   valueStreams, valueStreamStages, valueStreamStageCapabilities,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
@@ -11,7 +11,7 @@ import {
   principles, principleAdrs, principleCapabilities,
   glossaryTerms, glossaryTermSources,
 } from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, isNull } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { redirect } from 'next/navigation'
@@ -40,25 +40,52 @@ export async function resetToDataset(datasetKey: string) {
   await db.delete(applications).where(eq(applications.organizationId, orgId))
   await db.delete(capabilities).where(eq(capabilities.organizationId, orgId))
   await db.delete(personas).where(eq(personas.organizationId, orgId))
-  await db.delete(tags).where(eq(tags.organizationId, orgId))
-  await db.delete(personaTypes).where(eq(personaTypes.organizationId, orgId))
+  // Note: persona_types and tags tables were removed in migration 0016.
+  // Types are now managed via the Taxonomy page ("Persona Type" type).
+  // Tags are now taxonomy terms under "Persona Tag" type.
 
-  // ── Insert persona types ─────────────────────────────────────────────────
-  if (dataset.personaTypes.length > 0) {
-    await db.insert(personaTypes)
-      .values(dataset.personaTypes.map(name => ({ name, organizationId: orgId })))
-      .onConflictDoNothing()
+  // ── Resolve persona tag IDs from taxonomy ─────────────────────────────────
+  // Ensure the "Persona Tag" type exists, then find/create each tag as a child term.
+  let personaTagTypeId: string | null = null
+  if (dataset.tags.length > 0) {
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, orgId), isNull(t.parentId), e(t.slug, 'persona-tag')),
+    })
+    if (existing) {
+      personaTagTypeId = existing.id
+    } else {
+      const [created] = await db.insert(taxonomyTerms).values({
+        organizationId: orgId,
+        name: 'Persona Tag',
+        slug: 'persona-tag',
+        description: 'Cross-cutting labels used to filter and search personas.',
+        sortOrder: '20',
+      }).returning()
+      personaTagTypeId = created.id
+    }
   }
 
-  // ── Insert tags ───────────────────────────────────────────────────────────
-  const tagRows = dataset.tags.length > 0
-    ? await db.insert(tags)
-        .values(dataset.tags.map(name => ({ name, organizationId: orgId })))
-        .onConflictDoNothing()
-        .returning()
-    : []
-
-  const tagByName = Object.fromEntries(tagRows.map(t => [t.name, t.id]))
+  const tagByName: Record<string, string> = {}
+  for (const name of dataset.tags) {
+    if (!personaTagTypeId) break
+    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    const [term] = await db.insert(taxonomyTerms).values({
+      organizationId: orgId,
+      parentId: personaTagTypeId,
+      name,
+      slug,
+    }).onConflictDoNothing().returning()
+    if (term) {
+      tagByName[name] = term.id
+    } else {
+      const found = await db.query.taxonomyTerms.findFirst({
+        where: (t, { eq: e, and }) =>
+          and(e(t.organizationId, orgId), e(t.parentId, personaTagTypeId!), e(t.name, name)),
+      })
+      if (found) tagByName[name] = found.id
+    }
+  }
 
   if (dataset.personas.length === 0) return
 

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { personas, personaTypes, personaTags, tags } from '@/db/schema'
+import { personas, personaTags } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
@@ -21,114 +21,6 @@ async function requireAdmin() {
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) throw new Error('Forbidden')
   return session
-}
-
-// ── Persona Types ─────────────────────────────────────────────────────────────
-
-export async function getPersonaTypes(organizationId: string) {
-  return db.query.personaTypes.findMany({
-    where: (pt, { eq }) => eq(pt.organizationId, organizationId),
-    orderBy: (pt, { asc }) => [asc(pt.name)],
-  })
-}
-
-export async function createPersonaType(name: string) {
-  const session = await requireAdmin()
-  const orgId = session.user.organizationId!
-
-  const trimmed = name.trim()
-  if (!trimmed) throw new Error('Name is required')
-
-  const [pt] = await db.insert(personaTypes).values({
-    name: trimmed,
-    organizationId: orgId,
-  }).onConflictDoNothing().returning()
-
-  if (pt) {
-    await writeAuditLog({
-      action: 'persona_type.create',
-      entityType: 'persona_type',
-      entityId: pt.id,
-      userId: session.user.id,
-      organizationId: orgId,
-      after: { name: trimmed },
-    })
-  }
-}
-
-export async function deletePersonaType(typeId: string) {
-  const session = await requireAdmin()
-  const orgId = session.user.organizationId!
-
-  const before = await db.query.personaTypes.findFirst({
-    where: eq(personaTypes.id, typeId),
-  })
-
-  await db.delete(personaTypes).where(
-    and(eq(personaTypes.id, typeId), eq(personaTypes.organizationId, orgId))
-  )
-
-  await writeAuditLog({
-    action: 'persona_type.delete',
-    entityType: 'persona_type',
-    entityId: typeId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
-  })
-}
-
-// ── Tags ──────────────────────────────────────────────────────────────────────
-
-export async function getTags(organizationId: string) {
-  return db.query.tags.findMany({
-    where: (t, { eq }) => eq(t.organizationId, organizationId),
-    orderBy: (t, { asc }) => [asc(t.name)],
-  })
-}
-
-export async function createTag(name: string) {
-  const session = await requireAdmin()
-  const orgId = session.user.organizationId!
-
-  const trimmed = name.trim()
-  if (!trimmed) throw new Error('Name is required')
-
-  const [tag] = await db.insert(tags).values({
-    name: trimmed,
-    organizationId: orgId,
-  }).onConflictDoNothing().returning()
-
-  if (tag) {
-    await writeAuditLog({
-      action: 'tag.create',
-      entityType: 'tag',
-      entityId: tag.id,
-      userId: session.user.id,
-      organizationId: orgId,
-      after: { name: trimmed },
-    })
-  }
-}
-
-export async function deleteTag(tagId: string) {
-  const session = await requireAdmin()
-  const orgId = session.user.organizationId!
-
-  const before = await db.query.tags.findFirst({ where: eq(tags.id, tagId) })
-
-  await db.delete(tags).where(
-    and(eq(tags.id, tagId), eq(tags.organizationId, orgId))
-  )
-
-  await writeAuditLog({
-    action: 'tag.delete',
-    entityType: 'tag',
-    entityId: tagId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
-  })
 }
 
 // ── Personas ──────────────────────────────────────────────────────────────────

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -155,6 +155,34 @@ export async function deleteTaxonomyTerm(termId: string) {
   })
 }
 
+/** Returns values (children) of the "Persona Type" taxonomy type. */
+export async function getPersonaTypesFromTaxonomy(organizationId: string) {
+  const type = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq, and }) =>
+      and(eq(t.organizationId, organizationId), isNull(t.parentId), eq(t.slug, 'persona-type')),
+  })
+  if (!type) return []
+  return db.query.taxonomyTerms.findMany({
+    where: (t, { eq, and }) =>
+      and(eq(t.organizationId, organizationId), eq(t.parentId, type.id)),
+    orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
+  })
+}
+
+/** Returns values (children) of the "Persona Tag" taxonomy type. */
+export async function getPersonaTagsFromTaxonomy(organizationId: string) {
+  const type = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq, and }) =>
+      and(eq(t.organizationId, organizationId), isNull(t.parentId), eq(t.slug, 'persona-tag')),
+  })
+  if (!type) return []
+  return db.query.taxonomyTerms.findMany({
+    where: (t, { eq, and }) =>
+      and(eq(t.organizationId, organizationId), eq(t.parentId, type.id)),
+    orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
+  })
+}
+
 /**
  * Ad-hoc: creates a new value under the "Domain" type.
  * If the "Domain" type doesn't exist yet, it is created first.

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
-import { getPersona, getPersonaTypes, getTags } from '@/actions/personas'
+import { getPersona } from '@/actions/personas'
+import { getPersonaTypesFromTaxonomy, getPersonaTagsFromTaxonomy } from '@/actions/taxonomy'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
 import { canEdit } from '@/lib/rbac'
@@ -46,8 +47,8 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
     ? await Promise.all([
         getCapabilities(orgId),
         getValueStreams(orgId),
-        getPersonaTypes(orgId),
-        getTags(orgId),
+        getPersonaTypesFromTaxonomy(orgId),
+        getPersonaTagsFromTaxonomy(orgId),
       ])
     : [[], [], [], []]
 

--- a/apps/govea/src/app/(admin)/personas/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { getPersonas, getPersonaTypes, getTags } from '@/actions/personas'
+import { getPersonas } from '@/actions/personas'
+import { getPersonaTypesFromTaxonomy, getPersonaTagsFromTaxonomy } from '@/actions/taxonomy'
 import { PersonaTable } from './persona-table'
 export default async function PersonasPage() {
   const session = await auth()
@@ -11,8 +12,8 @@ export default async function PersonasPage() {
 
   const [personaList, typeList, tagList] = await Promise.all([
     getPersonas(orgId),
-    getPersonaTypes(orgId),
-    getTags(orgId),
+    getPersonaTypesFromTaxonomy(orgId),
+    getPersonaTagsFromTaxonomy(orgId),
   ])
 
   return (

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -1,12 +1,8 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import type { Persona, PersonaType, Tag } from '@/db/schema'
-import {
-  createPersona, editPersona, deletePersona,
-  createPersonaType, deletePersonaType,
-  createTag, deleteTag,
-} from '@/actions/personas'
+import type { Persona, TaxonomyTerm } from '@/db/schema'
+import { createPersona, editPersona, deletePersona } from '@/actions/personas'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
@@ -23,13 +19,13 @@ import type { Role } from '@/lib/rbac'
 
 type PersonaRow = Persona & {
   organization: { id: string; name: string } | null
-  personaTags: { tag: Tag }[]
+  personaTags: { tag: TaxonomyTerm }[]
 }
 
 interface Props {
   personas: PersonaRow[]
-  personaTypes: PersonaType[]
-  allTags: Tag[]
+  personaTypes: TaxonomyTerm[]
+  allTags: TaxonomyTerm[]
   role: Role
   currentOrgId: string
 }
@@ -69,10 +65,6 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<PersonaRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<PersonaRow | null>(null)
-  const [manageTypesOpen, setManageTypesOpen] = useState(false)
-  const [manageTagsOpen, setManageTagsOpen] = useState(false)
-  const [newTypeName, setNewTypeName] = useState('')
-  const [newTagName, setNewTagName] = useState('')
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -110,38 +102,6 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
     startTransition(async () => {
       await deletePersona(deleteTarget.id)
       setDeleteTarget(null)
-      refresh()
-    })
-  }
-
-  async function handleAddType() {
-    if (!newTypeName.trim()) return
-    startTransition(async () => {
-      await createPersonaType(newTypeName.trim())
-      setNewTypeName('')
-      refresh()
-    })
-  }
-
-  async function handleDeleteType(typeId: string) {
-    startTransition(async () => {
-      await deletePersonaType(typeId)
-      refresh()
-    })
-  }
-
-  async function handleAddTag() {
-    if (!newTagName.trim()) return
-    startTransition(async () => {
-      await createTag(newTagName.trim())
-      setNewTagName('')
-      refresh()
-    })
-  }
-
-  async function handleDeleteTag(tagId: string) {
-    startTransition(async () => {
-      await deleteTag(tagId)
       refresh()
     })
   }
@@ -197,16 +157,6 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           </select>
         )}
         <div className="ml-auto flex items-center gap-2">
-          {canDelete && (
-            <>
-              <Button variant="outline" size="sm" onClick={() => setManageTagsOpen(true)}>
-                Manage tags
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => setManageTypesOpen(true)}>
-                Manage types
-              </Button>
-            </>
-          )}
           {canEdit && (
             <Button onClick={() => setCreateOpen(true)} size="sm">
               + New persona
@@ -316,98 +266,6 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           </TableBody>
         </Table>
       </div>
-
-      {/* Manage Tags Dialog */}
-      <Dialog open={manageTagsOpen} onOpenChange={setManageTagsOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Manage tags</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Tags are cross-cutting labels for filtering and search. Changes apply to your organization only.
-          </p>
-          <div className="space-y-2">
-            {allTags.length === 0 && (
-              <p className="text-sm text-muted-foreground py-2">No tags defined yet.</p>
-            )}
-            {allTags.map(t => (
-              <div key={t.id} className="flex items-center justify-between rounded-md border px-3 py-2">
-                <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-200">
-                  {t.name}
-                </span>
-                <Button
-                  variant="ghost" size="sm"
-                  disabled={isPending}
-                  onClick={() => handleDeleteTag(t.id)}
-                  className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                >
-                  ×
-                </Button>
-              </div>
-            ))}
-          </div>
-          <div className="flex gap-2 pt-2">
-            <Input
-              placeholder="New tag name…"
-              value={newTagName}
-              onChange={e => setNewTagName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddTag() } }}
-              disabled={isPending}
-            />
-            <Button onClick={handleAddTag} disabled={isPending || !newTagName.trim()} size="sm">
-              Add
-            </Button>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setManageTagsOpen(false)}>Close</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Manage Types Dialog */}
-      <Dialog open={manageTypesOpen} onOpenChange={setManageTypesOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Manage persona types</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Types help categorize personas. Changes apply to your organization only.
-          </p>
-          <div className="space-y-2">
-            {personaTypes.length === 0 && (
-              <p className="text-sm text-muted-foreground py-2">No types defined yet.</p>
-            )}
-            {personaTypes.map(t => (
-              <div key={t.id} className="flex items-center justify-between rounded-md border px-3 py-2">
-                <span className="text-sm">{t.name}</span>
-                <Button
-                  variant="ghost" size="sm"
-                  disabled={isPending}
-                  onClick={() => handleDeleteType(t.id)}
-                  className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                >
-                  ×
-                </Button>
-              </div>
-            ))}
-          </div>
-          <div className="flex gap-2 pt-2">
-            <Input
-              placeholder="New type name…"
-              value={newTypeName}
-              onChange={e => setNewTypeName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddType() } }}
-              disabled={isPending}
-            />
-            <Button onClick={handleAddType} disabled={isPending || !newTypeName.trim()} size="sm">
-              Add
-            </Button>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setManageTypesOpen(false)}>Close</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>

--- a/apps/govea/src/app/(admin)/taxonomy/page.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/page.tsx
@@ -17,7 +17,7 @@ export default async function TaxonomyPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Taxonomy</h1>
         <p className="text-muted-foreground mt-1">
-          Classification types and their values — used to organize capabilities and glossary entries.
+          Classification types and their values — used to organize capabilities, glossary entries, and personas.
         </p>
       </div>
       <TaxonomyTable types={types} values={values} role={role} />

--- a/apps/govea/src/components/persona-edit-form.tsx
+++ b/apps/govea/src/components/persona-edit-form.tsx
@@ -8,12 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 
-interface PersonaType {
-  id: string
-  name: string
-}
-
-interface Tag {
+interface TaxonomyTerm {
   id: string
   name: string
 }
@@ -28,8 +23,8 @@ interface PersonaEditFormProps {
     visibility: 'org' | 'connections' | 'instance'
     tagIds: string[]
   }
-  personaTypes: PersonaType[]
-  tags: Tag[]
+  personaTypes: TaxonomyTerm[]
+  tags: TaxonomyTerm[]
   onCancel: () => void
 }
 

--- a/apps/govea/src/db/migrations/0016_busy_wrecker.sql
+++ b/apps/govea/src/db/migrations/0016_busy_wrecker.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "persona_types" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "tags" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "persona_types" CASCADE;--> statement-breakpoint
+-- CASCADE above also drops the old persona_tags_tag_id_tags_id_fk constraint.
+-- Clear stale persona_tags rows before re-pointing the FK to taxonomy_terms.
+DROP TABLE "tags" CASCADE;--> statement-breakpoint
+DELETE FROM "persona_tags";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "persona_tags" ADD CONSTRAINT "persona_tags_tag_id_taxonomy_terms_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."taxonomy_terms"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/govea/src/db/migrations/meta/0016_snapshot.json
+++ b/apps/govea/src/db/migrations/meta/0016_snapshot.json
@@ -1,0 +1,3209 @@
+{
+  "id": "3851331d-281d-4089-947f-0a21d644b1af",
+  "prevId": "c7830fb7-dd77-4bfc-9e6f-09660f18ac41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'govea'"
+        },
+        "enabled_modules": {
+          "name": "enabled_modules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_parent_id_organizations_id_fk": {
+          "name": "organizations_parent_id_organizations_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.persona_tags": {
+      "name": "persona_tags",
+      "schema": "",
+      "columns": {
+        "persona_id": {
+          "name": "persona_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_tags_persona_id_personas_id_fk": {
+          "name": "persona_tags_persona_id_personas_id_fk",
+          "tableFrom": "persona_tags",
+          "tableTo": "personas",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_tags_tag_id_taxonomy_terms_id_fk": {
+          "name": "persona_tags_tag_id_taxonomy_terms_id_fk",
+          "tableFrom": "persona_tags",
+          "tableTo": "taxonomy_terms",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personas": {
+      "name": "personas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personas_organization_id_organizations_id_fk": {
+          "name": "personas_organization_id_organizations_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personas_created_by_users_id_fk": {
+          "name": "personas_created_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "personas_updated_by_users_id_fk": {
+          "name": "personas_updated_by_users_id_fk",
+          "tableFrom": "personas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "behaviors": {
+          "name": "behaviors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capabilities_organization_id_organizations_id_fk": {
+          "name": "capabilities_organization_id_organizations_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capabilities_created_by_users_id_fk": {
+          "name": "capabilities_created_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capabilities_updated_by_users_id_fk": {
+          "name": "capabilities_updated_by_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_personas": {
+      "name": "capability_personas",
+      "schema": "",
+      "columns": {
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capability_personas_capability_id_capabilities_id_fk": {
+          "name": "capability_personas_capability_id_capabilities_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capability_personas_persona_id_personas_id_fk": {
+          "name": "capability_personas_persona_id_personas_id_fk",
+          "tableFrom": "capability_personas",
+          "tableTo": "personas",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_capabilities": {
+      "name": "application_capabilities",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_capabilities_application_id_applications_id_fk": {
+          "name": "application_capabilities_application_id_applications_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_capabilities_capability_id_capabilities_id_fk": {
+          "name": "application_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "application_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosting_model": {
+          "name": "hosting_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "applications_organization_id_organizations_id_fk": {
+          "name": "applications_organization_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_users_id_fk": {
+          "name": "applications_created_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "applications_updated_by_users_id_fk": {
+          "name": "applications_updated_by_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adr_applications": {
+      "name": "adr_applications",
+      "schema": "",
+      "columns": {
+        "adr_id": {
+          "name": "adr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adr_applications_adr_id_adrs_id_fk": {
+          "name": "adr_applications_adr_id_adrs_id_fk",
+          "tableFrom": "adr_applications",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "adr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adr_applications_application_id_applications_id_fk": {
+          "name": "adr_applications_application_id_applications_id_fk",
+          "tableFrom": "adr_applications",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adr_capabilities": {
+      "name": "adr_capabilities",
+      "schema": "",
+      "columns": {
+        "adr_id": {
+          "name": "adr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adr_capabilities_adr_id_adrs_id_fk": {
+          "name": "adr_capabilities_adr_id_adrs_id_fk",
+          "tableFrom": "adr_capabilities",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "adr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adr_capabilities_capability_id_capabilities_id_fk": {
+          "name": "adr_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "adr_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adr_initiatives": {
+      "name": "adr_initiatives",
+      "schema": "",
+      "columns": {
+        "adr_id": {
+          "name": "adr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adr_initiatives_adr_id_adrs_id_fk": {
+          "name": "adr_initiatives_adr_id_adrs_id_fk",
+          "tableFrom": "adr_initiatives",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "adr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adr_initiatives_initiative_id_initiatives_id_fk": {
+          "name": "adr_initiatives_initiative_id_initiatives_id_fk",
+          "tableFrom": "adr_initiatives",
+          "tableTo": "initiatives",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adr_objectives": {
+      "name": "adr_objectives",
+      "schema": "",
+      "columns": {
+        "adr_id": {
+          "name": "adr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_id": {
+          "name": "objective_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adr_objectives_adr_id_adrs_id_fk": {
+          "name": "adr_objectives_adr_id_adrs_id_fk",
+          "tableFrom": "adr_objectives",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "adr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adr_objectives_objective_id_strategic_objectives_id_fk": {
+          "name": "adr_objectives_objective_id_strategic_objectives_id_fk",
+          "tableFrom": "adr_objectives",
+          "tableTo": "strategic_objectives",
+          "columnsFrom": [
+            "objective_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adrs": {
+      "name": "adrs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consequences": {
+          "name": "consequences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "adr_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adrs_organization_id_organizations_id_fk": {
+          "name": "adrs_organization_id_organizations_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "adrs_superseded_by_adrs_id_fk": {
+          "name": "adrs_superseded_by_adrs_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "adrs_created_by_users_id_fk": {
+          "name": "adrs_created_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "adrs_updated_by_users_id_fk": {
+          "name": "adrs_updated_by_users_id_fk",
+          "tableFrom": "adrs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taxonomy_terms": {
+      "name": "taxonomy_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taxonomy_terms_organization_id_organizations_id_fk": {
+          "name": "taxonomy_terms_organization_id_organizations_id_fk",
+          "tableFrom": "taxonomy_terms",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_organization_id_organizations_id_fk": {
+          "name": "audit_log_organization_id_organizations_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_org_links": {
+      "name": "cross_org_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_org_id": {
+          "name": "source_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entity_type": {
+          "name": "source_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_org_id": {
+          "name": "target_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_entity_type": {
+          "name": "target_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "link_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cross_org_links_source_org_id_organizations_id_fk": {
+          "name": "cross_org_links_source_org_id_organizations_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "source_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_org_links_target_org_id_organizations_id_fk": {
+          "name": "cross_org_links_target_org_id_organizations_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "target_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cross_org_links_created_by_users_id_fk": {
+          "name": "cross_org_links_created_by_users_id_fk",
+          "tableFrom": "cross_org_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_connections": {
+      "name": "org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_org_id": {
+          "name": "from_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_org_id": {
+          "name": "to_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_connections_from_org_id_organizations_id_fk": {
+          "name": "org_connections_from_org_id_organizations_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "from_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_connections_to_org_id_organizations_id_fk": {
+          "name": "org_connections_to_org_id_organizations_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "to_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_connections_created_by_users_id_fk": {
+          "name": "org_connections_created_by_users_id_fk",
+          "tableFrom": "org_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_org_connection": {
+          "name": "unique_org_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "from_org_id",
+            "to_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_stream_personas": {
+      "name": "value_stream_personas",
+      "schema": "",
+      "columns": {
+        "value_stream_id": {
+          "name": "value_stream_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "value_stream_personas_value_stream_id_value_streams_id_fk": {
+          "name": "value_stream_personas_value_stream_id_value_streams_id_fk",
+          "tableFrom": "value_stream_personas",
+          "tableTo": "value_streams",
+          "columnsFrom": [
+            "value_stream_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "value_stream_personas_persona_id_personas_id_fk": {
+          "name": "value_stream_personas_persona_id_personas_id_fk",
+          "tableFrom": "value_stream_personas",
+          "tableTo": "personas",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_stream_stage_capabilities": {
+      "name": "value_stream_stage_capabilities",
+      "schema": "",
+      "columns": {
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "value_stream_stage_capabilities_stage_id_value_stream_stages_id_fk": {
+          "name": "value_stream_stage_capabilities_stage_id_value_stream_stages_id_fk",
+          "tableFrom": "value_stream_stage_capabilities",
+          "tableTo": "value_stream_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "value_stream_stage_capabilities_capability_id_capabilities_id_fk": {
+          "name": "value_stream_stage_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "value_stream_stage_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_stream_stages": {
+      "name": "value_stream_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "value_stream_id": {
+          "name": "value_stream_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "value_stream_stages_value_stream_id_value_streams_id_fk": {
+          "name": "value_stream_stages_value_stream_id_value_streams_id_fk",
+          "tableFrom": "value_stream_stages",
+          "tableTo": "value_streams",
+          "columnsFrom": [
+            "value_stream_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_streams": {
+      "name": "value_streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_item": {
+          "name": "value_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "value_streams_organization_id_organizations_id_fk": {
+          "name": "value_streams_organization_id_organizations_id_fk",
+          "tableFrom": "value_streams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "value_streams_created_by_users_id_fk": {
+          "name": "value_streams_created_by_users_id_fk",
+          "tableFrom": "value_streams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "value_streams_updated_by_users_id_fk": {
+          "name": "value_streams_updated_by_users_id_fk",
+          "tableFrom": "value_streams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_applications": {
+      "name": "objective_applications",
+      "schema": "",
+      "columns": {
+        "objective_id": {
+          "name": "objective_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "objective_applications_objective_id_strategic_objectives_id_fk": {
+          "name": "objective_applications_objective_id_strategic_objectives_id_fk",
+          "tableFrom": "objective_applications",
+          "tableTo": "strategic_objectives",
+          "columnsFrom": [
+            "objective_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_applications_application_id_applications_id_fk": {
+          "name": "objective_applications_application_id_applications_id_fk",
+          "tableFrom": "objective_applications",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_capabilities": {
+      "name": "objective_capabilities",
+      "schema": "",
+      "columns": {
+        "objective_id": {
+          "name": "objective_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "objective_capabilities_objective_id_strategic_objectives_id_fk": {
+          "name": "objective_capabilities_objective_id_strategic_objectives_id_fk",
+          "tableFrom": "objective_capabilities",
+          "tableTo": "strategic_objectives",
+          "columnsFrom": [
+            "objective_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_capabilities_capability_id_capabilities_id_fk": {
+          "name": "objective_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "objective_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_value_streams": {
+      "name": "objective_value_streams",
+      "schema": "",
+      "columns": {
+        "objective_id": {
+          "name": "objective_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_stream_id": {
+          "name": "value_stream_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "objective_value_streams_objective_id_strategic_objectives_id_fk": {
+          "name": "objective_value_streams_objective_id_strategic_objectives_id_fk",
+          "tableFrom": "objective_value_streams",
+          "tableTo": "strategic_objectives",
+          "columnsFrom": [
+            "objective_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_value_streams_value_stream_id_value_streams_id_fk": {
+          "name": "objective_value_streams_value_stream_id_value_streams_id_fk",
+          "tableFrom": "objective_value_streams",
+          "tableTo": "value_streams",
+          "columnsFrom": [
+            "value_stream_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strategic_objectives": {
+      "name": "strategic_objectives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_metric": {
+          "name": "success_metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_horizon": {
+          "name": "time_horizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strategic_objectives_organization_id_organizations_id_fk": {
+          "name": "strategic_objectives_organization_id_organizations_id_fk",
+          "tableFrom": "strategic_objectives",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "strategic_objectives_created_by_users_id_fk": {
+          "name": "strategic_objectives_created_by_users_id_fk",
+          "tableFrom": "strategic_objectives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "strategic_objectives_updated_by_users_id_fk": {
+          "name": "strategic_objectives_updated_by_users_id_fk",
+          "tableFrom": "strategic_objectives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative_applications": {
+      "name": "initiative_applications",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_applications_initiative_id_initiatives_id_fk": {
+          "name": "initiative_applications_initiative_id_initiatives_id_fk",
+          "tableFrom": "initiative_applications",
+          "tableTo": "initiatives",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_applications_application_id_applications_id_fk": {
+          "name": "initiative_applications_application_id_applications_id_fk",
+          "tableFrom": "initiative_applications",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative_capabilities": {
+      "name": "initiative_capabilities",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_capabilities_initiative_id_initiatives_id_fk": {
+          "name": "initiative_capabilities_initiative_id_initiatives_id_fk",
+          "tableFrom": "initiative_capabilities",
+          "tableTo": "initiatives",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_capabilities_capability_id_capabilities_id_fk": {
+          "name": "initiative_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "initiative_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiative_objectives": {
+      "name": "initiative_objectives",
+      "schema": "",
+      "columns": {
+        "initiative_id": {
+          "name": "initiative_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_id": {
+          "name": "objective_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiative_objectives_initiative_id_initiatives_id_fk": {
+          "name": "initiative_objectives_initiative_id_initiatives_id_fk",
+          "tableFrom": "initiative_objectives",
+          "tableTo": "initiatives",
+          "columnsFrom": [
+            "initiative_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiative_objectives_objective_id_strategic_objectives_id_fk": {
+          "name": "initiative_objectives_objective_id_strategic_objectives_id_fk",
+          "tableFrom": "initiative_objectives",
+          "tableTo": "strategic_objectives",
+          "columnsFrom": [
+            "objective_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.initiatives": {
+      "name": "initiatives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "initiative_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "initiatives_organization_id_organizations_id_fk": {
+          "name": "initiatives_organization_id_organizations_id_fk",
+          "tableFrom": "initiatives",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "initiatives_created_by_users_id_fk": {
+          "name": "initiatives_created_by_users_id_fk",
+          "tableFrom": "initiatives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "initiatives_updated_by_users_id_fk": {
+          "name": "initiatives_updated_by_users_id_fk",
+          "tableFrom": "initiatives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principle_adrs": {
+      "name": "principle_adrs",
+      "schema": "",
+      "columns": {
+        "principle_id": {
+          "name": "principle_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adr_id": {
+          "name": "adr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principle_adrs_principle_id_principles_id_fk": {
+          "name": "principle_adrs_principle_id_principles_id_fk",
+          "tableFrom": "principle_adrs",
+          "tableTo": "principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principle_adrs_adr_id_adrs_id_fk": {
+          "name": "principle_adrs_adr_id_adrs_id_fk",
+          "tableFrom": "principle_adrs",
+          "tableTo": "adrs",
+          "columnsFrom": [
+            "adr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principle_capabilities": {
+      "name": "principle_capabilities",
+      "schema": "",
+      "columns": {
+        "principle_id": {
+          "name": "principle_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principle_capabilities_principle_id_principles_id_fk": {
+          "name": "principle_capabilities_principle_id_principles_id_fk",
+          "tableFrom": "principle_capabilities",
+          "tableTo": "principles",
+          "columnsFrom": [
+            "principle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principle_capabilities_capability_id_capabilities_id_fk": {
+          "name": "principle_capabilities_capability_id_capabilities_id_fk",
+          "tableFrom": "principle_capabilities",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principles": {
+      "name": "principles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implications": {
+          "name": "implications",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principles_organization_id_organizations_id_fk": {
+          "name": "principles_organization_id_organizations_id_fk",
+          "tableFrom": "principles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principles_created_by_users_id_fk": {
+          "name": "principles_created_by_users_id_fk",
+          "tableFrom": "principles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "principles_updated_by_users_id_fk": {
+          "name": "principles_updated_by_users_id_fk",
+          "tableFrom": "principles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_term_sources": {
+      "name": "glossary_term_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_term_sources_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_sources_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_sources",
+          "tableTo": "glossary_terms",
+          "columnsFrom": [
+            "term_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_source": {
+          "name": "definition_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_source_url": {
+          "name": "definition_source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_terms_organization_id_organizations_id_fk": {
+          "name": "glossary_terms_organization_id_organizations_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossary_terms_created_by_users_id_fk": {
+          "name": "glossary_terms_created_by_users_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "glossary_terms_updated_by_users_id_fk": {
+          "name": "glossary_terms_updated_by_users_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "org",
+        "connections",
+        "instance"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "contributor",
+        "viewer"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.lifecycle_status": {
+      "name": "lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "sunset",
+        "decommissioned",
+        "planned"
+      ]
+    },
+    "public.adr_status": {
+      "name": "adr_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "accepted",
+        "deprecated",
+        "superseded"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rejected"
+      ]
+    },
+    "public.link_status": {
+      "name": "link_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rejected"
+      ]
+    },
+    "public.link_type": {
+      "name": "link_type",
+      "schema": "public",
+      "values": [
+        "implements",
+        "extends",
+        "maps_to"
+      ]
+    },
+    "public.initiative_status": {
+      "name": "initiative_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "active",
+        "on-hold",
+        "complete",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1776100000000,
       "tag": "0015_quiet_silver_surfer",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1776484301141,
+      "tag": "0016_busy_wrecker",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/govea/src/db/schema/personas.ts
+++ b/apps/govea/src/db/schema/personas.ts
@@ -1,36 +1,16 @@
-import { pgEnum, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core'
+import { pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
+import { taxonomyTerms } from './taxonomy'
 
 export const workflowStatusEnum = pgEnum('workflow_status', ['draft', 'published', 'archived'])
-
-export const personaTypes = pgTable('persona_types', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-}, (t) => ({
-  uniqueOrgType: unique('unique_org_persona_type').on(t.organizationId, t.name),
-}))
-
-export type PersonaType = typeof personaTypes.$inferSelect
-
-export const tags = pgTable('tags', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-}, (t) => ({
-  uniqueOrgTag: unique('unique_org_tag').on(t.organizationId, t.name),
-}))
-
-export type Tag = typeof tags.$inferSelect
 
 export const personas = pgTable('personas', {
   id: uuid('id').primaryKey().defaultRandom(),
   organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
   description: text('description'),
+  // Stores the name of a taxonomy term (child of "Persona Type") — same pattern as capabilities.domain
   type: text('type'),
   status: workflowStatusEnum('status').notNull().default('draft'),
   visibility: visibilityEnum('visibility').notNull().default('org'),
@@ -43,9 +23,11 @@ export const personas = pgTable('personas', {
 export type Persona = typeof personas.$inferSelect
 export type NewPersona = typeof personas.$inferInsert
 
+// Tags are taxonomy terms — children of the "Persona Tag" taxonomy type.
+// Management happens in the Taxonomy page, not the Personas page.
 export const personaTags = pgTable('persona_tags', {
   personaId: uuid('persona_id').notNull().references(() => personas.id, { onDelete: 'cascade' }),
-  tagId: uuid('tag_id').notNull().references(() => tags.id, { onDelete: 'cascade' }),
+  tagId: uuid('tag_id').notNull().references(() => taxonomyTerms.id, { onDelete: 'cascade' }),
 })
 
 export type PersonaTag = typeof personaTags.$inferSelect

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -1,7 +1,8 @@
 import { relations } from 'drizzle-orm'
 import { capabilities, capabilityPersonas } from './capabilities'
 import { applications, applicationCapabilities } from './applications'
-import { personas, personaTags, personaTypes, tags } from './personas'
+import { personas, personaTags } from './personas'
+import { taxonomyTerms } from './taxonomy'
 import { organizations } from './organizations'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas } from './value-streams'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams, objectiveApplications } from './objectives'
@@ -49,29 +50,14 @@ export const personasRelations = relations(personas, ({ one, many }) => ({
   valueStreamPersonas: many(valueStreamPersonas),
 }))
 
-export const tagsRelations = relations(tags, ({ one, many }) => ({
-  organization: one(organizations, {
-    fields: [tags.organizationId],
-    references: [organizations.id],
-  }),
-  personaTags: many(personaTags),
-}))
-
 export const personaTagsRelations = relations(personaTags, ({ one }) => ({
   persona: one(personas, {
     fields: [personaTags.personaId],
     references: [personas.id],
   }),
-  tag: one(tags, {
+  tag: one(taxonomyTerms, {
     fields: [personaTags.tagId],
-    references: [tags.id],
-  }),
-}))
-
-export const personaTypesRelations = relations(personaTypes, ({ one }) => ({
-  organization: one(organizations, {
-    fields: [personaTypes.organizationId],
-    references: [organizations.id],
+    references: [taxonomyTerms.id],
   }),
 }))
 

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -33,7 +33,9 @@ export const STATE_USERS = [
   { name: 'Sam StateAdmin',    email: 'sam@state.govea.dev',   role: 'admin'       as const },
 ]
 
-// ─── Persona types & tags (shared defaults) ──────────────────────────────────
+// ─── Persona types & tags (taxonomy-backed) ──────────────────────────────────
+// These are seeded as taxonomy terms under "Persona Type" and "Persona Tag"
+// taxonomy types. Management happens in the Taxonomy page, not the Personas page.
 
 export const DEFAULT_PERSONA_TYPES = [
   'Citizen',
@@ -42,7 +44,7 @@ export const DEFAULT_PERSONA_TYPES = [
   'External Partner',
 ]
 
-export const DEFAULT_TAGS = [
+export const DEFAULT_PERSONA_TAGS = [
   'mobile-first',
   'accessibility',
   'high-volume',
@@ -51,7 +53,7 @@ export const DEFAULT_TAGS = [
 ]
 
 // Tag assignments for specific personas — seeds the personaTags junction table.
-export const DEV_PERSONA_TAGS = [
+export const DEV_PERSONA_TAG_ASSIGNMENTS = [
   { personaName: 'Resident',             tags: ['mobile-first', 'high-volume', 'low-digital-literacy', 'multilingual'] },
   { personaName: 'Small Business Owner', tags: ['high-volume', 'multilingual'] },
   { personaName: 'Field Inspector',      tags: ['mobile-first', 'accessibility'] },

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -3,8 +3,8 @@ import { GOV_TAXONOMY } from './gov-taxonomy'
 import {
   DEV_ORG, STATE_ORG,
   DEV_USERS, STATE_USERS,
-  DEFAULT_PERSONA_TYPES, DEFAULT_TAGS,
-  DEV_PERSONA_TAGS,
+  DEFAULT_PERSONA_TYPES, DEFAULT_PERSONA_TAGS,
+  DEV_PERSONA_TAG_ASSIGNMENTS,
   DEV_PERSONAS, DEV_CAPABILITIES, DEV_APPLICATIONS,
   DEV_OBJECTIVES, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   DEV_PRINCIPLES, DEV_GLOSSARY,
@@ -13,7 +13,7 @@ import {
 } from './dev-fixtures'
 import { db } from '../client'
 import {
-  users, organizations, personaTypes, tags,
+  users, organizations,
   personas, personaTags, capabilities, applications,
   capabilityPersonas, applicationCapabilities,
   strategicObjectives, objectiveCapabilities, objectiveApplications, objectiveValueStreams,
@@ -99,27 +99,69 @@ async function seed() {
   }
   console.log(`  ✓ ${DEV_USERS.length} users (password: dev-password)`)
 
-  // Persona types
+  // Persona types — taxonomy terms under "Persona Type" type
+  let personaTypeTermId: string
+  const existingPersonaTypeType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'persona-type')),
+  })
+  if (existingPersonaTypeType) {
+    personaTypeTermId = existingPersonaTypeType.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Persona Type',
+      slug: 'persona-type',
+      description: 'Categories used to classify personas.',
+      sortOrder: '10',
+    }).returning()
+    personaTypeTermId = inserted.id
+  }
   for (const name of DEFAULT_PERSONA_TYPES) {
-    await db.insert(personaTypes).values({ name, organizationId: devOrgId }).onConflictDoNothing()
+    await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      parentId: personaTypeTermId,
+      name,
+      slug: toSlug(name),
+    }).onConflictDoNothing()
   }
 
-  // Tags — build id map for personaTags
+  // Persona tags — taxonomy terms under "Persona Tag" type; build id map for personaTags junction
+  let personaTagTypeId: string
+  const existingPersonaTagType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'persona-tag')),
+  })
+  if (existingPersonaTagType) {
+    personaTagTypeId = existingPersonaTagType.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Persona Tag',
+      slug: 'persona-tag',
+      description: 'Cross-cutting labels used to filter and search personas.',
+      sortOrder: '20',
+    }).returning()
+    personaTagTypeId = inserted.id
+  }
   const devTagIds: Record<string, string> = {}
-  for (const name of DEFAULT_TAGS) {
-    const [tag] = await db.insert(tags).values({ name, organizationId: devOrgId })
-      .onConflictDoNothing()
-      .returning()
-    if (tag) {
-      devTagIds[name] = tag.id
+  for (const name of DEFAULT_PERSONA_TAGS) {
+    const [term] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      parentId: personaTagTypeId,
+      name,
+      slug: toSlug(name),
+    }).onConflictDoNothing().returning()
+    if (term) {
+      devTagIds[name] = term.id
     } else {
-      const existing = await db.query.tags.findFirst({
-        where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, name)),
+      const existing = await db.query.taxonomyTerms.findFirst({
+        where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.parentId, personaTagTypeId), e(t.name, name)),
       })
       if (existing) devTagIds[name] = existing.id
     }
   }
-  console.log(`  ✓ ${DEFAULT_PERSONA_TYPES.length} persona types, ${DEFAULT_TAGS.length} tags`)
+  console.log(`  ✓ ${DEFAULT_PERSONA_TYPES.length} persona types, ${DEFAULT_PERSONA_TAGS.length} persona tags (taxonomy-backed)`)
 
   // Personas
   const devPersonaIds: Record<string, string> = {}
@@ -131,7 +173,7 @@ async function seed() {
   console.log(`  ✓ ${DEV_PERSONAS.length} personas`)
 
   // Persona tags — personaTags junction table
-  for (const assignment of DEV_PERSONA_TAGS) {
+  for (const assignment of DEV_PERSONA_TAG_ASSIGNMENTS) {
     const personaId = devPersonaIds[assignment.personaName]
     if (!personaId) continue
     for (const tagName of assignment.tags) {


### PR DESCRIPTION
## Summary

Persona types and tags were previously managed through inline "Manage types" / "Manage tags" dialogs on the Personas page. They are now managed in the Taxonomy page — consistent with how capability domains work.

- **Taxonomy > Persona Type** — add/edit/remove the type values that appear in the persona form
- **Taxonomy > Persona Tag** — add/edit/remove the tag values available for selection on personas

The "Manage types" and "Manage tags" buttons are removed from the Personas page.

## Changes

**DB (migration 0016):**
- Drop `persona_types` and `tags` tables
- `persona_tags.tag_id` now references `taxonomy_terms.id` (ON DELETE CASCADE)
- `personas.type` stays as a text field (same pattern as `capabilities.domain`)

**Actions:**
- Removed `getPersonaTypes`, `createPersonaType`, `deletePersonaType`, `getTags`, `createTag`, `deleteTag` from `personas.ts`
- Added `getPersonaTypesFromTaxonomy` and `getPersonaTagsFromTaxonomy` to `taxonomy.ts`
- Updated `dev.ts` reset-to-dataset to look up / create taxonomy tags rather than inserting into the old `tags` table

**UI:**
- Removed "Manage types" / "Manage tags" buttons and their dialogs from `persona-table.tsx`
- Updated persona list page, detail page, edit form, and edit button to consume taxonomy-backed lists
- Updated taxonomy page description to mention personas

**Seeds:**
- `run.ts` creates "Persona Type" and "Persona Tag" taxonomy types with values, and seeds `persona_tags` via taxonomy IDs
- Renamed `DEFAULT_TAGS` → `DEFAULT_PERSONA_TAGS` and `DEV_PERSONA_TAGS` → `DEV_PERSONA_TAG_ASSIGNMENTS`

## Test plan

- [ ] Seed runs clean (`pnpm db:seed`) — 4 persona types + 5 persona tags visible in Taxonomy
- [ ] Personas page loads; type and tag filter dropdowns populated from taxonomy
- [ ] Create/edit persona: type dropdown and tag checkboxes show taxonomy values
- [ ] Persona detail page shows tags correctly
- [ ] Taxonomy page: "Persona Type" and "Persona Tag" types are present with correct values
- [ ] Add a new persona tag in Taxonomy → appears in persona form without restarting
- [ ] Delete a persona tag in Taxonomy → removed from persona tag list (ON DELETE CASCADE clears junction rows)
- [ ] No "Manage types" or "Manage tags" buttons visible on the Personas page

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)