### PR TITLE
feat(ux): extend gap-card pattern to relationship panels

### DIFF
--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -132,6 +132,7 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
+          gapMessage="Not linked to any capability — what this application enables is undocumented."
           canEdit={canMutate}
           available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -176,6 +176,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: application.id, name: application.name,
             href: `/applications/${application.id}`, meta: application.vendor,
           }))}
+          gapMessage="No applications linked — the technology platform for this capability is unknown."
           canEdit={canMutate}
           available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
           addAction={addApplication}
@@ -190,6 +191,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             id: objective.id, name: objective.name,
             href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
           }))}
+          gapMessage="Not linked to any objective — the mission justification for this capability is undocumented."
           canEdit={canMutate}
           available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
           addAction={addObjective}

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -135,6 +135,7 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
         <RelationshipPanel
           title="Capabilities"
           items={capabilityItems}
+          gapMessage="No capabilities linked — the delivery scope of this initiative is unclear."
           canEdit={canMutate}
           available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -117,6 +117,7 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
             id: capability.id, name: capability.name,
             href: `/capabilities/${capability.id}`, meta: capability.domain,
           }))}
+          gapMessage="No capabilities linked — this objective has no organisational foundation mapped."
           canEdit={canMutate}
           available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}

--- a/apps/govea/src/app/(admin)/services/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/services/[id]/page.tsx
@@ -154,6 +154,7 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
             href: `/capabilities/${capability.id}`,
             meta: capability.domain ?? undefined,
           }))}
+          gapMessage="No capabilities linked — what makes this service possible is not mapped."
           canEdit={canMutate}
           available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}

--- a/apps/govea/src/components/relationship-panel.tsx
+++ b/apps/govea/src/components/relationship-panel.tsx
@@ -21,6 +21,13 @@ interface RelationshipPanelProps {
   title: string
   items: RelationshipItem[]
   emptyMessage?: string
+  /**
+   * Shown as an amber gap card when items is empty and canEdit is false.
+   * Use for architecturally-significant panels where an empty state has
+   * meaning (e.g. "No capabilities linked — delivery scope is unclear.").
+   * Falls back to the plain emptyMessage text when not provided.
+   */
+  gapMessage?: string
   /** Contributor+ only — when false, add/remove controls are hidden */
   canEdit: boolean
   /** Items available to add (caller should already exclude already-linked ones) */
@@ -37,6 +44,7 @@ export function RelationshipPanel({
   title,
   items: initialItems,
   emptyMessage,
+  gapMessage,
   canEdit,
   available = [],
   addAction,
@@ -127,7 +135,14 @@ export function RelationshipPanel({
       )}
 
       {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground">{empty}</p>
+        !canEdit && gapMessage ? (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 flex items-start gap-2">
+            <span className="shrink-0 mt-0.5">⚠</span>
+            <span>{gapMessage}</span>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">{empty}</p>
+        )
       ) : (
         <div className={cn('space-y-2', isPending && 'opacity-60')}>
           {items.map(item => (


### PR DESCRIPTION
Closes #226

## What changed

Added a `gapMessage` prop to `RelationshipPanel`. When a panel has zero items and `canEdit` is false, the amber gap card renders in place of the generic "no items" fallback text — the same pattern introduced in the traceability view (#225).

Editors (`canEdit=true`) still see the `+ Add` affordance on empty panels, unchanged. The gap card is strictly for read-only viewers where the missing link has no interactive remedy on the page.

## Panels wired up

| Page | Panel | Message |
|---|---|---|
| Capability | Applications | No applications linked — the technology platform for this capability is unknown. |
| Capability | Strategic Objectives | Not linked to any objective — the mission justification for this capability is undocumented. |
| Objective | Capabilities | No capabilities linked — this objective has no organisational foundation mapped. |
| Application | Capabilities | Not linked to any capability — what this application enables is undocumented. |
| Service | Capabilities | No capabilities linked — what makes this service possible is not mapped. |
| Initiative | Capabilities | No capabilities linked — the delivery scope of this initiative is unclear. |

## Implementation

Single prop addition to the component (`gapMessage?: string`); conditional render replaces the `<p>` fallback when the prop is present and the user can't edit. No behaviour change for editors or for panels without a `gapMessage`.

## Test plan
- [ ] As viewer: open a capability with no linked applications → amber gap card appears
- [ ] As viewer: open a capability with no linked objectives → amber gap card appears
- [ ] As contributor (canMutate=true): same panels show `+ Add` button, not the gap card
- [ ] Panels without `gapMessage` (e.g. Personas) still show plain fallback text when empty
- [ ] TypeScript: `pnpm --filter govea exec tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)