### PR TITLE
feat(traceability): mission-to-technology traceability view (#217)

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -1,0 +1,220 @@
+'use server'
+
+import { db } from '@/db/client'
+import {
+  strategicObjectives, capabilities, services,
+} from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { canReadFederatedEntity } from '@/lib/federation'
+
+// ── Shared sub-types ──────────────────────────────────────────────────────────
+
+export interface TraceApp {
+  id: string; name: string; vendor: string | null; lifecycleStatus: string | null
+}
+export interface TraceCapability {
+  id: string; name: string; domain: string | null
+  applications: TraceApp[]
+}
+export interface TraceInitiative {
+  id: string; name: string; status: string
+}
+export interface TraceObjective {
+  id: string; name: string; timeHorizon: string | null
+}
+export interface TracePersona {
+  id: string; name: string; type: string | null
+}
+export interface TraceAdr {
+  id: string; number: string; title: string; status: string
+}
+export interface TracePrinciple {
+  id: string; name: string
+}
+
+// ── Typed results ─────────────────────────────────────────────────────────────
+
+export interface ObjectiveTrace {
+  kind: 'objective'
+  id: string; name: string; description: string | null
+  successMetric: string | null; timeHorizon: string | null; status: string
+  capabilities: TraceCapability[]
+  directApplications: TraceApp[]
+  initiatives: TraceInitiative[]
+}
+
+export interface CapabilityTrace {
+  kind: 'capability'
+  id: string; name: string; domain: string | null; description: string | null; status: string
+  objectives: TraceObjective[]
+  applications: TraceApp[]
+  initiatives: TraceInitiative[]
+  personas: TracePersona[]
+  adrs: TraceAdr[]
+  principles: TracePrinciple[]
+}
+
+export interface ServiceTrace {
+  kind: 'service'
+  id: string; name: string; description: string | null; channels: string[]; status: string
+  personas: TracePersona[]
+  capabilities: TraceCapability[]
+  directApplications: TraceApp[]
+}
+
+export type TraceData = ObjectiveTrace | CapabilityTrace | ServiceTrace
+
+// ── Objective trace ───────────────────────────────────────────────────────────
+
+export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const row = await db.query.strategicObjectives.findFirst({
+    where: eq(strategicObjectives.id, id),
+    with: {
+      objectiveCapabilities: {
+        with: {
+          capability: {
+            with: {
+              applicationCapabilities: { with: { application: true } },
+            },
+          },
+        },
+      },
+      objectiveApplications: { with: { application: true } },
+      initiativeObjectives: { with: { initiative: true } },
+    },
+  })
+
+  if (!row) return null
+  const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
+  if (!visible) return null
+
+  return {
+    kind: 'objective',
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    successMetric: row.successMetric,
+    timeHorizon: row.timeHorizon,
+    status: row.status,
+    capabilities: row.objectiveCapabilities.map(({ capability: c }) => ({
+      id: c.id,
+      name: c.name,
+      domain: c.domain,
+      applications: c.applicationCapabilities.map(({ application: a }) => ({
+        id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
+      })),
+    })),
+    directApplications: row.objectiveApplications.map(({ application: a }) => ({
+      id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
+    })),
+    initiatives: row.initiativeObjectives.map(({ initiative: i }) => ({
+      id: i.id, name: i.name, status: i.status,
+    })),
+  }
+}
+
+// ── Capability trace ──────────────────────────────────────────────────────────
+
+export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const row = await db.query.capabilities.findFirst({
+    where: eq(capabilities.id, id),
+    with: {
+      objectiveCapabilities: { with: { objective: true } },
+      applicationCapabilities: { with: { application: true } },
+      initiativeCapabilities: { with: { initiative: true } },
+      capabilityPersonas: { with: { persona: true } },
+      adrCapabilities: { with: { adr: true } },
+      principleCapabilities: { with: { principle: true } },
+    },
+  })
+
+  if (!row) return null
+  const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
+  if (!visible) return null
+
+  return {
+    kind: 'capability',
+    id: row.id,
+    name: row.name,
+    domain: row.domain,
+    description: row.description,
+    status: row.status,
+    objectives: row.objectiveCapabilities.map(({ objective: o }) => ({
+      id: o.id, name: o.name, timeHorizon: o.timeHorizon,
+    })),
+    applications: row.applicationCapabilities.map(({ application: a }) => ({
+      id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
+    })),
+    initiatives: row.initiativeCapabilities.map(({ initiative: i }) => ({
+      id: i.id, name: i.name, status: i.status,
+    })),
+    personas: row.capabilityPersonas.map(({ persona: p }) => ({
+      id: p.id, name: p.name, type: p.type,
+    })),
+    adrs: row.adrCapabilities.map(({ adr: a }) => ({
+      id: a.id, number: a.number, title: a.title, status: a.status,
+    })),
+    principles: row.principleCapabilities.map(({ principle: p }) => ({
+      id: p.id, name: p.name,
+    })),
+  }
+}
+
+// ── Service trace ─────────────────────────────────────────────────────────────
+
+export async function getServiceTrace(id: string): Promise<ServiceTrace | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const row = await db.query.services.findFirst({
+    where: eq(services.id, id),
+    with: {
+      servicePersonas: { with: { persona: true } },
+      serviceCapabilities: {
+        with: {
+          capability: {
+            with: {
+              applicationCapabilities: { with: { application: true } },
+            },
+          },
+        },
+      },
+      serviceApplications: { with: { application: true } },
+    },
+  })
+
+  if (!row) return null
+  const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
+  if (!visible) return null
+
+  return {
+    kind: 'service',
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    channels: row.channels,
+    status: row.status,
+    personas: row.servicePersonas.map(({ persona: p }) => ({
+      id: p.id, name: p.name, type: p.type,
+    })),
+    capabilities: row.serviceCapabilities.map(({ capability: c }) => ({
+      id: c.id,
+      name: c.name,
+      domain: c.domain,
+      applications: c.applicationCapabilities.map(({ application: a }) => ({
+        id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
+      })),
+    })),
+    directApplications: row.serviceApplications.map(({ application: a }) => ({
+      id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
+    })),
+  }
+}

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -86,9 +86,17 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/capabilities" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Capabilities
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/capabilities" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Capabilities
+        </Link>
+        <Link
+          href={`/traceability?from=capability&id=${id}`}
+          className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          View traceability →
+        </Link>
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -63,9 +63,17 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/objectives" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Strategic Objectives
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/objectives" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Strategic Objectives
+        </Link>
+        <Link
+          href={`/traceability?from=objective&id=${id}`}
+          className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          View traceability →
+        </Link>
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/services/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/services/[id]/page.tsx
@@ -82,9 +82,17 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/services" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Services
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/services" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Services
+        </Link>
+        <Link
+          href={`/traceability?from=service&id=${id}`}
+          className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          View traceability →
+        </Link>
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -1,0 +1,470 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import { getObjectiveTrace, getCapabilityTrace, getServiceTrace } from '@/actions/traceability'
+import type { ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceCapability } from '@/actions/traceability'
+
+// ── Status colours ────────────────────────────────────────────────────────────
+
+const LIFECYCLE_STYLES: Record<string, string> = {
+  active:        'bg-emerald-50 text-emerald-700 border-emerald-200',
+  planned:       'bg-blue-50 text-blue-700 border-blue-200',
+  sunset:        'bg-amber-50 text-amber-700 border-amber-200',
+  decommissioned:'bg-red-50 text-red-700 border-red-200',
+}
+
+const INITIATIVE_STYLES: Record<string, string> = {
+  active:   'bg-emerald-50 text-emerald-700 border-emerald-200',
+  proposed: 'bg-slate-100 text-slate-700 border-slate-200',
+  'on-hold':'bg-amber-50 text-amber-700 border-amber-200',
+  complete: 'bg-blue-50 text-blue-700 border-blue-200',
+  cancelled:'bg-red-50 text-red-700 border-red-200',
+}
+
+const ADR_STYLES: Record<string, string> = {
+  accepted:   'bg-emerald-50 text-emerald-700 border-emerald-200',
+  proposed:   'bg-slate-100 text-slate-700 border-slate-200',
+  deprecated: 'bg-amber-50 text-amber-700 border-amber-200',
+  superseded: 'bg-red-50 text-red-700 border-red-200',
+}
+
+const CHANNEL_LABELS: Record<string, string> = {
+  online: 'Online', 'in-person': 'In-person', phone: 'Phone', mobile: 'Mobile',
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function LayerLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+      {children}
+    </p>
+  )
+}
+
+function Connector({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center py-2 text-muted-foreground select-none">
+      <div className="w-px h-4 bg-border" />
+      <span className="text-xs font-medium px-2 py-0.5 rounded border border-border bg-muted/40 my-1">
+        {label}
+      </span>
+      <div className="w-px h-2 bg-border" />
+      <span className="text-muted-foreground/60">▾</span>
+    </div>
+  )
+}
+
+function Gap({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 flex items-start gap-2">
+      <span className="shrink-0 mt-0.5">⚠</span>
+      <span>{message}</span>
+    </div>
+  )
+}
+
+function Badge({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium', className)}>
+      {children}
+    </span>
+  )
+}
+
+function TraceCard({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('rounded-lg border bg-card divide-y', className)}>
+      {children}
+    </div>
+  )
+}
+
+function TraceRow({
+  href, name, meta, badge, badgeClass,
+}: {
+  href: string
+  name: string
+  meta?: string | null
+  badge?: string | null
+  badgeClass?: string
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-muted/40 transition-colors group"
+    >
+      <span className="font-medium text-sm group-hover:text-primary transition-colors">{name}</span>
+      <div className="flex items-center gap-2 shrink-0">
+        {meta && <span className="text-xs text-muted-foreground">{meta}</span>}
+        {badge && <Badge className={badgeClass}>{badge}</Badge>}
+      </div>
+    </Link>
+  )
+}
+
+// ── Application list (deduplicated, used in both objective and service traces) ─
+
+function dedupeApps(apps: TraceApp[]): TraceApp[] {
+  const seen = new Set<string>()
+  return apps.filter(a => { if (seen.has(a.id)) return false; seen.add(a.id); return true })
+}
+
+function AppLayer({ apps }: { apps: TraceApp[] }) {
+  const deduped = dedupeApps(apps)
+  if (deduped.length === 0) {
+    return <Gap message="No applications linked — the technology platform for this area is not yet mapped." />
+  }
+  return (
+    <TraceCard>
+      {deduped.map(a => (
+        <TraceRow
+          key={a.id}
+          href={`/applications/${a.id}`}
+          name={a.name}
+          meta={a.vendor ?? undefined}
+          badge={a.lifecycleStatus ?? undefined}
+          badgeClass={LIFECYCLE_STYLES[a.lifecycleStatus ?? ''] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+        />
+      ))}
+    </TraceCard>
+  )
+}
+
+// ── Objective trace view ──────────────────────────────────────────────────────
+
+function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
+  // Merge applications: direct links + via capabilities, deduplicated
+  const allApps = dedupeApps([
+    ...trace.directApplications,
+    ...trace.capabilities.flatMap(c => c.applications),
+  ])
+
+  return (
+    <div className="space-y-1 max-w-2xl">
+      {/* Anchor */}
+      <LayerLabel>Strategic Objective</LayerLabel>
+      <TraceCard>
+        <div className="px-4 py-4">
+          <div className="font-semibold text-base">{trace.name}</div>
+          {trace.description && (
+            <p className="text-sm text-muted-foreground mt-1">{trace.description}</p>
+          )}
+          <div className="flex flex-wrap gap-4 mt-2 text-xs text-muted-foreground">
+            {trace.successMetric && <span>Success: {trace.successMetric}</span>}
+            {trace.timeHorizon && <span>Horizon: {trace.timeHorizon}</span>}
+          </div>
+        </div>
+      </TraceCard>
+
+      {/* Capabilities */}
+      <Connector label="requires" />
+      <LayerLabel>Capabilities</LayerLabel>
+      {trace.capabilities.length === 0 ? (
+        <Gap message="No capabilities linked — this objective has no technology foundation mapped yet. Link capabilities to show how the org delivers against this goal." />
+      ) : (
+        <TraceCard>
+          {trace.capabilities.map(c => (
+            <TraceRow
+              key={c.id}
+              href={`/capabilities/${c.id}`}
+              name={c.name}
+              meta={c.domain}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Applications */}
+      <Connector label="supported by" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={allApps} />
+
+      {/* Initiatives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Active Initiatives</LayerLabel>
+      {trace.initiatives.length === 0 ? (
+        <Gap message="No initiatives are currently advancing this objective. Consider creating an initiative to track delivery work against this goal." />
+      ) : (
+        <TraceCard>
+          {trace.initiatives.map(i => (
+            <TraceRow
+              key={i.id}
+              href={`/initiatives/${i.id}`}
+              name={i.name}
+              badge={i.status}
+              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+    </div>
+  )
+}
+
+// ── Capability trace view ─────────────────────────────────────────────────────
+
+function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
+  return (
+    <div className="space-y-1 max-w-2xl">
+      {/* Upstream: Strategic Objectives */}
+      <LayerLabel>Strategic Objectives</LayerLabel>
+      {trace.objectives.length === 0 ? (
+        <Gap message="Not linked to any strategic objective — the mission justification for this capability is not yet documented." />
+      ) : (
+        <TraceCard>
+          {trace.objectives.map(o => (
+            <TraceRow
+              key={o.id}
+              href={`/objectives/${o.id}`}
+              name={o.name}
+              meta={o.timeHorizon ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Anchor: Capability */}
+      <Connector label="requires" />
+      <LayerLabel>Capability</LayerLabel>
+      <TraceCard>
+        <div className="px-4 py-4">
+          <div className="font-semibold text-base">{trace.name}</div>
+          {trace.domain && <p className="text-xs text-muted-foreground mt-0.5">{trace.domain}</p>}
+          {trace.description && (
+            <p className="text-sm text-muted-foreground mt-1">{trace.description}</p>
+          )}
+        </div>
+      </TraceCard>
+
+      {/* Downstream: Applications */}
+      <Connector label="supported by" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={trace.applications} />
+
+      {/* Initiatives */}
+      {trace.initiatives.length > 0 && (
+        <>
+          <Connector label="changed by" />
+          <LayerLabel>Initiatives</LayerLabel>
+          <TraceCard>
+            {trace.initiatives.map(i => (
+              <TraceRow
+                key={i.id}
+                href={`/initiatives/${i.id}`}
+                name={i.name}
+                badge={i.status}
+                badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+              />
+            ))}
+          </TraceCard>
+        </>
+      )}
+
+      {/* Personas */}
+      {trace.personas.length > 0 && (
+        <>
+          <Connector label="used by" />
+          <LayerLabel>Personas</LayerLabel>
+          <TraceCard>
+            {trace.personas.map(p => (
+              <TraceRow
+                key={p.id}
+                href={`/personas/${p.id}`}
+                name={p.name}
+                meta={p.type ?? undefined}
+              />
+            ))}
+          </TraceCard>
+        </>
+      )}
+
+      {/* ADRs */}
+      {trace.adrs.length > 0 && (
+        <>
+          <Connector label="governed by" />
+          <LayerLabel>Architecture Decisions</LayerLabel>
+          <TraceCard>
+            {trace.adrs.map(a => (
+              <TraceRow
+                key={a.id}
+                href={`/adrs/${a.id}`}
+                name={`${a.number} — ${a.title}`}
+                badge={a.status}
+                badgeClass={ADR_STYLES[a.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+              />
+            ))}
+          </TraceCard>
+        </>
+      )}
+
+      {/* Principles */}
+      {trace.principles.length > 0 && (
+        <>
+          <Connector label="guided by" />
+          <LayerLabel>Principles</LayerLabel>
+          <TraceCard>
+            {trace.principles.map(p => (
+              <TraceRow
+                key={p.id}
+                href={`/principles/${p.id}`}
+                name={p.name}
+              />
+            ))}
+          </TraceCard>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Service trace view ────────────────────────────────────────────────────────
+
+function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
+  const allApps = dedupeApps([
+    ...trace.directApplications,
+    ...trace.capabilities.flatMap(c => c.applications),
+  ])
+
+  return (
+    <div className="space-y-1 max-w-2xl">
+      {/* Personas */}
+      <LayerLabel>Served Personas</LayerLabel>
+      {trace.personas.length === 0 ? (
+        <Gap message="No personas linked — who this service is for has not been documented." />
+      ) : (
+        <TraceCard>
+          {trace.personas.map(p => (
+            <TraceRow
+              key={p.id}
+              href={`/personas/${p.id}`}
+              name={p.name}
+              meta={p.type ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Anchor: Service */}
+      <Connector label="receives" />
+      <LayerLabel>Service</LayerLabel>
+      <TraceCard>
+        <div className="px-4 py-4">
+          <div className="font-semibold text-base">{trace.name}</div>
+          {trace.channels.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {trace.channels.map(ch => (
+                <span key={ch} className="text-xs text-muted-foreground border border-border rounded px-1.5 py-0.5">
+                  {CHANNEL_LABELS[ch] ?? ch}
+                </span>
+              ))}
+            </div>
+          )}
+          {trace.description && (
+            <p className="text-sm text-muted-foreground mt-2">{trace.description}</p>
+          )}
+        </div>
+      </TraceCard>
+
+      {/* Capabilities */}
+      <Connector label="requires" />
+      <LayerLabel>Capabilities</LayerLabel>
+      {trace.capabilities.length === 0 ? (
+        <Gap message="No capabilities linked — the organisational abilities that make this service possible are not yet mapped." />
+      ) : (
+        <TraceCard>
+          {trace.capabilities.map(c => (
+            <TraceRow
+              key={c.id}
+              href={`/capabilities/${c.id}`}
+              name={c.name}
+              meta={c.domain}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Applications */}
+      <Connector label="runs on" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={allApps} />
+    </div>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function TraceabilityPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ from?: string; id?: string }>
+}) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const { from, id } = await searchParams
+  if (!from || !id) notFound()
+
+  let trace = null
+  let backHref = '/'
+  let backLabel = 'Back'
+
+  if (from === 'objective') {
+    trace = await getObjectiveTrace(id)
+    backHref = `/objectives/${id}`
+    backLabel = '← Strategic Objective'
+  } else if (from === 'capability') {
+    trace = await getCapabilityTrace(id)
+    backHref = `/capabilities/${id}`
+    backLabel = '← Capability'
+  } else if (from === 'service') {
+    trace = await getServiceTrace(id)
+    backHref = `/services/${id}`
+    backLabel = '← Service'
+  } else {
+    notFound()
+  }
+
+  if (!trace) notFound()
+
+  const title =
+    trace.kind === 'objective' ? trace.name :
+    trace.kind === 'capability' ? trace.name :
+    trace.name
+
+  const subtitle =
+    trace.kind === 'objective' ? 'Mission → Technology Trace' :
+    trace.kind === 'capability' ? 'Objective → Capability → Delivery Trace' :
+    'Persona → Service → Technology Trace'
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <Link
+          href={backHref}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {backLabel}
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p>
+        </div>
+      </div>
+
+      <hr />
+
+      {trace.kind === 'objective' && <ObjectiveTraceView trace={trace} />}
+      {trace.kind === 'capability' && <CapabilityTraceView trace={trace} />}
+      {trace.kind === 'service' && <ServiceTraceView trace={trace} />}
+
+      <p className="text-xs text-muted-foreground pt-4 border-t">
+        Traceability view — relationships reflect published, visible records only.
+        <Link href={backHref} className="ml-2 underline underline-offset-2 hover:text-foreground">
+          Edit links on the detail page.
+        </Link>
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #217

## What this builds

A read-only `/traceability` page that turns GovEA's linked data model into a plain-language layered trace — answering "why does this system exist and what outcome does it support?" for three leadership personas.

## Three entry points

| Entry point | Audience | Flow |
|---|---|---|
| Strategic Objective | Department Director, Elected Official | Objective → Capabilities → Applications → Initiatives |
| Capability | Architecture Reviewer | Objectives (upstream) → Capability → Applications + Initiatives + Personas + ADRs + Principles |
| Service | Budget & Performance Analyst | Personas → Service → Capabilities → Applications |

Each entry point gets a **"View traceability →"** link in the top-right of its detail page.

## Design decisions

- **No graph library** — layered card layout with plain-language connector labels (requires / supported by / advanced by / changed by / governed by / runs on). Readable in a browser, screenshot-shareable, no JS hydration cost.
- **Gap cards** — missing links render as amber `⚠` messages with actionable text rather than blank space or raw IDs. The issue called this out explicitly.
- **Application deduplication** — apps linked both directly and via capabilities are merged and deduplicated at render time; no double-counting.
- **Optional downstream layers** — for capabilities, layers with zero items (e.g. no ADRs, no principles) are omitted entirely rather than shown as gaps. Gaps are only shown for structurally required layers.
- **Visibility respected** — all three fetchers check `canReadFederatedEntity` before returning data.

## Files

| File | Role |
|---|---|
| `src/actions/traceability.ts` | Three typed fetchers with deep Drizzle joins |
| `src/app/(admin)/traceability/page.tsx` | Server component, 470 lines, no client-side JS |
| `objectives/[id]/page.tsx` | +8 lines: "View traceability →" link |
| `capabilities/[id]/page.tsx` | +8 lines: "View traceability →" link |
| `services/[id]/page.tsx` | +8 lines: "View traceability →" link |

## Test plan
- [ ] CI type check, lint, build pass
- [ ] `/traceability?from=objective&id=<id>` — renders objective trace with gap cards where links are missing
- [ ] `/traceability?from=capability&id=<id>` — renders bidirectional trace
- [ ] `/traceability?from=service&id=<id>` — renders service trace
- [ ] "View traceability →" links appear on objective, capability, service detail pages
- [ ] Viewer role sees only published/visible entities (visibility filter on all fetchers)
- [ ] Invalid `?from` or missing `?id` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)