### PR TITLE
feat: standardize dialog titles and add ADR tooltip (#253)

### DIFF
--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -122,7 +122,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
         )}
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
-            + New ADR
+            + New Architecture Decision Record
           </Button>
         )}
       </div>
@@ -226,7 +226,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
       <Dialog open={createOpen} onOpenChange={open => { if (!open) setCreateOpen(false) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>New ADR</DialogTitle>
+            <DialogTitle>New Architecture Decision Record</DialogTitle>
           </DialogHeader>
           <form action={handleCreate} className="space-y-4">
             <div className="grid grid-cols-3 gap-3">
@@ -267,7 +267,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit ADR</DialogTitle>
+            <DialogTitle>Edit Architecture Decision Record</DialogTitle>
           </DialogHeader>
           <form action={handleEdit} className="space-y-4">
             <div className="grid grid-cols-3 gap-3">
@@ -307,7 +307,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete ADR</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Architecture Decision Record</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Permanently delete <strong>{deleteTarget?.number} — {deleteTarget?.title}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -174,7 +174,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         )}
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
-            + New application
+            + New Application
           </Button>
         )}
       </div>
@@ -296,7 +296,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>New application</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>New Application</DialogTitle></DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
             <div className="space-y-1.5">
@@ -368,7 +368,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       {/* Edit Dialog */}
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>Edit application</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Edit Application</DialogTitle></DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <div className="space-y-1.5">
@@ -446,7 +446,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete application</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Application</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Are you sure you want to permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -151,7 +151,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
         )}
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
-            + New capability
+            + New Capability
           </Button>
         )}
       </div>
@@ -255,7 +255,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>New capability</DialogTitle>
+            <DialogTitle>New Capability</DialogTitle>
           </DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
@@ -318,7 +318,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit capability</DialogTitle>
+            <DialogTitle>Edit Capability</DialogTitle>
           </DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
@@ -388,7 +388,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete capability</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Capability</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Are you sure you want to permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/dashboard/coverage-tile-label.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/coverage-tile-label.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+interface CoverageTileLabelProps {
+  label: string
+  tooltip?: string
+}
+
+export function CoverageTileLabel({ label, tooltip }: CoverageTileLabelProps) {
+  if (!tooltip) return <>{label}</>
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="underline decoration-dotted underline-offset-2 cursor-help">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/db/schema'
 import { and, count, eq, gt, isNotNull, desc, asc, inArray } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { CoverageTileLabel } from './coverage-tile-label'
 import { DomainBadge } from '@/components/domain-badge'
 import Link from 'next/link'
 
@@ -30,15 +32,15 @@ function pct(numerator: number, denominator: number) {
 }
 
 const COVERAGE_ENTITIES = [
-  { label: 'Capabilities',   key: 'capabilities' as const,  href: '/capabilities',   draftKey: 'draft'     },
-  { label: 'Applications',   key: 'applications' as const,  href: '/applications',   draftKey: 'draft'     },
-  { label: 'Personas',       key: 'personas'     as const,  href: '/personas',       draftKey: 'draft'     },
-  { label: 'Value Streams',  key: 'valueStreams'  as const,  href: '/value-streams',  draftKey: 'draft'     },
-  { label: 'Objectives',     key: 'objectives'   as const,  href: '/objectives',     draftKey: 'draft'     },
-  { label: 'Initiatives',    key: 'initiatives'  as const,  href: '/initiatives',    draftKey: 'proposed'  },
-  { label: 'Decisions',      key: 'adrs'         as const,  href: '/adrs',           draftKey: 'proposed'  },
-  { label: 'Principles',     key: 'principles'   as const,  href: '/principles',     draftKey: 'draft'     },
-  { label: 'Glossary',       key: 'glossary'     as const,  href: '/glossary',       draftKey: 'draft'     },
+  { label: 'Capabilities',   key: 'capabilities' as const,  href: '/capabilities',   draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Applications',   key: 'applications' as const,  href: '/applications',   draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Personas',       key: 'personas'     as const,  href: '/personas',       draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Value Streams',  key: 'valueStreams'  as const,  href: '/value-streams',  draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Objectives',     key: 'objectives'   as const,  href: '/objectives',     draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Initiatives',    key: 'initiatives'  as const,  href: '/initiatives',    draftKey: 'proposed', tooltip: undefined                         },
+  { label: 'Decisions',      key: 'adrs'         as const,  href: '/adrs',           draftKey: 'proposed', tooltip: 'Architecture Decision Records'   },
+  { label: 'Principles',     key: 'principles'   as const,  href: '/principles',     draftKey: 'draft',    tooltip: undefined                         },
+  { label: 'Glossary',       key: 'glossary'     as const,  href: '/glossary',       draftKey: 'draft',    tooltip: undefined                         },
 ]
 
 const INITIATIVE_STATUS_LABELS: Record<string, string> = {
@@ -175,27 +177,31 @@ export default async function DashboardPage() {
       {/* Coverage */}
       <div>
         <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Coverage</p>
-        <div className="grid gap-3 grid-cols-3">
-          {COVERAGE_ENTITIES.map(e => {
-            const s = stats[e.key]
-            const draftCount = s.byStatus[e.draftKey] ?? 0
-            return (
-              <Link key={e.key} href={e.href}>
-                <Card className="hover:bg-muted/50 transition-colors cursor-pointer h-full">
-                  <CardHeader className="pb-1 pt-4 px-4">
-                    <CardTitle className="text-xs font-medium text-muted-foreground">{e.label}</CardTitle>
-                  </CardHeader>
-                  <CardContent className="pb-4 px-4">
-                    <p className="text-2xl font-bold">{s.total}</p>
-                    {draftCount > 0 && (
-                      <p className="text-xs text-amber-600 mt-0.5">{draftCount} draft</p>
-                    )}
-                  </CardContent>
-                </Card>
-              </Link>
-            )
-          })}
-        </div>
+        <TooltipProvider>
+          <div className="grid gap-3 grid-cols-3">
+            {COVERAGE_ENTITIES.map(e => {
+              const s = stats[e.key]
+              const draftCount = s.byStatus[e.draftKey] ?? 0
+              return (
+                <Link key={e.key} href={e.href}>
+                  <Card className="hover:bg-muted/50 transition-colors cursor-pointer h-full">
+                    <CardHeader className="pb-1 pt-4 px-4">
+                      <CardTitle className="text-xs font-medium text-muted-foreground">
+                        <CoverageTileLabel label={e.label} tooltip={e.tooltip} />
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="pb-4 px-4">
+                      <p className="text-2xl font-bold">{s.total}</p>
+                      {draftCount > 0 && (
+                        <p className="text-xs text-amber-600 mt-0.5">{draftCount} draft</p>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Link>
+              )
+            })}
+          </div>
+        </TooltipProvider>
       </div>
 
       {/* Federation Activity */}

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -117,7 +117,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
         )}
         {canEditRole && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
-            + New Term
+            + New Glossary Term
           </Button>
         )}
       </div>
@@ -212,7 +212,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
       <Dialog open={createOpen} onOpenChange={open => { if (!open) setCreateOpen(false) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>New Term</DialogTitle>
+            <DialogTitle>New Glossary Term</DialogTitle>
           </DialogHeader>
           <TermForm
             domainTerms={domainTerms}
@@ -229,7 +229,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit Term</DialogTitle>
+            <DialogTitle>Edit Glossary Term</DialogTitle>
           </DialogHeader>
           <TermForm
             key={editTarget?.id}
@@ -247,7 +247,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete Term</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Glossary Term</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Permanently delete <strong>{deleteTarget?.term}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -142,7 +142,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
         )}
         {canEdit && (
           <Button onClick={openCreate} size="sm" className="ml-auto">
-            + New initiative
+            + New Initiative
           </Button>
         )}
       </div>
@@ -245,7 +245,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={open => { if (!open) { setCreateOpen(false); setSelectedCaps([]) } }}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>New initiative</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>New Initiative</DialogTitle></DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required placeholder="e.g. Replace OpenText Livelink" />
             <div className="space-y-1.5">
@@ -288,7 +288,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
       {/* Edit Dialog */}
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) { setEditTarget(null); setSelectedCaps([]) } }}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>Edit initiative</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Edit Initiative</DialogTitle></DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <div className="space-y-1.5">
@@ -334,7 +334,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete initiative</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Initiative</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/objectives/objective-table.tsx
+++ b/apps/govea/src/app/(admin)/objectives/objective-table.tsx
@@ -209,7 +209,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>New strategic objective</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>New Objective</DialogTitle></DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required placeholder="e.g. Reduce permit processing time by 40%" />
             <div className="space-y-1.5">
@@ -275,7 +275,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
       {/* Edit Dialog */}
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-lg">
-          <DialogHeader><DialogTitle>Edit objective</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Edit Objective</DialogTitle></DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <div className="space-y-1.5">
@@ -343,7 +343,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete objective</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Objective</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -159,7 +159,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
         <div className="ml-auto flex items-center gap-2">
           {canEdit && (
             <Button onClick={() => setCreateOpen(true)} size="sm">
-              + New persona
+              + New Persona
             </Button>
           )}
         </div>
@@ -271,7 +271,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>New persona</DialogTitle>
+            <DialogTitle>New Persona</DialogTitle>
           </DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
@@ -333,7 +333,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Edit persona</DialogTitle>
+            <DialogTitle>Edit Persona</DialogTitle>
           </DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
@@ -399,7 +399,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete persona</DialogTitle>
+            <DialogTitle>Delete Persona</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
             Are you sure you want to permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.

--- a/apps/govea/src/app/(admin)/services/service-table.tsx
+++ b/apps/govea/src/app/(admin)/services/service-table.tsx
@@ -144,7 +144,7 @@ export function ServiceTable({ services, personas, role }: Props) {
         </select>
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
-            + New service
+            + New Service
           </Button>
         )}
       </div>
@@ -236,7 +236,7 @@ export function ServiceTable({ services, personas, role }: Props) {
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>New service</DialogTitle>
+            <DialogTitle>New Service</DialogTitle>
           </DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
@@ -260,7 +260,7 @@ export function ServiceTable({ services, personas, role }: Props) {
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit service</DialogTitle>
+            <DialogTitle>Edit Service</DialogTitle>
           </DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
@@ -283,7 +283,7 @@ export function ServiceTable({ services, personas, role }: Props) {
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete service</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Service</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Are you sure you want to permanently delete <strong>{deleteTarget?.name}</strong>? This cannot be undone.
           </p>

--- a/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
@@ -120,7 +120,7 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
         )}
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
-            + New value stream
+            + New Value Stream
           </Button>
         )}
       </div>
@@ -212,7 +212,7 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
-          <DialogHeader><DialogTitle>New value stream</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>New Value Stream</DialogTitle></DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
             <div className="space-y-1.5">
@@ -250,7 +250,7 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
       {/* Edit Dialog */}
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Edit value stream</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Edit Value Stream</DialogTitle></DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <div className="space-y-1.5">
@@ -288,7 +288,7 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
-          <DialogHeader><DialogTitle>Delete value stream</DialogTitle></DialogHeader>
+          <DialogHeader><DialogTitle>Delete Value Stream</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
             Permanently delete <strong>{deleteTarget?.name}</strong> and all its stages? This cannot be undone.
           </p>

--- a/apps/govea/src/components/ui/tooltip.tsx
+++ b/apps/govea/src/components/ui/tooltip.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
+        'animate-in fade-in-0 zoom-in-95',
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -1382,6 +1385,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -4620,6 +4636,26 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- Normalizes all create/edit/delete dialog titles to `New/Edit/Delete [Full Entity Name]` title-case format across all 10 entity tables
- Glossary dialogs renamed to "New/Edit/Delete **Glossary Term**" (was "Term")
- ADR dialogs renamed to "New/Edit/Delete **Architecture Decision Record**" (was "ADR")
- All other entities (Capability, Application, Persona, Objective, Initiative, Service, Value Stream) normalized to consistent Title Case
- Adds a tooltip on the **Decisions** dashboard tile that expands to "Architecture Decision Records" on hover, using a dedicated `CoverageTileLabel` client component to correctly cross the Next.js App Router server/client boundary
- Adds `@radix-ui/react-tooltip` dependency and `components/ui/tooltip.tsx` (shadcn/ui pattern)

## Test plan

- [ ] Open any entity list and click New/Edit/Delete — confirm dialog title matches `New/Edit/Delete [Full Entity Name]` in Title Case
- [ ] Specifically confirm "New Architecture Decision Record" (not "New ADR") and "New Glossary Term" (not "New Term")
- [ ] Hover over the **Decisions** tile on the dashboard — tooltip reads "Architecture Decision Records"
- [ ] All other tiles have no tooltip (no underline, no hover behavior)
- [ ] `pnpm --filter govea tsc --noEmit` passes clean

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)