### PR TITLE
fix(search): correct header layout and add input to search page

### DIFF
--- a/apps/govea/src/app/(admin)/search/page.tsx
+++ b/apps/govea/src/app/(admin)/search/page.tsx
@@ -37,21 +37,33 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Search</h1>
-        {hasQuery && (
-          <p className="text-muted-foreground mt-1">
-            {totalCount === 0
-              ? `No results for "${query}"`
-              : `${totalCount} result${totalCount === 1 ? '' : 's'} for "${query}"`}
-          </p>
-        )}
-        {!hasQuery && (
-          <p className="text-muted-foreground mt-1">
-            Use the search bar above to find content across the repository.
-          </p>
-        )}
-      </div>
+      <h1 className="text-2xl font-bold tracking-tight">Search</h1>
+
+      {/* Search input — always visible; primary entry point on mobile */}
+      <form action="/search" method="get" className="flex gap-2">
+        <input
+          name="q"
+          type="search"
+          defaultValue={query}
+          placeholder="Search the repository…"
+          autoFocus
+          className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <button
+          type="submit"
+          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+        >
+          Search
+        </button>
+      </form>
+
+      {hasQuery && (
+        <p className="text-sm text-muted-foreground">
+          {totalCount === 0
+            ? `No results for "${query}"`
+            : `${totalCount} result${totalCount === 1 ? '' : 's'} for "${query}"`}
+        </p>
+      )}
 
       {hasQuery && totalCount === 0 && (
         <Card>

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -273,9 +273,9 @@ export function AppShell({
           </Link>
 
           {/* Search */}
-          <div className="flex-1 flex items-center lg:max-w-sm">
+          <div className="flex-1 flex items-center">
             {/* Desktop: visible input */}
-            <form action="/search" method="get" className="hidden lg:flex w-full">
+            <form action="/search" method="get" className="hidden lg:flex w-full max-w-sm">
               <input
                 name="q"
                 type="search"


### PR DESCRIPTION
## Summary
- Fixes desktop header: `max-w-sm` was on the `flex-1` wrapper div, so the search zone was capped at 24rem and user info clustered next to it instead of staying right-aligned. Moved the constraint onto the inner `<form>` so the wrapper truly fills available space.
- Fixes mobile search page: the page told users to "use the search bar above" but the mobile header only has an icon link — no visible input. Added a full search form at the top of the page so it works standalone on any screen size. Prefills with the current `?q=` value when returning to the page.

## Test plan
- [ ] Desktop: search input visible in header, left side; user info (role badge, sign out) stays right-aligned
- [ ] Mobile: search icon in header navigates to `/search`; page shows a usable input with a Search button
- [ ] Typing in the page input and submitting navigates to `/search?q=...` and shows results