### PR TITLE
feat(audit): add audit logging for initiative create/edit/delete (#209)

### DIFF
--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -9,6 +9,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canEdit, isAdmin } from '@/lib/rbac'
+import { writeAuditLog } from '@/lib/audit'
 
 async function requireContributor() {
   const session = await auth()
@@ -97,24 +98,36 @@ export async function createInitiative(formData: FormData) {
       .values(objectiveIds.map(objectiveId => ({ initiativeId: row.id, objectiveId })))
       .onConflictDoNothing()
   }
+
+  await writeAuditLog({
+    action: 'initiative.create',
+    entityType: 'initiative',
+    entityId: row.id,
+    userId,
+    organizationId: orgId,
+    after: { name: row.name, status: row.status, visibility: row.visibility },
+  })
 }
 
 export async function editInitiative(id: string, formData: FormData) {
   const session = await requireContributor()
   const orgId = session.user.organizationId!
 
-  const existing = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
-  assertOwnership(existing?.organizationId, orgId)
+  const before = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
+  assertOwnership(before?.organizationId, orgId)
 
   const userId = session.user.id
+  const name = formData.get('name') as string
+  const status = (formData.get('status') as 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled') || 'proposed'
+  const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') || 'org'
 
   await db.update(initiatives).set({
-    name: formData.get('name') as string,
+    name,
     description: (formData.get('description') as string) || null,
-    status: (formData.get('status') as 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled') || 'proposed',
+    status,
     startDate: (formData.get('startDate') as string) || null,
     endDate: (formData.get('endDate') as string) || null,
-    visibility: (formData.get('visibility') as 'org' | 'connections' | 'instance') || 'org',
+    visibility,
     updatedBy: userId,
     updatedAt: new Date(),
   }).where(eq(initiatives.id, id))
@@ -134,16 +147,35 @@ export async function editInitiative(id: string, formData: FormData) {
       .values(objectiveIds.map(objectiveId => ({ initiativeId: id, objectiveId })))
       .onConflictDoNothing()
   }
+
+  await writeAuditLog({
+    action: 'initiative.edit',
+    entityType: 'initiative',
+    entityId: id,
+    userId,
+    organizationId: orgId,
+    before: { name: before?.name, status: before?.status },
+    after: { name, status, visibility },
+  })
 }
 
 export async function deleteInitiative(id: string) {
   const session = await requireAdmin()
   const orgId = session.user.organizationId!
 
-  const existing = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
-  assertOwnership(existing?.organizationId, orgId)
+  const before = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
+  assertOwnership(before?.organizationId, orgId)
 
   await db.delete(initiatives).where(eq(initiatives.id, id))
+
+  await writeAuditLog({
+    action: 'initiative.delete',
+    entityType: 'initiative',
+    entityId: id,
+    userId: session.user.id,
+    organizationId: orgId,
+    before: { name: before?.name, status: before?.status },
+  })
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -9,7 +9,7 @@
  * Isolation is by organizationId; tests never touch the dev seed orgs.
  */
 import { db } from '@/db/client'
-import { organizations, users, capabilities, auditLog } from '@/db/schema'
+import { organizations, users, capabilities, initiatives, auditLog } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import bcrypt from 'bcryptjs'
@@ -126,6 +126,10 @@ export async function getAuditLogs(orgId: string, action?: string) {
 /** Returns all audit log entries for a specific entity (e.g. a capability id). */
 export async function getAuditLogsForEntity(entityId: string) {
   return db.select().from(auditLog).where(eq(auditLog.entityId, entityId))
+}
+
+export async function getInitiativesForOrg(orgId: string) {
+  return db.select().from(initiatives).where(eq(initiatives.organizationId, orgId))
 }
 
 /** Convenience: insert a capability row directly for cross-org / setup scenarios. */

--- a/apps/govea/tests/integration/initiatives.test.ts
+++ b/apps/govea/tests/integration/initiatives.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests: initiatives server actions
+ *
+ * Covers:
+ *  - Role enforcement (contributor creates/edits, admin deletes)
+ *  - createInitiative writes correct DB row + audit log
+ *  - editInitiative patches only the target row + audit before/after
+ *  - deleteInitiative removes row + captures before snapshot in audit log
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createInitiative, editInitiative, deleteInitiative } from '@/actions/initiatives'
+import { db } from '@/db/client'
+import { initiatives } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import {
+  createTestOrg, createTestUser, cleanupOrg,
+  makeSession, getInitiativesForOrg, getAuditLogsForEntity,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function initForm(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('name', overrides.name ?? 'Test Initiative')
+  fd.set('status', overrides.status ?? 'proposed')
+  fd.set('visibility', overrides.visibility ?? 'org')
+  if (overrides.description) fd.set('description', overrides.description)
+  if (overrides.startDate) fd.set('startDate', overrides.startDate)
+  if (overrides.endDate) fd.set('endDate', overrides.endDate)
+  return fd
+}
+
+describe('initiatives actions', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  // ── createInitiative ───────────────────────────────────────────────────────
+
+  describe('createInitiative', () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+    })
+
+    it('contributor can create an initiative', async () => {
+      const before = await getInitiativesForOrg(orgId)
+      await createInitiative(initForm({ name: 'Cloud Migration' }))
+      const after = await getInitiativesForOrg(orgId)
+
+      expect(after).toHaveLength(before.length + 1)
+      expect(after.some(i => i.name === 'Cloud Migration')).toBe(true)
+    })
+
+    it('created initiative belongs to the contributor org', async () => {
+      await createInitiative(initForm({ name: 'Org Scoped Initiative' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const row = rows.find(i => i.name === 'Org Scoped Initiative')!
+
+      expect(row.organizationId).toBe(orgId)
+      expect(row.createdBy).toBe(contributor.id)
+    })
+
+    it('admin can also create an initiative', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      await expect(createInitiative(initForm({ name: 'Admin Created' }))).resolves.not.toThrow()
+    })
+
+    it('viewer cannot create → throws Forbidden', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(createInitiative(initForm())).rejects.toThrow('Forbidden')
+    })
+
+    it('unauthenticated call redirects to /login', async () => {
+      mockAuth.mockResolvedValue(null)
+      await expect(createInitiative(initForm())).rejects.toThrow(/REDIRECT:\/login/)
+    })
+
+    it('writes audit log: action=initiative.create, before=null, after includes name', async () => {
+      await createInitiative(initForm({ name: 'Audit Create Target' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const row = rows.find(i => i.name === 'Audit Create Target')!
+
+      const logs = await getAuditLogsForEntity(row.id)
+      expect(logs).toHaveLength(1)
+      expect(logs[0].action).toBe('initiative.create')
+      expect(logs[0].userId).toBe(contributor.id)
+      expect(logs[0].organizationId).toBe(orgId)
+      expect(logs[0].before).toBeNull()
+      expect(logs[0].after).toMatchObject({ name: 'Audit Create Target' })
+    })
+  })
+
+  // ── editInitiative ─────────────────────────────────────────────────────────
+
+  describe('editInitiative', () => {
+    let initiativeId: string
+
+    beforeAll(async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createInitiative(initForm({ name: 'Edit Me', status: 'proposed', visibility: 'org' }))
+      const rows = await getInitiativesForOrg(orgId)
+      initiativeId = rows.find(i => i.name === 'Edit Me')!.id
+    })
+
+    it('contributor can edit an owned initiative', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await editInitiative(initiativeId, initForm({ name: 'Edited Name', status: 'active', visibility: 'org' }))
+
+      const row = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+      expect(row?.name).toBe('Edited Name')
+      expect(row?.status).toBe('active')
+      expect(row?.updatedBy).toBe(contributor.id)
+    })
+
+    it('admin can edit an initiative', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      await expect(
+        editInitiative(initiativeId, initForm({ name: 'Admin Edit', status: 'proposed', visibility: 'org' })),
+      ).resolves.not.toThrow()
+    })
+
+    it('viewer cannot edit → throws Forbidden', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(
+        editInitiative(initiativeId, initForm({ name: 'Hijack', status: 'active', visibility: 'org' })),
+      ).rejects.toThrow('Forbidden')
+    })
+
+    it('writes audit log with before/after snapshot', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await editInitiative(initiativeId, initForm({ name: 'Before State', status: 'proposed', visibility: 'org' }))
+      await editInitiative(initiativeId, initForm({ name: 'After State', status: 'active', visibility: 'org' }))
+
+      const logs = await getAuditLogsForEntity(initiativeId)
+      const entry = logs.find(
+        l => l.action === 'initiative.edit' && (l.after as Record<string, unknown>)?.name === 'After State',
+      )
+      expect(entry).toBeDefined()
+      expect(entry!.before).toMatchObject({ name: 'Before State', status: 'proposed' })
+      expect(entry!.after).toMatchObject({ name: 'After State', status: 'active' })
+    })
+  })
+
+  // ── deleteInitiative ───────────────────────────────────────────────────────
+
+  describe('deleteInitiative', () => {
+    it('admin can delete an initiative', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createInitiative(initForm({ name: 'Delete Me' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const initiativeId = rows.find(i => i.name === 'Delete Me')!.id
+
+      mockAuth.mockResolvedValue(makeSession(admin))
+      await deleteInitiative(initiativeId)
+
+      const check = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+      expect(check).toBeUndefined()
+    })
+
+    it('contributor cannot delete → admin required', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createInitiative(initForm({ name: 'Protected Initiative' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const initiativeId = rows.find(i => i.name === 'Protected Initiative')!.id
+
+      await expect(deleteInitiative(initiativeId)).rejects.toThrow('Forbidden')
+
+      const check = await db.query.initiatives.findFirst({ where: eq(initiatives.id, initiativeId) })
+      expect(check).toBeDefined()
+    })
+
+    it('viewer cannot delete → admin required', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createInitiative(initForm({ name: 'Viewer Block Test' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const initiativeId = rows.find(i => i.name === 'Viewer Block Test')!.id
+
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(deleteInitiative(initiativeId)).rejects.toThrow('Forbidden')
+    })
+
+    it('delete writes audit log with before snapshot and no after', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createInitiative(initForm({ name: 'Audit Delete Target' }))
+      const rows = await getInitiativesForOrg(orgId)
+      const initiativeId = rows.find(i => i.name === 'Audit Delete Target')!.id
+
+      mockAuth.mockResolvedValue(makeSession(admin))
+      await deleteInitiative(initiativeId)
+
+      const logs = await getAuditLogsForEntity(initiativeId)
+      const deleteLog = logs.find(l => l.action === 'initiative.delete')!
+      expect(deleteLog).toBeDefined()
+      expect(deleteLog.before).toMatchObject({ name: 'Audit Delete Target' })
+      expect(deleteLog.after).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Closes #209

## Summary
- `initiatives.ts`: imported `writeAuditLog` and added calls in all three mutations:
  - `createInitiative` — `initiative.create` with `after: { name, status, visibility }`
  - `editInitiative` — `initiative.edit` with `before: { name, status }` / `after: { name, status, visibility }`; renamed `existing` → `before` so the snapshot is captured before the update runs
  - `deleteInitiative` — `initiative.delete` with `before: { name, status }` and no `after`
- `helpers/db.ts`: added `getInitiativesForOrg` query helper for test assertions
- `initiatives.test.ts`: new integration test file covering role enforcement (contributor/admin/viewer), DB mutation correctness, and audit log payloads for create, edit, and delete

## Test plan
- [ ] CI type check, lint, integration tests pass
- [ ] `initiatives.test.ts` — all 15 tests green
- [ ] Manual: create/edit/delete an initiative as admin → confirm rows appear in `/audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)