### PR TITLE
refactor(data): centralise application deduplication rule

### DIFF
--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { getObjectiveTrace, getCapabilityTrace, getServiceTrace } from '@/actions/traceability'
 import type { ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceCapability } from '@/actions/traceability'
+import { dedupeById } from '@/lib/dedup'
 
 // ── Status colours ────────────────────────────────────────────────────────────
 
@@ -104,15 +105,10 @@ function TraceRow({
   )
 }
 
-// ── Application list (deduplicated, used in both objective and service traces) ─
-
-function dedupeApps(apps: TraceApp[]): TraceApp[] {
-  const seen = new Set<string>()
-  return apps.filter(a => { if (seen.has(a.id)) return false; seen.add(a.id); return true })
-}
+// ── Application list (deduplicated — see src/lib/dedup.ts for product rule) ───
 
 function AppLayer({ apps }: { apps: TraceApp[] }) {
-  const deduped = dedupeApps(apps)
+  const deduped = dedupeById(apps)
   if (deduped.length === 0) {
     return <Gap message="No applications linked — the technology platform for this area is not yet mapped." />
   }
@@ -136,7 +132,7 @@ function AppLayer({ apps }: { apps: TraceApp[] }) {
 
 function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
   // Merge applications: direct links + via capabilities, deduplicated
-  const allApps = dedupeApps([
+  const allApps = dedupeById([
     ...trace.directApplications,
     ...trace.capabilities.flatMap(c => c.applications),
   ])
@@ -322,7 +318,7 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
 // ── Service trace view ────────────────────────────────────────────────────────
 
 function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
-  const allApps = dedupeApps([
+  const allApps = dedupeById([
     ...trace.directApplications,
     ...trace.capabilities.flatMap(c => c.applications),
   ])

--- a/apps/govea/src/lib/dedup.ts
+++ b/apps/govea/src/lib/dedup.ts
@@ -1,0 +1,71 @@
+/**
+ * Cross-entity deduplication utility
+ *
+ * ## Product rule — single-appearance guarantee
+ *
+ * An entity (application, capability, or any other record with an `id`)
+ * appears **at most once** in any cross-entity view, regardless of how many
+ * graph paths lead to it.
+ *
+ * ### Why this matters
+ *
+ * GovEA's data model is a graph, not a tree. A single application can be
+ * reachable through several paths in the same view:
+ *
+ *   Objective A → direct link → App X
+ *   Objective A → Capability B → App X   (App X is linked to both)
+ *
+ * Showing App X twice in the same view would imply the portfolio is larger
+ * than it is and mislead stakeholders about the technology footprint.
+ *
+ * ### Multiple paths are signal, not duplicates
+ *
+ * The *presence* of multiple paths reaching the same application is
+ * architecturally meaningful: it indicates the application is load-bearing
+ * or cross-cutting. That signal belongs in a future portfolio heat-map
+ * feature, not in the count of items in a list.
+ *
+ * ### Direct links vs. capability-mediated links
+ *
+ * GovEA currently supports both:
+ *   - Direct: Objective → Application
+ *   - Mediated: Objective → Capability → Application
+ *
+ * Direct links bypass the capability layer and obscure the "what the
+ * organisation does" view. Future work should evaluate whether to
+ * deprecate direct obj→app and service→app links in favour of the
+ * capability-mediated path. Until that decision is made, both link types
+ * are merged before deduplication.
+ *
+ * ### Where to apply
+ *
+ * Any view, report, or API response that aggregates entities across graph
+ * paths **must** call `dedupeById` before rendering. This includes:
+ *   - Traceability views (objective, capability, service)
+ *   - Application portfolio heat maps (planned)
+ *   - Capability coverage reports (planned)
+ *   - Executive roadmap / timeline views (planned)
+ *
+ * @see https://github.com/roballred/GovEA/issues/227
+ */
+
+/**
+ * Returns a new array containing only the first occurrence of each item,
+ * identified by `item.id`. Order is preserved (first-seen wins).
+ *
+ * @example
+ * const apps = dedupeById([
+ *   { id: 'a', name: 'Finance' },
+ *   { id: 'b', name: 'HR' },
+ *   { id: 'a', name: 'Finance' },   // duplicate — removed
+ * ])
+ * // → [{ id: 'a', name: 'Finance' }, { id: 'b', name: 'HR' }]
+ */
+export function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>()
+  return items.filter(item => {
+    if (seen.has(item.id)) return false
+    seen.add(item.id)
+    return true
+  })
+}

--- a/apps/govea/tests/integration/dedup.test.ts
+++ b/apps/govea/tests/integration/dedup.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests: dedupeById utility (#227)
+ *
+ * Pure function — no DB access required. Lives in the integration folder
+ * because that is the only vitest suite configured for this package.
+ */
+import { describe, it, expect } from 'vitest'
+import { dedupeById } from '@/lib/dedup'
+
+describe('dedupeById', () => {
+  it('returns an empty array unchanged', () => {
+    expect(dedupeById([])).toEqual([])
+  })
+
+  it('returns a single-item array unchanged', () => {
+    const items = [{ id: 'a', name: 'Alpha' }]
+    expect(dedupeById(items)).toEqual(items)
+  })
+
+  it('removes exact duplicates — keeps first occurrence', () => {
+    const items = [
+      { id: 'a', name: 'First' },
+      { id: 'b', name: 'Bravo' },
+      { id: 'a', name: 'First again' },
+    ]
+    const result = dedupeById(items)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ id: 'a', name: 'First' })
+    expect(result[1]).toEqual({ id: 'b', name: 'Bravo' })
+  })
+
+  it('preserves insertion order', () => {
+    const items = [
+      { id: 'c', name: 'Charlie' },
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Bravo' },
+      { id: 'a', name: 'Alpha dup' },
+      { id: 'c', name: 'Charlie dup' },
+    ]
+    expect(dedupeById(items).map(i => i.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('handles a list where every item is a duplicate', () => {
+    const items = [
+      { id: 'x', value: 1 },
+      { id: 'x', value: 2 },
+      { id: 'x', value: 3 },
+    ]
+    const result = dedupeById(items)
+    expect(result).toHaveLength(1)
+    expect(result[0].value).toBe(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const items = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'a', name: 'Alpha dup' },
+    ]
+    const copy = [...items]
+    dedupeById(items)
+    expect(items).toEqual(copy)
+  })
+
+  // ── Product rule: multi-path graph deduplication ───────────────────────────
+
+  it('merges direct and capability-mediated app lists correctly (objective trace)', () => {
+    // Simulates: Objective → direct → App X
+    //            Objective → Capability → App X (same app, second path)
+    //            Objective → Capability → App Y (new app)
+    const directApps    = [{ id: 'app-x', name: 'Finance System' }]
+    const viaCapability = [{ id: 'app-x', name: 'Finance System' }, { id: 'app-y', name: 'HR System' }]
+
+    const merged = dedupeById([...directApps, ...viaCapability])
+
+    expect(merged).toHaveLength(2)
+    expect(merged.map(a => a.id)).toEqual(['app-x', 'app-y'])
+  })
+
+  it('works with arbitrary extra fields on the items', () => {
+    const items = [
+      { id: '1', name: 'Foo', vendor: 'Acme', lifecycleStatus: 'active' },
+      { id: '2', name: 'Bar', vendor: 'Corp', lifecycleStatus: 'planned' },
+      { id: '1', name: 'Foo', vendor: 'Acme', lifecycleStatus: 'active' },
+    ]
+    expect(dedupeById(items)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Closes #227

## Problem

`dedupeApps()` in the traceability render layer was undocumented implicit behaviour — the rule existed, but nothing named it or explained why it was correct. Any future portfolio view, heat map, or reporting feature written without knowing this file existed would silently produce duplicate counts.

## Changes

**`src/lib/dedup.ts`** (new) — the rule in one place:

```ts
export function dedupeById<T extends { id: string }>(items: T[]): T[]
```

The JSDoc covers:
- Why multiple paths = architectural signal, not duplicates
- The direct-link vs. capability-mediated-link question (documented, not decided)
- A list of planned views where the rule must be applied (portfolio heat maps, coverage reports, roadmap views)

**`traceability/page.tsx`** — drops local `dedupeApps`, imports `dedupeById`. No behaviour change.

**`tests/integration/dedup.test.ts`** (new) — 8 unit tests:
- Empty array, single item, duplicate removal (first wins)
- Insertion order preserved
- Immutability — input array unchanged
- All-duplicates edge case
- The actual product scenario: direct apps + capability-mediated apps merged with no double-count
- Works with arbitrary extra fields on items

## On the direct-link question

Issue #227 asks whether direct obj→app links should be deprecated in favour of capability-mediated paths. The doc in `dedup.ts` names the question explicitly but defers the decision — the dedup rule applies and is correct regardless of which link types exist.

## Test plan
- [ ] `pnpm --filter govea exec tsc --noEmit` → clean
- [ ] `pnpm --filter govea test:integration` → 74 passed
- [ ] Traceability view: open an objective where the same app appears via both a direct link and through a capability — app appears once

🤖 Generated with [Claude Code](https://claude.com/claude-code)