### PR TITLE
[codex] docs: align ADR and portfolio maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Containerized local development plus Azure Container Apps dev deployment support
 
 **Partially implemented / still maturing:**
-- ADRs — schema and listing exist, but the full end-user authoring experience is not complete
+- ADRs — basic CRUD, detail pages, and linkage exist, but the authoring experience is still maturing relative to the core portfolio records
 - Planning semantics and timeline presentation — useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Admin configuration beyond core settings
 - Repository completeness, end-to-end traceability, and architecture debt tooling

--- a/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
+++ b/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
@@ -35,13 +35,14 @@ The system must allow contributors to record, track, and supersede architecture 
 - Only published ADRs appear in front-end portfolio views
 
 ## Implementation Status
-Implemented in early v1:
-- Schema and server actions support the full ADR lifecycle, including supersession links
+Partially implemented in early v1:
+- Schema and server actions support ADR creation, editing, deletion, and supersession links
 - Admin UI includes list, detail, create, edit, and delete flows
 - ADRs can link to capabilities, applications, initiatives, and objectives
 
 Remaining gaps:
-- richer ADR analytics and debt-oriented reporting are still future work
+- the ADR experience is still lighter and less polished than the core application, capability, persona, service, and value-stream surfaces
+- richer ADR analytics, debt-oriented reporting, and broader decision-support workflows are still future work
 
 ## Links
 - Depends on: IAM — Role-Based Access Control, Content Management — Content Workflow

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -14,13 +14,10 @@ The system must allow contributors to maintain a structured inventory of the org
 | Capability | File | Description |
 |---|---|---|
 | Application Portfolio | [po-application-portfolio.md](./po-application-portfolio.md) | Manage applications with lifecycle status and capability links |
-| Services | [po-services.md](./po-services.md) | Manage government-facing services linked to personas, capabilities, applications, and value streams |
 | Capability Map | [po-capability-map.md](./po-capability-map.md) | Define business capabilities organized by domain, linked to applications and personas |
-| Personas | [po-personas.md](./po-personas.md) | Define the people the architecture exists to serve and connect them to capabilities and value streams |
 | Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
 | Principles | [po-principles.md](./po-principles.md) | Capture architecture principles and link them to capabilities and decisions |
 | Glossary | [po-glossary.md](./po-glossary.md) | Maintain shared terminology to support consistent EA language across the repository |
-| Value Streams | [po-value-streams.md](./po-value-streams.md) | Define end-to-end value delivery flows with ordered stages and linked capabilities |
 
 ## Rules
 - Portfolio records follow the standard content workflow: draft → published → archived

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -14,16 +14,24 @@ The system must allow contributors to maintain a structured inventory of the org
 | Capability | File | Description |
 |---|---|---|
 | Application Portfolio | [po-application-portfolio.md](./po-application-portfolio.md) | Manage applications with lifecycle status and capability links |
+| Services | [po-services.md](./po-services.md) | Manage government-facing services linked to personas, capabilities, applications, and value streams |
 | Capability Map | [po-capability-map.md](./po-capability-map.md) | Define business capabilities organized by domain, linked to applications and personas |
+| Personas | [po-personas.md](./po-personas.md) | Define the people the architecture exists to serve and connect them to capabilities and value streams |
 | Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
 | Principles | [po-principles.md](./po-principles.md) | Capture architecture principles and link them to capabilities and decisions |
 | Glossary | [po-glossary.md](./po-glossary.md) | Maintain shared terminology to support consistent EA language across the repository |
+| Value Streams | [po-value-streams.md](./po-value-streams.md) | Define end-to-end value delivery flows with ordered stages and linked capabilities |
 
 ## Rules
 - Portfolio records follow the standard content workflow: draft → published → archived
 - Only published records are visible to Content Viewers and Department Directors
 - Every application must link to at least one capability — this is a data integrity rule enforced at the application layer
 - Visibility controls (org / connections / instance) apply to all portfolio record types
+
+## Current Maturity
+Portfolio Management is one of GovEA's strongest shipped areas. Applications, capabilities, personas, services, value streams, principles, and glossary content all have meaningful day-to-day product surface today.
+
+ADRs are real and usable, but they are not yet as mature as the rest of the portfolio layer. Schema support, linking, list/detail pages, and basic CRUD exist; richer authoring polish, analytics, and broader decision-support workflows still need work. For that reason this group should currently be described as partially implemented overall, not fully implemented.
 
 ## Links
 - Related: Frontend Display — Portfolio Views, Planning, Content Management

--- a/capabilities.md
+++ b/capabilities.md
@@ -12,7 +12,7 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 |---|---|---|
 | 1 | [Identity & Access Management](#1-identity--access-management) | Implemented |
 | 2 | [Content Management](#2-content-management) | Partially implemented |
-| 3 | [Portfolio Management](#3-portfolio-management) | Implemented |
+| 3 | [Portfolio Management](#3-portfolio-management) | Partially implemented |
 | 4 | [Planning & Roadmap](#4-planning--roadmap) | Implemented |
 | 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
 | 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
@@ -75,7 +75,7 @@ The structured inventory of the organization's architecture objects.
 | Services | Implemented | Manage government-facing services linked to personas, capabilities, applications, and value streams |
 | Capability Map | Implemented | Define business capabilities organized by domain; linked to applications, personas, principles, and decisions |
 | Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
-| Architecture Decision Records (ADRs) | Implemented | Record, track, supersede, and link architecture decisions to capabilities, applications, initiatives, and objectives |
+| Architecture Decision Records (ADRs) | Partially implemented | Basic ADR CRUD, detail pages, supersession, and cross-linking exist, but the overall authoring experience is still maturing relative to the stronger core portfolio records |
 | Principles | Implemented | Capture architecture principles and link them to capabilities and decisions |
 | Glossary | Implemented | Maintain shared terminology to support consistent EA language across the repository |
 | Value Streams | Implemented | Define value streams with ordered stages; link to capabilities and personas |
@@ -91,6 +91,8 @@ ADRs → Capabilities, Applications, Initiatives, Objectives
 Principles → Capabilities, ADRs
 Glossary → Shared reference terms across all content
 ```
+
+This is still one of GovEA's strongest product areas, but it should be described as partially implemented overall until ADRs reach the same maturity as applications, capabilities, personas, services, and value streams.
 
 ---
 


### PR DESCRIPTION
## Summary

Focused docs correction pass for #150 so the ADR and portfolio maturity story matches the shipped product more closely.

- downgrades Portfolio Management from `Implemented` to `Partially implemented` in `capabilities.md`
- downgrades `Architecture Decision Records (ADRs)` from `Implemented` to `Partially implemented` in `capabilities.md`
- updates the README ADR summary to reflect the shipped surface more accurately: basic CRUD, detail pages, and linkage exist, but the ADR experience is still maturing
- expands the portfolio capability-group doc so it reflects the currently shipped portfolio sub-capabilities and explains why the group is still only partially implemented overall
- updates the ADR capability doc to describe the current implementation as real and usable, but lighter than the stronger core portfolio records

## Why

Issue #150 identified a documentation mismatch: the product has strong portfolio coverage overall, but the docs were overstating ADR maturity. The previous wording also understated the ADR surface in the README by implying that only schema and listing existed.

This PR brings the docs to a more accurate middle ground:
- ADRs are not merely stubbed schema
- ADRs are also not yet as mature as applications, capabilities, personas, services, and value streams

## Impact

- product positioning is more accurate for contributors and reviewers
- `capabilities.md`, `README.md`, and the portfolio capability docs now tell the same story
- follow-on product work on ADRs can build from a clearer baseline

Closes #150

## Validation

- `git diff --check -- capabilities.md README.md business-architecture/capabilities/cms/portfolio/portfolio.md business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md`
- reviewed against the shipped ADR list/detail/create/edit/delete surface in `apps/govea/src/app/(admin)/adrs/` and server actions in `apps/govea/src/actions/adrs.ts`
