### PR TITLE
fix: enforce viewer status gate in getADR and getInitiative actions (#208)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -73,7 +73,10 @@ export async function getADR(id: string) {
 
   if (!adr) return null
   const visible = await canReadFederatedEntity(adr.organizationId, adr.visibility, session.user.organizationId!)
-  return visible ? adr : null
+  if (!visible) return null
+  // Viewer status gate — enforced in the action so all callers inherit the rule (#208)
+  if (session.user.role === 'viewer' && adr.status !== VIEWER_ADR_STATUS) return null
+  return adr
 }
 
 export async function createADR(formData: FormData) {

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -66,7 +66,10 @@ export async function getInitiative(id: string) {
 
   if (!initiative) return null
   const visible = await canReadFederatedEntity(initiative.organizationId, initiative.visibility, session.user.organizationId!)
-  return visible ? initiative : null
+  if (!visible) return null
+  // Viewer status gate — enforced in the action so all callers inherit the rule (#208)
+  if (session.user.role === 'viewer' && !VIEWER_INITIATIVE_STATUSES.includes(initiative.status)) return null
+  return initiative
 }
 
 export async function createInitiative(formData: FormData) {

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -50,11 +50,7 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
   if (!session?.user) redirect('/login')
 
   const [adr, enabledModules] = await Promise.all([getADR(id), getEnabledModules()])
-  if (!adr) notFound()
-
-  // Viewers may only access accepted ADRs (#202)
-  const isViewer = session.user.role === 'viewer'
-  if (isViewer && adr.status !== 'accepted') notFound()
+  if (!adr) notFound() // also catches viewer status gate enforced in getADR (#208)
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -53,11 +53,7 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
   if (!session?.user) redirect('/login')
 
   const [initiative, enabledModules] = await Promise.all([getInitiative(id), getEnabledModules()])
-  if (!initiative) notFound()
-
-  // Viewers may only access active or complete initiatives (#202)
-  const isViewer = session.user.role === 'viewer'
-  if (isViewer && !['active', 'complete'].includes(initiative.status)) notFound()
+  if (!initiative) notFound() // also catches viewer status gate enforced in getInitiative (#208)
 
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -9,7 +9,7 @@
  * Isolation is by organizationId; tests never touch the dev seed orgs.
  */
 import { db } from '@/db/client'
-import { organizations, users, capabilities, initiatives, auditLog } from '@/db/schema'
+import { organizations, users, capabilities, initiatives, adrs, auditLog } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import bcrypt from 'bcryptjs'
@@ -139,4 +139,50 @@ export async function insertCapability(orgId: string, name = 'Test Capability') 
     .values({ name, organizationId: orgId, status: 'draft', visibility: 'org' })
     .returning()
   return cap
+}
+
+/** Insert an ADR directly — used by viewer-visibility tests to seed specific statuses. */
+export async function insertAdr(
+  orgId: string,
+  overrides: {
+    number?: string
+    title?: string
+    status?: 'proposed' | 'accepted' | 'deprecated' | 'superseded'
+    visibility?: 'org' | 'connections' | 'instance'
+  } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(adrs)
+    .values({
+      organizationId: orgId,
+      number: overrides.number ?? `ADR-T-${suffix}`,
+      title: overrides.title ?? `Test ADR ${suffix}`,
+      status: overrides.status ?? 'proposed',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert an initiative directly — used by viewer-visibility tests to seed specific statuses. */
+export async function insertInitiative(
+  orgId: string,
+  overrides: {
+    name?: string
+    status?: 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled'
+    visibility?: 'org' | 'connections' | 'instance'
+  } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(initiatives)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Initiative ${suffix}`,
+      status: overrides.status ?? 'proposed',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
 }

--- a/apps/govea/tests/integration/viewer-visibility.test.ts
+++ b/apps/govea/tests/integration/viewer-visibility.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests: viewer visibility for ADRs and initiatives (#208)
+ *
+ * The viewer status gate must be enforced in the action layer — not only in
+ * page components — so every caller of getADR / getInitiative inherits the
+ * rule automatically.
+ *
+ * Rules (Option B decision from #202):
+ *  - ADRs:        viewer sees only `accepted`
+ *  - Initiatives: viewer sees only `active` and `complete`
+ *
+ * Coverage matrix:
+ *  - getADRs        (list)   × viewer / contributor / admin
+ *  - getADR         (detail) × each ADR status × viewer / contributor
+ *  - getInitiatives (list)   × viewer / contributor / admin
+ *  - getInitiative  (detail) × each initiative status × viewer / contributor
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { getADRs, getADR } from '@/actions/adrs'
+import { getInitiatives, getInitiative } from '@/actions/initiatives'
+import {
+  createTestOrg, createTestUser, cleanupOrg,
+  makeSession, insertAdr, insertInitiative,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+// ── ADR visibility ─────────────────────────────────────────────────────────────
+
+describe('viewer visibility — ADRs', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  let acceptedId: string
+  let proposedId: string
+  let deprecatedId: string
+  let supersededId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+    ;[acceptedId, proposedId, deprecatedId, supersededId] = await Promise.all([
+      insertAdr(orgId, { number: 'ADR-V-001', status: 'accepted'   }).then(a => a.id),
+      insertAdr(orgId, { number: 'ADR-V-002', status: 'proposed'   }).then(a => a.id),
+      insertAdr(orgId, { number: 'ADR-V-003', status: 'deprecated' }).then(a => a.id),
+      insertAdr(orgId, { number: 'ADR-V-004', status: 'superseded' }).then(a => a.id),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  // ── getADRs list ─────────────────────────────────────────────────────────
+
+  describe('getADRs — list', () => {
+    it('viewer sees only accepted ADRs', async () => {
+      const result = await getADRs(orgId, 'viewer')
+      const ids = result.map(a => a.id)
+      expect(ids).toContain(acceptedId)
+      expect(ids).not.toContain(proposedId)
+      expect(ids).not.toContain(deprecatedId)
+      expect(ids).not.toContain(supersededId)
+    })
+
+    it('contributor sees all statuses', async () => {
+      const result = await getADRs(orgId, 'contributor')
+      const ids = result.map(a => a.id)
+      expect(ids).toContain(acceptedId)
+      expect(ids).toContain(proposedId)
+      expect(ids).toContain(deprecatedId)
+      expect(ids).toContain(supersededId)
+    })
+
+    it('admin sees all statuses', async () => {
+      const result = await getADRs(orgId, 'admin')
+      const ids = result.map(a => a.id)
+      expect(ids).toContain(acceptedId)
+      expect(ids).toContain(proposedId)
+      expect(ids).toContain(deprecatedId)
+      expect(ids).toContain(supersededId)
+    })
+  })
+
+  // ── getADR detail ─────────────────────────────────────────────────────────
+
+  describe('getADR — detail', () => {
+    it('viewer can access an accepted ADR by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      const result = await getADR(acceptedId)
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe(acceptedId)
+    })
+
+    it('viewer cannot access a proposed ADR by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getADR(proposedId)).toBeNull()
+    })
+
+    it('viewer cannot access a deprecated ADR by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getADR(deprecatedId)).toBeNull()
+    })
+
+    it('viewer cannot access a superseded ADR by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getADR(supersededId)).toBeNull()
+    })
+
+    it('contributor can access any ADR status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      const [a, b, c, d] = await Promise.all([
+        getADR(acceptedId),
+        getADR(proposedId),
+        getADR(deprecatedId),
+        getADR(supersededId),
+      ])
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(c).not.toBeNull()
+      expect(d).not.toBeNull()
+    })
+
+    it('admin can access any ADR status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      expect(await getADR(proposedId)).not.toBeNull()
+    })
+  })
+})
+
+// ── Initiative visibility ──────────────────────────────────────────────────────
+
+describe('viewer visibility — Initiatives', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  let activeId: string
+  let completeId: string
+  let proposedId: string
+  let onHoldId: string
+  let cancelledId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+    ;[activeId, completeId, proposedId, onHoldId, cancelledId] = await Promise.all([
+      insertInitiative(orgId, { status: 'active'    }).then(i => i.id),
+      insertInitiative(orgId, { status: 'complete'  }).then(i => i.id),
+      insertInitiative(orgId, { status: 'proposed'  }).then(i => i.id),
+      insertInitiative(orgId, { status: 'on-hold'   }).then(i => i.id),
+      insertInitiative(orgId, { status: 'cancelled' }).then(i => i.id),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  // ── getInitiatives list ───────────────────────────────────────────────────
+
+  describe('getInitiatives — list', () => {
+    it('viewer sees only active and complete initiatives', async () => {
+      const result = await getInitiatives(orgId, 'viewer')
+      const ids = result.map(i => i.id)
+      expect(ids).toContain(activeId)
+      expect(ids).toContain(completeId)
+      expect(ids).not.toContain(proposedId)
+      expect(ids).not.toContain(onHoldId)
+      expect(ids).not.toContain(cancelledId)
+    })
+
+    it('contributor sees all statuses', async () => {
+      const result = await getInitiatives(orgId, 'contributor')
+      const ids = result.map(i => i.id)
+      expect(ids).toContain(activeId)
+      expect(ids).toContain(completeId)
+      expect(ids).toContain(proposedId)
+      expect(ids).toContain(onHoldId)
+      expect(ids).toContain(cancelledId)
+    })
+
+    it('admin sees all statuses', async () => {
+      const result = await getInitiatives(orgId, 'admin')
+      const ids = result.map(i => i.id)
+      expect(ids).toContain(activeId)
+      expect(ids).toContain(proposedId)
+      expect(ids).toContain(cancelledId)
+    })
+  })
+
+  // ── getInitiative detail ──────────────────────────────────────────────────
+
+  describe('getInitiative — detail', () => {
+    it('viewer can access an active initiative by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      const result = await getInitiative(activeId)
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe(activeId)
+    })
+
+    it('viewer can access a complete initiative by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getInitiative(completeId)).not.toBeNull()
+    })
+
+    it('viewer cannot access a proposed initiative by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getInitiative(proposedId)).toBeNull()
+    })
+
+    it('viewer cannot access an on-hold initiative by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getInitiative(onHoldId)).toBeNull()
+    })
+
+    it('viewer cannot access a cancelled initiative by ID → returns null', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getInitiative(cancelledId)).toBeNull()
+    })
+
+    it('contributor can access any initiative status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      const [a, b, c, d, e] = await Promise.all([
+        getInitiative(activeId),
+        getInitiative(completeId),
+        getInitiative(proposedId),
+        getInitiative(onHoldId),
+        getInitiative(cancelledId),
+      ])
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(c).not.toBeNull()
+      expect(d).not.toBeNull()
+      expect(e).not.toBeNull()
+    })
+
+    it('admin can access any initiative status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      expect(await getInitiative(proposedId)).not.toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Closes #208

## Problem

The viewer status filter for ADRs (`accepted` only) and initiatives (`active`/`complete` only) was enforced in page components, not in the action layer. Any caller outside `adrs/[id]/page.tsx` or `initiatives/[id]/page.tsx` — including the traceability page, future server-side utilities, or API routes — received unfiltered data.

## Root cause

`getADR(id)` and `getInitiative(id)` checked federation visibility but not role-aware status. The guard existed only as a page-level `if (isViewer && ...) notFound()` after the data was already fetched.

## Fix

Move the status gate into the action for both functions:

- `getADR(id)` — returns `null` if viewer and `adr.status !== 'accepted'`
- `getInitiative(id)` — returns `null` if viewer and status not in `['active', 'complete']`

Both use the existing `VIEWER_ADR_STATUS` / `VIEWER_INITIATIVE_STATUSES` constants so the rule lives in one place. Remove the now-redundant page-level checks — the existing `if (!adr) notFound()` path handles the null return.

## Tests

New `viewer-visibility.test.ts` covers the full matrix:

| | list | detail (each status) |
|---|---|---|
| ADRs | viewer/contributor/admin | viewer blocked from proposed/deprecated/superseded; passes for accepted |
| Initiatives | viewer/contributor/admin | viewer blocked from proposed/on-hold/cancelled; passes for active/complete |

19 new tests, 102 total passing.

## Test plan
- [ ] Log in as a Viewer, navigate to an ADR in `proposed` status — should 404
- [ ] Log in as a Contributor, same ADR — should load
- [ ] Log in as a Viewer, navigate to a `proposed` initiative — should 404
- [ ] Log in as a Viewer, navigate to an `active` initiative — should load

🤖 Generated with [Claude Code](https://claude.com/claude-code)