### PR TITLE
[codex] docs: reconcile shipped search story

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Stakeholder-facing views and plain-language detail pages
 - Repository completeness signals and gap detection
 - Deeper federation management UX, notifications, and broader cross-org verification coverage
-- Repository-wide search and broader workflow consistency across all entity types
+- Broader workflow consistency across all entity types and continued search refinement
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
@@ -1,7 +1,7 @@
 # Capability: Content Search & Filtering
 
 ## What It Does
-The system must allow users to find content items quickly using list-level filtering, taxonomy context, and search where it exists today. A single repository-wide full-text search experience remains future work.
+The system must allow users to find content items quickly using list-level filtering, taxonomy context, and an embedded repository-wide search experience that works without an external search service in v1.
 
 ## Personas
 - **CMS Administrator** — searches across all content to manage the repository
@@ -9,6 +9,7 @@ The system must allow users to find content items quickly using list-level filte
 
 ## Behaviors
 - List-level filtering and search within the current screen
+- Repository-wide search across shipped EA entity types from a shared search surface
 - Filter content by content type
 - Filter content by taxonomy term
 - Filter content by workflow state (Admins and Contributors only)
@@ -16,8 +17,8 @@ The system must allow users to find content items quickly using list-level filte
 - Display filtered results with content type, title, and workflow state where those fields are available
 
 ## Rules
-- Viewers can only search and filter published content — draft and archived content is never returned in their results
-- Repository-wide search must work without an external search service in v1 when it is added
+- Viewers can only search and filter content visible to their role. For the core workflow-backed model that means published content only; for planning entities and ADRs, Viewer search follows the documented role-to-status mappings.
+- Repository-wide search must work without an external search service in v1
 - Filters are additive — multiple filters narrow results
 - Empty filters return all content matching the current screen and role context
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -57,7 +57,7 @@ Foundational content authoring and lifecycle capabilities shared across all EA c
 | Content Workflow | Partially implemented | Draft → Published → Archived is established for core content types, but planning entities still use their own lifecycle states |
 | Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for domains, persona types, persona tags, and other controlled vocabularies |
 | Content Relationships | Implemented | Link content items; enforce GovEA traceability rules at publish time |
-| Content Search & Filtering | Partially implemented | Per-entity filtering and taxonomy-driven browsing exist; repository-wide search is still future work |
+| Content Search & Filtering | Partially implemented | Per-entity filtering, taxonomy-driven browsing, and embedded repository-wide search are shipped; search relevance and workflow consistency are still maturing |
 | Content Types | Partially implemented | Configurable schemas for content; v1 types are fixed in the data model |
 | Content Versioning | Not implemented | Change history, diffs, and version restore |
 


### PR DESCRIPTION
## Summary

Final docs reconciliation pass after the merged ADR/portfolio docs work in #206.

- updates `capabilities.md` so Content Search & Filtering reflects the shipped embedded repository-wide search
- updates `cm-content-search-filtering.md` to describe the current repository-wide search behavior and Viewer visibility rules accurately
- removes the stale README near-term bullet that still described repository-wide search as future work

## Why

PR #206 corrected the ADR and portfolio maturity story, but the repo still had a smaller docs drift around search: the README reflected shipped search, while the capability summary and search capability doc still described repository-wide search as future work.

This follow-up brings those docs back into alignment with the current product surface on `main`.

## Validation

- `git diff --check -- README.md capabilities.md business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md business-architecture/capabilities/cms/portfolio/portfolio.md`
- confirmed the shipped search implementation in `apps/govea/src/actions/search.ts`
- confirmed PR #206's portfolio doc fix remains intact with no dead-link regression
