### PR TITLE
[codex] docs: refresh backlog priorities after shipped views

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Supporting reference content for principles and glossary terms
 - Mission-first traceability: Personas -> Capabilities -> Applications enforced at the application layer
 - Stakeholder-friendly traceability views: read-only objective, capability, and service traces that show how mission context connects to applications, initiatives, and related architecture records
+- Guided stakeholder answer view: `/answers?q=` turns repository search context into a briefing-style answer with capabilities, services, technology, initiatives, and objectives
 - Service catalogue: first-class service records linked to personas, capabilities, and value streams, with supporting applications derived through capabilities
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
-- Demo-ready planning module: strategic objectives plus initiatives with a roadmap view grouped by planning status
+- Demo-ready planning module: strategic objectives plus initiatives with roadmap grid and executive timeline views
 - Repository-wide search across the core content model
 - Guided product tour with role-aware coach marks for the main application areas
 - Audit trail: immutable before/after log of all changes
@@ -111,27 +112,29 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
+- Two-city demo seed data and dev login roster for Riverdale, Lakeside, state admin, and dev-only instance-admin scenarios
 - Reusable `@govea/core` package: RBAC, audit, taxonomy, workflow, content type, and recipe primitives
 - E2E smoke test coverage across all routes x roles (Playwright)
 - Containerized local development plus Azure Container Apps dev deployment support
 
 **Partially implemented / still maturing:**
 - ADRs: basic CRUD, detail pages, and linkage exist, but the authoring experience is still maturing relative to the core portfolio records
-- Planning semantics and timeline presentation: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
+- Planning semantics: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Admin configuration beyond core settings
-- Repository completeness, deeper end-to-end traceability analysis, and architecture debt tooling
+- Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
+- Reviewing create/edit dialog naming and tooltip consistency
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Second demo city dataset and updated dev/demo login roster
-- Additional stakeholder-facing answer views and leadership-ready visuals
-- Executive roadmap timeline for briefings and demos
 - TOGAF overlay demo dataset and first framework-mapping implementation slice
-- UX consistency cleanup across create/edit dialogs and tooltip labels
+- Typed principle sets for Architecture, Data, Security, Integration, and similar principle families
+- Stakeholder validation for demo/adoption-facing visuals
+- Repository confidence summary for leadership and public-facing trust cues
+- Application risk portfolio view for investment and modernization conversations
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/capabilities.md
+++ b/capabilities.md
@@ -80,7 +80,7 @@ The structured inventory of the organization's architecture objects.
 | Capability Map | Implemented | Define business capabilities organized by domain; linked to applications, personas, principles, and decisions |
 | Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
 | Architecture Decision Records (ADRs) | Partially implemented | Basic ADR CRUD, detail pages, supersession, and cross-linking exist, but the overall authoring experience is still maturing relative to the stronger core portfolio records |
-| Principles | Implemented | Capture architecture principles and link them to capabilities and decisions |
+| Principles | Implemented | Capture architecture principles and link them to capabilities and decisions; typed principle sets such as Architecture and Data are planned but not yet modeled |
 | Glossary | Implemented | Maintain shared terminology to support consistent EA language across the repository |
 | Value Streams | Implemented | Define value streams with ordered stages; link to capabilities and personas |
 
@@ -110,11 +110,11 @@ Strategic direction, change initiatives, and timeline visualization.
 |---|---|---|
 | Strategic Objectives | Implemented | Define and track business goals; link to capabilities and value streams |
 | Initiatives | Implemented | Track change programmes with planning lifecycle statuses; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
-| Roadmap View | Implemented | Visualize initiatives grouped by planning status with linked objectives and capability context |
+| Roadmap View | Implemented | Visualize initiatives in an executive timeline or planning grid, with linked objectives, date ranges, capability impact labels, and role-aware viewer filtering |
 
 **Design principle:** Planning capabilities are a lens on existing architecture content. Strategic objectives trace to capabilities. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
 
-**Current semantic model:** Strategic objectives follow the standard content workflow (`draft`, `published`, `archived`). Initiatives do not. They use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates. The roadmap is a read-only view over initiative records grouped by that planning status.
+**Current semantic model:** Strategic objectives follow the standard content workflow (`draft`, `published`, `archived`). Initiatives do not. They use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates. The roadmap is a read-only view over initiative records, shown either as an executive timeline or grouped planning grid.
 
 This area is strong enough for demos and early v1 use, but the planning model should still be treated as evolving rather than fully settled.
 
@@ -129,11 +129,14 @@ How content is presented to authenticated users and, optionally, the public.
 | Navigation | Implemented | App shell with role-aware sidebar navigation plus a distinct instance-admin console shell |
 | Portfolio Views | Implemented | List and detail pages for all EA entity types |
 | Mission-to-Technology Traceability Views | Implemented | Read-only layered trace views from strategic objectives, capabilities, and services to supporting applications and related records |
+| Guided Answer Views | Implemented | `/answers?q=` assembles capabilities, services, technology, active initiatives, and strategic objectives into a plain-language stakeholder answer with relevance explanations |
 | Relationship Navigation | Implemented | Navigate between linked entities (capability <-> application <-> persona) |
 | Value Stream Display | Implemented | Visualize value stream stages with linked capabilities |
 | Content Display | Implemented | Detail pages with status badges, metadata, linked records, and contributor-friendly edit affordances on shipped surfaces |
 | Product Tour | Implemented | Role-aware guided tour covering the main dashboard, architecture, portfolio, strategy, search, and role-specific workflows |
 | Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
+| Repository Confidence Summary | Not implemented | Plain-language freshness and trust cue for stakeholder-facing views |
+| Application Risk Portfolio | Not implemented | Leadership-oriented view of lifecycle, dependency, duplication, and modernization risk across applications |
 | Responsive Layout | Partially implemented | Desktop-first; mobile not a v1 priority |
 | Theming | Implemented | Organization-selected predefined themes applied through settings |
 
@@ -225,13 +228,13 @@ GovEA's long-term capability surface spans 9 groups, each defined through the Ea
 | Group | Near-term priorities |
 |---|---|
 | Identity & Access Management | Tenant-boundary tests, production hardening for instance-admin operations |
-| Repository & Modelling | End-to-end traceability, architecture debt tracking |
-| Application & IT Portfolio | Technology lifecycle tracking, rationalization views |
-| Business & Capability Architecture | Capability heat maps, operating model views |
-| Planning & Analysis | Executive roadmap timeline, scenario planning, value stream analytics |
+| Repository & Modelling | End-to-end traceability, architecture debt tracking, repository confidence summary |
+| Application & IT Portfolio | Technology lifecycle tracking, rationalization views, application risk portfolio |
+| Business & Capability Architecture | Capability heat maps, operating model views, typed principle sets |
+| Planning & Analysis | Scenario planning, value stream analytics |
 | Governance & Compliance | ARB review workflow, regulatory mapping |
 | Integration | ITSM/CMDB connectors, DevOps pipeline links |
-| Collaboration & Stakeholder Engagement | Guided answer views, repository confidence summaries, stakeholder-facing plain-language views |
+| Collaboration & Stakeholder Engagement | Stakeholder validation, repository confidence summaries, stakeholder-facing plain-language views |
 | Reporting & Documentation | Configurable reports, KPI tracking, elected-official summaries |
 | Framework Alignment | Optional TOGAF mapping, ADM phase alignment, and framework-aware reporting |
 

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,49 +1,51 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-04-22
+Last groomed: 2026-04-23
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
 ## Current Signal
 
-Recent merges strengthened the product in five areas:
+Recent merges strengthened the product in six areas:
 
-- Mission-to-technology traceability, repository-wide search, and viewer visibility rules are now shipped.
-- The product tour improved first-run orientation for admins, contributors, and viewers.
-- Direct Service/Application and Objective/Application shortcuts were removed, making Capability the consistent bridge from mission/service context to technology.
-- Instance administration moved from backend foundation to a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
-- Framework Alignment is now documented as an optional overlay, but implementation has not started.
+- The second municipal demo organization is now merged, so GovEA has a stronger multi-org and instance-admin demo base.
+- Guided stakeholder answers are now shipped through `/answers?q=`, connected from search results, and filtered by viewer publication rules.
+- The roadmap now has an executive timeline view in addition to the existing grid, and the viewer filter bug on roadmap data was fixed.
+- Mission-to-technology traceability, repository-wide search, and viewer visibility rules remain core shipped foundations.
+- Instance administration is a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
+- Framework Alignment is documented as an optional overlay, but implementation has not started.
 
 New signal since the prior grooming pass:
 
-- PR #257 is open and mergeable. It implements the second city demo dataset, updates the dev/demo login roster, and includes the glossary source pre-population fix described in #258.
-- Because #252 is now in review rather than untouched backlog, the immediate product-manager action is to validate and merge PR #257 instead of starting a new implementation slice for that same work.
+- PR #257 merged and closed #252. The glossary reference-source bug #258 should be closed if merge verification is complete.
+- PR #260 merged and closed #221, moving guided stakeholder answers from backlog to shipped capability.
+- PR #261 merged and closed #218, moving the executive roadmap timeline from backlog to shipped capability.
+- PR #263 is open and mergeable for #253, covering dialog title consistency and the ADR tooltip.
+- Issue #262 adds an important design question: principles likely need typed sets such as Architecture and Data before principle usage grows too far as one flat list.
 
-The next work should turn the shipped foundations into stronger demos, stakeholder-facing answers, and focused product polish.
+The next work should consolidate the shipped demo/story improvements, finish the visible UX cleanup, and choose the next product slice carefully rather than continuing to build only broad dashboard surfaces.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) / PR |
 |---|---|---|---|
-| 1 | Review, validate, and merge the City of Lakeside demo PR | PR #257 completes the highest-leverage multi-org demo slice and also fixes the glossary reference-source edit bug; it should be verified for seed idempotency, dev-only instance-admin gating, and Lakeside tenant boundaries before merge | PR #257, #252, #258 |
-| 2 | Ship one stakeholder-facing direct-answer view | Search and traceability are shipped, but adoption improves when a Department Director or elected official can ask a plain-language question and get a briefing-ready answer | #221, related #218, #219, #220 |
-| 3 | Build the executive roadmap timeline | Planning data exists, but leadership demos still need a clearer view of what is changing, when, and why it matters | #218 |
-| 4 | Define and seed the TOGAF overlay demo path before implementation | Framework Alignment is documented as optional; a demo dataset lets the team validate the overlay story without making TOGAF mandatory | #245, #247 |
-| 5 | Clean up create/edit dialog naming and tooltip consistency | This is a small visible UX quality issue surfaced after recent UI work; fixing it reduces friction and makes the product feel more coherent in demos | #253 |
+| 1 | Review, validate, and merge the dialog consistency PR | PR #263 is small, mergeable, and closes a visible demo-quality issue; validate dialog titles, the ADR tooltip, and the new tooltip dependency before merge | PR #263, #253 |
+| 2 | Define and seed the TOGAF overlay demo path before implementation | The core demo now has richer content and stakeholder views; framework alignment is the next credibility story, but it needs a constrained first slice before schema/UI work starts | #245, #247, related #89 |
+| 3 | Decide the principle-set model | Principle usage is implemented, but #262 correctly identifies that Architecture, Data, Security, and similar principle families should not remain a flat undifferentiated list | #262 |
+| 4 | Validate stakeholder demo personas and confidence needs | Guided answers and the executive timeline shipped from assumed stakeholder needs; before adding more leadership visuals, validate what Department Director, Budget/Performance, and Elected Official users actually trust | #216, #220 |
+| 5 | Ship the next stakeholder trust visual: repository confidence summary | After guided answers and the roadmap timeline, the next adoption gap is explaining whether the repository is current enough to trust without exposing internal maintenance noise | #220, related #219 |
 
 ## Product Manager Notes
 
-- Treat PR #257 as the first action item, not a new build request. The useful next step is review: run seed/reset validation, check the dev login roster, verify production does not expose the instance-admin shortcut, and confirm the glossary source edit fix.
-- If PR #257 merges cleanly, close #252 and #258, then promote the direct-answer view (#221) to the next implementation slice.
-- For stakeholder-facing views, start narrow. A guided answer for one question such as "what supports permitting?" is more useful than another broad dashboard.
-- Keep the executive roadmap work connected to the same stakeholder story; it should answer briefing questions, not only improve internal planning views.
-- Do not start framework overlay implementation until #245 has an accepted first slice. The likely first slice is framework mapping plus one TOGAF-aligned report.
-- Keep the UX consistency work small and opportunistic; it should not displace demo-data review or stakeholder-answer work.
+- Treat PR #263 as the immediate review item, not new implementation work. It is the fastest way to close the remaining item from the prior top-five list.
+- For TOGAF, keep the first implementation slice narrow: framework mapping plus one TOGAF-aligned report or demo path is enough to test the overlay story.
+- Do the principle-set decision before expanding data governance, AI, security, or integration principle content. Retrofitting types after many principles exist will be noisier.
+- Do not keep building leadership visuals from assumptions alone. #216 should inform whether #220 repository confidence or #219 application risk portfolio comes next.
+- If #258 was verified through PR #257, close it as fixed so open bugs reflect current reality.
 
 ## Documentation Follow-up
 
-This grooming pass keeps the active priority document aligned with current GitHub state:
+This grooming pass also updates the public docs so they do not describe merged work as future work:
 
-- #252 is now represented by open PR #257 rather than only as future backlog.
-- #258 is tracked as a bug fixed by PR #257 and should be closed after merge verification.
-- The remaining top priorities stay unchanged because no newer issue or PR displaced the stakeholder-answer, roadmap, TOGAF overlay, or dialog-consistency work.
+- `README.md`: current status and near-term priorities now reflect merged demo data, guided answers, and executive roadmap timeline.
+- `capabilities.md`: Planning & Roadmap and Frontend Display summaries now include the shipped timeline and guided-answer capabilities.


### PR DESCRIPTION
## Summary

This PR is the documentation output from the Backlog Grooming for GovEA automation.

It refreshes the product-priority shortlist after reviewing the current capability summary, open issues, and recent pull requests.

## What changed

- Updates `docs/product-priorities.md` now that PRs #257, #260, and #261 have merged.
- Reframes the top-five next things around PR #263, TOGAF overlay planning, typed principle sets, stakeholder validation, and repository confidence.
- Updates `README.md` so shipped two-city demo data, guided answers, and the executive roadmap timeline are no longer described as future work.
- Updates `capabilities.md` to mark guided answer views as implemented, describe the roadmap timeline/grid, and note the principle-set gap.

## Validation

- Reviewed current open issues through the GitHub connector, including #253, #262, #245, #247, #216, #220, #219, and #258.
- Reviewed recent pull requests through the GitHub connector, including merged #257, #259, #260, #261 and open #263.
- Compared branch against `main`; branch is ahead by 3 commits and behind by 0.
- Documentation-only change; no app test suite run.

## Traceability

Related issues: #253, #262, #245, #247, #216, #220, #219, #258

Capability groups: cms/frontend-display, cms/planning, cms/portfolio, ea/framework-alignment, ea/repository-modelling

Persona: Enterprise Architect (Central IT)
Persona: Agency EA Coordinator
Persona: CMS Administrator
Persona: Department Director
Persona: Elected Official
