### PR TITLE
fix(security): gate /settings to admin role only (#207)

### DIFF
--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -5,10 +5,12 @@ import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { ThemeSelector } from '@/components/theme-selector'
 import { ModuleToggles } from '@/components/module-toggles'
+import { isAdmin } from '@/lib/rbac'
 
 export default async function SettingsPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) redirect('/dashboard')
 
   const org = session.user.organizationId
     ? await db.query.organizations.findFirst({

--- a/apps/govea/tests/e2e/specs/iam.spec.ts
+++ b/apps/govea/tests/e2e/specs/iam.spec.ts
@@ -340,4 +340,35 @@ test.describe('authorization', () => {
     await expect(page).toHaveURL(/\/dashboard/)
     await ctx.close()
   })
+
+  // /settings — admin-only route (#207)
+  test('admin can access /settings', async ({ browser }) => {
+    const ctx = await browser.newContext({
+      storageState: 'tests/e2e/.auth/admin.json',
+    })
+    const page = await ctx.newPage()
+    await page.goto('/settings')
+    await expect(page).toHaveURL(/\/settings/)
+    await ctx.close()
+  })
+
+  test('contributor is redirected from /settings to /dashboard', async ({ browser }) => {
+    const ctx = await browser.newContext({
+      storageState: 'tests/e2e/.auth/contributor.json',
+    })
+    const page = await ctx.newPage()
+    await page.goto('/settings')
+    await expect(page).toHaveURL(/\/dashboard/)
+    await ctx.close()
+  })
+
+  test('viewer is redirected from /settings to /dashboard', async ({ browser }) => {
+    const ctx = await browser.newContext({
+      storageState: 'tests/e2e/.auth/viewer.json',
+    })
+    const page = await ctx.newPage()
+    await page.goto('/settings')
+    await expect(page).toHaveURL(/\/dashboard/)
+    await ctx.close()
+  })
 })


### PR DESCRIPTION
Closes #207

## Summary
- Added `isAdmin(session.user)` guard to `settings/page.tsx`, redirecting non-admins to `/dashboard` — matches the identical pattern used by `/users`, `/audit`, and `/connections`
- The underlying server actions (`setModuleEnabled`, `updateOrgTheme`) were already admin-only; this closes the route-level gap that let Contributors and Viewers reach the configuration UI
- Added three E2E tests to the `authorization` block in `iam.spec.ts`: Admin can access `/settings`, Contributor is redirected, Viewer is redirected

## Test plan
- [ ] CI type check, lint, build pass
- [ ] E2E smoke: new `/settings` authorization tests pass for all three roles
- [ ] Manual: log in as contributor → navigate to `/settings` → confirm redirect to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)