### PR TITLE
fix: enforce viewer status filter on standard entity list and detail actions (#238)

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -41,25 +41,24 @@ export async function getApplication(id: string) {
 
   if (!application) return null
   const visible = await canReadFederatedEntity(application.organizationId, application.visibility, session.user.organizationId!)
-  return visible ? application : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && application.status !== 'published') return null
+  return application
 }
 
-export async function getApplications(organizationId: string) {
+export async function getApplications(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.applications.findMany({
     where: (a, { eq, or, and, inArray }) => {
       const base = eq(a.organizationId, organizationId)
       const instanceWide = eq(a.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(a.organizationId, connectedOrgIds),
-          inArray(a.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(a.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(a.organizationId, connectedOrgIds), inArray(a.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -43,25 +43,24 @@ export async function getCapability(id: string) {
 
   if (!capability) return null
   const visible = await canReadFederatedEntity(capability.organizationId, capability.visibility, session.user.organizationId!)
-  return visible ? capability : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && capability.status !== 'published') return null
+  return capability
 }
 
-export async function getCapabilities(organizationId: string) {
+export async function getCapabilities(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.capabilities.findMany({
     where: (c, { eq, or, and, inArray }) => {
       const base = eq(c.organizationId, organizationId)
       const instanceWide = eq(c.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(c.organizationId, connectedOrgIds),
-          inArray(c.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(c.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(c.organizationId, connectedOrgIds), inArray(c.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -23,22 +23,19 @@ async function requireAdmin() {
   return session
 }
 
-export async function getObjectives(organizationId: string) {
+export async function getObjectives(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.strategicObjectives.findMany({
     where: (o, { eq, or, and, inArray }) => {
       const base = eq(o.organizationId, organizationId)
       const instanceWide = eq(o.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(o.organizationId, connectedOrgIds),
-          inArray(o.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(o.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(o.organizationId, connectedOrgIds), inArray(o.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     orderBy: (o, { asc }) => [asc(o.name)],
     with: {
@@ -65,7 +62,9 @@ export async function getObjective(id: string) {
 
   if (!objective) return null
   const visible = await canReadFederatedEntity(objective.organizationId, objective.visibility, session.user.organizationId!)
-  return visible ? objective : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && objective.status !== 'published') return null
+  return objective
 }
 
 export async function createObjective(formData: FormData) {

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -42,25 +42,24 @@ export async function getPersona(id: string) {
 
   if (!persona) return null
   const visible = await canReadFederatedEntity(persona.organizationId, persona.visibility, session.user.organizationId!)
-  return visible ? persona : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && persona.status !== 'published') return null
+  return persona
 }
 
-export async function getPersonas(organizationId: string) {
+export async function getPersonas(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.personas.findMany({
     where: (p, { eq, or, and, inArray }) => {
       const base = eq(p.organizationId, organizationId)
       const instanceWide = eq(p.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(p.organizationId, connectedOrgIds),
-          inArray(p.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(p.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(p.organizationId, connectedOrgIds), inArray(p.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     orderBy: (p, { asc }) => [asc(p.name)],
     with: {

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -30,22 +30,19 @@ async function insertJunctions(principleId: string, adrIds: string[], capability
     await db.insert(principleCapabilities).values(capabilityIds.map(capabilityId => ({ principleId, capabilityId }))).onConflictDoNothing()
 }
 
-export async function getPrinciples(orgId: string) {
+export async function getPrinciples(orgId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(orgId)
+  const isViewer = role === 'viewer'
 
   return db.query.principles.findMany({
     where: (p, { eq, or, and, inArray }) => {
       const base = eq(p.organizationId, orgId)
       const instanceWide = eq(p.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(p.organizationId, connectedOrgIds),
-          inArray(p.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(p.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(p.organizationId, connectedOrgIds), inArray(p.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,
@@ -71,7 +68,9 @@ export async function getPrinciple(id: string) {
 
   if (!principle) return null
   const visible = await canReadFederatedEntity(principle.organizationId, principle.visibility, session.user.organizationId!)
-  return visible ? principle : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && principle.status !== 'published') return null
+  return principle
 }
 
 export async function createPrinciple(formData: FormData) {

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -43,25 +43,24 @@ export async function getService(id: string) {
 
   if (!service) return null
   const visible = await canReadFederatedEntity(service.organizationId, service.visibility, session.user.organizationId!)
-  return visible ? service : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && service.status !== 'published') return null
+  return service
 }
 
-export async function getServices(organizationId: string) {
+export async function getServices(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.services.findMany({
     where: (s, { eq, or, and, inArray }) => {
       const base = eq(s.organizationId, organizationId)
       const instanceWide = eq(s.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(s.organizationId, connectedOrgIds),
-          inArray(s.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(s.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(s.organizationId, connectedOrgIds), inArray(s.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     with: {
       organization: true,

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -25,22 +25,19 @@ async function requireAdmin() {
 
 // ── Value Streams ─────────────────────────────────────────────────────────────
 
-export async function getValueStreams(organizationId: string) {
+export async function getValueStreams(organizationId: string, role?: string) {
   const connectedOrgIds = await getConnectedOrgIds(organizationId)
+  const isViewer = role === 'viewer'
 
   return db.query.valueStreams.findMany({
     where: (vs, { eq, or, and, inArray }) => {
       const base = eq(vs.organizationId, organizationId)
       const instanceWide = eq(vs.visibility, 'instance')
-      if (connectedOrgIds.length === 0) return or(base, instanceWide)
-      return or(
-        base,
-        instanceWide,
-        and(
-          inArray(vs.organizationId, connectedOrgIds),
-          inArray(vs.visibility, ['connections', 'instance'])
-        )
-      )
+      const statusFilter = isViewer ? eq(vs.status, 'published') : undefined
+      const orgFilter = connectedOrgIds.length === 0
+        ? or(base, instanceWide)
+        : or(base, instanceWide, and(inArray(vs.organizationId, connectedOrgIds), inArray(vs.visibility, ['connections', 'instance'])))
+      return statusFilter ? and(orgFilter, statusFilter) : orgFilter
     },
     orderBy: (vs, { asc }) => [asc(vs.name)],
     with: {
@@ -79,7 +76,9 @@ export async function getValueStream(id: string) {
 
   if (!valueStream) return null
   const visible = await canReadFederatedEntity(valueStream.organizationId, valueStream.visibility, session.user.organizationId!)
-  return visible ? valueStream : null
+  if (!visible) return null
+  if (session.user.role === 'viewer' && valueStream.status !== 'published') return null
+  return valueStream
 }
 
 export async function createValueStream(formData: FormData) {

--- a/apps/govea/src/app/(admin)/applications/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/page.tsx
@@ -11,8 +11,8 @@ export default async function ApplicationsPage() {
   const role = session.user.role
 
   const [applicationList, capabilityList] = await Promise.all([
-    getApplications(orgId),
-    getCapabilities(orgId),
+    getApplications(orgId, role),
+    getCapabilities(orgId, role),
   ])
 
   return (

--- a/apps/govea/src/app/(admin)/capabilities/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/page.tsx
@@ -12,8 +12,8 @@ export default async function CapabilitiesPage() {
   const role = session.user.role
 
   const [capabilityList, personaList, domainTerms] = await Promise.all([
-    getCapabilities(orgId),
-    getPersonas(orgId),
+    getCapabilities(orgId, role),
+    getPersonas(orgId, role),
     getTaxonomyDomains(orgId),
   ])
 

--- a/apps/govea/src/app/(admin)/objectives/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/page.tsx
@@ -12,9 +12,9 @@ export default async function ObjectivesPage() {
   const role = session.user.role
 
   const [objectiveList, capabilityList, valueStreamList] = await Promise.all([
-    getObjectives(orgId),
-    getCapabilities(orgId),
-    getValueStreams(orgId),
+    getObjectives(orgId, role),
+    getCapabilities(orgId, role),
+    getValueStreams(orgId, role),
   ])
 
   return (

--- a/apps/govea/src/app/(admin)/personas/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/page.tsx
@@ -11,7 +11,7 @@ export default async function PersonasPage() {
   const role = session.user.role
 
   const [personaList, typeList, tagList] = await Promise.all([
-    getPersonas(orgId),
+    getPersonas(orgId, role),
     getPersonaTypesFromTaxonomy(orgId),
     getPersonaTagsFromTaxonomy(orgId),
   ])

--- a/apps/govea/src/app/(admin)/principles/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/page.tsx
@@ -13,9 +13,9 @@ export default async function PrinciplesPage() {
   const role = session.user.role
 
   const [principleList, adrList, capabilityList] = await Promise.all([
-    getPrinciples(orgId),
-    getADRs(orgId),
-    getCapabilities(orgId),
+    getPrinciples(orgId, role),
+    getADRs(orgId, role),
+    getCapabilities(orgId, role),
   ])
 
   return (

--- a/apps/govea/src/app/(admin)/services/page.tsx
+++ b/apps/govea/src/app/(admin)/services/page.tsx
@@ -12,8 +12,8 @@ export default async function ServicesPage() {
   const role = session.user.role
 
   const [services, personas] = await Promise.all([
-    getServices(orgId),
-    getPersonas(orgId),
+    getServices(orgId, role),
+    getPersonas(orgId, role),
   ])
 
   return (

--- a/apps/govea/src/app/(admin)/value-streams/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/page.tsx
@@ -9,7 +9,7 @@ export default async function ValueStreamsPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const valueStreamList = await getValueStreams(orgId)
+  const valueStreamList = await getValueStreams(orgId, role)
 
   return (
     <div className="space-y-6">

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -9,7 +9,10 @@
  * Isolation is by organizationId; tests never touch the dev seed orgs.
  */
 import { db } from '@/db/client'
-import { organizations, users, capabilities, initiatives, adrs, auditLog } from '@/db/schema'
+import {
+  organizations, users, capabilities, initiatives, adrs, auditLog,
+  personas, applications, strategicObjectives, principles, valueStreams, services,
+} from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import bcrypt from 'bcryptjs'
@@ -133,10 +136,21 @@ export async function getInitiativesForOrg(orgId: string) {
 }
 
 /** Convenience: insert a capability row directly for cross-org / setup scenarios. */
-export async function insertCapability(orgId: string, name = 'Test Capability') {
+export async function insertCapability(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } | string = {},
+) {
+  // Accept legacy string signature for backward compat
+  const opts = typeof overrides === 'string' ? { name: overrides } : overrides
+  const suffix = randomUUID().slice(0, 8)
   const [cap] = await db
     .insert(capabilities)
-    .values({ name, organizationId: orgId, status: 'draft', visibility: 'org' })
+    .values({
+      name: opts.name ?? `Test Capability ${suffix}`,
+      organizationId: orgId,
+      status: opts.status ?? 'draft',
+      visibility: opts.visibility ?? 'org',
+    })
     .returning()
   return cap
 }
@@ -159,6 +173,117 @@ export async function insertAdr(
       number: overrides.number ?? `ADR-T-${suffix}`,
       title: overrides.title ?? `Test ADR ${suffix}`,
       status: overrides.status ?? 'proposed',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert a persona row directly — used by viewer-visibility tests. */
+export async function insertPersona(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(personas)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Persona ${suffix}`,
+      status: overrides.status ?? 'draft',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert an application row directly — used by viewer-visibility tests. */
+export async function insertApplication(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(applications)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Application ${suffix}`,
+      status: overrides.status ?? 'draft',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert a strategic objective row directly — used by viewer-visibility tests. */
+export async function insertObjective(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(strategicObjectives)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Objective ${suffix}`,
+      status: overrides.status ?? 'draft',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert a principle row directly — used by viewer-visibility tests. */
+export async function insertPrinciple(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(principles)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Principle ${suffix}`,
+      rationale: '',
+      implications: '',
+      status: overrides.status ?? 'draft',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert a value stream row directly — used by viewer-visibility tests. */
+export async function insertValueStream(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(valueStreams)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Value Stream ${suffix}`,
+      status: overrides.status ?? 'draft',
+      visibility: overrides.visibility ?? 'org',
+    })
+    .returning()
+  return row
+}
+
+/** Insert a service row directly — used by viewer-visibility tests. */
+export async function insertService(
+  orgId: string,
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived'; visibility?: 'org' | 'connections' | 'instance' } = {},
+) {
+  const suffix = randomUUID().slice(0, 8)
+  const [row] = await db
+    .insert(services)
+    .values({
+      organizationId: orgId,
+      name: overrides.name ?? `Test Service ${suffix}`,
+      channels: [],
+      status: overrides.status ?? 'draft',
       visibility: overrides.visibility ?? 'org',
     })
     .returning()

--- a/apps/govea/tests/integration/viewer-visibility.test.ts
+++ b/apps/govea/tests/integration/viewer-visibility.test.ts
@@ -18,9 +18,11 @@
 import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { getADRs, getADR } from '@/actions/adrs'
 import { getInitiatives, getInitiative } from '@/actions/initiatives'
+import { getCapabilities, getCapability } from '@/actions/capabilities'
+import { getPersonas, getPersona } from '@/actions/personas'
 import {
   createTestOrg, createTestUser, cleanupOrg,
-  makeSession, insertAdr, insertInitiative,
+  makeSession, insertAdr, insertInitiative, insertCapability, insertPersona,
   type TestUser,
 } from './helpers/db'
 
@@ -249,6 +251,190 @@ describe('viewer visibility — Initiatives', () => {
     it('admin can access any initiative status by ID', async () => {
       mockAuth.mockResolvedValue(makeSession(admin))
       expect(await getInitiative(proposedId)).not.toBeNull()
+    })
+  })
+})
+
+// ── Capability visibility ──────────────────────────────────────────────────────
+
+describe('viewer visibility — Capabilities', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  let publishedId: string
+  let draftId: string
+  let archivedId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+    ;[publishedId, draftId, archivedId] = await Promise.all([
+      insertCapability(orgId, { status: 'published' }).then(c => c.id),
+      insertCapability(orgId, { status: 'draft'     }).then(c => c.id),
+      insertCapability(orgId, { status: 'archived'  }).then(c => c.id),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  describe('getCapabilities — list', () => {
+    it('viewer sees only published capabilities', async () => {
+      const result = await getCapabilities(orgId, 'viewer')
+      const ids = result.map(c => c.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).not.toContain(draftId)
+      expect(ids).not.toContain(archivedId)
+    })
+
+    it('contributor sees all statuses', async () => {
+      const result = await getCapabilities(orgId, 'contributor')
+      const ids = result.map(c => c.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).toContain(draftId)
+      expect(ids).toContain(archivedId)
+    })
+
+    it('admin sees all statuses', async () => {
+      const result = await getCapabilities(orgId, 'admin')
+      const ids = result.map(c => c.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).toContain(draftId)
+      expect(ids).toContain(archivedId)
+    })
+  })
+
+  describe('getCapability — detail', () => {
+    it('viewer can access a published capability by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      const result = await getCapability(publishedId)
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe(publishedId)
+    })
+
+    it('viewer gets null for a draft capability', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getCapability(draftId)).toBeNull()
+    })
+
+    it('viewer gets null for an archived capability', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getCapability(archivedId)).toBeNull()
+    })
+
+    it('contributor can access any status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      const [a, b, c] = await Promise.all([
+        getCapability(publishedId),
+        getCapability(draftId),
+        getCapability(archivedId),
+      ])
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(c).not.toBeNull()
+    })
+
+    it('admin can access any status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      expect(await getCapability(draftId)).not.toBeNull()
+    })
+  })
+})
+
+// ── Persona visibility ─────────────────────────────────────────────────────────
+
+describe('viewer visibility — Personas', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  let publishedId: string
+  let draftId: string
+  let archivedId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+    ;[publishedId, draftId, archivedId] = await Promise.all([
+      insertPersona(orgId, { status: 'published' }).then(p => p.id),
+      insertPersona(orgId, { status: 'draft'     }).then(p => p.id),
+      insertPersona(orgId, { status: 'archived'  }).then(p => p.id),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  describe('getPersonas — list', () => {
+    it('viewer sees only published personas', async () => {
+      const result = await getPersonas(orgId, 'viewer')
+      const ids = result.map(p => p.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).not.toContain(draftId)
+      expect(ids).not.toContain(archivedId)
+    })
+
+    it('contributor sees all statuses', async () => {
+      const result = await getPersonas(orgId, 'contributor')
+      const ids = result.map(p => p.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).toContain(draftId)
+      expect(ids).toContain(archivedId)
+    })
+
+    it('admin sees all statuses', async () => {
+      const result = await getPersonas(orgId, 'admin')
+      const ids = result.map(p => p.id)
+      expect(ids).toContain(publishedId)
+      expect(ids).toContain(draftId)
+      expect(ids).toContain(archivedId)
+    })
+  })
+
+  describe('getPersona — detail', () => {
+    it('viewer can access a published persona by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      const result = await getPersona(publishedId)
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe(publishedId)
+    })
+
+    it('viewer gets null for a draft persona', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getPersona(draftId)).toBeNull()
+    })
+
+    it('viewer gets null for an archived persona', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      expect(await getPersona(archivedId)).toBeNull()
+    })
+
+    it('contributor can access any status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      const [a, b, c] = await Promise.all([
+        getPersona(publishedId),
+        getPersona(draftId),
+        getPersona(archivedId),
+      ])
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(c).not.toBeNull()
+    })
+
+    it('admin can access any status by ID', async () => {
+      mockAuth.mockResolvedValue(makeSession(admin))
+      expect(await getPersona(draftId)).not.toBeNull()
     })
   })
 })


### PR DESCRIPTION
Closes #238

## What changed

Extends the viewer status gate (established for ADRs and initiatives in #237) to all remaining standard entity types.

**Actions** — 14 functions across 7 files updated:
- List actions (`getCapabilities`, `getPersonas`, `getApplications`, `getObjectives`, `getPrinciples`, `getValueStreams`, `getServices`): add `role?: string` param; apply `status = 'published'` WHERE clause when `role === 'viewer'`
- Detail actions: add viewer gate after the federation visibility check — return `null` for non-published records when the caller is a viewer

**Pages** — 7 list pages updated to thread `session.user.role` into every list action call (all pages already extracted `role`, just needed to pass it through)

**Tests** — `viewer-visibility.test.ts` extended with capabilities and personas describe blocks covering list × detail × viewer/contributor/admin. Six new DB insert helpers added.

## Pattern

Identical to `getADRs`/`getInitiatives` from #237. For standard entities the viewer-visible status is `'published'` (no constant needed).

## Test plan

- [ ] Integration tests pass: `pnpm --filter govea test:integration`
- [ ] Viewer session: `/capabilities`, `/personas`, `/applications`, `/objectives`, `/principles`, `/value-streams`, `/services` — only published records visible
- [ ] Contributor/admin session: all statuses visible on same pages
- [ ] Viewer direct URL to draft entity (e.g. `/capabilities/[draft-id]`) → 404
- [ ] Contributor direct URL to draft entity → detail page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)