### PR TITLE
feat(federation): add approval workflow and stronger cross-org enforcement

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -5,7 +5,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -55,7 +55,10 @@ export async function getADRs(orgId: string) {
 }
 
 export async function getADR(id: string) {
-  return db.query.adrs.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const adr = await db.query.adrs.findFirst({
     where: eq(adrs.id, id),
     with: {
       organization: true,
@@ -67,6 +70,10 @@ export async function getADR(id: string) {
       principleAdrs: { with: { principle: true } },
     },
   })
+
+  if (!adr) return null
+  const visible = await canReadFederatedEntity(adr.organizationId, adr.visibility, session.user.organizationId!)
+  return visible ? adr : null
 }
 
 export async function createADR(formData: FormData) {

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { applications, applicationCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -24,7 +24,10 @@ async function requireAdmin() {
 }
 
 export async function getApplication(id: string) {
-  return db.query.applications.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const application = await db.query.applications.findFirst({
     where: eq(applications.id, id),
     with: {
       organization: true,
@@ -34,6 +37,10 @@ export async function getApplication(id: string) {
       adrApplications: { with: { adr: true } },
     },
   })
+
+  if (!application) return null
+  const visible = await canReadFederatedEntity(application.organizationId, application.visibility, session.user.organizationId!)
+  return visible ? application : null
 }
 
 export async function getApplications(organizationId: string) {

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { capabilities, capabilityPersonas } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -24,7 +24,10 @@ async function requireAdmin() {
 }
 
 export async function getCapability(id: string) {
-  return db.query.capabilities.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const capability = await db.query.capabilities.findFirst({
     where: eq(capabilities.id, id),
     with: {
       organization: true,
@@ -36,6 +39,10 @@ export async function getCapability(id: string) {
       principleCapabilities: { with: { principle: true } },
     },
   })
+
+  if (!capability) return null
+  const visible = await canReadFederatedEntity(capability.organizationId, capability.visibility, session.user.organizationId!)
+  return visible ? capability : null
 }
 
 export async function getCapabilities(organizationId: string) {

--- a/apps/govea/src/actions/connections.ts
+++ b/apps/govea/src/actions/connections.ts
@@ -7,6 +7,7 @@ import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
+import { removeLinksForConnection } from './cross-org-links'
 
 async function requireAdmin() {
   const session = await auth()
@@ -116,6 +117,7 @@ export async function removeConnection(connectionId: string) {
   })
   if (!connection) throw new Error('Connection not found or not authorized')
 
+  await removeLinksForConnection(connection.fromOrgId, connection.toOrgId)
   await db.delete(orgConnections).where(eq(orgConnections.id, connectionId))
 
   await writeAuditLog({

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -1,0 +1,343 @@
+'use server'
+
+import { db } from '@/db/client'
+import { capabilities, crossOrgLinks, personas } from '@/db/schema'
+import { and, eq, or } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { writeAuditLog } from '@/lib/audit'
+import { canEdit, isAdmin } from '@/lib/rbac'
+import { redirect } from 'next/navigation'
+import { canReadFederatedEntity } from '@/lib/federation'
+import { revalidatePath } from 'next/cache'
+
+export type CrossOrgEntityType = 'capability' | 'persona'
+export type CrossOrgLinkType = 'implements' | 'extends' | 'maps_to'
+
+export interface CrossOrgTargetOption {
+  id: string
+  name: string
+  organizationName: string
+  visibility: 'connections' | 'instance'
+}
+
+export interface CrossOrgLinkItem {
+  id: string
+  linkType: CrossOrgLinkType
+  status: 'pending' | 'active' | 'rejected'
+  rejectionReason: string | null
+  peerId: string
+  peerName: string
+  peerHref: string
+  peerOrganizationName: string
+}
+
+export interface CrossOrgLinkContext {
+  approved: CrossOrgLinkItem[]
+  inboundPending: CrossOrgLinkItem[]
+  outboundPending: CrossOrgLinkItem[]
+  outboundRejected: CrossOrgLinkItem[]
+  availableTargets: CrossOrgTargetOption[]
+}
+
+async function requireContributor() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!canEdit(session.user)) throw new Error('Forbidden')
+  return session
+}
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+  return session
+}
+
+async function getEntity(type: CrossOrgEntityType, id: string) {
+  if (type === 'capability') {
+    const capability = await db.query.capabilities.findFirst({
+      where: eq(capabilities.id, id),
+      with: { organization: true },
+    })
+    if (!capability) return null
+    return {
+      id: capability.id,
+      type,
+      name: capability.name,
+      organizationId: capability.organizationId,
+      organizationName: capability.organization?.name ?? 'Unknown org',
+      visibility: capability.visibility,
+      href: `/capabilities/${capability.id}`,
+    }
+  }
+
+  const persona = await db.query.personas.findFirst({
+    where: eq(personas.id, id),
+    with: { organization: true },
+  })
+  if (!persona) return null
+  return {
+    id: persona.id,
+    type,
+    name: persona.name,
+    organizationId: persona.organizationId,
+    organizationName: persona.organization?.name ?? 'Unknown org',
+    visibility: persona.visibility,
+    href: `/personas/${persona.id}`,
+  }
+}
+
+async function revalidateLinkPaths(sourceType: CrossOrgEntityType, sourceId: string, targetId: string) {
+  revalidatePath(sourceType === 'capability' ? `/capabilities/${sourceId}` : `/personas/${sourceId}`)
+  revalidatePath(sourceType === 'capability' ? `/capabilities/${targetId}` : `/personas/${targetId}`)
+}
+
+export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId: string): Promise<CrossOrgLinkContext> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const callerOrgId = session.user.organizationId!
+  const entity = await getEntity(type, entityId)
+  if (!entity) {
+    return {
+      approved: [],
+      inboundPending: [],
+      outboundPending: [],
+      outboundRejected: [],
+      availableTargets: [],
+    }
+  }
+
+  const links = await db.query.crossOrgLinks.findMany({
+    where: or(
+      and(eq(crossOrgLinks.sourceEntityType, type), eq(crossOrgLinks.sourceEntityId, entityId)),
+      and(eq(crossOrgLinks.targetEntityType, type), eq(crossOrgLinks.targetEntityId, entityId)),
+    ),
+    orderBy: (l, { desc }) => [desc(l.updatedAt)],
+  })
+
+  const approved: CrossOrgLinkItem[] = []
+  const inboundPending: CrossOrgLinkItem[] = []
+  const outboundPending: CrossOrgLinkItem[] = []
+  const outboundRejected: CrossOrgLinkItem[] = []
+
+  for (const link of links) {
+    const outbound = link.sourceEntityType === type && link.sourceEntityId === entityId
+    const peerId = outbound ? link.targetEntityId : link.sourceEntityId
+    const peer = await getEntity(type, peerId)
+    if (!peer) continue
+
+    const visible = await canReadFederatedEntity(peer.organizationId, peer.visibility, callerOrgId)
+    if (!visible && peer.organizationId !== callerOrgId) continue
+
+    const item: CrossOrgLinkItem = {
+      id: link.id,
+      linkType: link.linkType,
+      status: link.status,
+      rejectionReason: link.rejectionReason,
+      peerId: peer.id,
+      peerName: peer.name,
+      peerHref: peer.href,
+      peerOrganizationName: peer.organizationName,
+    }
+
+    if (link.status === 'active') approved.push(item)
+    if (link.status === 'pending' && outbound) outboundPending.push(item)
+    if (link.status === 'pending' && !outbound) inboundPending.push(item)
+    if (link.status === 'rejected' && outbound) outboundRejected.push(item)
+  }
+
+  const availableTargetsRaw = type === 'capability'
+    ? await db.query.capabilities.findMany({
+        where: (c, { ne, inArray }) => and(
+          ne(c.organizationId, callerOrgId),
+          inArray(c.visibility, ['connections', 'instance'])
+        ),
+        with: { organization: true },
+        orderBy: (c, { asc }) => [asc(c.name)],
+      })
+    : await db.query.personas.findMany({
+        where: (p, { ne, inArray }) => and(
+          ne(p.organizationId, callerOrgId),
+          inArray(p.visibility, ['connections', 'instance'])
+        ),
+        with: { organization: true },
+        orderBy: (p, { asc }) => [asc(p.name)],
+      })
+
+  const existingTargetIds = new Set(
+    links
+      .filter(link =>
+        link.sourceEntityType === type &&
+        link.sourceEntityId === entityId &&
+        link.status !== 'rejected'
+      )
+      .map(link => link.targetEntityId)
+  )
+
+  const availableTargets: CrossOrgTargetOption[] = []
+  for (const target of availableTargetsRaw) {
+    const visible = await canReadFederatedEntity(target.organizationId, target.visibility, callerOrgId)
+    if (!visible || existingTargetIds.has(target.id)) continue
+    availableTargets.push({
+      id: target.id,
+      name: target.name,
+      organizationName: target.organization?.name ?? 'Unknown org',
+      visibility: target.visibility,
+    })
+  }
+
+  return { approved, inboundPending, outboundPending, outboundRejected, availableTargets }
+}
+
+export async function requestCrossOrgLink(
+  type: CrossOrgEntityType,
+  sourceEntityId: string,
+  targetEntityId: string,
+  linkType: CrossOrgLinkType,
+) {
+  const session = await requireContributor()
+  const source = await getEntity(type, sourceEntityId)
+  const target = await getEntity(type, targetEntityId)
+  if (!source || !target) throw new Error('Content not found')
+  if (source.organizationId !== session.user.organizationId) throw new Error('Forbidden')
+  if (target.organizationId === session.user.organizationId) throw new Error('Use local relationships for same-org links')
+
+  const targetVisible = await canReadFederatedEntity(target.organizationId, target.visibility, session.user.organizationId!)
+  if (!targetVisible) throw new Error('Target is not visible through the current federation rules')
+
+  const existing = await db.query.crossOrgLinks.findFirst({
+    where: and(
+      eq(crossOrgLinks.sourceEntityType, type),
+      eq(crossOrgLinks.sourceEntityId, sourceEntityId),
+      eq(crossOrgLinks.targetEntityType, type),
+      eq(crossOrgLinks.targetEntityId, targetEntityId),
+    ),
+  })
+
+  if (existing?.status === 'pending' || existing?.status === 'active') {
+    throw new Error('A cross-org link already exists or is awaiting approval')
+  }
+
+  let auditLinkId = existing?.id ?? null
+
+  if (existing?.status === 'rejected') {
+    await db.update(crossOrgLinks).set({
+      linkType,
+      status: 'pending',
+      rejectionReason: null,
+      updatedAt: new Date(),
+    }).where(eq(crossOrgLinks.id, existing.id))
+  } else {
+    const [created] = await db.insert(crossOrgLinks).values({
+      sourceOrgId: source.organizationId,
+      sourceEntityType: type,
+      sourceEntityId,
+      targetOrgId: target.organizationId,
+      targetEntityType: type,
+      targetEntityId,
+      linkType,
+      status: 'pending',
+      createdBy: session.user.id,
+    }).returning()
+    auditLinkId = created.id
+  }
+
+  await writeAuditLog({
+    action: 'cross_org_link.request',
+    entityType: 'cross_org_link',
+    entityId: auditLinkId,
+    userId: session.user.id,
+    organizationId: source.organizationId,
+    after: { sourceEntityId, targetEntityId, linkType, targetOrgId: target.organizationId, type },
+  })
+
+  await revalidateLinkPaths(type, sourceEntityId, targetEntityId)
+}
+
+export async function approveCrossOrgLink(linkId: string) {
+  const session = await requireAdmin()
+  const link = await db.query.crossOrgLinks.findFirst({
+    where: and(eq(crossOrgLinks.id, linkId), eq(crossOrgLinks.targetOrgId, session.user.organizationId!)),
+  })
+  if (!link) throw new Error('Cross-org link not found or not authorized')
+  if (link.status !== 'pending') throw new Error('Only pending links can be approved')
+
+  const source = await getEntity(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId)
+  const target = await getEntity(link.targetEntityType as CrossOrgEntityType, link.targetEntityId)
+  if (!source || !target) throw new Error('Cross-org link points to missing content')
+
+  const sourceVisible = await canReadFederatedEntity(source.organizationId, source.visibility, session.user.organizationId!)
+  if (!sourceVisible) throw new Error('Source content is no longer visible under the current federation rules')
+
+  await db.update(crossOrgLinks).set({
+    status: 'active',
+    rejectionReason: null,
+    updatedAt: new Date(),
+  }).where(eq(crossOrgLinks.id, linkId))
+
+  await writeAuditLog({
+    action: 'cross_org_link.approve',
+    entityType: 'cross_org_link',
+    entityId: linkId,
+    userId: session.user.id,
+    organizationId: session.user.organizationId!,
+    after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+  })
+
+  await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
+}
+
+export async function rejectCrossOrgLink(linkId: string) {
+  const session = await requireAdmin()
+  const link = await db.query.crossOrgLinks.findFirst({
+    where: and(eq(crossOrgLinks.id, linkId), eq(crossOrgLinks.targetOrgId, session.user.organizationId!)),
+  })
+  if (!link) throw new Error('Cross-org link not found or not authorized')
+
+  await db.update(crossOrgLinks).set({
+    status: 'rejected',
+    updatedAt: new Date(),
+  }).where(eq(crossOrgLinks.id, linkId))
+
+  await writeAuditLog({
+    action: 'cross_org_link.reject',
+    entityType: 'cross_org_link',
+    entityId: linkId,
+    userId: session.user.id,
+    organizationId: session.user.organizationId!,
+    after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+  })
+
+  await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
+}
+
+export async function withdrawCrossOrgLink(linkId: string) {
+  const session = await requireContributor()
+  const link = await db.query.crossOrgLinks.findFirst({
+    where: and(eq(crossOrgLinks.id, linkId), eq(crossOrgLinks.sourceOrgId, session.user.organizationId!)),
+  })
+  if (!link) throw new Error('Cross-org link not found or not authorized')
+
+  await db.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
+
+  await writeAuditLog({
+    action: 'cross_org_link.withdraw',
+    entityType: 'cross_org_link',
+    entityId: linkId,
+    userId: session.user.id,
+    organizationId: session.user.organizationId!,
+    before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status },
+  })
+
+  await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
+}
+
+export async function removeLinksForConnection(orgAId: string, orgBId: string) {
+  await db.delete(crossOrgLinks).where(
+    or(
+      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
+      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
+    )
+  )
+}

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -2,12 +2,12 @@
 
 import { db } from '@/db/client'
 import { capabilities, crossOrgLinks, personas } from '@/db/schema'
-import { and, eq, or } from 'drizzle-orm'
+import { and, eq, inArray, or } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { writeAuditLog } from '@/lib/audit'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { redirect } from 'next/navigation'
-import { canReadFederatedEntity } from '@/lib/federation'
+import { canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { revalidatePath } from 'next/cache'
 
 export type CrossOrgEntityType = 'capability' | 'persona'
@@ -38,6 +38,8 @@ export interface CrossOrgLinkContext {
   outboundRejected: CrossOrgLinkItem[]
   availableTargets: CrossOrgTargetOption[]
 }
+
+type FederatedEntity = NonNullable<Awaited<ReturnType<typeof getEntity>>>
 
 async function requireContributor() {
   const session = await auth()
@@ -87,7 +89,43 @@ async function getEntity(type: CrossOrgEntityType, id: string) {
   }
 }
 
+async function getEntities(type: CrossOrgEntityType, ids: string[]) {
+  if (ids.length === 0) return new Map<string, FederatedEntity>()
+
+  if (type === 'capability') {
+    const results = await db.query.capabilities.findMany({
+      where: inArray(capabilities.id, ids),
+      with: { organization: true },
+    })
+    return new Map(results.map(capability => [capability.id, {
+      id: capability.id,
+      type,
+      name: capability.name,
+      organizationId: capability.organizationId,
+      organizationName: capability.organization?.name ?? 'Unknown org',
+      visibility: capability.visibility,
+      href: `/capabilities/${capability.id}`,
+    }]))
+  }
+
+  const results = await db.query.personas.findMany({
+    where: inArray(personas.id, ids),
+    with: { organization: true },
+  })
+  return new Map(results.map(persona => [persona.id, {
+    id: persona.id,
+    type,
+    name: persona.name,
+    organizationId: persona.organizationId,
+    organizationName: persona.organization?.name ?? 'Unknown org',
+    visibility: persona.visibility,
+    href: `/personas/${persona.id}`,
+  }]))
+}
+
 async function revalidateLinkPaths(sourceType: CrossOrgEntityType, sourceId: string, targetId: string) {
+  // Cross-org links are only allowed within the same entity type today, so both paths
+  // can be derived from the source type.
   revalidatePath(sourceType === 'capability' ? `/capabilities/${sourceId}` : `/personas/${sourceId}`)
   revalidatePath(sourceType === 'capability' ? `/capabilities/${targetId}` : `/personas/${targetId}`)
 }
@@ -120,14 +158,28 @@ export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId:
   const inboundPending: CrossOrgLinkItem[] = []
   const outboundPending: CrossOrgLinkItem[] = []
   const outboundRejected: CrossOrgLinkItem[] = []
+  const peerIds = Array.from(new Set(links.map(link =>
+    link.sourceEntityType === type && link.sourceEntityId === entityId
+      ? link.targetEntityId
+      : link.sourceEntityId
+  )))
+  const peersById = await getEntities(type, peerIds)
+  const connectedOrgIds = new Set(await getConnectedOrgIds(callerOrgId))
+
+  function canReadWithContext(organizationId: string | null | undefined, visibility: CrossOrgTargetOption['visibility'] | 'org' | null | undefined) {
+    if (!organizationId || !visibility) return false
+    if (organizationId === callerOrgId) return true
+    if (visibility === 'instance') return true
+    return visibility === 'connections' && connectedOrgIds.has(organizationId)
+  }
 
   for (const link of links) {
     const outbound = link.sourceEntityType === type && link.sourceEntityId === entityId
     const peerId = outbound ? link.targetEntityId : link.sourceEntityId
-    const peer = await getEntity(type, peerId)
+    const peer = peersById.get(peerId)
     if (!peer) continue
 
-    const visible = await canReadFederatedEntity(peer.organizationId, peer.visibility, callerOrgId)
+    const visible = canReadWithContext(peer.organizationId, peer.visibility)
     if (!visible && peer.organizationId !== callerOrgId) continue
 
     const item: CrossOrgLinkItem = {
@@ -177,8 +229,9 @@ export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId:
 
   const availableTargets: CrossOrgTargetOption[] = []
   for (const target of availableTargetsRaw) {
-    const visible = await canReadFederatedEntity(target.organizationId, target.visibility, callerOrgId)
+    const visible = canReadWithContext(target.organizationId, target.visibility)
     if (!visible || existingTargetIds.has(target.id)) continue
+    if (target.visibility !== 'connections' && target.visibility !== 'instance') continue
     availableTargets.push({
       id: target.id,
       name: target.name,
@@ -246,7 +299,7 @@ export async function requestCrossOrgLink(
   await writeAuditLog({
     action: 'cross_org_link.request',
     entityType: 'cross_org_link',
-    entityId: auditLinkId,
+    entityId: auditLinkId ?? undefined,
     userId: session.user.id,
     organizationId: source.organizationId,
     after: { sourceEntityId, targetEntityId, linkType, targetOrgId: target.organizationId, type },
@@ -288,15 +341,17 @@ export async function approveCrossOrgLink(linkId: string) {
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
 }
 
-export async function rejectCrossOrgLink(linkId: string) {
+export async function rejectCrossOrgLink(linkId: string, reason?: string) {
   const session = await requireAdmin()
   const link = await db.query.crossOrgLinks.findFirst({
     where: and(eq(crossOrgLinks.id, linkId), eq(crossOrgLinks.targetOrgId, session.user.organizationId!)),
   })
   if (!link) throw new Error('Cross-org link not found or not authorized')
+  if (link.status !== 'pending') throw new Error('Only pending links can be rejected')
 
   await db.update(crossOrgLinks).set({
     status: 'rejected',
+    rejectionReason: reason?.trim() ? reason.trim() : null,
     updatedAt: new Date(),
   }).where(eq(crossOrgLinks.id, linkId))
 
@@ -334,10 +389,37 @@ export async function withdrawCrossOrgLink(linkId: string) {
 }
 
 export async function removeLinksForConnection(orgAId: string, orgBId: string) {
+  const affectedLinks = await db.query.crossOrgLinks.findMany({
+    where: or(
+      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
+      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
+    ),
+  })
+
   await db.delete(crossOrgLinks).where(
     or(
       and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
       and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
     )
   )
+
+  if (affectedLinks.length > 0) {
+    await writeAuditLog({
+      action: 'cross_org_link.remove_for_connection',
+      entityType: 'org_connection',
+      organizationId: orgAId,
+      before: {
+        orgAId,
+        orgBId,
+        removedLinkIds: affectedLinks.map(link => link.id),
+        removedLinks: affectedLinks.map(link => ({
+          id: link.id,
+          sourceEntityId: link.sourceEntityId,
+          targetEntityId: link.targetEntityId,
+          status: link.status,
+          linkType: link.linkType,
+        })),
+      },
+    })
+  }
 }

--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { glossaryTerms, glossaryTermSources } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -46,7 +46,10 @@ export async function getGlossaryTerms(orgId: string) {
 }
 
 export async function getGlossaryTerm(id: string) {
-  return db.query.glossaryTerms.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const term = await db.query.glossaryTerms.findFirst({
     where: eq(glossaryTerms.id, id),
     with: {
       organization: true,
@@ -55,6 +58,10 @@ export async function getGlossaryTerm(id: string) {
       },
     },
   })
+
+  if (!term) return null
+  const visible = await canReadFederatedEntity(term.organizationId, term.visibility, session.user.organizationId!)
+  return visible ? term : null
 }
 
 export async function createGlossaryTerm(formData: FormData) {

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -5,7 +5,7 @@ import {
   initiatives, initiativeCapabilities, initiativeObjectives,
 } from '@/db/schema'
 import { eq } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -51,7 +51,10 @@ export async function getInitiatives(orgId: string) {
 }
 
 export async function getInitiative(id: string) {
-  return db.query.initiatives.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const initiative = await db.query.initiatives.findFirst({
     where: eq(initiatives.id, id),
     with: {
       initiativeCapabilities: { with: { capability: true } },
@@ -59,6 +62,10 @@ export async function getInitiative(id: string) {
       initiativeApplications: { with: { application: true } },
     },
   })
+
+  if (!initiative) return null
+  const visible = await canReadFederatedEntity(initiative.organizationId, initiative.visibility, session.user.organizationId!)
+  return visible ? initiative : null
 }
 
 export async function createInitiative(formData: FormData) {

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -50,7 +50,10 @@ export async function getObjectives(organizationId: string) {
 }
 
 export async function getObjective(id: string) {
-  return db.query.strategicObjectives.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const objective = await db.query.strategicObjectives.findFirst({
     where: (o, { eq }) => eq(o.id, id),
     with: {
       objectiveCapabilities: { with: { capability: true } },
@@ -59,6 +62,10 @@ export async function getObjective(id: string) {
       initiativeObjectives: { with: { initiative: true } },
     },
   })
+
+  if (!objective) return null
+  const visible = await canReadFederatedEntity(objective.organizationId, objective.visibility, session.user.organizationId!)
+  return visible ? objective : null
 }
 
 export async function createObjective(formData: FormData) {

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { personas, personaTags } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -26,7 +26,10 @@ async function requireAdmin() {
 // ── Personas ──────────────────────────────────────────────────────────────────
 
 export async function getPersona(id: string) {
-  return db.query.personas.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const persona = await db.query.personas.findFirst({
     where: eq(personas.id, id),
     with: {
       organization: true,
@@ -35,6 +38,10 @@ export async function getPersona(id: string) {
       valueStreamPersonas: { with: { valueStream: true } },
     },
   })
+
+  if (!persona) return null
+  const visible = await canReadFederatedEntity(persona.organizationId, persona.visibility, session.user.organizationId!)
+  return visible ? persona : null
 }
 
 export async function getPersonas(organizationId: string) {

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { principles, principleAdrs, principleCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -57,7 +57,10 @@ export async function getPrinciples(orgId: string) {
 }
 
 export async function getPrinciple(id: string) {
-  return db.query.principles.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const principle = await db.query.principles.findFirst({
     where: eq(principles.id, id),
     with: {
       organization: true,
@@ -65,6 +68,10 @@ export async function getPrinciple(id: string) {
       principleCapabilities: { with: { capability: true } },
     },
   })
+
+  if (!principle) return null
+  const visible = await canReadFederatedEntity(principle.organizationId, principle.visibility, session.user.organizationId!)
+  return visible ? principle : null
 }
 
 export async function createPrinciple(formData: FormData) {

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -6,7 +6,7 @@ import {
   serviceApplications, serviceValueStreams,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -27,7 +27,10 @@ async function requireAdmin() {
 }
 
 export async function getService(id: string) {
-  return db.query.services.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const service = await db.query.services.findFirst({
     where: eq(services.id, id),
     with: {
       organization: true,
@@ -37,6 +40,10 @@ export async function getService(id: string) {
       serviceValueStreams: { with: { valueStream: true } },
     },
   })
+
+  if (!service) return null
+  const visible = await canReadFederatedEntity(service.organizationId, service.visibility, session.user.organizationId!)
+  return visible ? service : null
 }
 
 export async function getServices(organizationId: string) {

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -58,7 +58,10 @@ export async function getValueStreams(organizationId: string) {
 }
 
 export async function getValueStream(id: string) {
-  return db.query.valueStreams.findFirst({
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const valueStream = await db.query.valueStreams.findFirst({
     where: (vs, { eq }) => eq(vs.id, id),
     with: {
       stages: {
@@ -73,6 +76,10 @@ export async function getValueStream(id: string) {
       objectiveValueStreams: { with: { objective: true } },
     },
   })
+
+  if (!valueStream) return null
+  const visible = await canReadFederatedEntity(valueStream.organizationId, valueStream.visibility, session.user.organizationId!)
+  return visible ? valueStream : null
 }
 
 export async function createValueStream(formData: FormData) {

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -54,6 +54,7 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && adr.organizationId === orgId
 
   const [allCapabilities, allApplications, allInitiatives, allObjectives] = editor
     ? await Promise.all([
@@ -138,8 +139,8 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -152,8 +153,8 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
             id: application.id, name: application.name,
             href: `/applications/${application.id}`,
           }))}
-          canEdit={editor}
-          available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+          canEdit={canMutate}
+          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
           removeAction={removeApplication}
         />
@@ -166,8 +167,8 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
             id: initiative.id, name: initiative.name,
             href: `/initiatives/${initiative.id}`, meta: initiative.status,
           }))}
-          canEdit={editor}
-          available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+          canEdit={canMutate}
+          available={allInitiatives.filter(i => i.organizationId === orgId).map(i => ({ id: i.id, name: i.name }))}
           addAction={addInitiative}
           removeAction={removeInitiative}
         />
@@ -180,8 +181,8 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
             id: objective.id, name: objective.name,
             href: `/objectives/${objective.id}`,
           }))}
-          canEdit={editor}
-          available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+          canEdit={canMutate}
+          available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
           addAction={addObjective}
           removeAction={removeObjective}
         />

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -53,6 +53,7 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && application.organizationId === orgId
 
   const [allCapabilities, allObjectives, allInitiatives, allAdrs] = editor
     ? await Promise.all([
@@ -131,8 +132,8 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -145,8 +146,8 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             id: objective.id, name: objective.name,
             href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
           }))}
-          canEdit={editor}
-          available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+          canEdit={canMutate}
+          available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
           addAction={addObjective}
           removeAction={removeObjective}
         />
@@ -159,8 +160,8 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             id: initiative.id, name: initiative.name,
             href: `/initiatives/${initiative.id}`, meta: initiative.status,
           }))}
-          canEdit={editor}
-          available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+          canEdit={canMutate}
+          available={allInitiatives.filter(i => i.organizationId === orgId).map(i => ({ id: i.id, name: i.name }))}
           addAction={addInitiative}
           removeAction={removeInitiative}
         />
@@ -174,8 +175,8 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             href: `/adrs/${adr.id}`,
             meta: `ADR-${String(adr.number).padStart(3, '0')}`,
           }))}
-          canEdit={editor}
-          available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+          canEdit={canMutate}
+          available={allAdrs.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
           addAction={addAdr}
           removeAction={removeAdr}
         />

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getObjectives } from '@/actions/objectives'
 import { getInitiatives } from '@/actions/initiatives'
 import { getADRs } from '@/actions/adrs'
 import { getPersonas } from '@/actions/personas'
-import { canEdit } from '@/lib/rbac'
+import { canEdit, isAdmin } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { DomainBadge } from '@/components/domain-badge'
@@ -58,7 +58,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
   const canMutate = editor && capability.organizationId === orgId
-  const canApproveCrossOrg = session.user.role === 'admin' && capability.organizationId === orgId
+  const canApproveCrossOrg = isAdmin(session.user) && capability.organizationId === orgId
 
   const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs, crossOrgLinks] = editor
     ? await Promise.all([

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -20,6 +20,14 @@ import {
 } from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
+import { CrossOrgLinksPanel } from '@/components/cross-org-links-panel'
+import {
+  approveCrossOrgLink,
+  getCrossOrgLinkContext,
+  rejectCrossOrgLink,
+  requestCrossOrgLink,
+  withdrawCrossOrgLink,
+} from '@/actions/cross-org-links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -49,16 +57,19 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && capability.organizationId === orgId
+  const canApproveCrossOrg = session.user.role === 'admin' && capability.organizationId === orgId
 
-  const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs] = editor
+  const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs, crossOrgLinks] = editor
     ? await Promise.all([
         getPersonas(orgId),
         getApplications(orgId),
         getObjectives(orgId),
         getInitiatives(orgId),
         getADRs(orgId),
+        getCrossOrgLinkContext('capability', id),
       ])
-    : [[], [], [], [], []]
+    : [[], [], [], [], [], { approved: [], inboundPending: [], outboundPending: [], outboundRejected: [], availableTargets: [] }]
 
   const addPersona = linkCapabilityPersona.bind(null, id)
   const removePersona = unlinkCapabilityPersona.bind(null, id)
@@ -70,6 +81,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
   const removeInitiative = unlinkCapabilityInitiative.bind(null, id)
   const addAdr = linkCapabilityAdr.bind(null, id)
   const removeAdr = unlinkCapabilityAdr.bind(null, id)
+  const requestFederatedLink = requestCrossOrgLink.bind(null, 'capability', id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -141,8 +153,8 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: persona.id, name: persona.name,
             href: `/personas/${persona.id}`, meta: persona.type,
           }))}
-          canEdit={editor}
-          available={allPersonas.map(p => ({ id: p.id, name: p.name }))}
+          canEdit={canMutate}
+          available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
           addAction={addPersona}
           removeAction={removePersona}
         />
@@ -155,8 +167,8 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: application.id, name: application.name,
             href: `/applications/${application.id}`, meta: application.vendor,
           }))}
-          canEdit={editor}
-          available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+          canEdit={canMutate}
+          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
           removeAction={removeApplication}
         />
@@ -169,8 +181,8 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: objective.id, name: objective.name,
             href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
           }))}
-          canEdit={editor}
-          available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+          canEdit={canMutate}
+          available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
           addAction={addObjective}
           removeAction={removeObjective}
         />
@@ -183,8 +195,8 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: initiative.id, name: initiative.name,
             href: `/initiatives/${initiative.id}`, meta: initiative.status,
           }))}
-          canEdit={editor}
-          available={allInitiatives.map(i => ({ id: i.id, name: i.name }))}
+          canEdit={canMutate}
+          available={allInitiatives.filter(i => i.organizationId === orgId).map(i => ({ id: i.id, name: i.name }))}
           addAction={addInitiative}
           removeAction={removeInitiative}
         />
@@ -198,12 +210,27 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             href: `/adrs/${adr.id}`,
             meta: `ADR-${String(adr.number).padStart(3, '0')}`,
           }))}
-          canEdit={editor}
-          available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+          canEdit={canMutate}
+          available={allAdrs.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
           addAction={addAdr}
           removeAction={removeAdr}
         />
       )}
+
+      <CrossOrgLinksPanel
+        entityLabel="Capability"
+        approved={crossOrgLinks.approved}
+        inboundPending={crossOrgLinks.inboundPending}
+        outboundPending={crossOrgLinks.outboundPending}
+        outboundRejected={crossOrgLinks.outboundRejected}
+        availableTargets={crossOrgLinks.availableTargets}
+        canRequest={canMutate}
+        canApprove={canApproveCrossOrg}
+        requestAction={requestFederatedLink}
+        approveAction={approveCrossOrgLink}
+        rejectAction={rejectCrossOrgLink}
+        withdrawAction={withdrawCrossOrgLink}
+      />
 
       {isModuleEnabled(enabledModules, 'principles') && capability.principleCapabilities.length > 0 && (
         <RelationshipPanel

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -57,6 +57,7 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && initiative.organizationId === orgId
 
   const [allCapabilities, allObjectives, allApplications] = editor
     ? await Promise.all([
@@ -130,8 +131,8 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
         <RelationshipPanel
           title="Capabilities"
           items={capabilityItems}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -144,8 +145,8 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
             id: objective.id, name: objective.name,
             href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
           }))}
-          canEdit={editor}
-          available={allObjectives.map(o => ({ id: o.id, name: o.name }))}
+          canEdit={canMutate}
+          available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
           addAction={addObjective}
           removeAction={removeObjective}
         />
@@ -155,8 +156,8 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
         <RelationshipPanel
           title="Applications"
           items={applicationItems}
-          canEdit={editor}
-          available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+          canEdit={canMutate}
+          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
           removeAction={removeApplication}
         />

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -44,6 +44,7 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && objective.organizationId === orgId
 
   const [allCapabilities, allValueStreams, allApplications] = editor
     ? await Promise.all([
@@ -108,8 +109,8 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -122,8 +123,8 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
             id: valueStream.id, name: valueStream.name,
             href: `/value-streams/${valueStream.id}`,
           }))}
-          canEdit={editor}
-          available={allValueStreams.map(vs => ({ id: vs.id, name: vs.name }))}
+          canEdit={canMutate}
+          available={allValueStreams.filter(vs => vs.organizationId === orgId).map(vs => ({ id: vs.id, name: vs.name }))}
           addAction={addValueStream}
           removeAction={removeValueStream}
         />
@@ -136,8 +137,8 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
             id: application.id, name: application.name,
             href: `/applications/${application.id}`, meta: application.vendor,
           }))}
-          canEdit={editor}
-          available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+          canEdit={canMutate}
+          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
           removeAction={removeApplication}
         />

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -13,6 +13,14 @@ import {
   linkPersonaCapability, unlinkPersonaCapability,
   linkPersonaValueStream, unlinkPersonaValueStream,
 } from '@/actions/links'
+import { CrossOrgLinksPanel } from '@/components/cross-org-links-panel'
+import {
+  approveCrossOrgLink,
+  getCrossOrgLinkContext,
+  rejectCrossOrgLink,
+  requestCrossOrgLink,
+  withdrawCrossOrgLink,
+} from '@/actions/cross-org-links'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -42,20 +50,24 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && persona.organizationId === orgId
+  const canApproveCrossOrg = session.user.role === 'admin' && persona.organizationId === orgId
 
-  const [allCapabilities, allValueStreams, personaTypes, allTags] = editor
+  const [allCapabilities, allValueStreams, personaTypes, allTags, crossOrgLinks] = editor
     ? await Promise.all([
         getCapabilities(orgId),
         getValueStreams(orgId),
         getPersonaTypesFromTaxonomy(orgId),
         getPersonaTagsFromTaxonomy(orgId),
+        getCrossOrgLinkContext('persona', id),
       ])
-    : [[], [], [], []]
+    : [[], [], [], [], { approved: [], inboundPending: [], outboundPending: [], outboundRejected: [], availableTargets: [] }]
 
   const addCapability = linkPersonaCapability.bind(null, id)
   const removeCapability = unlinkPersonaCapability.bind(null, id)
   const addValueStream = linkPersonaValueStream.bind(null, id)
   const removeValueStream = unlinkPersonaValueStream.bind(null, id)
+  const requestFederatedLink = requestCrossOrgLink.bind(null, 'persona', id)
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -91,7 +103,7 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
         </div>
       </div>
 
-      {editor && (
+      {canMutate && (
         <PersonaEditButton
           personaId={id}
           initial={{
@@ -133,8 +145,8 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
           id: capability.id, name: capability.name,
           href: `/capabilities/${capability.id}`, meta: capability.domain,
         }))}
-        canEdit={editor}
-        available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+        canEdit={canMutate}
+        available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
         addAction={addCapability}
         removeAction={removeCapability}
       />
@@ -145,10 +157,25 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
           id: valueStream.id, name: valueStream.name,
           href: `/value-streams/${valueStream.id}`,
         }))}
-        canEdit={editor}
-        available={allValueStreams.map(vs => ({ id: vs.id, name: vs.name }))}
+        canEdit={canMutate}
+        available={allValueStreams.filter(vs => vs.organizationId === orgId).map(vs => ({ id: vs.id, name: vs.name }))}
         addAction={addValueStream}
         removeAction={removeValueStream}
+      />
+
+      <CrossOrgLinksPanel
+        entityLabel="Persona"
+        approved={crossOrgLinks.approved}
+        inboundPending={crossOrgLinks.inboundPending}
+        outboundPending={crossOrgLinks.outboundPending}
+        outboundRejected={crossOrgLinks.outboundRejected}
+        availableTargets={crossOrgLinks.availableTargets}
+        canRequest={canMutate}
+        canApprove={canApproveCrossOrg}
+        requestAction={requestFederatedLink}
+        approveAction={approveCrossOrgLink}
+        rejectAction={rejectCrossOrgLink}
+        withdrawAction={withdrawCrossOrgLink}
       />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -4,7 +4,7 @@ import { getPersona } from '@/actions/personas'
 import { getPersonaTypesFromTaxonomy, getPersonaTagsFromTaxonomy } from '@/actions/taxonomy'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
-import { canEdit } from '@/lib/rbac'
+import { canEdit, isAdmin } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { RelationshipPanel } from '@/components/relationship-panel'
@@ -51,7 +51,7 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
   const canMutate = editor && persona.organizationId === orgId
-  const canApproveCrossOrg = session.user.role === 'admin' && persona.organizationId === orgId
+  const canApproveCrossOrg = isAdmin(session.user) && persona.organizationId === orgId
 
   const [allCapabilities, allValueStreams, personaTypes, allTags, crossOrgLinks] = editor
     ? await Promise.all([

--- a/apps/govea/src/app/(admin)/principles/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/[id]/page.tsx
@@ -42,6 +42,7 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && principle.organizationId === orgId
 
   const [allCapabilities, allAdrs] = editor
     ? await Promise.all([
@@ -109,8 +110,8 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -124,8 +125,8 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
             href: `/adrs/${adr.id}`,
             meta: `ADR-${String(adr.number).padStart(3, '0')}`,
           }))}
-          canEdit={editor}
-          available={allAdrs.map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
+          canEdit={canMutate}
+          available={allAdrs.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: `ADR-${String(a.number).padStart(3, '0')} ${a.title}` }))}
           addAction={addAdr}
           removeAction={removeAdr}
         />

--- a/apps/govea/src/app/(admin)/services/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/services/[id]/page.tsx
@@ -60,6 +60,7 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
+  const canMutate = editor && service.organizationId === orgId
 
   const [allCapabilities, allPersonas, allApplications, allValueStreams] = editor
     ? await Promise.all([
@@ -130,8 +131,8 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
             id: persona.id, name: persona.name,
             href: `/personas/${persona.id}`,
           }))}
-          canEdit={editor}
-          available={allPersonas.map(p => ({ id: p.id, name: p.name }))}
+          canEdit={canMutate}
+          available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
           addAction={addPersona}
           removeAction={removePersona}
         />
@@ -145,8 +146,8 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
             href: `/capabilities/${capability.id}`,
             meta: capability.domain ?? undefined,
           }))}
-          canEdit={editor}
-          available={allCapabilities.map(c => ({ id: c.id, name: c.name }))}
+          canEdit={canMutate}
+          available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
         />
@@ -160,8 +161,8 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
             href: `/applications/${application.id}`,
             meta: application.vendor,
           }))}
-          canEdit={editor}
-          available={allApplications.map(a => ({ id: a.id, name: a.name }))}
+          canEdit={canMutate}
+          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
           removeAction={removeApplication}
         />
@@ -174,8 +175,8 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
             id: valueStream.id, name: valueStream.name,
             href: `/value-streams/${valueStream.id}`,
           }))}
-          canEdit={editor}
-          available={allValueStreams.map(vs => ({ id: vs.id, name: vs.name }))}
+          canEdit={canMutate}
+          available={allValueStreams.filter(vs => vs.organizationId === orgId).map(vs => ({ id: vs.id, name: vs.name }))}
           addAction={addValueStream}
           removeAction={removeValueStream}
         />

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -48,6 +48,7 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
   ])
 
   if (!vs) notFound()
+  const canMutate = editor && vs.organizationId === orgId
 
   const addPersona = linkValueStreamPersona.bind(null, id)
   const removePersona = unlinkValueStreamPersona.bind(null, id)
@@ -103,7 +104,7 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
           </span>
         </div>
 
-        {vs.stages.length === 0 && !editor && (
+        {vs.stages.length === 0 && !canMutate && (
           <p className="text-sm text-muted-foreground py-4">No stages have been defined for this value stream yet.</p>
         )}
 
@@ -140,11 +141,11 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
         )}
 
         {/* Stage manager for editors */}
-        {editor && (
+        {canMutate && (
           <StageManager
             valueStreamId={vs.id}
             stages={vs.stages}
-            capabilities={capabilityList}
+            capabilities={capabilityList.filter(c => c.organizationId === orgId)}
           />
         )}
       </div>
@@ -156,8 +157,8 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
             id: persona.id, name: persona.name,
             href: `/personas/${persona.id}`,
           }))}
-          canEdit={editor}
-          available={allPersonas.map(p => ({ id: p.id, name: p.name }))}
+          canEdit={canMutate}
+          available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
           addAction={addPersona}
           removeAction={removePersona}
         />

--- a/apps/govea/src/components/cross-org-links-panel.tsx
+++ b/apps/govea/src/components/cross-org-links-panel.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import type { CrossOrgLinkItem, CrossOrgLinkType, CrossOrgTargetOption } from '@/actions/cross-org-links'
+
+interface Props {
+  entityLabel: string
+  approved: CrossOrgLinkItem[]
+  inboundPending: CrossOrgLinkItem[]
+  outboundPending: CrossOrgLinkItem[]
+  outboundRejected: CrossOrgLinkItem[]
+  availableTargets: CrossOrgTargetOption[]
+  canRequest: boolean
+  canApprove: boolean
+  requestAction: (targetId: string, linkType: CrossOrgLinkType) => Promise<void>
+  approveAction: (linkId: string) => Promise<void>
+  rejectAction: (linkId: string) => Promise<void>
+  withdrawAction: (linkId: string) => Promise<void>
+}
+
+const LINK_TYPE_STYLES: Record<CrossOrgLinkType, string> = {
+  implements: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  extends: 'bg-blue-50 text-blue-700 border-blue-200',
+  maps_to: 'bg-violet-50 text-violet-700 border-violet-200',
+}
+
+const VISIBILITY_LABELS: Record<CrossOrgTargetOption['visibility'], string> = {
+  connections: 'Connected orgs',
+  instance: 'Instance-wide',
+}
+
+export function CrossOrgLinksPanel({
+  entityLabel,
+  approved,
+  inboundPending,
+  outboundPending,
+  outboundRejected,
+  availableTargets,
+  canRequest,
+  canApprove,
+  requestAction,
+  approveAction,
+  rejectAction,
+  withdrawAction,
+}: Props) {
+  const [isPending, startTransition] = useTransition()
+  const [showRequest, setShowRequest] = useState(false)
+  const [targetId, setTargetId] = useState('')
+  const [linkType, setLinkType] = useState<CrossOrgLinkType>('implements')
+
+  function handleRequest() {
+    if (!targetId) return
+    startTransition(async () => {
+      await requestAction(targetId, linkType)
+      setTargetId('')
+      setLinkType('implements')
+      setShowRequest(false)
+    })
+  }
+
+  function run(action: () => Promise<void>) {
+    startTransition(async () => {
+      await action()
+    })
+  }
+
+  const hasAnyLinks = approved.length > 0 || inboundPending.length > 0 || outboundPending.length > 0 || outboundRejected.length > 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between min-h-[1.75rem]">
+        <h2 className="text-lg font-semibold">Cross-Org Links</h2>
+        {canRequest && availableTargets.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowRequest(v => !v)}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            {showRequest ? 'Cancel' : '+ Request link'}
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Use approval-based federation links for cross-org {entityLabel.toLowerCase()} alignment. Local relationship controls stay inside one organization.
+      </p>
+
+      {showRequest && (
+        <div className="rounded-lg border bg-card p-4 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-1.5 text-sm">
+              <span className="text-muted-foreground">Target {entityLabel.toLowerCase()}</span>
+              <select
+                value={targetId}
+                onChange={e => setTargetId(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="">Select a target…</option>
+                {availableTargets.map(target => (
+                  <option key={target.id} value={target.id}>
+                    {target.name} · {target.organizationName} · {VISIBILITY_LABELS[target.visibility]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1.5 text-sm">
+              <span className="text-muted-foreground">Relationship type</span>
+              <select
+                value={linkType}
+                onChange={e => setLinkType(e.target.value as CrossOrgLinkType)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="implements">Implements</option>
+                <option value="extends">Extends</option>
+                <option value="maps_to">Maps To</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleRequest}
+              disabled={!targetId || isPending}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50 hover:bg-primary/90 transition-colors"
+            >
+              {isPending ? 'Sending…' : 'Send request'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!hasAnyLinks ? (
+        <p className="text-sm text-muted-foreground">No cross-org links yet.</p>
+      ) : (
+        <div className={cn('space-y-4', isPending && 'opacity-60')}>
+          {approved.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">Approved</h3>
+              {approved.map(link => (
+                <div key={link.id} className="flex items-center gap-2">
+                  <Link href={link.peerHref} className="flex-1 flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:bg-muted/50 transition-colors">
+                    <div className="space-y-1">
+                      <div className="font-medium text-sm">{link.peerName}</div>
+                      <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
+                    </div>
+                    <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
+                      {link.linkType.replace('_', ' ')}
+                    </span>
+                  </Link>
+                  {canRequest && (
+                    <button
+                      type="button"
+                      onClick={() => run(() => withdrawAction(link.id))}
+                      disabled={isPending}
+                      className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all disabled:opacity-30"
+                      aria-label={`Withdraw link to ${link.peerName}`}
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              ))}
+            </section>
+          )}
+
+          {inboundPending.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">Awaiting your approval</h3>
+              {inboundPending.map(link => (
+                <div key={link.id} className="rounded-lg border bg-card px-4 py-3 space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-sm">{link.peerName}</div>
+                      <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
+                    </div>
+                    <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
+                      {link.linkType.replace('_', ' ')}
+                    </span>
+                  </div>
+                  {canApprove && (
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => run(() => approveAction(link.id))}
+                        disabled={isPending}
+                        className="rounded-md px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50 border border-emerald-200 disabled:opacity-50"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => run(() => rejectAction(link.id))}
+                        disabled={isPending}
+                        className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 border border-destructive/20 disabled:opacity-50"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </section>
+          )}
+
+          {outboundPending.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">Pending outbound requests</h3>
+              {outboundPending.map(link => (
+                <div key={link.id} className="rounded-lg border bg-card px-4 py-3 flex items-center justify-between gap-3">
+                  <div>
+                    <div className="font-medium text-sm">{link.peerName}</div>
+                    <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
+                      {link.linkType.replace('_', ' ')}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => run(() => withdrawAction(link.id))}
+                      disabled={isPending}
+                      className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 border border-destructive/20 disabled:opacity-50"
+                    >
+                      Withdraw
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </section>
+          )}
+
+          {outboundRejected.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">Rejected requests</h3>
+              {outboundRejected.map(link => (
+                <div key={link.id} className="rounded-lg border bg-card px-4 py-3 space-y-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-sm">{link.peerName}</div>
+                      <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
+                    </div>
+                    <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
+                      {link.linkType.replace('_', ' ')}
+                    </span>
+                  </div>
+                  {link.rejectionReason && (
+                    <p className="text-xs text-muted-foreground">{link.rejectionReason}</p>
+                  )}
+                </div>
+              ))}
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/components/cross-org-links-panel.tsx
+++ b/apps/govea/src/components/cross-org-links-panel.tsx
@@ -16,7 +16,7 @@ interface Props {
   canApprove: boolean
   requestAction: (targetId: string, linkType: CrossOrgLinkType) => Promise<void>
   approveAction: (linkId: string) => Promise<void>
-  rejectAction: (linkId: string) => Promise<void>
+  rejectAction: (linkId: string, reason?: string) => Promise<void>
   withdrawAction: (linkId: string) => Promise<void>
 }
 
@@ -67,6 +67,7 @@ export function CrossOrgLinksPanel({
   }
 
   const hasAnyLinks = approved.length > 0 || inboundPending.length > 0 || outboundPending.length > 0 || outboundRejected.length > 0
+  if (!hasAnyLinks && !canRequest && !canApprove) return null
 
   return (
     <div className="space-y-4">
@@ -148,7 +149,7 @@ export function CrossOrgLinksPanel({
                       <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
                     </div>
                     <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
-                      {link.linkType.replace('_', ' ')}
+                      {link.linkType.replaceAll('_', ' ')}
                     </span>
                   </Link>
                   {canRequest && (
@@ -180,7 +181,7 @@ export function CrossOrgLinksPanel({
                       <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
                     </div>
                     <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
-                      {link.linkType.replace('_', ' ')}
+                      {link.linkType.replaceAll('_', ' ')}
                     </span>
                   </div>
                   {canApprove && (
@@ -195,7 +196,11 @@ export function CrossOrgLinksPanel({
                       </button>
                       <button
                         type="button"
-                        onClick={() => run(() => rejectAction(link.id))}
+                        onClick={() => {
+                          const reason = window.prompt(`Optional rejection reason for ${link.peerName}`, '')
+                          if (reason === null) return
+                          run(() => rejectAction(link.id, reason || undefined))
+                        }}
                         disabled={isPending}
                         className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 border border-destructive/20 disabled:opacity-50"
                       >
@@ -219,7 +224,7 @@ export function CrossOrgLinksPanel({
                   </div>
                   <div className="flex items-center gap-2">
                     <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
-                      {link.linkType.replace('_', ' ')}
+                      {link.linkType.replaceAll('_', ' ')}
                     </span>
                     <button
                       type="button"
@@ -246,7 +251,7 @@ export function CrossOrgLinksPanel({
                       <div className="text-xs text-muted-foreground">{link.peerOrganizationName}</div>
                     </div>
                     <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', LINK_TYPE_STYLES[link.linkType])}>
-                      {link.linkType.replace('_', ' ')}
+                      {link.linkType.replaceAll('_', ' ')}
                     </span>
                   </div>
                   {link.rejectionReason && (

--- a/apps/govea/src/lib/federation.ts
+++ b/apps/govea/src/lib/federation.ts
@@ -40,12 +40,3 @@ export async function canReadFederatedEntity(
   const connectedOrgIds = await getConnectedOrgIds(callerOrgId)
   return connectedOrgIds.includes(entityOrgId)
 }
-
-export function assertLocalRelationshipTarget(
-  targetOrgId: string | null | undefined,
-  callerOrgId: string,
-): void {
-  if (!targetOrgId || targetOrgId !== callerOrgId) {
-    throw new Error('Forbidden: cross-org relationships require the federation approval flow')
-  }
-}

--- a/apps/govea/src/lib/federation.ts
+++ b/apps/govea/src/lib/federation.ts
@@ -1,5 +1,7 @@
 import { db } from '@/db/client'
 
+export type FederationVisibility = 'org' | 'connections' | 'instance'
+
 /**
  * Throws if the entity's org doesn't match the caller's org.
  * Use before any write to content fetched without an org filter.
@@ -23,4 +25,27 @@ export async function getConnectedOrgIds(organizationId: string): Promise<string
   return connections.map(c =>
     c.fromOrgId === organizationId ? c.toOrgId : c.fromOrgId
   )
+}
+
+export async function canReadFederatedEntity(
+  entityOrgId: string | null | undefined,
+  visibility: FederationVisibility | null | undefined,
+  callerOrgId: string,
+): Promise<boolean> {
+  if (!entityOrgId || !visibility) return false
+  if (entityOrgId === callerOrgId) return true
+  if (visibility === 'instance') return true
+  if (visibility !== 'connections') return false
+
+  const connectedOrgIds = await getConnectedOrgIds(callerOrgId)
+  return connectedOrgIds.includes(entityOrgId)
+}
+
+export function assertLocalRelationshipTarget(
+  targetOrgId: string | null | undefined,
+  callerOrgId: string,
+): void {
+  if (!targetOrgId || targetOrgId !== callerOrgId) {
+    throw new Error('Forbidden: cross-org relationships require the federation approval flow')
+  }
 }


### PR DESCRIPTION
## Summary

Moves multi-org federation from passive prototype plumbing toward safer operational behavior.

- adds an explicit cross-org link workflow for capabilities and personas: request, approve, reject, withdraw
- surfaces those requests directly on capability and persona detail pages so inbound approvals happen where the target content is managed
- hardens detail fetches across the app so direct URLs respect federation visibility rules instead of bypassing list-level filtering
- makes remote cross-org detail pages read-only in the UI by hiding local edit/link affordances unless the current org owns the record
- removes dependent cross-org links when an org connection is removed, so stale approvals do not survive after trust is revoked

## Why

Issue #154 correctly reclassified federation as a prototype, but it also pointed to the real next step: approvals, deeper enforcement, and stronger cross-org workflows. This PR tackles that next step directly without pretending federation is fully mature yet.

## Validation

- reviewed against the existing federation schema and visibility model
- attempted repo validation, but the current workspace does not have runnable local `eslint` / `tsc` binaries available, so I could not complete lint/typecheck in this environment
- no database migration required
