### PR TITLE
[codex] docs: refresh backlog priorities after #268 and security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 
 **Implemented:**
 - Full CRUD for the core EA object model: applications, services, capabilities, personas, value streams, strategic objectives, initiatives, ADRs
-- Supporting reference content for principles and glossary terms
+- Supporting reference content for principles and glossary terms, including taxonomy-backed principle sets
 - Mission-first traceability: Personas -> Capabilities -> Applications enforced at the application layer
 - Stakeholder-friendly traceability views: read-only objective, capability, and service traces that show how mission context connects to applications, initiatives, and related architecture records
 - Guided stakeholder answer view: `/answers?q=` turns repository search context into a briefing-style answer with capabilities, services, technology, initiatives, and objectives
 - Service catalogue: first-class service records linked to personas, capabilities, and value streams, with supporting applications derived through capabilities
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
+- Markdown-rendered long-form detail pages across the portfolio model, with shared prose styling for descriptions and other narrative fields
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
 - Demo-ready planning module: strategic objectives plus initiatives with roadmap grid and executive timeline views
 - Repository-wide search across the core content model
@@ -120,21 +121,23 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 **Partially implemented / still maturing:**
 - ADRs: basic CRUD, detail pages, and linkage exist, but the authoring experience is still maturing relative to the core portfolio records
 - Planning semantics: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
+- Long-form authoring: markdown now renders on detail pages, but editing still uses plain textareas rather than a richer toolbar/preview workflow
 - Admin configuration beyond core settings
 - Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
-- Reviewing taxonomy-backed typed principle sets and the related taxonomy delete safety follow-up
+- Hardening multi-org auth, viewer visibility, and glossary-link safety after the latest security findings
+- Closing the taxonomy delete-safety gap for in-use principle types
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- TOGAF overlay demo dataset and first framework-mapping implementation slice
-- Typed principle sets for Architecture, Data, Security, Integration, and similar principle families
-- Stakeholder validation for demo/adoption-facing visuals
-- Repository confidence summary for leadership and public-facing trust cues
-- Application risk portfolio view for investment and modernization conversations
+- Resolve the multi-org auth identity model and duplicate-email tenant-boundary risk
+- Fix glossary viewer-publishing and URL-validation gaps
+- Upgrade Next.js to the patched App Router security release
+- Add taxonomy delete safety for in-use principle types
+- Add a markdown editor with preview for long-text fields
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/capabilities.md
+++ b/capabilities.md
@@ -57,7 +57,7 @@ Foundational content authoring and lifecycle capabilities shared across all EA c
 
 | Capability | Status | Description |
 |---|---|---|
-| Content Authoring | Implemented | Create, edit, and save content items |
+| Content Authoring | Implemented | Create, edit, and save content items, including markdown-authored long-text fields |
 | Content Workflow | Partially implemented | Draft -> Published -> Archived is established for core content types, but planning entities still use their own lifecycle states |
 | Taxonomy Management | Implemented | Hierarchical org-scoped taxonomy terms for domains, persona types, persona tags, and other controlled vocabularies |
 | Content Relationships | Implemented | Link content items; enforce GovEA traceability rules at publish time |
@@ -80,7 +80,7 @@ The structured inventory of the organization's architecture objects.
 | Capability Map | Implemented | Define business capabilities organized by domain; linked to applications, personas, principles, and decisions |
 | Personas | Implemented | Define the people GovEA serves; linked to capabilities and value streams |
 | Architecture Decision Records (ADRs) | Partially implemented | Basic ADR CRUD, detail pages, supersession, and cross-linking exist, but the overall authoring experience is still maturing relative to the stronger core portfolio records |
-| Principles | Implemented | Capture architecture principles and link them to capabilities and decisions; typed principle sets such as Architecture and Data are planned but not yet modeled |
+| Principles | Implemented | Capture architecture principles, link them to capabilities and decisions, and classify them with taxonomy-backed principle sets |
 | Glossary | Implemented | Maintain shared terminology to support consistent EA language across the repository |
 | Value Streams | Implemented | Define value streams with ordered stages; link to capabilities and personas |
 
@@ -132,7 +132,7 @@ How content is presented to authenticated users and, optionally, the public.
 | Guided Answer Views | Implemented | `/answers?q=` assembles capabilities, services, technology, active initiatives, and strategic objectives into a plain-language stakeholder answer with relevance explanations |
 | Relationship Navigation | Implemented | Navigate between linked entities (capability <-> application <-> persona) |
 | Value Stream Display | Implemented | Visualize value stream stages with linked capabilities |
-| Content Display | Implemented | Detail pages with status badges, metadata, linked records, and contributor-friendly edit affordances on shipped surfaces |
+| Content Display | Implemented | Detail pages with status badges, metadata, linked records, contributor-friendly edit affordances, and markdown-rendered narrative fields on shipped surfaces |
 | Product Tour | Implemented | Role-aware guided tour covering the main dashboard, architecture, portfolio, strategy, search, and role-specific workflows |
 | Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
 | Repository Confidence Summary | Not implemented | Plain-language freshness and trust cue for stakeholder-facing views |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -11,6 +11,7 @@ It is intentionally implementation-focused:
 Recent product-shape changes reflected here:
 - `services` is a first-class entity in the portfolio model
 - persona types and persona tags are taxonomy-backed, not separate vocabulary tables
+- `principles.principle_type` is now taxonomy-backed text rather than a fixed enum
 - applications are surfaced for services and strategic objectives through capabilities, not through direct service/objective application joins
 - instance-admin schema and console primitives now exist, including `users.instance_role`, `organizations.is_system_org`, org suspension fields, and `break_glass_sessions`
 
@@ -130,7 +131,7 @@ Additional Auth.js support tables:
 | `strategic_objectives` | Strategy records | Linked to capabilities and value streams; supporting applications are derived through linked capabilities |
 | `initiatives` | Change initiatives | Linked to capabilities, objectives, and applications; capability/application links can carry free-text impact labels |
 | `adrs` | Architecture Decision Records | Linked to capabilities, applications, initiatives, and objectives; can supersede another ADR |
-| `principles` | Architecture principles | Linked to capabilities and ADRs |
+| `principles` | Architecture principles | Linked to capabilities and ADRs; `principle_type` stores the taxonomy term slug |
 | `glossary_terms` | Shared terminology with optional source attribution | Source definitions live in `glossary_term_sources` |
 | `value_streams` | End-to-end value delivery flows | Linked to personas; stages link to capabilities |
 | `taxonomy_terms` | Org-scoped controlled vocabulary hierarchy | Used for capability domains, persona types, persona tags, and other controlled terms |
@@ -264,7 +265,8 @@ These details matter when writing migrations, actions, tests, or exports:
 8. `users.is_active` is currently stored as text with values like `'true'`, not a native boolean column.
 9. `users.instance_role` is intentionally separate from org-scoped `users.role`.
 10. `cross_org_links` intentionally avoids direct FKs to business entity tables because those links cross tenant boundaries and are enforced in application code.
-11. `audit_log.before`, `audit_log.after`, and `audit_log.metadata` are JSONB and should be treated as schemaless event payloads.
+11. `principles.principle_type` stores a taxonomy-backed slug as text, not a foreign key or enum, so term lifecycle safety must be enforced in application logic.
+12. `audit_log.before`, `audit_log.after`, and `audit_log.metadata` are JSONB and should be treated as schemaless event payloads.
 
 ## Source of Truth
 

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -12,41 +12,46 @@ Recent merges strengthened the product in seven areas:
 - Guided stakeholder answers are now shipped through `/answers?q=`, connected from search results, and filtered by viewer publication rules.
 - The roadmap now has an executive timeline view in addition to the existing grid, and the viewer filter bug on roadmap data was fixed.
 - Dialog naming and ADR tooltip consistency have merged, closing the last visible UX cleanup item from the prior shortlist.
+- PR #268 merged the typed-principle and markdown-rendering slice, so principle sets and prose rendering are now part of the shipped baseline.
 - Mission-to-technology traceability, repository-wide search, and viewer visibility rules remain core shipped foundations.
 - Instance administration is a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
 - Framework Alignment is documented as an optional overlay, but implementation has not started.
 
 New signal since the prior grooming pass:
 
-- PR #263 merged and closed #253. Dialog title consistency is no longer a top-five backlog item.
-- PR #265 is open and mergeable for #262, adding taxonomy-backed principle sets for Architecture and Data.
-- Issue #266 surfaced an important taxonomy safety gap: deleting a Principle Type can orphan existing principles because the reference is stored as plain text.
+- PR #268 merged and superseded PR #265, so #262 is now shipped and docs should treat taxonomy-backed principle sets as implemented.
+- Issue #266 is now a true post-merge integrity gap: deleting a Principle Type can orphan existing principles because the reference is stored as plain text.
+- Four fresh security and tenancy issues now dominate near-term priority: bare-email auth lookup across orgs (#269), viewer access to unpublished glossary content (#270), the Next.js App Router DoS advisory (#271), and unsafe glossary source URLs (#272).
+- Issue #273 is the clear UX follow-up to the markdown-rendering merge: authoring still uses plain textareas even though display now supports markdown.
 - Issue #258 still appears open even though its body says it was fixed in PR #257; close it after merge verification if no regression remains.
-- Stakeholder-facing visuals are now useful enough for demos, but further leadership-facing work should be validated against real stakeholder confidence needs.
+- Stakeholder-facing visuals are now useful enough for demos, but the immediate backlog should favor security, tenant-boundary correctness, and content-integrity fixes before more demo-surface expansion.
 
-The next work should finish the principle-set slice safely, then move into framework alignment and stakeholder trust only where the scope is narrow and traceable.
+The next work should first harden security and tenancy boundaries around the now-richer content model, then close the taxonomy-integrity gap introduced by the shipped principle-type work.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) / PR |
 |---|---|---|---|
-| 1 | Review and merge typed principle sets, then handle taxonomy delete safety | PR #265 closes the principle-set design gap, but #266 shows the follow-up safety work needed before admins can freely manage Principle Type taxonomy values | PR #265, #262, #266 |
-| 2 | Define and seed the TOGAF overlay demo path before implementation | The core demo now has richer content and stakeholder views; framework alignment is the next credibility story, but it needs a constrained first slice before schema/UI work starts | #245, #247, related #89 |
-| 3 | Validate stakeholder demo personas and confidence needs | Guided answers and the executive timeline shipped from assumed stakeholder needs; before adding more leadership visuals, validate what Department Director, Budget/Performance, and Elected Official users actually trust | #216, #220 |
-| 4 | Ship the next stakeholder trust visual: repository confidence summary | After guided answers and the roadmap timeline, the next adoption gap is explaining whether the repository is current enough to trust without exposing internal maintenance noise | #220, related #219 |
-| 5 | Decide the next EA analysis slice: application risk, lifecycle, or rationalisation | The portfolio is strong as inventory; the next product value step is decision support that helps leaders see risk, modernization pressure, and investment tradeoffs | #219, #92 |
+| 1 | Fix multi-org auth identity binding | #269 is the highest-risk tenant-boundary issue in the repo: auth and SSO resolve users by bare email even though uniqueness is only guaranteed per organization | #269 |
+| 2 | Enforce published-only glossary access for viewers | #270 breaks the Viewer contract and leaks unpublished shared-reference content, which is especially visible now that glossary content is more central to stakeholder-facing views | #270 |
+| 3 | Patch the Next.js App Router security advisory | #271 is a framework-level DoS fix with a known patched target release, so it is a straightforward security-hardening move with broad platform value | #271 |
+| 4 | Validate glossary source URLs on write | #272 is a stored click-through script-injection vector; it should be closed before glossary usage expands further | #272 |
+| 5 | Add taxonomy delete safety for in-use principle types | #266 is the main post-merge integrity gap from the shipped principle-set work and should be fixed before admins manage principle vocabularies more aggressively | #266 |
 
 ## Product Manager Notes
 
-- Treat PR #265 as the immediate review item. Validate taxonomy seeding, edit pre-selection, type badges, and the migration note before merge.
-- Treat #266 as a near-immediate follow-up to #265. Blocking deletion for in-use taxonomy terms is safer than silently clearing or rewriting principle types.
-- For TOGAF, keep the first implementation slice narrow: framework mapping plus one TOGAF-aligned report or demo path is enough to test the overlay story.
-- Do not keep building leadership visuals from assumptions alone. #216 should inform whether #220 repository confidence or #219 application risk portfolio comes next.
+- Treat #269 as the main product decision item, not just a bug. The team needs to choose between global unique identity and org-qualified sign-in, then make schema, login UX, and docs agree.
+- Treat #270 and #272 as trust-and-safety fixes for the glossary slice. The glossary is now shared reference content, so visibility and outbound-link hygiene need to be explicit.
+- Treat #271 as the cleanest platform-hardening task: patch, refresh lockfile, and run build/lint plus targeted auth and server-action regression checks.
+- Treat #266 as the principal non-security follow-up. Blocking deletion for in-use taxonomy terms is safer than silently clearing or rewriting principle types.
+- Keep #273 close behind the top five. Markdown display shipped, but better authoring should wait until the current security and integrity work is closed.
 - If #258 was verified through PR #257, close it as fixed so open bugs reflect current reality.
 
 ## Documentation Follow-up
 
 This grooming pass also keeps public docs aligned with current repo state:
 
-- `docs/product-priorities.md`: removes merged #253 from the active top-five list and adds #265/#266 as the immediate principle-set thread.
-- `README.md`: active work now reflects typed principle review and taxonomy safety rather than already-merged dialog consistency work.
+- `docs/product-priorities.md`: replaces the stale PR-#265 review framing with the post-#268 security and integrity shortlist.
+- `README.md`: treats taxonomy-backed principle sets and markdown-rendered detail pages as shipped, and updates active work to the new hardening priorities.
+- `capabilities.md`: marks principles as taxonomy-backed and content display as markdown-rendered so the product summary matches the merged implementation.
+- `docs/data-model.md`: documents that `principles.principle_type` is taxonomy-backed text and therefore depends on application-level integrity checks.


### PR DESCRIPTION
## Summary

This PR is the documentation output from the Backlog Grooming for GovEA automation.

It refreshes the product-priority shortlist and the public product docs after reviewing the current capability summary, open issues, and recent pull requests.

## What changed

- Updates `docs/product-priorities.md` to reflect the post-PR #268 state.
- Re-ranks the top five next things to do around the new security and tenancy issues: #269, #270, #271, #272, then #266.
- Updates `README.md` so taxonomy-backed principle sets and markdown-rendered detail pages are treated as shipped.
- Updates `capabilities.md` so the capability summary matches shipped markdown rendering and taxonomy-backed principles.
- Updates `docs/data-model.md` to document that `principles.principle_type` is taxonomy-backed text and depends on application-level integrity checks.

## Why now

PR #268 merged the typed-principle and markdown-rendering slice, but the backlog docs still treated that work as pending review. Since then, several higher-priority security and tenant-boundary issues were opened, so the priority list and supporting docs needed to be brought back in line with current repo reality.

## Validation

- Reviewed current open issues through the GitHub connector, including #266, #269, #270, #271, #272, #273, and #258.
- Reviewed recent pull requests through the GitHub connector, including merged #268, #267, #264, #263, #261, #260, and #257.
- Reviewed local docs and schema references for consistency across `README.md`, `capabilities.md`, `docs/product-priorities.md`, and `docs/data-model.md`.
- Documentation-only change; no app test suite run.

## Top 5 next things

1. Fix multi-org auth identity binding (#269)
2. Enforce published-only glossary access for viewers (#270)
3. Patch the Next.js App Router security advisory (#271)
4. Validate glossary source URLs on write (#272)
5. Add taxonomy delete safety for in-use principle types (#266)

## Traceability

Related issues: #269, #270, #271, #272, #266, #273, #258

Capability groups: cms/iam, cms/multi-org, cms/content-management, cms/portfolio, cms/frontend-display

Persona: CMS Administrator
Persona: Enterprise Architect (Central IT)
Persona: Viewer
Persona: Department Director