### PR TITLE
[codex] docs: update backlog grooming priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Audit trail: immutable before/after log of all changes
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
-- Instance-admin foundation: schema, session claim, RBAC helper, server guard, `/instance` route gate, system org, and dev seed user
+- Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, and audited break-glass sessions
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
@@ -119,7 +119,6 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - ADRs: basic CRUD, detail pages, and linkage exist, but the authoring experience is still maturing relative to the core portfolio records
 - Planning semantics and timeline presentation: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Admin configuration beyond core settings
-- Instance-admin operations: the foundation exists, but the dedicated console, org inventory, break-glass workflow, and tenant-boundary test expansion are still next
 - Repository completeness, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
@@ -128,9 +127,9 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Instance admin console and audited break-glass operations
 - Second demo city dataset and updated dev/demo login roster
 - Additional stakeholder-facing answer views and leadership-ready visuals
+- Executive roadmap timeline for briefings and demos
 - TOGAF overlay demo dataset and first framework-mapping implementation slice
 - UX consistency cleanup across create/edit dialogs and tooltip labels
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -30,10 +30,10 @@ Controls authentication, authorization, and all identity events.
 |---|---|---|
 | User Management | Implemented | Create, edit, deactivate, and assign org-scoped roles to user accounts |
 | Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions |
-| Instance Admin Foundation | Partially implemented | Instance-scoped admin schema, session claim, RBAC helper, server guard, `/instance` route gate, system org, and dev seed user exist; the operating console and workflows are still future work |
+| Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, and audited break-glass sessions |
 | SSO Authentication | Implemented | Microsoft Entra ID sign-in via OpenID Connect (OIDC) with admin-managed pre-provisioned access |
 | Local Authentication | Implemented | Email and password login; always available as SSO fallback |
-| IAM Audit Trail | Implemented | Immutable log of all identity and access events |
+| IAM Audit Trail | Implemented | Immutable log of all identity and access events, including instance-scoped platform events |
 | First-Run Setup | Implemented | Bootstrap the initial Admin account on first launch |
 | API Auth Decision | Implemented | Auth strategy for API routes (session-based, not token-based in v1) |
 
@@ -126,7 +126,7 @@ How content is presented to authenticated users and, optionally, the public.
 
 | Capability | Status | Description |
 |---|---|---|
-| Navigation | Implemented | App shell with role-aware sidebar navigation |
+| Navigation | Implemented | App shell with role-aware sidebar navigation plus a distinct instance-admin console shell |
 | Portfolio Views | Implemented | List and detail pages for all EA entity types |
 | Mission-to-Technology Traceability Views | Implemented | Read-only layered trace views from strategic objectives, capabilities, and services to supporting applications and related records |
 | Relationship Navigation | Implemented | Navigate between linked entities (capability <-> application <-> persona) |
@@ -224,7 +224,7 @@ GovEA's long-term capability surface spans 9 groups, each defined through the Ea
 
 | Group | Near-term priorities |
 |---|---|
-| Identity & Access Management | Instance admin console, audited break-glass workflows, tenant-boundary tests |
+| Identity & Access Management | Tenant-boundary tests, production hardening for instance-admin operations |
 | Repository & Modelling | End-to-end traceability, architecture debt tracking |
 | Application & IT Portfolio | Technology lifecycle tracking, rationalization views |
 | Business & Capability Architecture | Capability heat maps, operating model views |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -12,7 +12,7 @@ Recent product-shape changes reflected here:
 - `services` is a first-class entity in the portfolio model
 - persona types and persona tags are taxonomy-backed, not separate vocabulary tables
 - applications are surfaced for services and strategic objectives through capabilities, not through direct service/objective application joins
-- instance-admin schema primitives now exist, including `users.instance_role`, `organizations.is_system_org`, and `break_glass_sessions`
+- instance-admin schema and console primitives now exist, including `users.instance_role`, `organizations.is_system_org`, org suspension fields, and `break_glass_sessions`
 
 For product intent, personas, and capability definitions, see `business-architecture/`.
 
@@ -90,6 +90,8 @@ Represents the tenant boundary for almost all business data.
 | `enabled_modules` | JSONB | Yes | Feature/module flags; defaults to `{}` |
 | `is_system_org` | boolean | Yes | Marks the operator/system organization for instance administration; defaults to `false` |
 | `parent_id` | UUID | No | Self-reference for hierarchy; `SET NULL` on delete |
+| `suspended_at` | timestamp | No | Set when an instance admin suspends the organization |
+| `suspended_reason` | text | No | Audit-facing reason for suspension |
 | `created_at` | timestamp | Yes | Defaults to `now()` |
 | `updated_at` | timestamp | Yes | Defaults to `now()` |
 
@@ -195,7 +197,7 @@ Time-bound support sessions that let an instance admin request audited access to
 | `revoked_at` | timestamp | No | Manual revocation timestamp |
 | `revoked_by` | UUID | No | FK to the user who revoked the session |
 
-The schema exists before the full break-glass UI/workflow. Instance-admin access boundaries are enforced in application code, not by this table alone.
+Break-glass sessions are exposed through the instance-admin console and should be treated as audited support access, not normal tenant ownership.
 
 ## Audit Table
 
@@ -206,10 +208,10 @@ Immutable event log for content and security-relevant actions.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `id` | UUID | Yes | Primary key |
-| `organization_id` | UUID | No | Set null if org is deleted |
+| `organization_id` | UUID | No | Set null if org is deleted; instance-level events use `null` |
 | `user_id` | UUID | No | Set null if user is deleted |
-| `action` | text | Yes | Event name like `create`, `update`, `delete`, `login` |
-| `entity_type` | text | Yes | Entity category such as `persona` or `application` |
+| `action` | text | Yes | Event name like `create`, `update`, `delete`, `login`, or `instance.org.suspend` |
+| `entity_type` | text | Yes | Entity category such as `persona`, `application`, `organization`, or `break_glass_session` |
 | `entity_id` | UUID | No | Changed record id |
 | `before` | JSONB | No | Snapshot before change |
 | `after` | JSONB | No | Snapshot after change |

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -6,37 +6,38 @@ This note summarizes the top next product moves from the current capability inve
 
 ## Current Signal
 
-Recent merges strengthened the product in four areas:
+Recent merges strengthened the product in five areas:
 
 - Mission-to-technology traceability, repository-wide search, and viewer visibility rules are now shipped.
 - The product tour improved first-run orientation for admins, contributors, and viewers.
 - Direct Service/Application and Objective/Application shortcuts were removed, making Capability the consistent bridge from mission/service context to technology.
-- Instance-admin phase 1 shipped: schema, auth/session claim, RBAC helper, middleware guard, system org, and dev seed user.
+- Instance administration moved from backend foundation to a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
+- Framework Alignment is now documented as an optional overlay, but implementation has not started.
 
-The next work should convert those foundations into demoable, stakeholder-facing value while closing the most visible operating gaps.
+The next work should convert those foundations into stronger demo data, stakeholder-facing answers, and focused product polish.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Build the instance admin console and audited break-glass workflow | Phase 1 is merged, so the product now has backend primitives without the operator experience needed to manage orgs, users, audit, and support access safely | #240, #235 |
-| 2 | Add the second city demo dataset and updated dev/demo login roster | Multi-org behavior is a core GovEA differentiator, but demos still lean too heavily on one city; this also exercises instance-admin and tenant-boundary assumptions | #252 |
-| 3 | Ship one stakeholder-facing direct-answer view | Search and traceability are shipped, but adoption improves when a Department Director or elected official can ask a plain-language question and get a briefing-ready answer | #221, related #218, #219, #220 |
-| 4 | Define and seed the TOGAF overlay demo path before implementation | Framework Alignment is now documented as an optional capability group; a demo dataset lets the team validate the overlay story without making TOGAF mandatory | #245, #247 |
+| 1 | Add the second city demo dataset and updated dev/demo login roster | Instance admin and federation now need richer multi-org data to demonstrate tenant boundaries, separate municipal admin experiences, and dev-only instance-admin login behavior | #252 |
+| 2 | Ship one stakeholder-facing direct-answer view | Search and traceability are shipped, but adoption improves when a Department Director or elected official can ask a plain-language question and get a briefing-ready answer | #221, related #218, #219, #220 |
+| 3 | Build the executive roadmap timeline | Planning data exists, but leadership demos still need a clearer view of what is changing, when, and why it matters | #218 |
+| 4 | Define and seed the TOGAF overlay demo path before implementation | Framework Alignment is documented as optional; a demo dataset lets the team validate the overlay story without making TOGAF mandatory | #245, #247 |
 | 5 | Clean up create/edit dialog naming and tooltip consistency | This is a small visible UX quality issue surfaced after recent UI work; fixing it reduces friction and makes the product feel more coherent in demos | #253 |
 
 ## Product Manager Notes
 
-- Treat #240 as the highest leverage engineering slice because it turns the new instance-admin foundation into an operable product surface.
-- Keep #252 close behind #240. A second city will make federation, instance administration, demo logins, and tenant boundaries easier to verify and explain.
+- Treat #252 as the highest leverage next slice because it turns the now-shipped instance-admin and federation features into a credible multi-org demo.
 - For stakeholder-facing views, start narrow. A guided answer for one question such as "what supports permitting?" is more useful than another broad dashboard.
+- Keep the executive roadmap work connected to the same stakeholder story; it should answer briefing questions, not only improve internal planning views.
 - Do not start framework overlay implementation until #245 has an accepted first slice. The likely first slice is framework mapping plus one TOGAF-aligned report.
-- Keep the UX consistency work small and opportunistic; it should not displace the platform-admin or demo-data work.
+- Keep the UX consistency work small and opportunistic; it should not displace demo-data or stakeholder-answer work.
 
 ## Documentation Follow-up
 
 This grooming pass also refreshed:
 
 - `README.md`: current status and near-term priorities
-- `capabilities.md`: instance-admin foundation, product tour, and capability-mediated application links
-- `docs/data-model.md`: current schema shape, removed direct joins, and instance-admin tables/fields
+- `capabilities.md`: instance-admin console, product tour, and capability-mediated application links
+- `docs/data-model.md`: current schema shape, removed direct joins, instance-admin fields, and org suspension fields


### PR DESCRIPTION
## Summary

This PR is the documentation output from the Backlog Grooming for GovEA automation.

It updates the public docs to match the current product state and records the next product priorities after reviewing capabilities, recent merged PRs, and open issues.

## What changed

- Updates `docs/product-priorities.md` with the current top 5 next things to do:
  1. second city demo dataset and updated demo logins (#252)
  2. one stakeholder-facing direct-answer view (#221)
  3. executive roadmap timeline (#218)
  4. TOGAF overlay demo path (#245, #247)
  5. create/edit dialog naming and tooltip consistency (#253)
- Updates `README.md` so current status reflects capability-mediated application links and the shipped instance-admin console.
- Updates `capabilities.md` to describe instance administration as implemented and to clarify that services/objectives surface applications through capabilities.
- Refreshes `docs/data-model.md` so it no longer lists removed direct joins and now documents `instance_role`, `break_glass_sessions`, and org suspension fields.

## Validation

- Reviewed open issues and recent merged PRs through the GitHub connector.
- Compared docs against current schema files through the GitHub connector.
- Documentation-only change; no app test suite run.
- Rebased branch ref onto current `main`; compare now shows the branch ahead by 4 and behind by 0.

## Traceability

Related issues: #252, #221, #218, #245, #247, #253

Capability groups: cms/iam, cms/multi-org, cms/frontend-display, cms/planning, ea/framework-alignment

Persona: CMS Administrator
Persona: Enterprise Architect (Central IT)
Persona: Agency EA Coordinator
Persona: Department Director
Persona: Elected Official
