### PR TITLE
feat: add product tour with Driver.js coach marks

### DIFF
--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -28,6 +28,7 @@
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "driver.js": "^1.4.0",
     "drizzle-orm": "^0.36.0",
     "lucide-react": "^0.462.0",
     "next": "^15.0.0",

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { DevToolbar } from '@/components/dev-toolbar'
 import { DarkModeToggle } from '@/components/dark-mode-toggle'
+import { TourButton } from '@/components/product-tour'
 import { isModuleEnabled, moduleForPath } from '@/lib/modules'
 
 // ── Nav structure ─────────────────────────────────────────────────────────────
@@ -75,6 +76,7 @@ function SidebarContent({
       <Link
         href="/dashboard"
         onClick={onClose}
+        data-tour="dashboard"
         className={cn(
           'rounded-md px-3 py-2 text-sm font-medium transition-colors',
           pathname === '/dashboard' || pathname.startsWith('/dashboard/')
@@ -93,7 +95,10 @@ function SidebarContent({
           if (visibleItems.length === 0) return null
           return (
             <div key={group.label}>
-              <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-white/40 select-none">
+              <p
+                data-tour={group.label === 'Business Architecture' ? 'nav-business-arch' : group.label === 'Strategy' ? 'nav-strategy' : undefined}
+                className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-white/40 select-none"
+              >
                 {group.label}
               </p>
               <div className="mt-0.5 space-y-0.5">
@@ -104,6 +109,16 @@ function SidebarContent({
                       key={item.href}
                       href={item.href}
                       onClick={onClose}
+                      data-tour={
+                        item.href === '/personas'      ? 'nav-personas'      :
+                        item.href === '/value-streams' ? 'nav-value-streams' :
+                        item.href === '/capabilities'  ? 'nav-capabilities'  :
+                        item.href === '/services'      ? 'nav-services'      :
+                        item.href === '/applications'  ? 'nav-applications'  :
+                        item.href === '/adrs'          ? 'nav-adrs'          :
+                        item.href === '/roadmap'       ? 'nav-roadmap'       :
+                        undefined
+                      }
                       className={cn(
                         'block rounded-md px-3 py-2 text-sm transition-colors',
                         active
@@ -280,6 +295,7 @@ export function AppShell({
                 name="q"
                 type="search"
                 placeholder="Search…"
+                data-tour="search"
                 className="w-full rounded-md border border-white/20 bg-white/10 px-3 py-1.5 text-sm text-white placeholder:text-white/50 focus:outline-none focus:ring-1 focus:ring-white/40"
               />
             </form>
@@ -298,12 +314,16 @@ export function AppShell({
           {/* User info */}
           <div className="flex items-center gap-3">
             <span className="hidden sm:block text-sm text-white/70">{email}</span>
-            <span className={cn(
-              'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
-              roleBadgeClass
-            )}>
+            <span
+              data-tour="role-badge"
+              className={cn(
+                'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
+                roleBadgeClass
+              )}
+            >
               {role}
             </span>
+            <TourButton role={role} />
             <DarkModeToggle />
             {signOutSlot}
           </div>

--- a/apps/govea/src/components/product-tour.tsx
+++ b/apps/govea/src/components/product-tour.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useEffect } from 'react'
+import { driver } from 'driver.js'
+import 'driver.js/dist/driver.css'
+import type { Role } from '@/lib/rbac'
+
+const ROLE_COPY: Record<Role, string> = {
+  admin:       'As an Admin, you can create and edit all EA content and manage users, connections, and org settings.',
+  contributor: 'As a Contributor, you can create and edit all EA content. Set items to Published to make them visible to read-only colleagues.',
+  viewer:      'As a Viewer, you have read-only access to published content across the catalog.',
+}
+
+function buildTour(role: Role) {
+  return driver({
+    showProgress: true,
+    progressText: '{{current}} of {{total}}',
+    nextBtnText: 'Next →',
+    prevBtnText: '← Back',
+    doneBtnText: 'Done',
+    popoverClass: 'govea-tour-popover',
+    steps: [
+      {
+        popover: {
+          title: 'Welcome to GovEA',
+          description: 'Your organization\'s enterprise architecture workspace — built for state and local government teams using the EasyEA methodology. This tour walks you through the key sections and what makes GovEA different.',
+          side: 'over' as const,
+          align: 'center',
+        },
+      },
+      {
+        element: '[data-tour="dashboard"]',
+        popover: {
+          title: 'Dashboard — Your EA Health Check',
+          description: 'See catalog coverage at a glance: how many items are published vs. draft, review health scores, and recent activity. Before any ARB meeting, this is the first place to check — it shows you exactly where your gaps are.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-business-arch"]',
+        popover: {
+          title: 'Business Architecture — Start Here',
+          description: 'The foundation of EasyEA. Document who you serve, what you deliver, what your organization does, and how value flows. Everything in your portfolio — every application, every decision — connects back to this layer.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-personas"]',
+        popover: {
+          title: 'Personas — People Before Systems',
+          description: 'Personas represent everyone who interacts with government: residents, businesses, internal staff, and partner agencies. In EasyEA, you start here — not with technology. Every service, capability, and application you catalog should ultimately trace to a person it serves.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-value-streams"]',
+        popover: {
+          title: 'Value Streams — How Work Flows',
+          description: 'Model the end-to-end flow of value from a triggering event to an outcome. Each stage maps to the capabilities that enable it. This is how you find redundancies, handoff gaps, and the real cost of legacy systems — before you try to replace them.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-capabilities"]',
+        popover: {
+          title: 'Capabilities — What Your Organization Does',
+          description: 'Capabilities are technology-agnostic. "Process Permit Applications" is a capability — the system that does it today is just an implementation detail. This separation lets you plan replacements, measure coverage, and survive application turnover without losing institutional knowledge.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-services"]',
+        popover: {
+          title: 'Services — What You Deliver to the Public',
+          description: 'Services are the tangible things residents and businesses interact with — permitting, licensing, benefits enrollment. Link them to the personas who use them and the capabilities that power them to build a complete picture of government service delivery.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-applications"]',
+        popover: {
+          title: 'Applications — Your Technology Portfolio',
+          description: 'Track every application with its lifecycle status (active, sunset, or decommissioned), the capabilities it supports, and the decisions made about it. When leadership asks "why are we still running this?" — the answer is here.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-adrs"]',
+        popover: {
+          title: 'Decisions — Institutional Memory',
+          description: 'Architecture Decision Records (ADRs) capture the "why" behind every major technical choice — not just what was decided, but the context, constraints, and alternatives considered. Future teams won\'t repeat past mistakes if the reasoning is documented here.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-strategy"]',
+        popover: {
+          title: 'Strategy — Mission to Technology',
+          description: 'Connect your architecture to mission. Link capabilities to strategic objectives and running initiatives. This is how you justify every system you operate — and surface the ones you can\'t justify. Essential for budget season and IT governance reviews.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="nav-roadmap"]',
+        popover: {
+          title: 'Roadmap — The Executive View',
+          description: 'A visual timeline of active initiatives and planned changes. Built for elected officials and non-technical stakeholders who need to see what\'s changing, when, and why — without reading a 40-page strategy document.',
+          side: 'right' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="search"]',
+        popover: {
+          title: 'Search Everything',
+          description: 'Find any persona, capability, application, decision, or principle across your catalog instantly. Especially useful when linking items — check for duplicates before creating something new, and discover connections you didn\'t know existed.',
+          side: 'bottom' as const,
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="role-badge"]',
+        popover: {
+          title: `Your Role: ${role.charAt(0).toUpperCase() + role.slice(1)}`,
+          description: ROLE_COPY[role],
+          side: 'bottom' as const,
+          align: 'end',
+        },
+      },
+    ],
+  })
+}
+
+export function TourButton({ role }: { role: Role }) {
+  useEffect(() => {
+    // Inject subtle custom styles for the popover without fighting with driver.js defaults
+    const style = document.createElement('style')
+    style.id = 'govea-tour-styles'
+    style.textContent = `
+      .govea-tour-popover .driver-popover-title {
+        font-size: 15px;
+        font-weight: 600;
+      }
+      .govea-tour-popover .driver-popover-description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #555;
+      }
+      .driver-popover-progress-text {
+        font-size: 11px;
+      }
+    `
+    if (!document.getElementById('govea-tour-styles')) {
+      document.head.appendChild(style)
+    }
+    return () => {
+      document.getElementById('govea-tour-styles')?.remove()
+    }
+  }, [])
+
+  const handleClick = () => {
+    const tour = buildTour(role)
+    tour.drive()
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      title="Take the tour"
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/20 bg-white/10 px-2.5 py-1 text-xs font-medium text-white/80 hover:bg-white/20 hover:text-white transition-colors"
+    >
+      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+      </svg>
+      Tour
+    </button>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
@@ -2146,6 +2149,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
   drizzle-kit@0.28.1:
     resolution: {integrity: sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ==}
@@ -5317,6 +5323,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  driver.js@1.4.0: {}
 
   drizzle-kit@0.28.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a 13-step guided product tour using [Driver.js](https://driverjs.com/) triggered by a "Tour" button in the app header
- Tour covers every major section: Dashboard, Business Architecture (Personas, Value Streams, Capabilities, Services), Portfolio (Applications, Decisions), Strategy (Objectives, Initiatives, Roadmap), Search, and role-specific guidance
- Each step highlights what makes that section valuable — e.g. "Capabilities are technology-agnostic" and "ADRs capture the why, not just the what"
- Tour content is role-aware: the final step shows a description tailored to admin, contributor, or viewer
- `data-tour` attributes added to all anchored nav elements in `app-shell.tsx`

## Test plan

- [ ] Click "Tour" button in header — step 1 of 13 should appear
- [ ] Advance through all 13 steps, verify each popover anchors to the correct element
- [ ] Verify final step shows role-appropriate copy for admin, contributor, and viewer logins
- [ ] Dismiss mid-tour with the × button — overlay should clear cleanly
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)