### PR TITLE
feat(planning): enforce Viewer visibility rules for initiatives and ADRs

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -25,22 +25,22 @@ async function requireAdmin() {
   return session
 }
 
-export async function getADRs(orgId: string) {
+// Viewer-visible ADR status — Option B decision from #202
+const VIEWER_ADR_STATUS = 'accepted' as const
+
+export async function getADRs(orgId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(orgId)
+  const isViewer = role === 'viewer'
 
   return db.query.adrs.findMany({
     where: (a, { eq, or, and, inArray }) => {
       const base = eq(a.organizationId, orgId)
       const instanceWide = eq(a.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(a.organizationId, connectedOrgIds),
-          inArray(a.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(a.status, VIEWER_ADR_STATUS) : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(a.organizationId, connectedOrgIds), inArray(a.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -24,22 +24,22 @@ async function requireAdmin() {
   return session
 }
 
-export async function getInitiatives(orgId: string) {
+// Viewer-visible initiative statuses — Option B decision from #202
+const VIEWER_INITIATIVE_STATUSES = ['active', 'complete'] as const
+
+export async function getInitiatives(orgId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(orgId)
+  const isViewer = role === 'viewer'
 
   return db.query.initiatives.findMany({
     where: (i, { eq, or, and, inArray }) => {
       const base = eq(i.organizationId, orgId)
       const instanceWide = eq(i.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(i.organizationId, connectedOrgIds),
-          inArray(i.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? inArray(i.status, VIEWER_INITIATIVE_STATUSES) : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(i.organizationId, connectedOrgIds), inArray(i.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -25,7 +25,7 @@ async function requireAdmin() {
 }
 
 // Viewer-visible initiative statuses — Option B decision from #202
-const VIEWER_INITIATIVE_STATUSES = ['active', 'complete'] as const
+const VIEWER_INITIATIVE_STATUSES: Array<'active' | 'proposed' | 'on-hold' | 'complete' | 'cancelled'> = ['active', 'complete']
 
 export async function getInitiatives(orgId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(orgId)

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -52,6 +52,10 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
   const [adr, enabledModules] = await Promise.all([getADR(id), getEnabledModules()])
   if (!adr) notFound()
 
+  // Viewers may only access accepted ADRs (#202)
+  const isViewer = session.user.role === 'viewer'
+  if (isViewer && adr.status !== 'accepted') notFound()
+
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
   const canMutate = editor && adr.organizationId === orgId

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -106,17 +106,20 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-3">
-        <select
-          value={statusFilter}
-          onChange={e => setStatusFilter(e.target.value)}
-          className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="all">All statuses</option>
-          <option value="proposed">Proposed</option>
-          <option value="accepted">Accepted</option>
-          <option value="deprecated">Deprecated</option>
-          <option value="superseded">Superseded</option>
-        </select>
+        {!canEdit && null /* viewers see pre-filtered results — no status filter needed */}
+        {canEdit && (
+          <select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value)}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All statuses</option>
+            <option value="proposed">Proposed</option>
+            <option value="accepted">Accepted</option>
+            <option value="deprecated">Deprecated</option>
+            <option value="superseded">Superseded</option>
+          </select>
+        )}
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
             + New ADR

--- a/apps/govea/src/app/(admin)/adrs/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/page.tsx
@@ -15,7 +15,7 @@ export default async function ADRsPage() {
   const role = session.user.role
 
   const [adrList, capabilityList, applicationList, initiativeList, objectiveList] = await Promise.all([
-    getADRs(orgId),
+    getADRs(orgId, role),
     getCapabilities(orgId),
     getApplications(orgId),
     getInitiatives(orgId),

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -55,6 +55,10 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
   const [initiative, enabledModules] = await Promise.all([getInitiative(id), getEnabledModules()])
   if (!initiative) notFound()
 
+  // Viewers may only access active or complete initiatives (#202)
+  const isViewer = session.user.role === 'viewer'
+  if (isViewer && !['active', 'complete'].includes(initiative.status)) notFound()
+
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
   const canMutate = editor && initiative.organizationId === orgId

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -116,18 +116,21 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-3">
-        <select
-          value={statusFilter}
-          onChange={e => setStatusFilter(e.target.value)}
-          className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="all">All statuses</option>
-          <option value="proposed">Proposed</option>
-          <option value="active">Active</option>
-          <option value="on-hold">On Hold</option>
-          <option value="complete">Complete</option>
-          <option value="cancelled">Cancelled</option>
-        </select>
+        {!canEdit && null /* viewers see pre-filtered results — no status filter needed */}
+        {canEdit && (
+          <select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value)}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="all">All statuses</option>
+            <option value="proposed">Proposed</option>
+            <option value="active">Active</option>
+            <option value="on-hold">On Hold</option>
+            <option value="complete">Complete</option>
+            <option value="cancelled">Cancelled</option>
+          </select>
+        )}
         {orgOptions.length > 1 && (
           <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
             <option value="all">All organizations</option>

--- a/apps/govea/src/app/(admin)/initiatives/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/page.tsx
@@ -12,7 +12,7 @@ export default async function InitiativesPage() {
   const role = session.user.role
 
   const [initiativeList, capabilityList, objectiveList] = await Promise.all([
-    getInitiatives(orgId),
+    getInitiatives(orgId, role),
     getCapabilities(orgId),
     getObjectives(orgId),
   ])


### PR DESCRIPTION
## Summary

Implements the Option B decision from #202 in the actual data layer. The decision was documented and applied to search, but `getInitiatives` and `getADRs` were returning all statuses to all roles with no Viewer restriction in practice.

**Changes:**
- `getInitiatives(orgId, role?)` — Viewers receive only `active` and `complete` initiatives; all other statuses filtered at the query level
- `getADRs(orgId, role?)` — Viewers receive only `accepted` ADRs; `proposed`, `deprecated`, and `superseded` filtered at the query level
- `initiatives/page.tsx` and `adrs/page.tsx` — pass `role` to the fetch functions
- `initiatives/[id]/page.tsx` — returns `notFound()` if a Viewer navigates directly to a non-visible initiative
- `adrs/[id]/page.tsx` — returns `notFound()` if a Viewer navigates directly to a non-accepted ADR
- `initiative-table.tsx` and `adr-table.tsx` — status filter dropdown hidden for Viewers (results are pre-filtered server-side; showing Proposed/On Hold/Cancelled options would be confusing and return nothing)

Strategic objectives already use `workflowStatusEnum` and are covered by the existing `published`-only Viewer pattern — no change needed there.

## Test plan
- [ ] Sign in as Viewer — initiatives list shows only active/complete items
- [ ] Sign in as Viewer — ADRs list shows only accepted ADRs
- [ ] Sign in as Viewer — no status filter dropdown on either list page
- [ ] Sign in as Viewer — navigate directly to a proposed initiative URL → 404
- [ ] Sign in as Viewer — navigate directly to a proposed ADR URL → 404
- [ ] Sign in as Contributor/Admin — all statuses visible, status filter present

Capability: cm-content-workflow
Closes #202