### PR TITLE
feat(federation): revoke, dashboard activity card, approval polish (#42)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "govea-dev",
       "runtimeExecutable": "/opt/homebrew/bin/node",
-      "runtimeArgs": ["/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs", "--dir", "/Users/roballred/Repos/Claude/govea-app/.claude/worktrees/inspiring-murdock-60fcc9", "--filter", "govea", "dev"],
+      "runtimeArgs": ["/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs", "--dir", "/Users/roballred/Repos/Claude/govea-app", "--filter", "govea", "dev"],
       "port": 3000,
       "autoPort": false
     }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "govea-dev",
       "runtimeExecutable": "/opt/homebrew/bin/node",
-      "runtimeArgs": ["/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs", "--dir", "/Users/roballred/Repos/Claude/govea-app", "--filter", "govea", "dev"],
+      "runtimeArgs": ["/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs", "--dir", "/Users/roballred/Repos/Claude/govea-app/.claude/worktrees/inspiring-murdock-60fcc9", "--filter", "govea", "dev"],
       "port": 3000,
       "autoPort": false
     }

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -388,6 +388,28 @@ export async function withdrawCrossOrgLink(linkId: string) {
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
 }
 
+export async function revokeCrossOrgLink(linkId: string) {
+  const session = await requireAdmin()
+  const link = await db.query.crossOrgLinks.findFirst({
+    where: and(eq(crossOrgLinks.id, linkId), eq(crossOrgLinks.targetOrgId, session.user.organizationId!)),
+  })
+  if (!link) throw new Error('Cross-org link not found or not authorized')
+  if (link.status !== 'active') throw new Error('Only active links can be revoked')
+
+  await db.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
+
+  await writeAuditLog({
+    action: 'cross_org_link.revoke',
+    entityType: 'cross_org_link',
+    entityId: linkId,
+    userId: session.user.id,
+    organizationId: session.user.organizationId!,
+    before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status, type: link.sourceEntityType },
+  })
+
+  await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
+}
+
 export async function removeLinksForConnection(orgAId: string, orgBId: string) {
   const affectedLinks = await db.query.crossOrgLinks.findMany({
     where: or(

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -180,7 +180,11 @@ export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId:
     if (!peer) continue
 
     const visible = canReadWithContext(peer.organizationId, peer.visibility)
-    if (!visible && peer.organizationId !== callerOrgId) continue
+    // Always show inbound pending links regardless of source visibility —
+    // the target org needs to see who is requesting approval even if the
+    // source entity is not yet shared with them.
+    const isInboundPending = link.status === 'pending' && !outbound
+    if (!visible && peer.organizationId !== callerOrgId && !isInboundPending) continue
 
     const item: CrossOrgLinkItem = {
       id: link.id,
@@ -315,13 +319,6 @@ export async function approveCrossOrgLink(linkId: string) {
   })
   if (!link) throw new Error('Cross-org link not found or not authorized')
   if (link.status !== 'pending') throw new Error('Only pending links can be approved')
-
-  const source = await getEntity(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId)
-  const target = await getEntity(link.targetEntityType as CrossOrgEntityType, link.targetEntityId)
-  if (!source || !target) throw new Error('Cross-org link points to missing content')
-
-  const sourceVisible = await canReadFederatedEntity(source.organizationId, source.visibility, session.user.organizationId!)
-  if (!sourceVisible) throw new Error('Source content is no longer visible under the current federation rules')
 
   await db.update(crossOrgLinks).set({
     status: 'active',

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   getCrossOrgLinkContext,
   rejectCrossOrgLink,
   requestCrossOrgLink,
+  revokeCrossOrgLink,
   withdrawCrossOrgLink,
 } from '@/actions/cross-org-links'
 
@@ -230,6 +231,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
         approveAction={approveCrossOrgLink}
         rejectAction={rejectCrossOrgLink}
         withdrawAction={withdrawCrossOrgLink}
+        revokeAction={revokeCrossOrgLink}
       />
 
       {isModuleEnabled(enabledModules, 'principles') && capability.principleCapabilities.length > 0 && (

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -4,9 +4,9 @@ import { db } from '@/db/client'
 import {
   personas, capabilities, applications, adrs, initiatives,
   strategicObjectives, valueStreams, principles, glossaryTerms,
-  auditLog, users,
+  auditLog, users, crossOrgLinks,
 } from '@/db/schema'
-import { and, count, eq, gt, isNotNull, desc, asc } from 'drizzle-orm'
+import { and, count, eq, gt, isNotNull, desc, asc, or } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DomainBadge } from '@/components/domain-badge'
 import Link from 'next/link'
@@ -66,6 +66,7 @@ export default async function DashboardPage() {
     capTotal, capModified, capReviewed,
     appTotal, appModified, appReviewed,
     personaTotal, personaModified, personaReviewed,
+    fedInboundPending, fedOutboundPending, fedOutboundRejected, fedTotal,
   ] = await Promise.all([
     db.select({ status: personas.status,           count: count() }).from(personas)           .where(eq(personas.organizationId,           orgId)).groupBy(personas.status),
     db.select({ status: capabilities.status,       count: count() }).from(capabilities)       .where(eq(capabilities.organizationId,       orgId)).groupBy(capabilities.status),
@@ -101,6 +102,11 @@ export default async function DashboardPage() {
     db.select({ count: count() }).from(personas).where(eq(personas.organizationId, orgId)),
     db.select({ count: count() }).from(personas).where(and(eq(personas.organizationId, orgId), gt(personas.updatedAt, staleThreshold))),
     db.select({ count: count() }).from(personas).where(and(eq(personas.organizationId, orgId), isNotNull(personas.lastReviewedAt), gt(personas.lastReviewedAt, staleThreshold))),
+    // Federation activity
+    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.targetOrgId, orgId), eq(crossOrgLinks.status, 'pending'))),
+    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.status, 'pending'))),
+    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.status, 'rejected'))),
+    db.select({ count: count() }).from(crossOrgLinks).where(or(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.targetOrgId, orgId))),
   ])
 
   const stats = {
@@ -124,6 +130,13 @@ export default async function DashboardPage() {
   const needsAttention = COVERAGE_ENTITIES
     .map(e => ({ ...e, draftCount: stats[e.key].byStatus[e.draftKey] ?? 0 }))
     .filter(e => e.draftCount > 0)
+
+  const federation = {
+    inboundPending:   Number(fedInboundPending[0].count),
+    outboundPending:  Number(fedOutboundPending[0].count),
+    outboundRejected: Number(fedOutboundRejected[0].count),
+    total:            Number(fedTotal[0].count),
+  }
 
   return (
     <div className="space-y-6">
@@ -159,6 +172,48 @@ export default async function DashboardPage() {
           })}
         </div>
       </div>
+
+      {/* Federation Activity */}
+      {federation.total > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Federation Activity</p>
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              {federation.inboundPending === 0 && federation.outboundPending === 0 && federation.outboundRejected === 0 ? (
+                <p className="text-sm text-muted-foreground">All cross-org links are active — no pending actions.</p>
+              ) : (
+                <div className="space-y-2">
+                  {federation.inboundPending > 0 && (
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="h-2 w-2 rounded-full bg-amber-500 shrink-0" />
+                      <span className="text-amber-600 font-medium">
+                        {federation.inboundPending} inbound link request{federation.inboundPending !== 1 ? 's' : ''} awaiting your approval
+                      </span>
+                    </div>
+                  )}
+                  {federation.outboundRejected > 0 && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <span className="h-2 w-2 rounded-full bg-destructive/60 shrink-0" />
+                      <span>
+                        {federation.outboundRejected} outbound request{federation.outboundRejected !== 1 ? 's' : ''} rejected by the target org
+                      </span>
+                    </div>
+                  )}
+                  {federation.outboundPending > 0 && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <span className="h-2 w-2 rounded-full bg-muted-foreground/40 shrink-0" />
+                      <span>
+                        {federation.outboundPending} outbound request{federation.outboundPending !== 1 ? 's' : ''} awaiting the target org&apos;s approval
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground mt-3">Review and act on cross-org links from the entity detail pages.</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
 
       {/* Review Health */}
       <div>

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import {
   strategicObjectives, valueStreams, principles, glossaryTerms,
   auditLog, users, crossOrgLinks,
 } from '@/db/schema'
-import { and, count, eq, gt, isNotNull, desc, asc, or } from 'drizzle-orm'
+import { and, count, eq, gt, isNotNull, desc, asc, or, inArray } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DomainBadge } from '@/components/domain-badge'
 import Link from 'next/link'
@@ -66,7 +66,7 @@ export default async function DashboardPage() {
     capTotal, capModified, capReviewed,
     appTotal, appModified, appReviewed,
     personaTotal, personaModified, personaReviewed,
-    fedInboundPending, fedOutboundPending, fedOutboundRejected, fedTotal,
+    fedInboundLinks, fedOutboundRows,
   ] = await Promise.all([
     db.select({ status: personas.status,           count: count() }).from(personas)           .where(eq(personas.organizationId,           orgId)).groupBy(personas.status),
     db.select({ status: capabilities.status,       count: count() }).from(capabilities)       .where(eq(capabilities.organizationId,       orgId)).groupBy(capabilities.status),
@@ -102,11 +102,16 @@ export default async function DashboardPage() {
     db.select({ count: count() }).from(personas).where(eq(personas.organizationId, orgId)),
     db.select({ count: count() }).from(personas).where(and(eq(personas.organizationId, orgId), gt(personas.updatedAt, staleThreshold))),
     db.select({ count: count() }).from(personas).where(and(eq(personas.organizationId, orgId), isNotNull(personas.lastReviewedAt), gt(personas.lastReviewedAt, staleThreshold))),
-    // Federation activity
-    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.targetOrgId, orgId), eq(crossOrgLinks.status, 'pending'))),
-    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.status, 'pending'))),
-    db.select({ count: count() }).from(crossOrgLinks).where(and(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.status, 'rejected'))),
-    db.select({ count: count() }).from(crossOrgLinks).where(or(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.targetOrgId, orgId))),
+    // Federation: inbound pending links targeting this org (needs approval)
+    db.query.crossOrgLinks.findMany({
+      where: and(eq(crossOrgLinks.targetOrgId, orgId), eq(crossOrgLinks.status, 'pending')),
+      orderBy: (l, { asc }) => [asc(l.createdAt)],
+    }),
+    // Federation: outbound link status counts
+    db.select({ status: crossOrgLinks.status, count: count() })
+      .from(crossOrgLinks)
+      .where(eq(crossOrgLinks.sourceOrgId, orgId))
+      .groupBy(crossOrgLinks.status),
   ])
 
   const stats = {
@@ -131,11 +136,30 @@ export default async function DashboardPage() {
     .map(e => ({ ...e, draftCount: stats[e.key].byStatus[e.draftKey] ?? 0 }))
     .filter(e => e.draftCount > 0)
 
+  // Resolve target entity names for inbound pending links
+  const fedCapIds = fedInboundLinks.filter(l => l.targetEntityType === 'capability').map(l => l.targetEntityId)
+  const fedPersonaIds = fedInboundLinks.filter(l => l.targetEntityType === 'persona').map(l => l.targetEntityId)
+  const [fedCaps, fedPersonas] = await Promise.all([
+    fedCapIds.length ? db.query.capabilities.findMany({ where: inArray(capabilities.id, fedCapIds) }) : Promise.resolve([]),
+    fedPersonaIds.length ? db.query.personas.findMany({ where: inArray(personas.id, fedPersonaIds) }) : Promise.resolve([]),
+  ])
+  const fedEntityMap = new Map([
+    ...fedCaps.map(c => [c.id, { name: c.name, href: `/capabilities/${c.id}` }] as const),
+    ...fedPersonas.map(p => [p.id, { name: p.name, href: `/personas/${p.id}` }] as const),
+  ])
+
+  const fedOutboundByStatus: Record<string, number> = {}
+  for (const row of fedOutboundRows) fedOutboundByStatus[row.status] = Number(row.count)
+
   const federation = {
-    inboundPending:   Number(fedInboundPending[0].count),
-    outboundPending:  Number(fedOutboundPending[0].count),
-    outboundRejected: Number(fedOutboundRejected[0].count),
-    total:            Number(fedTotal[0].count),
+    inboundPending: fedInboundLinks.map(l => ({
+      id: l.id,
+      linkType: l.linkType,
+      entity: fedEntityMap.get(l.targetEntityId) ?? null,
+    })),
+    outboundPending:  fedOutboundByStatus['pending']  ?? 0,
+    outboundRejected: fedOutboundByStatus['rejected'] ?? 0,
+    hasAny: fedInboundLinks.length > 0 || Object.keys(fedOutboundByStatus).length > 0,
   }
 
   return (
@@ -174,42 +198,53 @@ export default async function DashboardPage() {
       </div>
 
       {/* Federation Activity */}
-      {federation.total > 0 && (
+      {federation.hasAny && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Federation Activity</p>
           <Card>
-            <CardContent className="pt-4 pb-4">
-              {federation.inboundPending === 0 && federation.outboundPending === 0 && federation.outboundRejected === 0 ? (
-                <p className="text-sm text-muted-foreground">All cross-org links are active — no pending actions.</p>
-              ) : (
+            <CardContent className="pt-4 pb-4 space-y-3">
+              {federation.inboundPending.length > 0 && (
                 <div className="space-y-2">
-                  {federation.inboundPending > 0 && (
-                    <div className="flex items-center gap-2 text-sm">
-                      <span className="h-2 w-2 rounded-full bg-amber-500 shrink-0" />
-                      <span className="text-amber-600 font-medium">
-                        {federation.inboundPending} inbound link request{federation.inboundPending !== 1 ? 's' : ''} awaiting your approval
-                      </span>
-                    </div>
-                  )}
+                  <p className="text-xs font-medium text-amber-600">
+                    {federation.inboundPending.length} link request{federation.inboundPending.length !== 1 ? 's' : ''} awaiting your approval
+                  </p>
+                  <ul className="space-y-1">
+                    {federation.inboundPending.map(link => (
+                      <li key={link.id}>
+                        {link.entity ? (
+                          <Link
+                            href={link.entity.href}
+                            className="flex items-center gap-2 text-sm rounded-md px-2 py-1.5 hover:bg-muted/50 transition-colors"
+                          >
+                            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
+                            <span className="font-medium">{link.entity.name}</span>
+                            <span className="text-xs text-muted-foreground ml-auto">{link.linkType.replaceAll('_', ' ')} →</span>
+                          </Link>
+                        ) : (
+                          <span className="text-sm text-muted-foreground px-2">Unknown entity</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {(federation.outboundPending > 0 || federation.outboundRejected > 0) && (
+                <div className="space-y-1 border-t pt-3">
                   {federation.outboundRejected > 0 && (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <span className="h-2 w-2 rounded-full bg-destructive/60 shrink-0" />
-                      <span>
-                        {federation.outboundRejected} outbound request{federation.outboundRejected !== 1 ? 's' : ''} rejected by the target org
-                      </span>
-                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      <span className="text-destructive font-medium">{federation.outboundRejected}</span> outbound request{federation.outboundRejected !== 1 ? 's' : ''} rejected by the target org
+                    </p>
                   )}
                   {federation.outboundPending > 0 && (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <span className="h-2 w-2 rounded-full bg-muted-foreground/40 shrink-0" />
-                      <span>
-                        {federation.outboundPending} outbound request{federation.outboundPending !== 1 ? 's' : ''} awaiting the target org&apos;s approval
-                      </span>
-                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      <span className="font-medium">{federation.outboundPending}</span> outbound request{federation.outboundPending !== 1 ? 's' : ''} pending the target org&apos;s approval
+                    </p>
                   )}
                 </div>
               )}
-              <p className="text-xs text-muted-foreground mt-3">Review and act on cross-org links from the entity detail pages.</p>
+              {federation.inboundPending.length === 0 && federation.outboundPending === 0 && federation.outboundRejected === 0 && (
+                <p className="text-sm text-muted-foreground">All cross-org links are active — no pending actions.</p>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import {
   strategicObjectives, valueStreams, principles, glossaryTerms,
   auditLog, users, crossOrgLinks,
 } from '@/db/schema'
-import { and, count, eq, gt, isNotNull, desc, asc, or, inArray } from 'drizzle-orm'
+import { and, count, eq, gt, isNotNull, desc, asc, inArray } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DomainBadge } from '@/components/domain-badge'
 import Link from 'next/link'
@@ -107,10 +107,10 @@ export default async function DashboardPage() {
       where: and(eq(crossOrgLinks.targetOrgId, orgId), eq(crossOrgLinks.status, 'pending')),
       orderBy: (l, { asc }) => [asc(l.createdAt)],
     }),
-    // Federation: all link status counts for this org (source or target)
+    // Federation: outbound link status counts (this org is the source)
     db.select({ status: crossOrgLinks.status, count: count() })
       .from(crossOrgLinks)
-      .where(or(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.targetOrgId, orgId)))
+      .where(eq(crossOrgLinks.sourceOrgId, orgId))
       .groupBy(crossOrgLinks.status),
   ])
 

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -107,10 +107,10 @@ export default async function DashboardPage() {
       where: and(eq(crossOrgLinks.targetOrgId, orgId), eq(crossOrgLinks.status, 'pending')),
       orderBy: (l, { asc }) => [asc(l.createdAt)],
     }),
-    // Federation: outbound link status counts
+    // Federation: all link status counts for this org (source or target)
     db.select({ status: crossOrgLinks.status, count: count() })
       .from(crossOrgLinks)
-      .where(eq(crossOrgLinks.sourceOrgId, orgId))
+      .where(or(eq(crossOrgLinks.sourceOrgId, orgId), eq(crossOrgLinks.targetOrgId, orgId)))
       .groupBy(crossOrgLinks.status),
   ])
 
@@ -148,8 +148,8 @@ export default async function DashboardPage() {
     ...fedPersonas.map(p => [p.id, { name: p.name, href: `/personas/${p.id}` }] as const),
   ])
 
-  const fedOutboundByStatus: Record<string, number> = {}
-  for (const row of fedOutboundRows) fedOutboundByStatus[row.status] = Number(row.count)
+  const fedByStatus: Record<string, number> = {}
+  for (const row of fedOutboundRows) fedByStatus[row.status] = (fedByStatus[row.status] ?? 0) + Number(row.count)
 
   const federation = {
     inboundPending: fedInboundLinks.map(l => ({
@@ -157,9 +157,10 @@ export default async function DashboardPage() {
       linkType: l.linkType,
       entity: fedEntityMap.get(l.targetEntityId) ?? null,
     })),
-    outboundPending:  fedOutboundByStatus['pending']  ?? 0,
-    outboundRejected: fedOutboundByStatus['rejected'] ?? 0,
-    hasAny: fedInboundLinks.length > 0 || Object.keys(fedOutboundByStatus).length > 0,
+    outboundPending:  fedByStatus['pending']  ?? 0,
+    outboundRejected: fedByStatus['rejected'] ?? 0,
+    totalActive:      fedByStatus['active']   ?? 0,
+    hasAny: Object.values(fedByStatus).some(n => n > 0) || fedInboundLinks.length > 0,
   }
 
   return (
@@ -243,7 +244,9 @@ export default async function DashboardPage() {
                 </div>
               )}
               {federation.inboundPending.length === 0 && federation.outboundPending === 0 && federation.outboundRejected === 0 && (
-                <p className="text-sm text-muted-foreground">All cross-org links are active — no pending actions.</p>
+                <p className="text-sm text-muted-foreground">
+                  {federation.totalActive} active cross-org link{federation.totalActive !== 1 ? 's' : ''} — no pending actions.
+                </p>
               )}
             </CardContent>
           </Card>

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -143,7 +143,7 @@ export default async function DashboardPage() {
     fedCapIds.length ? db.query.capabilities.findMany({ where: inArray(capabilities.id, fedCapIds) }) : Promise.resolve([]),
     fedPersonaIds.length ? db.query.personas.findMany({ where: inArray(personas.id, fedPersonaIds) }) : Promise.resolve([]),
   ])
-  const fedEntityMap = new Map([
+  const fedEntityMap = new Map<string, { name: string; href: string }>([
     ...fedCaps.map(c => [c.id, { name: c.name, href: `/capabilities/${c.id}` }] as const),
     ...fedPersonas.map(p => [p.id, { name: p.name, href: `/personas/${p.id}` }] as const),
   ])

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
   getCrossOrgLinkContext,
   rejectCrossOrgLink,
   requestCrossOrgLink,
+  revokeCrossOrgLink,
   withdrawCrossOrgLink,
 } from '@/actions/cross-org-links'
 
@@ -176,6 +177,7 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
         approveAction={approveCrossOrgLink}
         rejectAction={rejectCrossOrgLink}
         withdrawAction={withdrawCrossOrgLink}
+        revokeAction={revokeCrossOrgLink}
       />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">

--- a/apps/govea/src/components/cross-org-links-panel.tsx
+++ b/apps/govea/src/components/cross-org-links-panel.tsx
@@ -18,6 +18,7 @@ interface Props {
   approveAction: (linkId: string) => Promise<void>
   rejectAction: (linkId: string, reason?: string) => Promise<void>
   withdrawAction: (linkId: string) => Promise<void>
+  revokeAction?: (linkId: string) => Promise<void>
 }
 
 const LINK_TYPE_STYLES: Record<CrossOrgLinkType, string> = {
@@ -44,6 +45,7 @@ export function CrossOrgLinksPanel({
   approveAction,
   rejectAction,
   withdrawAction,
+  revokeAction,
 }: Props) {
   const [isPending, startTransition] = useTransition()
   const [showRequest, setShowRequest] = useState(false)
@@ -182,6 +184,17 @@ export function CrossOrgLinksPanel({
                       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                       </svg>
+                    </button>
+                  )}
+                  {canApprove && revokeAction && (
+                    <button
+                      type="button"
+                      onClick={() => run(() => revokeAction(link.id))}
+                      disabled={isPending}
+                      className="shrink-0 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-destructive hover:bg-destructive/10 border border-border hover:border-destructive/20 transition-all disabled:opacity-30"
+                      aria-label={`Revoke link to ${link.peerName}`}
+                    >
+                      Revoke
                     </button>
                   )}
                 </div>

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -647,8 +647,12 @@ async function seed() {
         targetEntityType: 'capability',
         targetEntityId: targetCapId,
         linkType: link.linkType,
-        status: 'active',
+        status: 'pending',
       })
+    } else if (existingLink.status !== 'pending' || existingLink.linkType !== link.linkType) {
+      await db.update(crossOrgLinks)
+        .set({ status: 'pending', linkType: link.linkType })
+        .where(eq(crossOrgLinks.id, existingLink.id))
     }
     console.log(`  ✓ Cross-org link (${link.linkType}): "${link.sourceCapabilityName}" → "${link.targetCapabilityName}"`)
   }


### PR DESCRIPTION
## Summary

Federation follow-up polish for issue #42, plus three bug fixes uncovered during dev testing.

**New features (issue #42):**
- Revoke action — target org admin can hard-delete an active cross-org link with full audit trail
- Dashboard Federation Activity card — shows inbound pending requests (clickable to entity), outbound pending/rejected counts, and active link total
- Approval polish — Approve/Reject buttons visible to target org admin on capability and persona detail pages

**Bug fixes:**
- Fixes #198 — inbound pending links invisible to target org when source entity has `org` visibility
- Fixes #199 — `approveCrossOrgLink` blocked by unnecessary `sourceVisible` guard
- Fixes #200 — seed inserted links as `active` instead of `pending`; reseed silently skipped existing records (upsert fix)

## Changed files

| File | Change |
|---|---|
| `src/actions/cross-org-links.ts` | Added `revokeCrossOrgLink`; fixed visibility bypass for inbound pending; removed `sourceVisible` guard from `approveCrossOrgLink` |
| `src/components/cross-org-links-panel.tsx` | Added Revoke button in Approved section |
| `src/app/(admin)/dashboard/page.tsx` | Added Federation Activity card with entity name resolution |
| `src/app/(admin)/capabilities/[id]/page.tsx` | Wire `revokeAction` prop |
| `src/app/(admin)/personas/[id]/page.tsx` | Wire `revokeAction` prop |
| `src/db/seeds/run.ts` | Fix status (`pending`); add upsert to keep reseed idempotent |
| `.claude/launch.json` | Point worktree preview server at worktree path |

## Test plan

- [ ] Log in as City of Riverdale admin — dashboard shows 3 outbound pending requests
- [ ] Log in as Office of Digital Services admin (Sam) — dashboard shows 3 inbound pending requests with clickable capability names
- [ ] Navigate to a capability — Approve/Reject buttons visible; approving moves link to active
- [ ] After approving — Revoke button visible to target org admin; revoking removes the link
- [ ] Source entity with `visibility: org` — pending request still visible and approvable by target org

🤖 Generated with [Claude Code](https://claude.com/claude-code)