### PR TITLE
docs: sync shipped data model and taxonomy-backed persona metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Personas -> Capabilities -> Applications
 - **Services** model the government-facing delivery layer and can link to personas, capabilities, applications, and value streams.
 - **Persona Type** and **Persona Tag** values are managed through **Taxonomy**, not through persona-specific admin tables.
 - **Organization** is the top-level tenant boundary.
-- Additional core entities include **Architecture Decision Record (ADR)** and **Technology Lifecycle**.
-- v1 is single-organization, but the data model must preserve a path to v2 multi-tenancy by scoping users, roles, content types, and taxonomies to an organization.
+- Additional core entities include **Architecture Decision Records (ADRs)**, **Strategic Objectives**, **Initiatives**, **Principles**, and the **Glossary**.
+- Single-org use is still the default operating mode, but GovEA now also ships a prototype multi-organization model with org-scoped visibility and approval-based cross-org links.
 
 For the implementation-level schema reference — including field metadata, enums, and junction tables — see [`docs/data-model.md`](./docs/data-model.md).
 
@@ -96,14 +96,14 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Mission-first traceability: Personas → Capabilities → Applications enforced at the application layer
 - Service catalogue: first-class service records linked to personas, capabilities, applications, and value streams
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
-- Live dashboard for EA practitioners with repository activity and coverage signals
+- Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
 - Demo-ready planning module — strategic objectives plus initiatives with a roadmap view grouped by planning status
 - Audit trail — immutable before/after log of all changes
 - Taxonomy management — org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management — SSO via Microsoft Entra ID (OIDC), local auth fallback, Admin/Contributor/Viewer roles
 - User management and first-run setup flow
-- Live admin dashboard with coverage, recent activity, and domain summaries
-- Prototype multi-org federation — connection requests, visibility levels, shared content, cross-org linking
+- Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
+- Prototype multi-org federation — connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
 - Reusable `@govea/core` package — RBAC, audit, taxonomy, workflow, content type, and recipe primitives
 - E2E smoke test coverage across all routes × roles (Playwright)
 - Containerized local development plus Azure Container Apps dev deployment support
@@ -121,7 +121,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 **Near-term:**
 - Stakeholder-facing views and plain-language detail pages
 - Repository completeness signals and gap detection
-- Stronger multi-organization support
+- Deeper federation management UX, notifications, and broader cross-org verification coverage
 - Repository-wide search and broader workflow consistency across all entity types
 
 **Longer-term:**

--- a/business-architecture/capabilities/cms/admin-configuration/ac-persona-tags.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-persona-tags.md
@@ -1,29 +1,31 @@
 # Capability: Persona Tags
 
 ## What It Does
-The system must allow organization administrators to define a list of cross-cutting tags scoped to their organization, and allow contributors to assign multiple tags to each persona. Tags enable flexible filtering and search that cuts across the type hierarchy — e.g. flagging personas as 'mobile-first', 'accessibility', or 'high-volume' regardless of their type.
+The system must allow organization administrators to manage taxonomy-backed persona tags scoped to their organization, and allow contributors to assign multiple tags to each persona. Persona tags are modeled as values under the top-level `Persona Tag` taxonomy type. They enable flexible filtering and search that cuts across the type hierarchy — e.g. flagging personas as `mobile-first`, `accessibility`, or `high-volume` regardless of their type.
 
 ## Personas
-- **CMS Administrator** — creates and removes tags for the organization; assigns tags to personas
+- **CMS Administrator** — manages the `Persona Tag` taxonomy branch for the organization
 - **Agency EA Coordinator** — assigns tags to personas to improve search and cross-referencing
 
 ## Behaviors
-- Display the current list of org-scoped tags in a Manage tags dialog (admin only)
-- Allow administrators to add a new tag by name; duplicate names within the same org are rejected
-- Allow administrators to remove a tag; the `persona_tags` junction rows for that tag are cascade-deleted
+- Display persona tag values through the Taxonomy Management page rather than a standalone tag-management dialog
+- Allow administrators to create a top-level `Persona Tag` taxonomy type if it does not exist yet
+- Allow administrators to add, edit, and delete tag values under that taxonomy type
+- Allow administrators to remove a tag; the `persona_tags` junction rows for that taxonomy term are cascade-deleted
 - Tags appear as colored pill badges on each persona row in the table
 - A tag filter dropdown in the toolbar filters personas to those carrying the selected tag
 - The create and edit dialogs show a scrollable checklist of available tags; contributors may select any combination
-- A persona may have zero or more tags; tags are stored in a `persona_tags` junction table
+- A persona may have zero or more tags; tags are stored in a `persona_tags` junction table that points to taxonomy terms
 
 ## Rules
-- Only Admins may add or remove tags — Contributors and Viewers cannot manage the tag list
+- Persona tags are organization-scoped taxonomy values, not a dedicated table or enum
+- Only Admins may delete persona tag taxonomy terms; Admins and Contributors may create or edit taxonomy terms through Taxonomy Management
 - Contributors and above may assign or remove tags when creating or editing a persona
-- Tag names must be unique within an organization; instance-level uniqueness is not required
+- Tag names must be unique within the `Persona Tag` branch for an organization
 - Deleting a tag cascades — all `persona_tags` rows referencing that tag are removed automatically (FK cascade)
-- No rename operation in v1; to rename, delete the old tag and add the new one
+- The `Persona Tag` taxonomy branch is the source of truth for current selectable tags in the UI
 
 ## Links
-- Depends on: IAM — Role-Based Access Control
+- Depends on: IAM — Role-Based Access Control, Content Management — Taxonomy Management
 - Used by: Content Management — Personas
 - Related: Persona Type Management

--- a/business-architecture/capabilities/cms/admin-configuration/ac-persona-type-management.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-persona-type-management.md
@@ -1,25 +1,26 @@
 # Capability: Persona Type Management
 
 ## What It Does
-The system must allow organization administrators to define and maintain the list of persona types available within their organization. Persona types are used to categorize personas (e.g. Citizen, Staff, Elected Official, External Partner) and drive filtering in the personas UI. Each organization controls its own type list independently.
+The system must allow organization administrators to manage the taxonomy-backed persona type vocabulary available within their organization. Persona types are modeled as values under the top-level `Persona Type` taxonomy type, and those values drive persona classification and filtering in the personas UI.
 
 ## Personas
-- **CMS Administrator** — creates, renames, and removes persona types to match the organization's classification needs
+- **CMS Administrator** — manages the `Persona Type` taxonomy branch so persona classification stays consistent with the organization's language
 
 ## Behaviors
-- Display the current list of persona types scoped to the administrator's organization
-- Allow administrators to add a new type by entering a name (duplicate names within the same org are rejected)
-- Allow administrators to remove a type; existing personas that used the removed type retain the type value as a text label but it no longer appears in the type selector
-- Persona type names are treated as plain text — no enum constraint in the database
-- Default types (Citizen, Staff, Elected Official, External Partner) are seeded at bootstrap for new organizations; administrators may delete them
-- Type list is used in the persona create/edit dialog and the type filter on the personas page
+- Display persona types through the Taxonomy Management page, not a dedicated standalone persona-type list
+- Allow administrators to create a top-level `Persona Type` taxonomy type if it does not exist yet
+- Allow administrators to add, edit, and delete persona type values under that taxonomy type
+- Use persona type values in the persona create/edit dialog and the type filter on the personas page
+- Keep existing persona records stable when a taxonomy value is deleted — the stored `personas.type` text remains until the persona is edited
+- Seed common starting values such as Citizen, Staff, Elected Official, and External Partner through the taxonomy seed/bootstrap flow
 
 ## Rules
-- Only Admins may add or remove persona types — Contributors and Viewers cannot
-- Type names must be unique within an organization; instance-level uniqueness is not required
-- Removing a type does not cascade to update or null personas — personas retain their stored type string
-- No rename operation in v1; to rename, delete the old type and add the new one
+- Persona types are organization-scoped taxonomy values, not a dedicated table or enum
+- Only Admins may delete persona type taxonomy terms; Admins and Contributors may create or edit taxonomy terms through Taxonomy Management
+- Persona type values must be unique within the `Persona Type` branch for an organization
+- Removing a persona type does not cascade to null out existing personas — they retain their stored type label until edited
+- The `Persona Type` taxonomy branch is the source of truth for current selectable options in the UI
 
 ## Links
-- Depends on: IAM — Role-Based Access Control
+- Depends on: IAM — Role-Based Access Control, Content Management — Taxonomy Management
 - Used by: Content Management — Personas

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -380,6 +380,7 @@ Usage notes:
 - capability domains are stored as taxonomy terms
 - persona types are taxonomy terms under the `Persona Type` branch
 - persona tags are taxonomy terms under the `Persona Tag` branch and linked through `persona_tags`
+- personas store the selected type label as text rather than a FK, so removing a taxonomy value does not rewrite existing persona records
 
 ## Federation and Visibility Tables
 
@@ -408,13 +409,13 @@ Cross-org relationships between content items. These intentionally avoid FKs on 
 |---|---|---|---|
 | `id` | UUID | Yes | Primary key |
 | `source_org_id` | UUID | Yes | Owning org of the source entity |
-| `source_entity_type` | text | Yes | Currently documented for capability/persona use |
+| `source_entity_type` | text | Yes | Currently used for capability/persona cross-org links |
 | `source_entity_id` | UUID | Yes | Source record id |
 | `target_org_id` | UUID | Yes | Owning org of the target entity |
-| `target_entity_type` | text | Yes | Currently documented for capability/persona use |
+| `target_entity_type` | text | Yes | Currently used for capability/persona cross-org links |
 | `target_entity_id` | UUID | Yes | Target record id |
 | `link_type` | `link_type` enum | Yes | `implements`, `extends`, `maps_to` |
-| `status` | `link_status` enum | Yes | `pending`, `active`, `rejected` |
+| `status` | `link_status` enum | Yes | `pending`, `active`, `rejected`; approval is required before a link becomes active |
 | `rejection_reason` | text | No | Reason for rejection |
 | `created_by` | UUID | No | FK to user |
 | `created_at` | timestamp | Yes | Defaults to `now()` |
@@ -480,10 +481,11 @@ These details matter when writing migrations, actions, tests, or exports:
    - `strategic_objectives.time_horizon`
    - `applications.hosting_model`
 4. `capabilities.behaviors` and `capabilities.rules` are stored as newline-delimited text rather than structured child records.
-5. `taxonomy_terms.parent_id` is hierarchical metadata, but it is not declared with an explicit FK in the schema file.
-6. `users.is_active` is currently stored as text with values like `'true'`, not a native boolean column.
-7. `cross_org_links` intentionally avoids direct FKs to business entity tables because those links cross tenant boundaries and are enforced in application code.
-8. `audit_log.before`, `audit_log.after`, and `audit_log.metadata` are JSONB and should be treated as schemaless event payloads.
+5. `personas.type` stores the selected taxonomy-backed type label as text, not a foreign key to `taxonomy_terms`.
+6. `taxonomy_terms.parent_id` is hierarchical metadata, but it is not declared with an explicit FK in the schema file.
+7. `users.is_active` is currently stored as text with values like `'true'`, not a native boolean column.
+8. `cross_org_links` intentionally avoids direct FKs to business entity tables because those links cross tenant boundaries and are enforced in application code.
+9. `audit_log.before`, `audit_log.after`, and `audit_log.metadata` are JSONB and should be treated as schemaless event payloads.
 
 ## Source of Truth
 


### PR DESCRIPTION
## Summary

Focused docs-sync pass to bring the repo back in line with what is already shipped on `main`.

- updates the top-level README summary so it reflects services, taxonomy-backed persona metadata, federation approval flow, and review-health tracking more accurately
- tightens `docs/data-model.md` around taxonomy-backed persona metadata and the shipped federation approval model
- rewrites the persona type/tag admin capability docs so they describe taxonomy-backed management instead of deleted standalone tables/lists

## Why

Recent merges moved the product forward faster than the docs:

- `#185` and `#186` moved persona types/tags into taxonomy
- `#187` added services
- `#190` shipped the approval-based federation workflow and related guardrails
- `#194` improved review-health tracking on the dashboard surface

This PR is a focused catch-up pass before adding more product surface.

## Validation

- docs-only change
- `git diff --check`
