### PR TITLE
feat: planned maintenance mode (#236)

### DIFF
--- a/apps/govea/src/app/maintenance/page.tsx
+++ b/apps/govea/src/app/maintenance/page.tsx
@@ -1,0 +1,12 @@
+export default function MaintenancePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <div className="p-8 text-center">
+        <h1 className="text-xl font-semibold">Down for maintenance</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          We&apos;re making updates and will be back shortly.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/apps/govea/src/middleware.ts
+++ b/apps/govea/src/middleware.ts
@@ -5,7 +5,9 @@ import { NextResponse } from 'next/server'
 // Use the edge-safe config so middleware never touches Node.js built-ins (net, etc.)
 const { auth } = NextAuth(authConfig)
 
-const PUBLIC_PATHS = ['/login', '/setup', '/error', '/api/auth']
+const PUBLIC_PATHS = ['/login', '/setup', '/error', '/api/auth', '/maintenance']
+
+const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === 'true'
 
 export default auth((req) => {
   const { pathname } = req.nextUrl
@@ -17,6 +19,10 @@ export default auth((req) => {
 
   if (!req.auth) {
     return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  if (MAINTENANCE_MODE && req.auth.user?.role !== 'admin') {
+    return NextResponse.redirect(new URL('/maintenance', req.url))
   }
 
   return NextResponse.next()

--- a/docs/ops-downtime.md
+++ b/docs/ops-downtime.md
@@ -1,0 +1,44 @@
+# GovEA — Downtime & Maintenance Posture
+
+## Scenario 1 — Planned maintenance (app still running)
+
+Set `MAINTENANCE_MODE=true` in the Azure Container App environment variables, then restart the revision. The Next.js middleware redirects all non-admin traffic to `/maintenance`. Admins who are already authenticated pass through; others can still reach `/login` to authenticate.
+
+To re-open: unset the variable and restart.
+
+**Azure CLI:**
+```bash
+# Enable
+az containerapp update \
+  --name govea-dev \
+  --resource-group govea \
+  --set-env-vars MAINTENANCE_MODE=true
+
+# Disable
+az containerapp update \
+  --name govea-dev \
+  --resource-group govea \
+  --remove-env-vars MAINTENANCE_MODE
+```
+
+Or set via the Azure Portal → Container App → Settings → Environment variables.
+
+---
+
+## Scenario 2 — True downtime (container unreachable)
+
+**Current posture:** best-effort via rolling deploys.
+
+Azure Container Apps performs a rolling revision replacement — the old revision serves traffic until the new one passes health checks. A normal `./scripts/azure-dev.sh update` run has minimal true downtime. The main risk window is a slow `db:migrate` or `db:seed` that causes the new revision to fail its health probe before becoming healthy.
+
+**There is no static fallback page for true downtime today.** Visitors see Azure's default error response.
+
+### Options (not yet decided)
+
+| Option | Complexity | Notes |
+|---|---|---|
+| Azure Front Door + Static Web Apps failover | High | Full CDN failover; overkill until traffic justifies cost |
+| Azure Static Web Apps custom 404/maintenance page | Medium | Requires Front Door or Traffic Manager in front of Container Apps |
+| Accept rolling-deploy gap as-is | None | Current posture; acceptable for pre-production and low-traffic deploys |
+
+**Decision pending:** whether to put anything in front of the Container Apps URL. Until then, keep `db:migrate` fast and lean on rolling deploys to minimise the gap.


### PR DESCRIPTION
Closes #236

## Summary

- `MAINTENANCE_MODE=true` env var gates all non-admin traffic to a `/maintenance` page via Next.js middleware
- Admins bypass the gate (checked against JWT role claim); unauthenticated users can still reach `/login` to authenticate
- `/maintenance` page matches the existing auth error page style (centered card, no nav)
- `docs/ops-downtime.md` documents the planned-maintenance workflow (Azure CLI commands) and the open true-downtime decision (Front Door vs. best-effort rolling deploy)

## How to enable on Azure

```bash
az containerapp update \
  --name govea-dev \
  --resource-group govea \
  --set-env-vars MAINTENANCE_MODE=true
```

Unset to re-open:

```bash
az containerapp update \
  --name govea-dev \
  --resource-group govea \
  --remove-env-vars MAINTENANCE_MODE
```

## Test plan

- [ ] Set `MAINTENANCE_MODE=true` in `.env.local`, visit any page as unauthenticated → lands on `/maintenance`
- [ ] Same with a logged-in viewer/contributor → redirected to `/maintenance`
- [ ] Logged-in admin → passes through normally
- [ ] Unset `MAINTENANCE_MODE` → all traffic flows normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)