### PR TITLE
[codex] docs: define stakeholder demo visualization capabilities

### DIFF
--- a/business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md
@@ -1,0 +1,26 @@
+# Capability: Application Risk Portfolio View
+
+## What It Does
+The system must provide a visual portfolio view that helps stakeholders identify which applications are aging, business-critical, duplicated, or likely to require investment attention soon.
+
+## Personas
+- **Department Director** — needs to understand which systems create operational risk for their department
+- **Budget & Performance Analyst** — needs a portfolio-level picture of where technology risk is likely to drive cost or service disruption
+- **Enterprise Architect** — needs a credible visual to explain application risk and rationalisation priorities to leadership
+
+## Behaviors
+- Display applications in a visual portfolio view using lifecycle status, criticality, dependency concentration, or equivalent risk cues
+- Allow filtering by department, domain, hosting model, or lifecycle status
+- Highlight applications with sunset or decommission status that still support important capabilities or services
+- Surface duplicate or overlapping applications where they serve the same capability area
+- Allow drill-down from a portfolio cell or card into the application record and linked capabilities
+
+## Rules
+- The primary view must communicate risk and investment posture, not just inventory size
+- Risk cues must use plain-language labels and intuitive color/status treatment
+- The visual must not imply precision the repository does not support; any derived score should be explainable
+- Viewer-facing output should emphasize operational meaning such as `aging`, `replacement underway`, or `high dependency`
+
+## Links
+- Depends on: Portfolio Management — Application Portfolio, Front-end Display — Portfolio Views
+- Related: Planning — Initiatives, Repository & Modelling — Repository Completeness

--- a/business-architecture/capabilities/cms/frontend-display/fd-executive-roadmap-timeline.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-executive-roadmap-timeline.md
@@ -1,0 +1,26 @@
+# Capability: Executive Roadmap Timeline
+
+## What It Does
+The system must present a roadmap timeline view that shows what is changing, when it is expected to happen, and which strategic objectives, capabilities, and services are affected, using a visual format suitable for leadership review.
+
+## Personas
+- **Department Director** — needs to see what is changing in their area and when
+- **Budget & Performance Analyst** — needs to compare planned investment timing against risk and strategic priorities
+- **Elected Official** — needs a clear visual timeline of technology change with plain-language impact statements
+
+## Behaviors
+- Display initiatives on a timeline using start and end dates where available
+- Group or filter the timeline by department, strategic objective, capability domain, or service area
+- Show a short plain-language impact summary for each initiative
+- Distinguish `planned`, `underway`, `at risk`, and `completed` states visually
+- Allow drill-down from a timeline item to its linked objective, capabilities, and applications
+
+## Rules
+- The roadmap must remain useful when dates are partial or approximate; missing dates should degrade gracefully rather than hide the initiative
+- Timeline labels must describe business impact, not just internal initiative names
+- The visual should prioritize sequencing and stakeholder impact over detailed project-management semantics
+- Viewer-visible items must follow the current planning visibility rules for initiatives and objectives
+
+## Links
+- Depends on: Planning — Roadmap, Planning — Initiatives, Planning — Strategic Objectives
+- Related: Mission-to-Technology Traceability Views, Front-end Display — Portfolio Views

--- a/business-architecture/capabilities/cms/frontend-display/fd-guided-answer-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-guided-answer-views.md
@@ -1,0 +1,27 @@
+# Capability: Guided Answer Views
+
+## What It Does
+The system must answer common stakeholder questions with a structured result view that assembles the most relevant linked content into a direct, readable response instead of forcing the user to interpret multiple records manually.
+
+## Personas
+- **Department Director** — asks task-oriented questions like `what supports permitting?`
+- **Budget & Performance Analyst** — asks investment-oriented questions like `what systems are being replaced?`
+- **Elected Official** — asks plain-language oversight questions like `what is changing in this service area?`
+- **Content Viewer** — needs a quick path to a direct answer without knowing GovEA's data model
+
+## Behaviors
+- Accept a guided question or search query and return a structured answer view
+- Summarize the relevant capability, service, applications, initiatives, and objectives tied to that question
+- Present the answer in plain language with links to the underlying records for deeper inspection
+- Show why each returned record is relevant to the question
+- Support presentation-ready or print-friendly formatting for briefing use
+
+## Rules
+- The answer view must optimize for clarity and directness, not exhaustive search-result volume
+- Viewer-visible answers must include only records the current role is allowed to see
+- The generated answer framing must avoid jargon and internal field names
+- Search and answer confidence should be explainable when multiple related records are returned
+
+## Links
+- Depends on: Content Management — Content Search & Filtering, Front-end Display — Content Display, Front-end Display — Relationship Navigation
+- Related: Mission-to-Technology Traceability Views, Front-end Display — Portfolio Views

--- a/business-architecture/capabilities/cms/frontend-display/fd-repository-confidence-summary.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-repository-confidence-summary.md
@@ -1,0 +1,25 @@
+# Capability: Repository Confidence Summary
+
+## What It Does
+The system must present a concise, plain-language summary of how trustworthy and current the published repository is, so stakeholders can judge whether to rely on the content without seeing internal maintenance details.
+
+## Personas
+- **Department Director** — needs to know whether the repository is current enough to trust in planning and oversight
+- **Elected Official** — needs a confidence cue before using the output in a briefing or decision context
+- **CMS Administrator** — needs a publishable confidence summary that does not expose internal draft or quality backlog details
+
+## Behaviors
+- Display a summary status such as `actively maintained`, `under development`, or `getting started`
+- Optionally pair the summary with a short admin-authored narrative that explains the current confidence level in plain language
+- Show freshness signals such as most recent review or update date in a non-technical way
+- Allow the summary to appear alongside major stakeholder-facing visuals such as roadmap, traceability, and portfolio views
+
+## Rules
+- The stakeholder-facing summary must never expose draft-only details, incomplete object lists, or internal remediation queues
+- Plain-language labels are the default; raw percentages are optional and should remain secondary
+- The summary must be suppressible when repository quality falls below an admin-defined threshold
+- Confidence messaging must describe repository currency and completeness, not system uptime or infrastructure health
+
+## Links
+- Depends on: Repository & Modelling — Repository Completeness, Front-end Display — Content Display
+- Related: Front-end Display — Portfolio Views, Executive Roadmap Timeline

--- a/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
@@ -1,0 +1,26 @@
+# Capability: Mission-to-Technology Traceability Views
+
+## What It Does
+The system must provide stakeholder-friendly visual views that trace a mission or strategic objective down through capabilities, services, and applications so non-architect users can understand why a system exists and what outcome it supports.
+
+## Personas
+- **Department Director** — needs to understand how department goals connect to systems and service delivery
+- **Budget & Performance Analyst** — needs to connect investment decisions to mission outcomes and business capability coverage
+- **Elected Official** — needs a concise visual explanation of what technology supports a public service or strategic goal
+
+## Behaviors
+- From a strategic objective, display linked initiatives, capabilities, services, and applications in a readable visual chain
+- From a capability or service, display upstream objectives and downstream applications without requiring the user to open multiple detail pages
+- Show relationship labels in plain language such as `supports`, `enables`, and `changes`
+- Allow the user to switch between a compact summary view and a deeper drill-down view
+- Provide a printable or presentation-friendly layout suitable for briefings
+
+## Rules
+- The default visual must optimize for readability over relationship density; it is not a general-purpose graph explorer
+- Viewer-visible results must respect publication and visibility rules at every step of the chain
+- The visual must avoid EA jargon in headings, legends, and labels
+- Missing links should surface as plain-language gaps such as `No supporting applications recorded yet`
+
+## Links
+- Depends on: Front-end Display — Content Display, Front-end Display — Relationship Navigation, Repository & Modelling — End-to-End Traceability
+- Related: Planning — Strategic Objectives, Planning — Initiatives, Front-end Display — Portfolio Views

--- a/business-architecture/capabilities/cms/frontend-display/frontend-display.md
+++ b/business-architecture/capabilities/cms/frontend-display/frontend-display.md
@@ -12,9 +12,14 @@ The system must present EA content to users in a way that is clear, navigable, a
 | Capability | File | Description |
 |---|---|---|
 | Content Display | [fd-content-display.md](./fd-content-display.md) | Render published content in plain-language, readable layouts |
+| Mission-to-Technology Traceability Views | [fd-traceability-views.md](./fd-traceability-views.md) | Stakeholder-friendly visual chains from objectives and services down to supporting technology |
 | Navigation | [fd-navigation.md](./fd-navigation.md) | Menus, breadcrumbs, and consistent site structure |
 | Relationship Navigation | [fd-relationship-navigation.md](./fd-relationship-navigation.md) | Traverse links between applications, capabilities, and personas |
 | Portfolio Views | [fd-portfolio-views.md](./fd-portfolio-views.md) | Curated overviews: capability map, application portfolio, persona directory, ADR list |
+| Application Risk Portfolio View | [fd-application-risk-portfolio.md](./fd-application-risk-portfolio.md) | Visualize application lifecycle and dependency risk for leadership audiences |
+| Executive Roadmap Timeline | [fd-executive-roadmap-timeline.md](./fd-executive-roadmap-timeline.md) | Leadership-friendly timeline of technology change and business impact |
+| Repository Confidence Summary | [fd-repository-confidence-summary.md](./fd-repository-confidence-summary.md) | Plain-language confidence cue for how trustworthy the published repository is |
+| Guided Answer Views | [fd-guided-answer-views.md](./fd-guided-answer-views.md) | Direct answer pages for stakeholder questions assembled from linked repository content |
 | Responsive Layout | [fd-responsive-layout.md](./fd-responsive-layout.md) | Works on any device without horizontal scrolling or zooming |
 | Public & Authenticated Views | [fd-public-authenticated-views.md](./fd-public-authenticated-views.md) | Control what requires login vs. what is publicly accessible |
 | Theming | [fd-theming.md](./fd-theming.md) | Theme selection, agency branding, and content rendering customization |

--- a/business-architecture/personas/budget-performance-analyst.md
+++ b/business-architecture/personas/budget-performance-analyst.md
@@ -1,0 +1,35 @@
+# Persona: Budget & Performance Analyst
+
+**Validation Status: Assumed** — drafted from government EA market context and product direction. Must not drive implementation until validated through interviews with real budget, finance, or performance staff in a state or local government setting.
+
+## Role Type
+Internal — Finance / Performance / Budget Oversight
+
+## Who They Are
+The Budget & Performance Analyst works between programme leadership, finance, and IT governance. They prepare budget recommendations, assemble performance materials for leadership, and need credible evidence about what systems support which services, where risk is concentrated, and whether current investment aligns to stated priorities.
+
+They are not an architect and usually do not maintain EA content themselves. They consume EA outputs when preparing budget books, investment decisions, oversight briefings, and audit responses.
+
+## Goals
+- See which applications are business-critical, aging, duplicated, or scheduled for replacement
+- Understand how proposed investments connect to strategic objectives and service delivery
+- Prepare plain-language budget or oversight materials without rebuilding the analysis in PowerPoint
+- Identify where technology risk is likely to create budget pressure or service disruption
+- Compare “what we are funding” against “what mission outcome it supports”
+
+## Pain Points
+- Application inventories are too technical and do not explain business importance
+- Roadmaps show projects but not whether those projects reduce risk or advance strategy
+- Budget decisions depend on fragmented spreadsheets and slide decks rather than one trusted source
+- IT can describe systems, but not always the service or objective each system supports
+- Risk is often surfaced only as anecdotes, not as a visual portfolio picture leadership can act on
+
+## Critical Insight
+This persona adopts EA outputs only when they are presentation-ready and decision-ready. They need visuals that answer “what is at risk, why does it matter, and what are we doing about it?” without requiring them to translate architectural metadata into budget language first.
+
+## Relevant Capabilities
+- Application risk portfolio views
+- Executive roadmap timeline views
+- Mission-to-technology traceability views
+- Repository confidence summary
+- Guided answer views for stakeholder questions

--- a/business-architecture/personas/elected-official.md
+++ b/business-architecture/personas/elected-official.md
@@ -1,0 +1,33 @@
+# Persona: Elected Official
+
+**Validation Status: Assumed** — drafted from public-sector stakeholder context. Must not drive implementation until validated through interviews with real elected officials, chiefs of staff, or equivalent public-sector decision-makers.
+
+## Role Type
+External / Internal — Executive Civic Leadership
+
+## Who They Are
+The Elected Official is a mayor, council member, county commissioner, board member, or similar public-sector leader who needs to understand technology posture in relation to constituent outcomes, service risk, and planned investment. They are not a direct maintainer of EA content and have very limited time.
+
+They engage only when the output is concise, visually clear, and obviously tied to mission or service delivery.
+
+## Goals
+- Understand what technology investments are underway and when they will affect public-facing services
+- See where operational or constituent-facing risk is concentrated
+- Ask simple questions like “what supports permitting?” or “what is replacing this aging system?” and get direct answers
+- Use credible visuals in briefings, hearings, or oversight sessions without needing an architect in the room
+
+## Pain Points
+- Most architecture artifacts are unreadable without technical mediation
+- Project updates are easy to collect, but their service impact is hard to see
+- Risk is usually described in technical terms rather than constituent or operational terms
+- Technology presentations often feel disconnected from mission priorities and public outcomes
+
+## Critical Insight
+This persona does not want an EA tool. They want a trusted visual explanation. If GovEA can produce a small number of plain-language, obviously current, high-confidence visuals, adoption will follow through leadership pull rather than training push.
+
+## Relevant Capabilities
+- Executive roadmap timeline views
+- Mission-to-technology traceability views
+- Application risk portfolio views
+- Repository confidence summary
+- Guided answer views for stakeholder questions


### PR DESCRIPTION
## Summary

Adds the EasyEA documentation needed to support adoption-focused demo visuals as first-class product capabilities.

- adds two new assumed stakeholder personas: `Budget & Performance Analyst` and `Elected Official`
- extends the existing `frontend-display` capability group with five new visualization-oriented sub-capabilities
- creates the matching GitHub issues so implementation work follows the normal issue-first flow

New sub-capabilities:
- `fd-traceability-views`
- `fd-executive-roadmap-timeline`
- `fd-application-risk-portfolio`
- `fd-repository-confidence-summary`
- `fd-guided-answer-views`

## Why

The current product is strong for practitioners, but the adoption story depends on whether GovEA can demo well to non-architect stakeholders.

Using the EasyEA framing already in this repo, the next gap was not raw implementation first — it was documenting the personas and capabilities for the visuals that make the product legible to Department Directors, budget/oversight users, and elected leadership.

This PR defines those artifacts before implementation so the follow-on work stays traceable and reviewable.

## Impact

- the business architecture now treats stakeholder demo/adoption visuals as explicit capability work rather than ad hoc UI polish
- the repo has matching issue-first backlog items for each proposed visualization area
- persona-risk is called out explicitly: the two new stakeholder personas are marked `Assumed`, and a validation issue is included before UI semantics are treated as settled

## Validation

- `git diff --check -- business-architecture/personas/budget-performance-analyst.md business-architecture/personas/elected-official.md business-architecture/capabilities/cms/frontend-display/frontend-display.md business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md business-architecture/capabilities/cms/frontend-display/fd-executive-roadmap-timeline.md business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md business-architecture/cms/frontend-display/fd-repository-confidence-summary.md business-architecture/capabilities/cms/frontend-display/fd-guided-answer-views.md`
- created linked issues #216 through #221 to follow the repo's normal process

Capability group: cms/frontend-display
Closes #216
Closes #217
Closes #218
Closes #219
Closes #220
Closes #221