### PR TITLE
docs: sync product story and planning semantics after recent merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Open source enterprise architecture for state and local government.**
 
-GovEA helps government IT teams catalogue their application portfolio, map business capabilities to the people they serve, and make architecture decisions that trace back to real mission needs — not just technology inventory.
+GovEA helps government IT teams catalogue their application and service portfolio, map business capabilities to the people they serve, and make architecture decisions that trace back to real mission needs — not just technology inventory.
 
 Free. Open source. Runs on-prem or as a hosted service.
 
@@ -29,10 +29,13 @@ GovEA is built around a mission-first traceability chain:
 
 ```text
 Personas -> Capabilities -> Applications
+Personas -> Services -> Applications
 ```
 
 - Every **Application** must link to at least one **Capability**.
 - Every **Capability** must link to at least one **Persona**.
+- **Services** model the government-facing delivery layer and can link to personas, capabilities, applications, and value streams.
+- **Persona Type** and **Persona Tag** values are managed through **Taxonomy**, not through persona-specific admin tables.
 - **Organization** is the top-level tenant boundary.
 - Additional core entities include **Architecture Decision Record (ADR)** and **Technology Lifecycle**.
 - v1 is single-organization, but the data model must preserve a path to v2 multi-tenancy by scoping users, roles, content types, and taxonomies to an organization.
@@ -89,17 +92,18 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 ## Current Status
 
 **Implemented:**
-- Full CRUD for the core EA object model: applications, capabilities, personas, value streams, strategic objectives, initiatives, ADRs
+- Full CRUD for the core EA object model: applications, services, capabilities, personas, value streams, strategic objectives, initiatives, ADRs
 - Supporting reference content for principles and glossary terms
 - Mission-first traceability: Personas → Capabilities → Applications enforced at the application layer
+- Service catalogue: first-class service records linked to personas, capabilities, applications, and value streams
+- Contributor-friendly relationship panels across detail pages, including in-context persona editing
 - Live dashboard for EA practitioners with repository activity and coverage signals
 - Roadmap view — initiatives and objectives visualized through planning-status columns
 - Audit trail — immutable before/after log of all changes
-- Taxonomy management — org-scoped taxonomy with admin UI, controlled domain vocabulary, and domain-aware filtering
+- Taxonomy management — org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management — SSO via Microsoft Entra ID (OIDC), local auth fallback, Admin/Contributor/Viewer roles
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, and domain summaries
-- Multi-org federation prototype — connections, visibility controls, cross-org linking, and write-protection enforcement
 - Prototype multi-org federation — connection requests, visibility levels, shared content, cross-org linking
 - Reusable `@govea/core` package — RBAC, audit, taxonomy, workflow, content type, and recipe primitives
 - E2E smoke test coverage across all routes × roles (Playwright)
@@ -114,13 +118,12 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 **Active work:**
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
-- Aligning product documentation with actual feature maturity
 
 **Near-term:**
 - Stakeholder-facing views and plain-language detail pages
 - Repository completeness signals and gap detection
 - Stronger multi-organization support
-- Repository-wide search and consistent workflow behavior across all entity types
+- Repository-wide search and broader workflow consistency across all entity types
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Service catalogue: first-class service records linked to personas, capabilities, applications, and value streams
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
 - Live dashboard for EA practitioners with repository activity and coverage signals
-- Roadmap view — initiatives and objectives visualized through planning-status columns
+- Demo-ready planning module — strategic objectives plus initiatives with a roadmap view grouped by planning status
 - Audit trail — immutable before/after log of all changes
 - Taxonomy management — org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management — SSO via Microsoft Entra ID (OIDC), local auth fallback, Admin/Contributor/Viewer roles
@@ -111,7 +111,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 
 **Partially implemented / still maturing:**
 - ADRs — schema and listing exist, but the full end-user authoring experience is not complete
-- Planning semantics and timeline presentation — useful for demos and early v1, but not fully settled
+- Planning semantics and timeline presentation — useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Admin configuration beyond core settings
 - Repository completeness, end-to-end traceability, and architecture debt tooling
 

--- a/business-architecture/capabilities/cms/planning/pl-initiatives.md
+++ b/business-architecture/capabilities/cms/planning/pl-initiatives.md
@@ -1,7 +1,7 @@
 # Capability: Initiatives
 
 ## What It Does
-The system must allow organizations to document change programmes (initiatives, projects, programmes), link them to the capabilities they affect and the objectives they advance, and track their status and timeline. This makes the connection between investment decisions and the architecture they change explicit and visible.
+The system must allow organizations to document change programmes (initiatives, projects, programmes), link them to the capabilities they affect and the objectives they advance, and track their status and timeline. This makes the connection between investment decisions and the architecture they change explicit and visible. In the shipped product, initiatives are planning records, not workflow-governed content items.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — tracks enterprise-level programmes and their impact on the enterprise capability portfolio
@@ -17,12 +17,15 @@ The system must allow organizations to document change programmes (initiatives, 
 - View which initiatives affect a given capability
 - Track initiative status through its lifecycle (proposed, active, on-hold, complete, cancelled)
 - Display initiatives in roadmap and planning views using their planning status and dates
+- Share initiatives across federation scopes using visibility settings (`org`, `connections`, `instance`)
 
 ## Rules
 - An initiative must belong to an organization
 - Initiatives follow the planning lifecycle documented here: proposed, active, on-hold, complete, cancelled
+- Initiatives do not use the standard content workflow (`draft`, `published`, `archived`)
 - An initiative with no linked capabilities is architecturally incomplete — this should surface as a completeness signal in the admin dashboard
 - Impact labels on capability links are optional but recommended; they communicate whether the initiative is building new capability or changing existing capability
+- Viewer access is not currently driven by a published-only planning workflow; admin surfaces render initiatives based on auth, organization, federation visibility, and route access rules
 
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships

--- a/business-architecture/capabilities/cms/planning/pl-roadmap.md
+++ b/business-architecture/capabilities/cms/planning/pl-roadmap.md
@@ -3,7 +3,7 @@
 ## What It Does
 The system must provide a roadmap view of initiatives and their relationship to strategic objectives, allowing stakeholders to see what is planned, what is underway, and what has been delivered — and how these changes connect to the capability portfolio.
 
-The roadmap is a view over existing planning content, not a standalone data store. It renders what is already captured in initiatives and objectives as a governed, readable timeline.
+The roadmap is a view over existing planning content, not a standalone data store. It renders what is already captured in initiatives and objectives as a readable planning view.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — reviews the enterprise initiative timeline and identifies sequencing conflicts or gaps in capability coverage
@@ -14,17 +14,17 @@ The roadmap is a view over existing planning content, not a standalone data stor
 - Display initiatives grouped by planning status
 - Show the strategic objectives each initiative advances
 - Show the capabilities each initiative affects, with impact label
-- Filter the roadmap by status, capability, or objective
-- Display start and end dates where available; display "TBD" or "ongoing" where dates are not set
+- Display start and end dates where available
 - Render the roadmap directly from initiative records and their planning metadata
 
 ## Rules
 - The roadmap does not have its own data — it is a rendered view of initiatives with planning metadata
-- Initiatives without start/end dates appear in a "Unscheduled" section rather than being hidden
+- The current v1 roadmap groups initiatives by planning status, not by a richer date-based timeline model
+- Initiatives without start/end dates are still shown; dates are additive metadata rather than a requirement for roadmap visibility
 - The roadmap is read-only; editing is done through the initiatives management interface
 
 ## Implementation Status
-- **v1:** Basic roadmap view implemented. Displays initiatives grouped by planning status with objective and capability links. Richer date-based timeline rendering is deferred to a future iteration.
+- **v1:** Basic roadmap view implemented. Displays initiatives grouped by planning status with objective and capability links. Richer date-based timeline rendering, filtering, and scheduling semantics are deferred to a future iteration.
 
 ## Links
 - Depends on: Initiatives, Strategic Objectives, Capabilities

--- a/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
+++ b/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
@@ -1,7 +1,7 @@
 # Capability: Strategic Objectives
 
 ## What It Does
-The system must allow organizations to define strategic business objectives, link them to the capabilities and value streams that deliver on them, and track their status over time. This closes the gap between stated strategy and the architecture that enables it.
+The system must allow organizations to define strategic business objectives, link them to the capabilities and value streams that deliver on them, and track their status over time. This closes the gap between stated strategy and the architecture that enables it. In the shipped product, objectives are the planning artifact that most closely follows the standard governed-content model.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — defines enterprise-level objectives and links them to enterprise capabilities
@@ -14,15 +14,15 @@ The system must allow organizations to define strategic business objectives, lin
 - Link a strategic objective to one or more value streams
 - View which capabilities and value streams support a given objective
 - View which objectives a given capability or value stream contributes to
-- Track objective status through a defined lifecycle (draft, active, achieved, on-hold, cancelled)
-- Publish objectives so they are visible to non-admin users
+- Track objective status through the standard content workflow (`draft`, `published`, `archived`)
+- Share objectives across federation scopes using visibility settings (`org`, `connections`, `instance`)
 
 ## Rules
 - A strategic objective must belong to an organization
 - Strategic objectives follow the standard content workflow: draft → published → archived
-- Only published objectives are visible to Viewer-role users
 - An objective's success metric is optional but strongly encouraged — objectives without measurable outcomes are flagged as incomplete in the admin dashboard
 - Linking to capabilities and value streams is optional but recommended; unlinked objectives are architecturally orphaned and should surface as a completeness signal
+- Admin planning surfaces are authenticated workspace views; visibility across organizations is controlled by federation scope rather than a separate planning-only publication rule
 
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships

--- a/business-architecture/capabilities/cms/planning/planning.md
+++ b/business-architecture/capabilities/cms/planning/planning.md
@@ -1,6 +1,6 @@
 # Capability Group: Planning
 
-The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio. In the current product this is a strong early-v1 capability, but its workflow model is intentionally different from the core content workflow.
+The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio. In the current product this is a strong early-v1 capability: demo-ready and useful, but not yet semantically uniform across every planning artifact.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — publishes enterprise-wide objectives and tracks capability alignment across agencies
@@ -11,9 +11,15 @@ The system must allow organizations to document their strategic direction, track
 
 | Capability | File | Description |
 |---|---|---|
-| Strategic Objectives | [pl-strategic-objectives.md](./pl-strategic-objectives.md) | Define and track business goals; link to capabilities and value streams |
-| Initiatives | [pl-initiatives.md](./pl-initiatives.md) | Track change programmes; link to capabilities and objectives with impact |
-| Roadmap | [pl-roadmap.md](./pl-roadmap.md) | Visualize initiatives and objectives on a governed timeline |
+| Strategic Objectives | [pl-strategic-objectives.md](./pl-strategic-objectives.md) | Define and track business goals using the standard content workflow; link to capabilities and value streams |
+| Initiatives | [pl-initiatives.md](./pl-initiatives.md) | Track change programmes using planning lifecycle states; link to capabilities and objectives with impact |
+| Roadmap | [pl-roadmap.md](./pl-roadmap.md) | Visualize initiatives and objectives in a read-only status-grouped roadmap view |
 
 ## Design Principle
 Planning capabilities are a lens on existing architecture content — they do not exist in isolation. Strategic objectives trace to capabilities and value streams. Initiatives trace to objectives and capabilities. The roadmap visualizes initiative timelines against the architecture they affect. Nothing in this capability group is meaningful unless the underlying capability and persona content is maintained.
+
+## Current Semantic Model
+- Strategic objectives are treated like governed content: they use the standard workflow (`draft`, `published`, `archived`) plus visibility settings.
+- Initiatives are treated like planning records: they use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates.
+- The roadmap is a rendered view over initiative records. It groups initiatives by planning status and shows their linked objectives and capabilities.
+- This is intentionally good enough for demos and early-v1 use, but still evolving. A future iteration may unify planning semantics further, but the current docs should describe the shipped split model accurately.

--- a/capabilities.md
+++ b/capabilities.md
@@ -12,7 +12,7 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 |---|---|---|
 | 1 | [Identity & Access Management](#1-identity--access-management) | Implemented |
 | 2 | [Content Management](#2-content-management) | Partially implemented |
-| 3 | [Portfolio Management](#3-portfolio-management) | Partially implemented |
+| 3 | [Portfolio Management](#3-portfolio-management) | Implemented |
 | 4 | [Planning & Roadmap](#4-planning--roadmap) | Implemented |
 | 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
 | 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
@@ -55,7 +55,7 @@ Foundational content authoring and lifecycle capabilities shared across all EA c
 |---|---|---|
 | Content Authoring | Implemented | Create, edit, and save content items |
 | Content Workflow | Partially implemented | Draft → Published → Archived is established for core content types, but planning entities still use their own lifecycle states |
-| Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for categorizing all content |
+| Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for domains, persona types, persona tags, and other controlled vocabularies |
 | Content Relationships | Implemented | Link content items; enforce GovEA traceability rules at publish time |
 | Content Search & Filtering | Partially implemented | Per-entity filtering and taxonomy-driven browsing exist; repository-wide search is still future work |
 | Content Types | Partially implemented | Configurable schemas for content; v1 types are fixed in the data model |
@@ -72,6 +72,7 @@ The structured inventory of the organization's architecture objects.
 | Capability | Status | Description |
 |---|---|---|
 | Application Portfolio | Implemented | Manage applications with lifecycle status, capability links, and metadata |
+| Services | Implemented | Manage government-facing services linked to personas, capabilities, applications, and value streams |
 | Capability Map | Implemented | Define business capabilities organized by domain; linked to applications, personas, principles, and decisions |
 | Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
 | Architecture Decision Records (ADRs) | Implemented | Record, track, supersede, and link architecture decisions to capabilities, applications, initiatives, and objectives |
@@ -83,6 +84,7 @@ The structured inventory of the organization's architecture objects.
 
 ```
 Personas → Capabilities → Applications
+Personas → Services → Applications, Capabilities, Value Streams
 Strategic Objectives → Capabilities, Value Streams, Applications
 Initiatives → Capabilities, Objectives, Applications
 ADRs → Capabilities, Applications, Initiatives, Objectives
@@ -132,8 +134,8 @@ Organization-level settings and administrative tools.
 | Capability | Status | Description |
 |---|---|---|
 | Organization Settings | Partially implemented | Theme selection is available today; broader org settings remain future work |
-| Persona Type Management | Implemented | Create and manage persona type categories |
-| Persona Tags | Implemented | Tag-based classification for personas |
+| Persona Type Management | Implemented | Manage persona type categories as taxonomy terms under the `Persona Type` branch |
+| Persona Tags | Implemented | Manage persona tag values as taxonomy terms under the `Persona Tag` branch |
 | Admin Dashboard | Implemented | Live practitioner dashboard with repository activity, coverage signals, and navigation shortcuts |
 | Feature Management | Not implemented | Enable/disable optional product features per org |
 | Email Configuration | Not implemented | SMTP setup for notifications and password reset |

--- a/capabilities.md
+++ b/capabilities.md
@@ -101,10 +101,12 @@ Strategic direction, change initiatives, and timeline visualization.
 | Capability | Status | Description |
 |---|---|---|
 | Strategic Objectives | Implemented | Define and track business goals; link to capabilities and value streams |
-| Initiatives | Implemented | Track change programmes; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
+| Initiatives | Implemented | Track change programmes with planning lifecycle statuses; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
 | Roadmap View | Implemented | Visualize initiatives grouped by planning status with linked objectives and capability context |
 
 **Design principle:** Planning capabilities are a lens on existing architecture content. Strategic objectives trace to capabilities. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
+
+**Current semantic model:** Strategic objectives follow the standard content workflow (`draft`, `published`, `archived`). Initiatives do not. They use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates. The roadmap is a read-only view over initiative records grouped by that planning status.
 
 This area is strong enough for demos and early v1 use, but the planning model should still be treated as evolving rather than fully settled.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -473,6 +473,7 @@ These details matter when writing migrations, actions, tests, or exports:
 
 1. `visibility` is a publication scope, not an authorization role. Access still depends on application logic and federation state.
 2. `status` is not uniform across all tables. Most content uses `workflow_status`, but initiatives and ADRs have their own enums.
+   Planning is intentionally split today: `strategic_objectives` use `workflow_status`, while `initiatives` use `initiative_status`.
 3. Several planning and display fields are stored as free text instead of stricter types:
    - `initiatives.start_date`
    - `initiatives.end_date`

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -8,6 +8,10 @@ It is intentionally implementation-focused:
 - which fields are required, optional, or enum-backed
 - how the major many-to-many relationships are modeled
 
+Recent product-shape changes reflected here:
+- `services` is now a first-class entity in the portfolio model
+- persona types and persona tags are taxonomy-backed, not separate vocabulary tables
+
 For product intent, personas, and capability definitions, see `business-architecture/`.
 
 ## Design Conventions
@@ -28,7 +32,7 @@ Shared enum semantics:
 | Enum | Values | Used by |
 |---|---|---|
 | `visibility` | `org`, `connections`, `instance` | Most publishable content |
-| `workflow_status` | `draft`, `published`, `archived` | Personas, capabilities, applications, value streams, objectives, principles, glossary |
+| `workflow_status` | `draft`, `published`, `archived` | Personas, capabilities, applications, services, value streams, objectives, principles, glossary |
 | `user_role` | `admin`, `contributor`, `viewer` | Users |
 
 ## Top-Level Model
@@ -39,6 +43,7 @@ erDiagram
   ORGANIZATIONS ||--o{ PERSONAS : owns
   ORGANIZATIONS ||--o{ CAPABILITIES : owns
   ORGANIZATIONS ||--o{ APPLICATIONS : owns
+  ORGANIZATIONS ||--o{ SERVICES : owns
   ORGANIZATIONS ||--o{ ADRS : owns
   ORGANIZATIONS ||--o{ VALUE_STREAMS : owns
   ORGANIZATIONS ||--o{ STRATEGIC_OBJECTIVES : owns
@@ -49,6 +54,10 @@ erDiagram
 
   PERSONAS }o--o{ CAPABILITIES : supports
   CAPABILITIES }o--o{ APPLICATIONS : implemented_by
+  SERVICES }o--o{ PERSONAS : serves
+  SERVICES }o--o{ CAPABILITIES : enabled_by
+  SERVICES }o--o{ APPLICATIONS : delivered_through
+  SERVICES }o--o{ VALUE_STREAMS : participates_in
   VALUE_STREAMS }o--o{ PERSONAS : serves
   VALUE_STREAM_STAGES }o--o{ CAPABILITIES : uses
   STRATEGIC_OBJECTIVES }o--o{ CAPABILITIES : advances
@@ -104,28 +113,6 @@ Additional Auth.js support tables:
 - `sessions`: persisted login sessions
 - `verification_tokens`: email/token verification records
 
-### `persona_types`
-
-Org-scoped controlled vocabulary for persona categories.
-
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `id` | UUID | Yes | Primary key |
-| `organization_id` | UUID | Yes | FK to organization |
-| `name` | text | Yes | Unique per organization |
-| `created_at` | timestamp | Yes | Defaults to `now()` |
-
-### `tags`
-
-Org-scoped tag vocabulary used for personas.
-
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `id` | UUID | Yes | Primary key |
-| `organization_id` | UUID | Yes | FK to organization |
-| `name` | text | Yes | Unique per organization |
-| `created_at` | timestamp | Yes | Defaults to `now()` |
-
 ### `personas`
 
 People-centered anchor objects representing who the organization serves.
@@ -136,7 +123,7 @@ People-centered anchor objects representing who the organization serves.
 | `organization_id` | UUID | Yes | FK to organization |
 | `name` | text | Yes | Persona label |
 | `description` | text | No | Narrative description |
-| `type` | text | No | Current selected persona type label |
+| `type` | text | No | Current selected persona type label; value is chosen from taxonomy |
 | `status` | `workflow_status` enum | Yes | Defaults to `draft` |
 | `visibility` | `visibility` enum | Yes | Defaults to `org` |
 | `created_by` | UUID | No | FK to user |
@@ -145,7 +132,7 @@ People-centered anchor objects representing who the organization serves.
 | `updated_at` | timestamp | Yes | Defaults to `now()` |
 
 Related tables:
-- `persona_tags`: join table between personas and tags
+- `persona_tags`: join table between personas and taxonomy-backed persona tags
 
 ### `capabilities`
 
@@ -196,6 +183,31 @@ Related tables:
 
 Implementation rule:
 - every application is expected to link to at least one capability at the application layer
+
+### `services`
+
+Government-facing service records that connect user-facing delivery to the underlying architecture.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | UUID | Yes | Primary key |
+| `organization_id` | UUID | Yes | FK to organization |
+| `name` | text | Yes | Service name |
+| `description` | text | No | Summary text |
+| `service_owner` | text | No | Free-text owner name or team |
+| `channels` | `text[]` | Yes | Delivery channels such as `online`, `in-person`, `phone`, `mobile` |
+| `status` | `workflow_status` enum | Yes | Defaults to `draft` |
+| `visibility` | `visibility` enum | Yes | Defaults to `org` |
+| `created_by` | UUID | No | FK to user |
+| `updated_by` | UUID | No | FK to user |
+| `created_at` | timestamp | Yes | Defaults to `now()` |
+| `updated_at` | timestamp | Yes | Defaults to `now()` |
+
+Related tables:
+- `service_personas`
+- `service_capabilities`
+- `service_applications`
+- `service_value_streams`
 
 ### `adrs`
 
@@ -364,6 +376,11 @@ Org-scoped taxonomy hierarchy used for controlled vocabularies.
 | `created_at` | timestamp | Yes | Defaults to `now()` |
 | `updated_at` | timestamp | Yes | Defaults to `now()` |
 
+Usage notes:
+- capability domains are stored as taxonomy terms
+- persona types are taxonomy terms under the `Persona Type` branch
+- persona tags are taxonomy terms under the `Persona Tag` branch and linked through `persona_tags`
+
 ## Federation and Visibility Tables
 
 ### `org_connections`
@@ -428,9 +445,13 @@ GovEA uses explicit many-to-many join tables rather than arrays or JSON relation
 
 | Table | Connects | Extra metadata |
 |---|---|---|
-| `persona_tags` | personas ↔ tags | None |
+| `persona_tags` | personas ↔ taxonomy terms | None |
 | `capability_personas` | capabilities ↔ personas | None |
 | `application_capabilities` | applications ↔ capabilities | None |
+| `service_personas` | services ↔ personas | None |
+| `service_capabilities` | services ↔ capabilities | None |
+| `service_applications` | services ↔ applications | None |
+| `service_value_streams` | services ↔ value streams | None |
 | `value_stream_personas` | value streams ↔ personas | None |
 | `value_stream_stage_capabilities` | value stream stages ↔ capabilities | None |
 | `objective_capabilities` | objectives ↔ capabilities | None |


### PR DESCRIPTION
## Summary

Follow-up cleanup after the latest merges so the top-level product story and planning docs match shipped behavior.

- updates `README.md` to describe the new service catalog, taxonomy-backed persona types/tags, and the current shipped maturity more accurately
- updates `capabilities.md` to reflect services in the portfolio model and to describe the current planning semantic split explicitly
- updates `docs/data-model.md` to remove deleted `persona_types` / `tags` tables, document the new `services` entity, and clarify that objectives and initiatives use different status models
- updates the planning capability docs to match implementation: objectives use the standard content workflow, initiatives use planning lifecycle states, and the roadmap is a read-only status-grouped view over initiatives
- closes stale issue #90 as completed, since PR #179 already delivered in-context persona editing on the persona detail page

Closes #151
Closes #74

## Validation

- docs-only change; reviewed against the current schema and merged PRs #179, #185, #186, and #187
- planning semantics verified against the current implementation in `apps/govea/src/actions/objectives.ts`, `apps/govea/src/actions/initiatives.ts`, `apps/govea/src/db/schema/initiatives.ts`, and `apps/govea/src/app/(admin)/roadmap/page.tsx`
- no code or behavior changes
