### PR TITLE
refactor: deprecate direct obj/service→app links; capability is the only bridge

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -32,9 +32,12 @@ export async function getApplication(id: string) {
     where: eq(applications.id, id),
     with: {
       organization: true,
-      applicationCapabilities: { with: { capability: true } },
+      applicationCapabilities: {
+        with: {
+          capability: { with: { objectiveCapabilities: { with: { objective: true } } } },
+        },
+      },
       initiativeApplications: { with: { initiative: true } },
-      objectiveApplications: { with: { objective: true } },
       adrApplications: { with: { adr: true } },
     },
   })

--- a/apps/govea/src/actions/dev.ts
+++ b/apps/govea/src/actions/dev.ts
@@ -10,7 +10,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
   principles, principleAdrs, principleCapabilities,
   glossaryTerms, glossaryTermSources,
-  services, serviceCapabilities, servicePersonas, serviceApplications, serviceValueStreams,
+  services, serviceCapabilities, servicePersonas, serviceValueStreams,
 } from '@/db/schema'
 import { eq, isNull } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
@@ -392,15 +392,13 @@ export async function resetToDataset(datasetKey: string) {
 
   // ── Insert services ───────────────────────────────────────────────────────
   // Re-query name→id maps so we're not relying on variables from early-return branches
-  const [svcPersonaRows, svcCapRows, svcAppRows, svcVsRows] = await Promise.all([
+  const [svcPersonaRows, svcCapRows, svcVsRows] = await Promise.all([
     db.select({ id: personas.id, name: personas.name }).from(personas).where(eq(personas.organizationId, orgId)),
     db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities).where(eq(capabilities.organizationId, orgId)),
-    db.select({ id: applications.id, name: applications.name }).from(applications).where(eq(applications.organizationId, orgId)),
     db.select({ id: valueStreams.id, name: valueStreams.name }).from(valueStreams).where(eq(valueStreams.organizationId, orgId)),
   ])
   const svcPersonaByName = Object.fromEntries(svcPersonaRows.map(r => [r.name, r.id]))
   const svcCapByName = Object.fromEntries(svcCapRows.map(r => [r.name, r.id]))
-  const svcAppByName = Object.fromEntries(svcAppRows.map(r => [r.name, r.id]))
   const svcVsByName = Object.fromEntries(svcVsRows.map(r => [r.name, r.id]))
 
   for (const svcDef of dataset.services) {
@@ -425,13 +423,6 @@ export async function resetToDataset(datasetKey: string) {
       .map(n => ({ serviceId: svcRow.id, capabilityId: svcCapByName[n] }))
     if (svcCapJoins.length > 0) {
       await db.insert(serviceCapabilities).values(svcCapJoins).onConflictDoNothing()
-    }
-
-    const svcAppJoins = svcDef.applications
-      .filter(n => svcAppByName[n])
-      .map(n => ({ serviceId: svcRow.id, applicationId: svcAppByName[n] }))
-    if (svcAppJoins.length > 0) {
-      await db.insert(serviceApplications).values(svcAppJoins).onConflictDoNothing()
     }
 
     const svcVsJoins = svcDef.valueStreams

--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -22,7 +22,6 @@ import {
   strategicObjectives,
   objectiveCapabilities,
   objectiveValueStreams,
-  objectiveApplications,
   initiatives,
   initiativeCapabilities,
   initiativeObjectives,
@@ -38,7 +37,6 @@ import {
   services,
   serviceCapabilities,
   servicePersonas,
-  serviceApplications,
   serviceValueStreams,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
@@ -171,26 +169,6 @@ export async function unlinkApplicationCapability(applicationId: string, capabil
   assertOwnership(app?.organizationId, user.organizationId!)
   await db.delete(applicationCapabilities).where(
     and(eq(applicationCapabilities.applicationId, applicationId), eq(applicationCapabilities.capabilityId, capabilityId))
-  )
-  revalidatePath(`/applications/${applicationId}`)
-}
-
-// ── Application ↔ Objective ─────────────────────────────────────────────────
-
-export async function linkApplicationObjective(applicationId: string, objectiveId: string) {
-  const { user } = await requireContributor()
-  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
-  assertOwnership(app?.organizationId, user.organizationId!)
-  await db.insert(objectiveApplications).values({ applicationId, objectiveId }).onConflictDoNothing()
-  revalidatePath(`/applications/${applicationId}`)
-}
-
-export async function unlinkApplicationObjective(applicationId: string, objectiveId: string) {
-  const { user } = await requireContributor()
-  const app = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
-  assertOwnership(app?.organizationId, user.organizationId!)
-  await db.delete(objectiveApplications).where(
-    and(eq(objectiveApplications.applicationId, applicationId), eq(objectiveApplications.objectiveId, objectiveId))
   )
   revalidatePath(`/applications/${applicationId}`)
 }
@@ -331,26 +309,6 @@ export async function unlinkObjectiveValueStream(objectiveId: string, valueStrea
   assertOwnership(obj?.organizationId, user.organizationId!)
   await db.delete(objectiveValueStreams).where(
     and(eq(objectiveValueStreams.objectiveId, objectiveId), eq(objectiveValueStreams.valueStreamId, valueStreamId))
-  )
-  revalidatePath(`/objectives/${objectiveId}`)
-}
-
-// ── Objective ↔ Application ─────────────────────────────────────────────────
-
-export async function linkObjectiveApplication(objectiveId: string, applicationId: string) {
-  const { user } = await requireContributor()
-  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
-  assertOwnership(obj?.organizationId, user.organizationId!)
-  await db.insert(objectiveApplications).values({ objectiveId, applicationId }).onConflictDoNothing()
-  revalidatePath(`/objectives/${objectiveId}`)
-}
-
-export async function unlinkObjectiveApplication(objectiveId: string, applicationId: string) {
-  const { user } = await requireContributor()
-  const obj = await db.query.strategicObjectives.findFirst({ where: eq(strategicObjectives.id, objectiveId) })
-  assertOwnership(obj?.organizationId, user.organizationId!)
-  await db.delete(objectiveApplications).where(
-    and(eq(objectiveApplications.objectiveId, objectiveId), eq(objectiveApplications.applicationId, applicationId))
   )
   revalidatePath(`/objectives/${objectiveId}`)
 }
@@ -571,26 +529,6 @@ export async function unlinkServicePersona(serviceId: string, personaId: string)
   assertOwnership(svc?.organizationId, user.organizationId!)
   await db.delete(servicePersonas).where(
     and(eq(servicePersonas.serviceId, serviceId), eq(servicePersonas.personaId, personaId))
-  )
-  revalidatePath(`/services/${serviceId}`)
-}
-
-// ── Service ↔ Application ───────────────────────────────────────────────────
-
-export async function linkServiceApplication(serviceId: string, applicationId: string) {
-  const { user } = await requireContributor()
-  const svc = await db.query.services.findFirst({ where: eq(services.id, serviceId) })
-  assertOwnership(svc?.organizationId, user.organizationId!)
-  await db.insert(serviceApplications).values({ serviceId, applicationId }).onConflictDoNothing()
-  revalidatePath(`/services/${serviceId}`)
-}
-
-export async function unlinkServiceApplication(serviceId: string, applicationId: string) {
-  const { user } = await requireContributor()
-  const svc = await db.query.services.findFirst({ where: eq(services.id, serviceId) })
-  assertOwnership(svc?.organizationId, user.organizationId!)
-  await db.delete(serviceApplications).where(
-    and(eq(serviceApplications.serviceId, serviceId), eq(serviceApplications.applicationId, applicationId))
   )
   revalidatePath(`/services/${serviceId}`)
 }

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -56,9 +56,12 @@ export async function getObjective(id: string) {
   const objective = await db.query.strategicObjectives.findFirst({
     where: (o, { eq }) => eq(o.id, id),
     with: {
-      objectiveCapabilities: { with: { capability: true } },
+      objectiveCapabilities: {
+        with: {
+          capability: { with: { applicationCapabilities: { with: { application: true } } } },
+        },
+      },
       objectiveValueStreams: { with: { valueStream: true } },
-      objectiveApplications: { with: { application: true } },
       initiativeObjectives: { with: { initiative: true } },
     },
   })

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import {
   services, serviceCapabilities, servicePersonas,
-  serviceApplications, serviceValueStreams,
+  serviceValueStreams,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
@@ -34,9 +34,12 @@ export async function getService(id: string) {
     where: eq(services.id, id),
     with: {
       organization: true,
-      serviceCapabilities: { with: { capability: true } },
+      serviceCapabilities: {
+        with: {
+          capability: { with: { applicationCapabilities: { with: { application: true } } } },
+        },
+      },
       servicePersonas: { with: { persona: true } },
-      serviceApplications: { with: { application: true } },
       serviceValueStreams: { with: { valueStream: true } },
     },
   })

--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -41,7 +41,6 @@ export interface ObjectiveTrace {
   id: string; name: string; description: string | null
   successMetric: string | null; timeHorizon: string | null; status: string
   capabilities: TraceCapability[]
-  directApplications: TraceApp[]
   initiatives: TraceInitiative[]
 }
 
@@ -61,7 +60,6 @@ export interface ServiceTrace {
   id: string; name: string; description: string | null; channels: string[]; status: string
   personas: TracePersona[]
   capabilities: TraceCapability[]
-  directApplications: TraceApp[]
 }
 
 export type TraceData = ObjectiveTrace | CapabilityTrace | ServiceTrace
@@ -84,7 +82,6 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
           },
         },
       },
-      objectiveApplications: { with: { application: true } },
       initiativeObjectives: { with: { initiative: true } },
     },
   })
@@ -108,9 +105,6 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
       applications: c.applicationCapabilities.map(({ application: a }) => ({
         id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
       })),
-    })),
-    directApplications: row.objectiveApplications.map(({ application: a }) => ({
-      id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
     })),
     initiatives: row.initiativeObjectives.map(({ initiative: i }) => ({
       id: i.id, name: i.name, status: i.status,
@@ -187,7 +181,6 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
           },
         },
       },
-      serviceApplications: { with: { application: true } },
     },
   })
 
@@ -212,9 +205,6 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
       applications: c.applicationCapabilities.map(({ application: a }) => ({
         id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
       })),
-    })),
-    directApplications: row.serviceApplications.map(({ application: a }) => ({
-      id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
     })),
   }
 }

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -2,7 +2,6 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getApplication, markApplicationReviewed } from '@/actions/applications'
 import { getCapabilities } from '@/actions/capabilities'
-import { getObjectives } from '@/actions/objectives'
 import { getInitiatives } from '@/actions/initiatives'
 import { getADRs } from '@/actions/adrs'
 import { canEdit } from '@/lib/rbac'
@@ -11,12 +10,12 @@ import Link from 'next/link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkApplicationCapability, unlinkApplicationCapability,
-  linkApplicationObjective, unlinkApplicationObjective,
   linkApplicationInitiative, unlinkApplicationInitiative,
   linkApplicationAdr, unlinkApplicationAdr,
 } from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
+import { dedupeById } from '@/lib/dedup'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -55,23 +54,31 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
   const orgId = session.user.organizationId!
   const canMutate = editor && application.organizationId === orgId
 
-  const [allCapabilities, allObjectives, allInitiatives, allAdrs] = editor
+  const [allCapabilities, allInitiatives, allAdrs] = editor
     ? await Promise.all([
         getCapabilities(orgId),
-        getObjectives(orgId),
         getInitiatives(orgId),
         getADRs(orgId),
       ])
-    : [[], [], [], []]
+    : [[], [], []]
 
   const addCapability = linkApplicationCapability.bind(null, id)
   const removeCapability = unlinkApplicationCapability.bind(null, id)
-  const addObjective = linkApplicationObjective.bind(null, id)
-  const removeObjective = unlinkApplicationObjective.bind(null, id)
   const addInitiative = linkApplicationInitiative.bind(null, id)
   const removeInitiative = unlinkApplicationInitiative.bind(null, id)
   const addAdr = linkApplicationAdr.bind(null, id)
   const removeAdr = unlinkApplicationAdr.bind(null, id)
+
+  const linkedObjectives = dedupeById(
+    application.applicationCapabilities.flatMap(({ capability }) =>
+      capability.objectiveCapabilities.map(({ objective }) => ({
+        id: objective.id,
+        name: objective.name,
+        href: `/objectives/${objective.id}`,
+        meta: objective.timeHorizon ?? undefined,
+      }))
+    )
+  )
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -143,14 +150,9 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
       {isModuleEnabled(enabledModules, 'objectives') && (
         <RelationshipPanel
           title="Strategic Objectives"
-          items={application.objectiveApplications.map(({ objective }) => ({
-            id: objective.id, name: objective.name,
-            href: `/objectives/${objective.id}`, meta: objective.timeHorizon,
-          }))}
-          canEdit={canMutate}
-          available={allObjectives.filter(o => o.organizationId === orgId).map(o => ({ id: o.id, name: o.name }))}
-          addAction={addObjective}
-          removeAction={removeObjective}
+          items={linkedObjectives}
+          gapMessage="Objectives appear here through capabilities — link capabilities above to see strategic alignment."
+          canEdit={false}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -3,7 +3,6 @@ import { redirect, notFound } from 'next/navigation'
 import { getObjective } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
-import { getApplications } from '@/actions/applications'
 import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
@@ -11,10 +10,10 @@ import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkObjectiveCapability, unlinkObjectiveCapability,
   linkObjectiveValueStream, unlinkObjectiveValueStream,
-  linkObjectiveApplication, unlinkObjectiveApplication,
 } from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
+import { dedupeById } from '@/lib/dedup'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -46,20 +45,28 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
   const orgId = session.user.organizationId!
   const canMutate = editor && objective.organizationId === orgId
 
-  const [allCapabilities, allValueStreams, allApplications] = editor
+  const [allCapabilities, allValueStreams] = editor
     ? await Promise.all([
         getCapabilities(orgId),
         getValueStreams(orgId),
-        getApplications(orgId),
       ])
-    : [[], [], []]
+    : [[], []]
 
   const addCapability = linkObjectiveCapability.bind(null, id)
   const removeCapability = unlinkObjectiveCapability.bind(null, id)
   const addValueStream = linkObjectiveValueStream.bind(null, id)
   const removeValueStream = unlinkObjectiveValueStream.bind(null, id)
-  const addApplication = linkObjectiveApplication.bind(null, id)
-  const removeApplication = unlinkObjectiveApplication.bind(null, id)
+
+  const capabilityApps = dedupeById(
+    objective.objectiveCapabilities.flatMap(({ capability }) =>
+      capability.applicationCapabilities.map(({ application }) => ({
+        id: application.id,
+        name: application.name,
+        href: `/applications/${application.id}`,
+        meta: application.vendor ?? undefined,
+      }))
+    )
+  )
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -142,14 +149,9 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
       {isModuleEnabled(enabledModules, 'applications') && (
         <RelationshipPanel
           title="Applications"
-          items={objective.objectiveApplications.map(({ application }) => ({
-            id: application.id, name: application.name,
-            href: `/applications/${application.id}`, meta: application.vendor,
-          }))}
-          canEdit={canMutate}
-          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
-          addAction={addApplication}
-          removeAction={removeApplication}
+          items={capabilityApps}
+          gapMessage="Applications appear here through capabilities — link capabilities above to map your application landscape."
+          canEdit={false}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/services/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/services/[id]/page.tsx
@@ -2,7 +2,6 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getService } from '@/actions/services'
 import { getCapabilities } from '@/actions/capabilities'
-import { getApplications } from '@/actions/applications'
 import { getPersonas } from '@/actions/personas'
 import { getValueStreams } from '@/actions/value-streams'
 import { canEdit } from '@/lib/rbac'
@@ -12,11 +11,11 @@ import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkServiceCapability, unlinkServiceCapability,
   linkServicePersona, unlinkServicePersona,
-  linkServiceApplication, unlinkServiceApplication,
   linkServiceValueStream, unlinkServiceValueStream,
 } from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
+import { dedupeById } from '@/lib/dedup'
 
 const CHANNEL_LABELS: Record<string, string> = {
   online: 'Online',
@@ -62,23 +61,31 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
   const orgId = session.user.organizationId!
   const canMutate = editor && service.organizationId === orgId
 
-  const [allCapabilities, allPersonas, allApplications, allValueStreams] = editor
+  const [allCapabilities, allPersonas, allValueStreams] = editor
     ? await Promise.all([
         getCapabilities(orgId),
         getPersonas(orgId),
-        getApplications(orgId),
         getValueStreams(orgId),
       ])
-    : [[], [], [], []]
+    : [[], [], []]
 
   const addCapability = linkServiceCapability.bind(null, id)
   const removeCapability = unlinkServiceCapability.bind(null, id)
   const addPersona = linkServicePersona.bind(null, id)
   const removePersona = unlinkServicePersona.bind(null, id)
-  const addApplication = linkServiceApplication.bind(null, id)
-  const removeApplication = unlinkServiceApplication.bind(null, id)
   const addValueStream = linkServiceValueStream.bind(null, id)
   const removeValueStream = unlinkServiceValueStream.bind(null, id)
+
+  const capabilityApps = dedupeById(
+    service.serviceCapabilities.flatMap(({ capability }) =>
+      capability.applicationCapabilities.map(({ application }) => ({
+        id: application.id,
+        name: application.name,
+        href: `/applications/${application.id}`,
+        meta: application.vendor ?? undefined,
+      }))
+    )
+  )
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -165,15 +172,9 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
       {isModuleEnabled(enabledModules, 'applications') && (
         <RelationshipPanel
           title="Applications"
-          items={service.serviceApplications.map(({ application }) => ({
-            id: application.id, name: application.name,
-            href: `/applications/${application.id}`,
-            meta: application.vendor,
-          }))}
-          canEdit={canMutate}
-          available={allApplications.filter(a => a.organizationId === orgId).map(a => ({ id: a.id, name: a.name }))}
-          addAction={addApplication}
-          removeAction={removeApplication}
+          items={capabilityApps}
+          gapMessage="Applications appear here through capabilities — link capabilities above to map your application landscape."
+          canEdit={false}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -131,11 +131,7 @@ function AppLayer({ apps }: { apps: TraceApp[] }) {
 // ── Objective trace view ──────────────────────────────────────────────────────
 
 function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
-  // Merge applications: direct links + via capabilities, deduplicated
-  const allApps = dedupeById([
-    ...trace.directApplications,
-    ...trace.capabilities.flatMap(c => c.applications),
-  ])
+  const allApps = dedupeById(trace.capabilities.flatMap(c => c.applications))
 
   return (
     <div className="space-y-1 max-w-2xl">
@@ -318,10 +314,7 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
 // ── Service trace view ────────────────────────────────────────────────────────
 
 function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
-  const allApps = dedupeById([
-    ...trace.directApplications,
-    ...trace.capabilities.flatMap(c => c.applications),
-  ])
+  const allApps = dedupeById(trace.capabilities.flatMap(c => c.applications))
 
   return (
     <div className="space-y-1 max-w-2xl">

--- a/apps/govea/src/app/maintenance/page.tsx
+++ b/apps/govea/src/app/maintenance/page.tsx
@@ -1,0 +1,12 @@
+export default function MaintenancePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <div className="p-8 text-center">
+        <h1 className="text-xl font-semibold">Down for maintenance</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          We&apos;re making updates and will be back shortly.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/apps/govea/src/db/schema/objectives.ts
+++ b/apps/govea/src/db/schema/objectives.ts
@@ -3,7 +3,6 @@ import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 import { workflowStatusEnum } from './personas'
 import { capabilities } from './capabilities'
-import { applications } from './applications'
 import { valueStreams } from './value-streams'
 
 export const strategicObjectives = pgTable('strategic_objectives', {
@@ -37,10 +36,3 @@ export const objectiveValueStreams = pgTable('objective_value_streams', {
 
 export type ObjectiveValueStream = typeof objectiveValueStreams.$inferSelect
 
-// Junction: strategic objective ↔ application
-export const objectiveApplications = pgTable('objective_applications', {
-  objectiveId: uuid('objective_id').notNull().references(() => strategicObjectives.id, { onDelete: 'cascade' }),
-  applicationId: uuid('application_id').notNull().references(() => applications.id, { onDelete: 'cascade' }),
-})
-
-export type ObjectiveApplication = typeof objectiveApplications.$inferSelect

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -5,12 +5,12 @@ import { personas, personaTags } from './personas'
 import { taxonomyTerms } from './taxonomy'
 import { organizations } from './organizations'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas } from './value-streams'
-import { strategicObjectives, objectiveCapabilities, objectiveValueStreams, objectiveApplications } from './objectives'
+import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from './objectives'
 import { initiatives, initiativeCapabilities, initiativeObjectives, initiativeApplications } from './initiatives'
 import { adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives } from './adrs'
 import { principles, principleAdrs, principleCapabilities } from './principles'
 import { glossaryTerms, glossaryTermSources } from './glossary'
-import { services, serviceCapabilities, servicePersonas, serviceApplications, serviceValueStreams } from './services'
+import { services, serviceCapabilities, servicePersonas, serviceValueStreams } from './services'
 
 // ─── Capabilities ────────────────────────────────────────────────────────────
 
@@ -113,7 +113,6 @@ export const strategicObjectivesRelations = relations(strategicObjectives, ({ on
   }),
   objectiveCapabilities: many(objectiveCapabilities),
   objectiveValueStreams: many(objectiveValueStreams),
-  objectiveApplications: many(objectiveApplications),
   initiativeObjectives: many(initiativeObjectives),
   adrObjectives: many(adrObjectives),
 }))
@@ -137,17 +136,6 @@ export const objectiveValueStreamsRelations = relations(objectiveValueStreams, (
   valueStream: one(valueStreams, {
     fields: [objectiveValueStreams.valueStreamId],
     references: [valueStreams.id],
-  }),
-}))
-
-export const objectiveApplicationsRelations = relations(objectiveApplications, ({ one }) => ({
-  objective: one(strategicObjectives, {
-    fields: [objectiveApplications.objectiveId],
-    references: [strategicObjectives.id],
-  }),
-  application: one(applications, {
-    fields: [objectiveApplications.applicationId],
-    references: [applications.id],
   }),
 }))
 
@@ -206,7 +194,6 @@ export const applicationsRelations = relations(applications, ({ one, many }) => 
   }),
   applicationCapabilities: many(applicationCapabilities),
   initiativeApplications: many(initiativeApplications),
-  objectiveApplications: many(objectiveApplications),
   adrApplications: many(adrApplications),
 }))
 
@@ -348,7 +335,6 @@ export const servicesRelations = relations(services, ({ one, many }) => ({
   }),
   serviceCapabilities: many(serviceCapabilities),
   servicePersonas: many(servicePersonas),
-  serviceApplications: many(serviceApplications),
   serviceValueStreams: many(serviceValueStreams),
 }))
 
@@ -371,17 +357,6 @@ export const servicePersonasRelations = relations(servicePersonas, ({ one }) => 
   persona: one(personas, {
     fields: [servicePersonas.personaId],
     references: [personas.id],
-  }),
-}))
-
-export const serviceApplicationsRelations = relations(serviceApplications, ({ one }) => ({
-  service: one(services, {
-    fields: [serviceApplications.serviceId],
-    references: [services.id],
-  }),
-  application: one(applications, {
-    fields: [serviceApplications.applicationId],
-    references: [applications.id],
   }),
 }))
 

--- a/apps/govea/src/db/schema/services.ts
+++ b/apps/govea/src/db/schema/services.ts
@@ -4,7 +4,6 @@ import { users } from './users'
 import { workflowStatusEnum } from './personas'
 import { capabilities } from './capabilities'
 import { personas } from './personas'
-import { applications } from './applications'
 import { valueStreams } from './value-streams'
 
 export const services = pgTable('services', {
@@ -32,12 +31,6 @@ export const serviceCapabilities = pgTable('service_capabilities', {
 export const servicePersonas = pgTable('service_personas', {
   serviceId: uuid('service_id').notNull().references(() => services.id, { onDelete: 'cascade' }),
   personaId: uuid('persona_id').notNull().references(() => personas.id, { onDelete: 'cascade' }),
-})
-
-// Junction table: services ↔ applications (many-to-many)
-export const serviceApplications = pgTable('service_applications', {
-  serviceId: uuid('service_id').notNull().references(() => services.id, { onDelete: 'cascade' }),
-  applicationId: uuid('application_id').notNull().references(() => applications.id, { onDelete: 'cascade' }),
 })
 
 // Junction table: services ↔ value streams (many-to-many)

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -326,7 +326,6 @@ export const DEV_OBJECTIVES = [
     status: 'published' as const,
     visibility: 'org' as const,
     capabilities: ['Online Permitting', 'Service Request Management', 'Digital Identity & Authentication'],
-    applications: ['Accela', 'Microsoft Entra ID'],
     valueStreams: ['Permit to Certificate', 'Service Request to Resolution'],
   },
   {
@@ -337,7 +336,6 @@ export const DEV_OBJECTIVES = [
     status: 'published' as const,
     visibility: 'org' as const,
     capabilities: ['GIS Mapping', 'Service Request Management'],
-    applications: ['CityWorks', 'Legacy Permitting System'],
     valueStreams: ['Permit to Certificate'],
   },
   {
@@ -348,7 +346,6 @@ export const DEV_OBJECTIVES = [
     status: 'draft' as const,
     visibility: 'connections' as const,
     capabilities: ['Cross-Agency Data Sharing', 'Digital Identity & Authentication'],
-    applications: [] as string[],
     valueStreams: [] as string[],
   },
   // archived + instance — exercises both missing enum values
@@ -360,7 +357,6 @@ export const DEV_OBJECTIVES = [
     status: 'archived' as const,
     visibility: 'instance' as const,
     capabilities: ['Digital Identity & Authentication'],
-    applications: [] as string[],
     valueStreams: [] as string[],
   },
 ]
@@ -1296,7 +1292,6 @@ export const DEV_SERVICES = [
     visibility: 'org' as const,
     capabilities: ['Online Permitting'],
     personas: ['Resident', 'Small Business Owner', 'Field Inspector'],
-    applications: ['Accela', 'Microsoft Entra ID'],
     valueStreams: ['Permit to Certificate'],
   },
   {
@@ -1308,7 +1303,6 @@ export const DEV_SERVICES = [
     visibility: 'org' as const,
     capabilities: ['Business License Management', 'Online Permitting'],
     personas: ['Small Business Owner', 'Department Director'],
-    applications: ['Accela'],
     valueStreams: ['Business Registration'],
   },
   {
@@ -1320,7 +1314,6 @@ export const DEV_SERVICES = [
     visibility: 'org' as const,
     capabilities: ['Service Request Management'],
     personas: ['Resident'],
-    applications: ['CityWorks'],
     valueStreams: ['Service Request to Resolution'],
   },
   {
@@ -1332,7 +1325,6 @@ export const DEV_SERVICES = [
     visibility: 'instance' as const,
     capabilities: ['GIS Mapping'],
     personas: ['Resident', 'Small Business Owner', 'Field Inspector'],
-    applications: ['ArcGIS Online'],
     valueStreams: [],
   },
   {
@@ -1344,7 +1336,6 @@ export const DEV_SERVICES = [
     visibility: 'org' as const,
     capabilities: ['HR Self-Service'],
     personas: ['IT Staff', 'Department Director'],
-    applications: ['Workday', 'Microsoft Entra ID'],
     valueStreams: [],
   },
   {
@@ -1356,7 +1347,6 @@ export const DEV_SERVICES = [
     visibility: 'org' as const,
     capabilities: ['Budget Reporting'],
     personas: ['Department Director', 'City Council Member'],
-    applications: ['OpenGov'],
     valueStreams: [],
   },
   {
@@ -1368,7 +1358,6 @@ export const DEV_SERVICES = [
     visibility: 'connections' as const,
     capabilities: ['Digital Identity & Authentication'],
     personas: ['Resident', 'Small Business Owner'],
-    applications: ['Microsoft Entra ID'],
     valueStreams: [],
   },
 ]

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -16,14 +16,14 @@ import {
   users, organizations,
   personas, personaTags, capabilities, applications,
   capabilityPersonas, applicationCapabilities,
-  strategicObjectives, objectiveCapabilities, objectiveApplications, objectiveValueStreams,
+  strategicObjectives, objectiveCapabilities, objectiveValueStreams,
   valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
   initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
   principles, principleAdrs, principleCapabilities,
   glossaryTerms, glossaryTermSources,
   taxonomyTerms,
-  services, serviceCapabilities, servicePersonas, serviceApplications, serviceValueStreams,
+  services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
 } from '../schema'
 import bcrypt from 'bcryptjs'
@@ -360,16 +360,6 @@ async function seed() {
       if (!exists) await db.insert(objectiveCapabilities).values({ objectiveId: objId, capabilityId: capId })
     }
 
-    // objectiveApplications
-    for (const appName of o.applications) {
-      const appId = devApplicationIds[appName]
-      if (!appId) continue
-      const exists = await db.query.objectiveApplications.findFirst({
-        where: (t, { eq: e, and }) => and(e(t.objectiveId, objId), e(t.applicationId, appId)),
-      })
-      if (!exists) await db.insert(objectiveApplications).values({ objectiveId: objId, applicationId: appId })
-    }
-
     // objectiveValueStreams
     for (const vsName of o.valueStreams) {
       const vsId = devValueStreamIds[vsName]
@@ -607,15 +597,6 @@ async function seed() {
       if (!exists) await db.insert(servicePersonas).values({ serviceId: svcId, personaId })
     }
 
-    for (const appName of svc.applications) {
-      const appId = devApplicationIds[appName]
-      if (!appId) continue
-      const exists = await db.query.serviceApplications.findFirst({
-        where: (t, { eq: e, and }) => and(e(t.serviceId, svcId), e(t.applicationId, appId)),
-      })
-      if (!exists) await db.insert(serviceApplications).values({ serviceId: svcId, applicationId: appId })
-    }
-
     for (const vsName of svc.valueStreams) {
       const vsId = devValueStreamIds[vsName]
       if (!vsId) continue
@@ -625,7 +606,7 @@ async function seed() {
       if (!exists) await db.insert(serviceValueStreams).values({ serviceId: svcId, valueStreamId: vsId })
     }
   }
-  console.log(`  ✓ ${DEV_SERVICES.length} services with capability, persona, application, and value stream links`)
+  console.log(`  ✓ ${DEV_SERVICES.length} services with capability, persona, and value stream links`)
 
   // ── Org 2: Office of Digital Services ────────────────────────────────────
 

--- a/apps/govea/src/middleware.ts
+++ b/apps/govea/src/middleware.ts
@@ -5,7 +5,9 @@ import { NextResponse } from 'next/server'
 // Use the edge-safe config so middleware never touches Node.js built-ins (net, etc.)
 const { auth } = NextAuth(authConfig)
 
-const PUBLIC_PATHS = ['/login', '/setup', '/error', '/api/auth']
+const PUBLIC_PATHS = ['/login', '/setup', '/error', '/api/auth', '/maintenance']
+
+const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === 'true'
 
 export default auth((req) => {
   const { pathname } = req.nextUrl
@@ -17,6 +19,10 @@ export default auth((req) => {
 
   if (!req.auth) {
     return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  if (MAINTENANCE_MODE && req.auth.user?.role !== 'admin') {
+    return NextResponse.redirect(new URL('/maintenance', req.url))
   }
 
   return NextResponse.next()

--- a/docs/ops-downtime.md
+++ b/docs/ops-downtime.md
@@ -1,0 +1,44 @@
+# GovEA — Downtime & Maintenance Posture
+
+## Scenario 1 — Planned maintenance (app still running)
+
+Set `MAINTENANCE_MODE=true` in the Azure Container App environment variables, then restart the revision. The Next.js middleware redirects all non-admin traffic to `/maintenance`. Admins who are already authenticated pass through; others can still reach `/login` to authenticate.
+
+To re-open: unset the variable and restart.
+
+**Azure CLI:**
+```bash
+# Enable
+az containerapp update \
+  --name govea-dev \
+  --resource-group govea \
+  --set-env-vars MAINTENANCE_MODE=true
+
+# Disable
+az containerapp update \
+  --name govea-dev \
+  --resource-group govea \
+  --remove-env-vars MAINTENANCE_MODE
+```
+
+Or set via the Azure Portal → Container App → Settings → Environment variables.
+
+---
+
+## Scenario 2 — True downtime (container unreachable)
+
+**Current posture:** best-effort via rolling deploys.
+
+Azure Container Apps performs a rolling revision replacement — the old revision serves traffic until the new one passes health checks. A normal `./scripts/azure-dev.sh update` run has minimal true downtime. The main risk window is a slow `db:migrate` or `db:seed` that causes the new revision to fail its health probe before becoming healthy.
+
+**There is no static fallback page for true downtime today.** Visitors see Azure's default error response.
+
+### Options (not yet decided)
+
+| Option | Complexity | Notes |
+|---|---|---|
+| Azure Front Door + Static Web Apps failover | High | Full CDN failover; overkill until traffic justifies cost |
+| Azure Static Web Apps custom 404/maintenance page | Medium | Requires Front Door or Traffic Manager in front of Container Apps |
+| Accept rolling-deploy gap as-is | None | Current posture; acceptable for pre-production and low-traffic deploys |
+
+**Decision pending:** whether to put anything in front of the Container Apps URL. Until then, keep `db:migrate` fast and lean on rolling deploys to minimise the gap.


### PR DESCRIPTION
Closes #232

## What changed

Direct `objective_applications` and `service_applications` join tables are gone. Applications now surface on Objective, Service, and Application detail pages **only through the capability bridge** — editors get an amber nudge card pointing them to link capabilities first.

## Why

The EasyEA model already treats Capability as the bridge between mission (objectives) and technology (applications). Maintaining two parallel paths — direct and mediated — created inconsistent completeness signals and undermined the core methodology. Since we're pre-prod with no real tenant data, this is the right moment to cut the shortcut cleanly.

## Changes

**Schema** — removed `objectiveApplications` and `serviceApplications` tables and all FK/relation definitions

**Actions**
- `links.ts` — removed 6 direct-link server actions (`linkObjectiveApplication`, `unlinkObjectiveApplication`, `linkApplicationObjective`, `unlinkApplicationObjective`, `linkServiceApplication`, `unlinkServiceApplication`)
- `objectives.ts`, `services.ts`, `applications.ts` — deepened Drizzle `with:` queries to traverse `capability → applicationCapabilities` and `capability → objectiveCapabilities`
- `traceability.ts` — removed `directApplications` field from `ObjectiveTrace` / `ServiceTrace`; merge path simplified to `capabilities.flatMap(c => c.applications)`

**UI** — Objectives `[id]`, Services `[id]`, Applications `[id]` pages: replaced editable Applications/Objectives panels with read-only `canEdit={false}` + `gapMessage` nudge

**Seeds** — removed `objective_applications` / `service_applications` seeding blocks; stripped `applications:` arrays from DEV_OBJECTIVES and DEV_SERVICES fixtures

## Test plan

- [ ] `/objectives/[id]` — Applications panel shows capability-derived apps, amber nudge when no capabilities linked
- [ ] `/services/[id]` — same
- [ ] `/applications/[id]` — Strategic Objectives panel shows capability-derived objectives, amber nudge when no capabilities linked
- [ ] `/traceability?from=objective&id=...` — trace renders correctly, no direct-app merge
- [ ] `/traceability?from=service&id=...` — same
- [ ] `db:push` drops both tables cleanly; `db:seed` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)