### PR TITLE
feat: guided stakeholder answer view

### DIFF
--- a/apps/govea/src/actions/answers.ts
+++ b/apps/govea/src/actions/answers.ts
@@ -1,0 +1,288 @@
+'use server'
+
+import { db } from '@/db/client'
+import { serviceCapabilities } from '@/db/schema'
+import { inArray } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+
+export type AnswerItem = {
+  id: string
+  title: string
+  description: string | null
+  href: string
+  relevance: string
+  status: string
+  entityType: string
+}
+
+export type AnswerSection = {
+  heading: string
+  subheading: string
+  items: AnswerItem[]
+}
+
+export type AnswerContent = {
+  query: string
+  sections: AnswerSection[]
+}
+
+const VIEWER_INITIATIVE_STATUSES = ['active', 'complete'] as const
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export async function getAnswerContent(query: string): Promise<AnswerContent> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  if (!query || query.trim().length < 2) {
+    return { query, sections: [] }
+  }
+
+  const orgId = session.user.organizationId!
+  const isViewer = session.user.role === 'viewer'
+  const q = `%${query.trim()}%`
+
+  // Primary: matching capabilities with all relevant relationships
+  const matchedCaps = await db.query.capabilities.findMany({
+    where: (c, { eq, and, or, ilike }) =>
+      and(
+        eq(c.organizationId, orgId),
+        or(ilike(c.name, q), ilike(c.description, q)),
+        isViewer ? eq(c.status, 'published') : undefined,
+      ),
+    with: {
+      applicationCapabilities: { with: { application: true } },
+      initiativeCapabilities: { with: { initiative: true } },
+      objectiveCapabilities: { with: { objective: true } },
+    },
+  })
+
+  const matchedCapIds = matchedCaps.map(c => c.id)
+
+  // Direct matches for other types + services linked to matched capabilities
+  const [matchedServices, matchedObjectives, matchedInitiatives, linkedServiceRows] =
+    await Promise.all([
+      db.query.services.findMany({
+        where: (s, { eq, and, or, ilike }) =>
+          and(
+            eq(s.organizationId, orgId),
+            or(ilike(s.name, q), ilike(s.description, q)),
+            isViewer ? eq(s.status, 'published') : undefined,
+          ),
+      }),
+      db.query.strategicObjectives.findMany({
+        where: (o, { eq, and, or, ilike }) =>
+          and(
+            eq(o.organizationId, orgId),
+            or(ilike(o.name, q), ilike(o.description, q)),
+            isViewer ? eq(o.status, 'published') : undefined,
+          ),
+      }),
+      db.query.initiatives.findMany({
+        where: (i, { eq, and, or, ilike, inArray }) =>
+          and(
+            eq(i.organizationId, orgId),
+            or(ilike(i.name, q), ilike(i.description, q)),
+            isViewer ? inArray(i.status, [...VIEWER_INITIATIVE_STATUSES]) : undefined,
+          ),
+      }),
+      matchedCapIds.length > 0
+        ? db
+            .select()
+            .from(serviceCapabilities)
+            .where(inArray(serviceCapabilities.capabilityId, matchedCapIds))
+        : Promise.resolve([] as (typeof serviceCapabilities.$inferSelect)[]),
+    ])
+
+  // Fetch service records for linked service IDs
+  const linkedServiceIds = [...new Set(linkedServiceRows.map(r => r.serviceId))]
+  const linkedServices =
+    linkedServiceIds.length > 0
+      ? await db.query.services.findMany({
+          where: (s, { inArray }) => inArray(s.id, linkedServiceIds),
+        })
+      : []
+
+  // ── Capabilities ──────────────────────────────────────────────────────────
+  const capItems: AnswerItem[] = matchedCaps.map(c => ({
+    id: c.id,
+    title: c.name,
+    description: c.description,
+    href: `/capabilities/${c.id}`,
+    relevance: `Matches "${query.trim()}" in its name or description`,
+    status: c.status,
+    entityType: 'capability',
+  }))
+
+  // ── Applications (via capabilities) ───────────────────────────────────────
+  const appMap = new Map<string, AnswerItem>()
+  for (const cap of matchedCaps) {
+    for (const { application } of cap.applicationCapabilities) {
+      if (isViewer && application.status !== 'published') continue
+      if (!appMap.has(application.id)) {
+        appMap.set(application.id, {
+          id: application.id,
+          title: application.name,
+          description: application.description,
+          href: `/applications/${application.id}`,
+          relevance: `Supports the ${cap.name} capability`,
+          status: application.status,
+          entityType: 'application',
+        })
+      }
+    }
+  }
+  const appItems = Array.from(appMap.values())
+
+  // ── Initiatives (via capabilities + direct) ───────────────────────────────
+  const initiativeMap = new Map<string, AnswerItem>()
+  for (const cap of matchedCaps) {
+    for (const { initiative, impact } of cap.initiativeCapabilities) {
+      if (
+        isViewer &&
+        !VIEWER_INITIATIVE_STATUSES.includes(
+          initiative.status as (typeof VIEWER_INITIATIVE_STATUSES)[number],
+        )
+      )
+        continue
+      if (!initiativeMap.has(initiative.id)) {
+        initiativeMap.set(initiative.id, {
+          id: initiative.id,
+          title: initiative.name,
+          description: initiative.description,
+          href: `/initiatives/${initiative.id}`,
+          relevance: impact
+            ? `${capitalize(impact)}s the ${cap.name} capability`
+            : `Affects the ${cap.name} capability`,
+          status: initiative.status,
+          entityType: 'initiative',
+        })
+      }
+    }
+  }
+  for (const init of matchedInitiatives) {
+    if (!initiativeMap.has(init.id)) {
+      initiativeMap.set(init.id, {
+        id: init.id,
+        title: init.name,
+        description: init.description,
+        href: `/initiatives/${init.id}`,
+        relevance: `Matches "${query.trim()}" in its name or description`,
+        status: init.status,
+        entityType: 'initiative',
+      })
+    }
+  }
+  const initiativeItems = Array.from(initiativeMap.values())
+
+  // ── Objectives (via capabilities + direct) ────────────────────────────────
+  const objectiveMap = new Map<string, AnswerItem>()
+  for (const cap of matchedCaps) {
+    for (const { objective } of cap.objectiveCapabilities) {
+      if (isViewer && objective.status !== 'published') continue
+      if (!objectiveMap.has(objective.id)) {
+        objectiveMap.set(objective.id, {
+          id: objective.id,
+          title: objective.name,
+          description: objective.description,
+          href: `/objectives/${objective.id}`,
+          relevance: `Linked to the ${cap.name} capability`,
+          status: objective.status,
+          entityType: 'objective',
+        })
+      }
+    }
+  }
+  for (const obj of matchedObjectives) {
+    if (!objectiveMap.has(obj.id)) {
+      objectiveMap.set(obj.id, {
+        id: obj.id,
+        title: obj.name,
+        description: obj.description,
+        href: `/objectives/${obj.id}`,
+        relevance: `Matches "${query.trim()}" in its name or description`,
+        status: obj.status,
+        entityType: 'objective',
+      })
+    }
+  }
+  const objectiveItems = Array.from(objectiveMap.values())
+
+  // ── Services (direct + via capabilities) ──────────────────────────────────
+  const serviceMap = new Map<string, AnswerItem>()
+  for (const svc of matchedServices) {
+    serviceMap.set(svc.id, {
+      id: svc.id,
+      title: svc.name,
+      description: svc.description,
+      href: `/services/${svc.id}`,
+      relevance: `Matches "${query.trim()}" in its name or description`,
+      status: svc.status,
+      entityType: 'service',
+    })
+  }
+  for (const row of linkedServiceRows) {
+    const svc = linkedServices.find(s => s.id === row.serviceId)
+    if (!svc) continue
+    if (isViewer && svc.status !== 'published') continue
+    if (!serviceMap.has(svc.id)) {
+      const cap = matchedCaps.find(c => c.id === row.capabilityId)
+      serviceMap.set(svc.id, {
+        id: svc.id,
+        title: svc.name,
+        description: svc.description,
+        href: `/services/${svc.id}`,
+        relevance: cap
+          ? `Delivers the ${cap.name} capability to stakeholders`
+          : 'Linked to a matching capability',
+        status: svc.status,
+        entityType: 'service',
+      })
+    }
+  }
+  const serviceItems = Array.from(serviceMap.values())
+
+  // ── Assemble sections (omit empty) ────────────────────────────────────────
+  const sections: AnswerSection[] = []
+
+  if (capItems.length > 0) {
+    sections.push({
+      heading: 'Capabilities',
+      subheading: 'What the organization is able to do in this area',
+      items: capItems,
+    })
+  }
+  if (serviceItems.length > 0) {
+    sections.push({
+      heading: 'Services',
+      subheading: 'How this area is delivered to stakeholders and the public',
+      items: serviceItems,
+    })
+  }
+  if (appItems.length > 0) {
+    sections.push({
+      heading: 'Technology',
+      subheading: 'Systems and applications that support these capabilities',
+      items: appItems,
+    })
+  }
+  if (initiativeItems.length > 0) {
+    sections.push({
+      heading: 'Active Initiatives',
+      subheading: 'Work underway that affects this area',
+      items: initiativeItems,
+    })
+  }
+  if (objectiveItems.length > 0) {
+    sections.push({
+      heading: 'Strategic Objectives',
+      subheading: 'Mission and strategy this area supports',
+      items: objectiveItems,
+    })
+  }
+
+  return { query, sections }
+}

--- a/apps/govea/src/app/(admin)/answers/page.tsx
+++ b/apps/govea/src/app/(admin)/answers/page.tsx
@@ -1,0 +1,145 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getAnswerContent, type AnswerItem, type AnswerSection } from '@/actions/answers'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface AnswerPageProps {
+  searchParams: Promise<{ q?: string }>
+}
+
+function AnswerCard({ item }: { item: AnswerItem }) {
+  return (
+    <Card>
+      <CardContent className="py-4 px-5 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <Link href={item.href} className="font-medium hover:underline text-sm leading-snug">
+            {item.title}
+          </Link>
+          <Badge variant="outline" className="shrink-0 text-xs">
+            {item.status}
+          </Badge>
+        </div>
+        {item.description && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{item.description}</p>
+        )}
+        <p className="text-xs text-muted-foreground border-t pt-2">
+          <span className="font-medium text-foreground">Why relevant: </span>
+          {item.relevance}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function AnswerSectionBlock({ section }: { section: AnswerSection }) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">{section.heading}</h2>
+        <p className="text-sm text-muted-foreground">{section.subheading}</p>
+      </div>
+      <div className="space-y-3">
+        {section.items.map(item => (
+          <AnswerCard key={item.id} item={item} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default async function AnswerPage({ searchParams }: AnswerPageProps) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const { q } = await searchParams
+  const query = q?.trim() ?? ''
+  const hasQuery = query.length >= 2
+
+  const answer = hasQuery ? await getAnswerContent(query) : null
+  const totalItems = answer?.sections.reduce((sum, s) => sum + s.items.length, 0) ?? 0
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <div className="space-y-4">
+        <Link
+          href={query ? `/search?q=${encodeURIComponent(query)}` : '/search'}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← Back to search results
+        </Link>
+
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold tracking-tight">
+            {query ? `"${query}"` : 'Guided Answer'}
+          </h1>
+          {answer && (
+            <p className="text-sm text-muted-foreground">
+              {totalItems === 0
+                ? 'No published content found for this question.'
+                : `${totalItems} item${totalItems === 1 ? '' : 's'} across ${answer.sections.length} area${answer.sections.length === 1 ? '' : 's'}`}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <form action="/answers" method="get" className="flex gap-2">
+        <input
+          name="q"
+          type="search"
+          defaultValue={query}
+          placeholder="Ask a question about your architecture…"
+          autoFocus={!hasQuery}
+          className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <button
+          type="submit"
+          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+        >
+          Answer
+        </button>
+      </form>
+
+      {!hasQuery && (
+        <div className="rounded-lg border border-dashed p-10 text-center space-y-2 text-muted-foreground">
+          <p className="font-medium text-foreground">Ask a question about your architecture</p>
+          <p className="text-sm">
+            Try: &ldquo;permitting&rdquo;, &ldquo;replaced systems&rdquo;, &ldquo;digital
+            services&rdquo;, &ldquo;financial reporting&rdquo;
+          </p>
+          <p className="text-xs pt-2">
+            Results draw from published capabilities, services, applications, initiatives, and
+            objectives — assembled for a stakeholder briefing, not raw search results.
+          </p>
+        </div>
+      )}
+
+      {hasQuery && totalItems === 0 && (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No published content found for &ldquo;{query}&rdquo;. Try a broader term or check that
+            relevant items are published.
+          </CardContent>
+        </Card>
+      )}
+
+      {hasQuery && totalItems > 0 && (
+        <div className="space-y-10">
+          {answer!.sections.map(section => (
+            <AnswerSectionBlock key={section.heading} section={section} />
+          ))}
+
+          <p className="text-xs text-muted-foreground border-t pt-4">
+            Generated from repository content &middot;{' '}
+            {new Date().toLocaleDateString('en-US', {
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/search/page.tsx
+++ b/apps/govea/src/app/(admin)/search/page.tsx
@@ -58,11 +58,21 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
       </form>
 
       {hasQuery && (
-        <p className="text-sm text-muted-foreground">
-          {totalCount === 0
-            ? `No results for "${query}"`
-            : `${totalCount} result${totalCount === 1 ? '' : 's'} for "${query}"`}
-        </p>
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            {totalCount === 0
+              ? `No results for "${query}"`
+              : `${totalCount} result${totalCount === 1 ? '' : 's'} for "${query}"`}
+          </p>
+          {totalCount > 0 && (
+            <Link
+              href={`/answers?q=${encodeURIComponent(query)}`}
+              className="text-sm font-medium text-primary hover:text-primary/80 transition-colors shrink-0"
+            >
+              Get guided answer →
+            </Link>
+          )}
+        </div>
       )}
 
       {hasQuery && totalCount === 0 && (


### PR DESCRIPTION
Closes #221

## Summary

- Adds `/answers?q=` — a structured answer page that assembles repository content into a stakeholder briefing
- Each answer is organized into sections: **Capabilities**, **Services**, **Technology**, **Active Initiatives**, **Strategic Objectives**
- Each item includes a **Why relevant** explanation (direct text match or relationship to a matching capability)
- Publication and visibility rules are enforced — viewer roles see only published/active content
- Search results page gains a **Get guided answer →** link when results exist

## How it works

`getAnswerContent()` in `src/actions/answers.ts`:
1. Fetches capabilities matching the query, with their linked applications, initiatives, and objectives
2. Fetches directly matching services, objectives, and initiatives
3. Fetches services linked to matched capabilities via the `serviceCapabilities` junction
4. Deduplicates across all maps and assembles per-section

The answer page at `src/app/(admin)/answers/page.tsx` renders the result with section headings, item cards, relevance labels, and a "Generated from repository content · [date]" footer.

## Test plan

- [ ] Search for a term with results (e.g. "permitting") — confirm "Get guided answer →" appears
- [ ] Click through to `/answers?q=permitting` — confirm sections render with capabilities, services, tech, initiatives, objectives
- [ ] Verify each item shows a "Why relevant" reason
- [ ] Sign in as Viewer — confirm only published content appears
- [ ] Try a term with no results — confirm empty-state message
- [ ] Try `/answers` with no query — confirm prompt state renders

## Traceability

Capability: `fd-guided-answer-views`

🤖 Generated with [Claude Code](https://claude.com/claude-code)