### PR TITLE
[codex] docs: refresh backlog grooming priorities

### DIFF
--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -2,7 +2,7 @@
 
 Last groomed: 2026-04-22
 
-This note summarizes the top next product moves from the current capability inventory, open issues, and recent merged pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
+This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
 ## Current Signal
 
@@ -14,13 +14,18 @@ Recent merges strengthened the product in five areas:
 - Instance administration moved from backend foundation to a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
 - Framework Alignment is now documented as an optional overlay, but implementation has not started.
 
-The next work should convert those foundations into stronger demo data, stakeholder-facing answers, and focused product polish.
+New signal since the prior grooming pass:
+
+- PR #257 is open and mergeable. It implements the second city demo dataset, updates the dev/demo login roster, and includes the glossary source pre-population fix described in #258.
+- Because #252 is now in review rather than untouched backlog, the immediate product-manager action is to validate and merge PR #257 instead of starting a new implementation slice for that same work.
+
+The next work should turn the shipped foundations into stronger demos, stakeholder-facing answers, and focused product polish.
 
 ## Top 5 Next Things To Do
 
-| Rank | Recommended next thing | Why now | Primary issue(s) |
+| Rank | Recommended next thing | Why now | Primary issue(s) / PR |
 |---|---|---|---|
-| 1 | Add the second city demo dataset and updated dev/demo login roster | Instance admin and federation now need richer multi-org data to demonstrate tenant boundaries, separate municipal admin experiences, and dev-only instance-admin login behavior | #252 |
+| 1 | Review, validate, and merge the City of Lakeside demo PR | PR #257 completes the highest-leverage multi-org demo slice and also fixes the glossary reference-source edit bug; it should be verified for seed idempotency, dev-only instance-admin gating, and Lakeside tenant boundaries before merge | PR #257, #252, #258 |
 | 2 | Ship one stakeholder-facing direct-answer view | Search and traceability are shipped, but adoption improves when a Department Director or elected official can ask a plain-language question and get a briefing-ready answer | #221, related #218, #219, #220 |
 | 3 | Build the executive roadmap timeline | Planning data exists, but leadership demos still need a clearer view of what is changing, when, and why it matters | #218 |
 | 4 | Define and seed the TOGAF overlay demo path before implementation | Framework Alignment is documented as optional; a demo dataset lets the team validate the overlay story without making TOGAF mandatory | #245, #247 |
@@ -28,16 +33,17 @@ The next work should convert those foundations into stronger demo data, stakehol
 
 ## Product Manager Notes
 
-- Treat #252 as the highest leverage next slice because it turns the now-shipped instance-admin and federation features into a credible multi-org demo.
+- Treat PR #257 as the first action item, not a new build request. The useful next step is review: run seed/reset validation, check the dev login roster, verify production does not expose the instance-admin shortcut, and confirm the glossary source edit fix.
+- If PR #257 merges cleanly, close #252 and #258, then promote the direct-answer view (#221) to the next implementation slice.
 - For stakeholder-facing views, start narrow. A guided answer for one question such as "what supports permitting?" is more useful than another broad dashboard.
 - Keep the executive roadmap work connected to the same stakeholder story; it should answer briefing questions, not only improve internal planning views.
 - Do not start framework overlay implementation until #245 has an accepted first slice. The likely first slice is framework mapping plus one TOGAF-aligned report.
-- Keep the UX consistency work small and opportunistic; it should not displace demo-data or stakeholder-answer work.
+- Keep the UX consistency work small and opportunistic; it should not displace demo-data review or stakeholder-answer work.
 
 ## Documentation Follow-up
 
-This grooming pass also refreshed:
+This grooming pass keeps the active priority document aligned with current GitHub state:
 
-- `README.md`: current status and near-term priorities
-- `capabilities.md`: instance-admin console, product tour, and capability-mediated application links
-- `docs/data-model.md`: current schema shape, removed direct joins, instance-admin fields, and org suspension fields
+- #252 is now represented by open PR #257 rather than only as future backlog.
+- #258 is tracked as a bug fixed by PR #257 and should be closed after merge verification.
+- The remaining top priorities stay unchanged because no newer issue or PR displaced the stakeholder-answer, roadmap, TOGAF overlay, or dialog-consistency work.


### PR DESCRIPTION
## Summary

This PR is the documentation output from the Backlog Grooming for GovEA automation.

It refreshes `docs/product-priorities.md` after reviewing current capabilities, open issues, recent pull requests, and the merged prior backlog-grooming docs PR.

## What changed

- Keeps the top-five product priorities current now that PR #257 is open and mergeable.
- Reframes #252 as review/validation/merge work through PR #257 instead of untouched backlog.
- Notes that #258 is fixed by PR #257 and should be closed after merge verification.
- Leaves #221, #218, #245/#247, and #253 as the next product priorities after the City of Lakeside PR is handled.

## Validation

- Reviewed open issues through the GitHub connector, including #218, #221, #245, #247, #252, #253, and #258.
- Reviewed recent pull requests through the GitHub connector, including merged PR #256 and open PR #257.
- Documentation-only change; no app test suite run.

## Traceability

Related issues: #252, #258, #221, #218, #245, #247, #253

Capability groups: cms/iam, cms/multi-org, cms/frontend-display, cms/planning, ea/framework-alignment

Persona: CMS Administrator
Persona: Enterprise Architect (Central IT)
Persona: Agency EA Coordinator
Persona: Department Director
Persona: Elected Official
