### PR TITLE
[codex] docs: clarify capability-mediated application links

### DIFF
--- a/business-architecture/capabilities/cms/content-management/cm-content-relationships.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-relationships.md
@@ -3,30 +3,40 @@
 ## What It Does
 The system must allow content items to be linked to other content items, enforcing the core GovEA constraint that every Application links to a Capability and every Capability links to a Persona.
 
+Capabilities are the canonical bridge from mission and service context to technology. Strategic Objectives and Services do not link directly to Applications; their supporting applications are derived through linked Capabilities.
+
 ## Personas
-- **CMS Administrator** — defines and manages relationships between content items
-- **Content Viewer** — navigates relationships to understand how applications, capabilities, and personas connect
+- **CMS Administrator** - defines and manages relationships between content items
+- **Content Viewer** - navigates relationships to understand how applications, capabilities, and personas connect
 
 ## Behaviors
-- Link a content item to one or more items of another content type (e.g. Application → Capability)
+- Link a content item to one or more items of another content type (e.g. Application -> Capability)
 - Display related content items on the detail view of a content item
 - Enforce required relationship rules at publish time
 - Navigate from any content item to its related items
 - Display reverse relationships (e.g. view all Applications linked to a Capability)
+- Derive Objective -> Application and Service -> Application context through the Capability bridge
 
 ## Core Relationship Rules (GovEA)
 
 | From | To | Rule |
 |---|---|---|
-| Application | Capability | Required — at least one |
-| Capability | Persona | Required — at least one |
+| Application | Capability | Required - at least one |
+| Capability | Persona | Required - at least one |
+| Strategic Objective | Capability | Optional, but required to show supporting applications |
+| Service | Capability | Optional, but required to show supporting applications |
+| Service | Persona | Optional |
+| Service | Value Stream | Optional |
+| Initiative | Capability | Optional |
+| Initiative | Application | Optional |
 | ADR | Capability | Optional |
 | ADR | Application | Optional |
 
 ## Rules
 - Required relationships must be satisfied before a content item can be published
 - Deleting a content item that is referenced by another item must warn the user and list the dependent items
-- Relationships are bidirectional — both sides are visible in the UI
+- Relationships are bidirectional - both sides are visible in the UI
+- Objective and Service application panels are read-only derived views; editors should link Capabilities first when the supporting technology is unknown
 
 ## Links
 - Depends on: Content Types, Content Authoring

--- a/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
@@ -3,13 +3,15 @@
 ## What It Does
 The system must provide stakeholder-friendly visual views that trace a mission or strategic objective down through capabilities, services, and applications so non-architect users can understand why a system exists and what outcome it supports.
 
+Capabilities are the required bridge from mission/service context to applications. Strategic Objective and Service traces surface supporting applications through linked Capabilities rather than through direct Objective -> Application or Service -> Application links.
+
 ## Personas
-- **Department Director** — needs to understand how department goals connect to systems and service delivery
-- **Budget & Performance Analyst** — needs to connect investment decisions to mission outcomes and business capability coverage
-- **Elected Official** — needs a concise visual explanation of what technology supports a public service or strategic goal
+- **Department Director** - needs to understand how department goals connect to systems and service delivery
+- **Budget & Performance Analyst** - needs to connect investment decisions to mission outcomes and business capability coverage
+- **Elected Official** - needs a concise visual explanation of what technology supports a public service or strategic goal
 
 ## Behaviors
-- From a strategic objective, display linked initiatives, capabilities, services, and applications in a readable visual chain
+- From a strategic objective, display linked initiatives, capabilities, and capability-derived applications in a readable visual chain
 - From a capability or service, display upstream objectives and downstream applications without requiring the user to open multiple detail pages
 - Show relationship labels in plain language such as `supports`, `enables`, and `changes`
 - Allow the user to switch between a compact summary view and a deeper drill-down view
@@ -19,8 +21,8 @@ The system must provide stakeholder-friendly visual views that trace a mission o
 - The default visual must optimize for readability over relationship density; it is not a general-purpose graph explorer
 - Viewer-visible results must respect publication and visibility rules at every step of the chain
 - The visual must avoid EA jargon in headings, legends, and labels
-- Missing links should surface as plain-language gaps such as `No supporting applications recorded yet`
+- Missing capability links should surface as plain-language gaps because those links are now the path to supporting applications
 
 ## Links
-- Depends on: Front-end Display — Content Display, Front-end Display — Relationship Navigation, Repository & Modelling — End-to-End Traceability
-- Related: Planning — Strategic Objectives, Planning — Initiatives, Front-end Display — Portfolio Views
+- Depends on: Front-end Display - Content Display, Front-end Display - Relationship Navigation, Repository & Modelling - End-to-End Traceability
+- Related: Planning - Strategic Objectives, Planning - Initiatives, Front-end Display - Portfolio Views


### PR DESCRIPTION
## Summary

Clarifies the documentation after PR #244 removed direct Objective -> Application and Service -> Application links.

## What changed

- Updates `cm-content-relationships.md` to state that Capabilities are the canonical bridge from mission/service context to Applications
- Documents that Strategic Objectives and Services surface supporting Applications through linked Capabilities, not direct application joins
- Updates `fd-traceability-views.md` so stakeholder traceability behavior matches the current implementation
- Reframes missing capability links as the actionable gap when supporting applications are unknown

## Why

The merged implementation now intentionally preserves the EasyEA model by making Capability the only bridge from mission/service records to technology. These docs now match that product decision and reduce the chance that future work reintroduces parallel direct-link paths.

## Validation

- Reviewed merged PR #244 and current schema files on `main`
- Compared docs against current `services.ts`, `objectives.ts`, and `relations.ts`
- Documentation-only change; no test suite run

Capability: cm-content-relationships
Capability: fd-traceability-views
Related: #232
