### PR TITLE
fix: block deletion of in-use principle type taxonomy terms

### DIFF
--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -1,8 +1,8 @@
 'use server'
 
 import { db } from '@/db/client'
-import { taxonomyTerms } from '@/db/schema'
-import { eq, and, isNull } from 'drizzle-orm'
+import { taxonomyTerms, principles } from '@/db/schema'
+import { eq, and, isNull, inArray, count } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { assertOwnership } from '@/lib/federation'
@@ -66,6 +66,46 @@ export async function getTaxonomyTermsWithChildren(organizationId: string) {
   const values = allTerms.filter(t => t.parentId !== null)
 
   return { types, values }
+}
+
+/**
+ * Returns a map of taxonomy term id → count of principles using that term as their
+ * principleType, for all values under the "Principle Type" taxonomy type.
+ *
+ * Used by the taxonomy management page to show blocking warnings before deletion.
+ * Returns an empty object if the "Principle Type" type doesn't exist or has no values.
+ */
+export async function getPrincipleTypeValueUsage(organizationId: string): Promise<Record<string, number>> {
+  const principleType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq, and, isNull }) =>
+      and(eq(t.organizationId, organizationId), isNull(t.parentId), eq(t.slug, 'principle-type')),
+  })
+  if (!principleType) return {}
+
+  const children = await db.query.taxonomyTerms.findMany({
+    where: (t, { eq, and }) =>
+      and(eq(t.organizationId, organizationId), eq(t.parentId, principleType.id)),
+  })
+  if (children.length === 0) return {}
+
+  const slugToId = Object.fromEntries(children.map(c => [c.slug, c.id]))
+
+  const rows = await db
+    .select({ principleType: principles.principleType, total: count() })
+    .from(principles)
+    .where(and(
+      eq(principles.organizationId, organizationId),
+      inArray(principles.principleType, children.map(c => c.slug))
+    ))
+    .groupBy(principles.principleType)
+
+  // Map from termId → count, defaulting to 0 for values with no principles
+  const result: Record<string, number> = Object.fromEntries(children.map(c => [c.id, 0]))
+  for (const row of rows) {
+    const id = slugToId[row.principleType]
+    if (id) result[id] = row.total
+  }
+  return result
 }
 
 // ── Writes ────────────────────────────────────────────────────────────────────
@@ -134,6 +174,50 @@ export async function deleteTaxonomyTerm(termId: string) {
     where: eq(taxonomyTerms.id, termId),
   })
   assertOwnership(existing?.organizationId, orgId)
+
+  // ── Principle-type safety guard ───────────────────────────────────────────
+  // principles.principleType stores taxonomy slugs as plain text (no FK).
+  // Deleting a principle-type value or its parent type would silently orphan
+  // any principles referencing those slugs. Block deletion if any are in use.
+
+  if (existing?.parentId !== null && existing) {
+    // Deleting a value — check if its parent is the "Principle Type" type
+    const parent = await db.query.taxonomyTerms.findFirst({
+      where: eq(taxonomyTerms.id, existing.parentId!),
+    })
+    if (parent?.slug === 'principle-type') {
+      const [{ total }] = await db
+        .select({ total: count() })
+        .from(principles)
+        .where(and(eq(principles.organizationId, orgId), eq(principles.principleType, existing.slug)))
+      if (total > 0) {
+        throw new Error(
+          `Cannot delete "${existing.name}" — ${total} principle${total !== 1 ? 's' : ''} use this type. Reassign them before deleting.`
+        )
+      }
+    }
+  }
+
+  if (existing?.parentId === null && existing?.slug === 'principle-type') {
+    // Deleting the "Principle Type" parent — check all its children
+    const children = await db.query.taxonomyTerms.findMany({
+      where: and(eq(taxonomyTerms.parentId, termId), eq(taxonomyTerms.organizationId, orgId)),
+    })
+    if (children.length > 0) {
+      const [{ total }] = await db
+        .select({ total: count() })
+        .from(principles)
+        .where(and(
+          eq(principles.organizationId, orgId),
+          inArray(principles.principleType, children.map(c => c.slug))
+        ))
+      if (total > 0) {
+        throw new Error(
+          `Cannot delete "Principle Type" — ${total} principle${total !== 1 ? 's' : ''} use one of its values. Reassign them before deleting.`
+        )
+      }
+    }
+  }
 
   // When deleting a type, also delete its values (not promote — orphaned values are useless)
   // When deleting a value, just delete it

--- a/apps/govea/src/app/(admin)/taxonomy/page.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { getTaxonomyTermsWithChildren } from '@/actions/taxonomy'
+import { getTaxonomyTermsWithChildren, getPrincipleTypeValueUsage } from '@/actions/taxonomy'
 import { TaxonomyTable } from './taxonomy-table'
 
 export default async function TaxonomyPage() {
@@ -10,7 +10,10 @@ export default async function TaxonomyPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const { types, values } = await getTaxonomyTermsWithChildren(orgId)
+  const [{ types, values }, principleTypeUsage] = await Promise.all([
+    getTaxonomyTermsWithChildren(orgId),
+    getPrincipleTypeValueUsage(orgId),
+  ])
 
   return (
     <div className="space-y-6">
@@ -20,7 +23,7 @@ export default async function TaxonomyPage() {
           Classification types and their values — used to organize capabilities, glossary entries, personas, and principles.
         </p>
       </div>
-      <TaxonomyTable types={types} values={values} role={role} />
+      <TaxonomyTable types={types} values={values} role={role} principleTypeUsage={principleTypeUsage} />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
@@ -16,12 +16,14 @@ interface Props {
   types: TaxonomyTerm[]
   values: TaxonomyTerm[]
   role: Role
+  /** termId → number of principles that reference that term's slug as their principleType */
+  principleTypeUsage: Record<string, number>
 }
 
 type EditTarget = { term: TaxonomyTerm; kind: 'type' | 'value' }
-type DeleteTarget = { term: TaxonomyTerm; valueCount: number }
+type DeleteTarget = { term: TaxonomyTerm; valueCount: number; principleCount: number }
 
-export function TaxonomyTable({ types, values, role }: Props) {
+export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -149,7 +151,13 @@ export function TaxonomyTable({ types, values, role }: Props) {
                       <Button
                         variant="ghost" size="sm"
                         className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
-                        onClick={() => setDeleteTarget({ term: type, valueCount: typeValues.length })}
+                        onClick={() => {
+                          // For the "Principle Type" parent, sum usage across all its children
+                          const principleCount = type.slug === 'principle-type'
+                            ? typeValues.reduce((sum, v) => sum + (principleTypeUsage[v.id] ?? 0), 0)
+                            : 0
+                          setDeleteTarget({ term: type, valueCount: typeValues.length, principleCount })
+                        }}
                         disabled={isPending}
                       >
                         Delete
@@ -195,7 +203,7 @@ export function TaxonomyTable({ types, values, role }: Props) {
                           <Button
                             variant="ghost" size="sm"
                             className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
-                            onClick={() => setDeleteTarget({ term: val, valueCount: 0 })}
+                            onClick={() => setDeleteTarget({ term: val, valueCount: 0, principleCount: principleTypeUsage[val.id] ?? 0 })}
                             disabled={isPending}
                           >
                             Delete
@@ -280,10 +288,20 @@ export function TaxonomyTable({ types, values, role }: Props) {
                 This type has <strong>{deleteTarget?.valueCount} value{deleteTarget?.valueCount !== 1 ? 's' : ''}</strong> which will also be deleted.
               </p>
             )}
+            {(deleteTarget?.principleCount ?? 0) > 0 && (
+              <p className="text-destructive bg-destructive/5 border border-destructive/20 rounded-md px-3 py-2">
+                <strong>{deleteTarget?.principleCount} principle{deleteTarget?.principleCount !== 1 ? 's' : ''}</strong>{' '}
+                use this type. Reassign them to a different type before deleting.
+              </p>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isPending || (deleteTarget?.principleCount ?? 0) > 0}
+            >
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary

Closes #266

`principles.principleType` is a plain-text slug — no FK constraint enforces referential integrity when a taxonomy value is deleted. Before this change, deleting a "Principle Type" value while principles referenced its slug produced silent orphans: grey unstyled badges with raw slug text on the principles table/detail pages.

**Two-layer guard (defense in depth):**

- **Server action** (`deleteTaxonomyTerm`): counts referencing principles before executing the delete and throws a user-facing error if any are found. Covers both value deletion and parent-type deletion. Acts as the safety net even if the UI is somehow bypassed.
- **UI** (`TaxonomyTable`): page now fetches `principleTypeUsage` (termId → count) in parallel with the taxonomy term list. Delete dialog shows a red blocking message and the confirm button is **disabled** when any principles reference that type — admin sees the count and knows to reassign before proceeding.

## Changed files

| File | Change |
|---|---|
| `src/actions/taxonomy.ts` | Import `principles`, `count`, `inArray`; add `getPrincipleTypeValueUsage()`; add guard block in `deleteTaxonomyTerm` |
| `src/app/(admin)/taxonomy/page.tsx` | Fetch usage in parallel; pass `principleTypeUsage` prop |
| `src/app/(admin)/taxonomy/taxonomy-table.tsx` | Extend `Props` + `DeleteTarget`; wire counts into both Delete buttons; blocking warning + disabled state in dialog |

## Test plan

- [ ] Create a "Principle Type" taxonomy type with values "Security" and "Architecture"
- [ ] Assign several principles to "Security"
- [ ] Click Delete on "Security" — confirm dialog shows red "X principle(s) use this type. Reassign them before deleting." and Delete button is disabled
- [ ] Click Delete on "Architecture" (unused) — confirm dialog shows no warning and Delete proceeds normally
- [ ] Click Delete on the "Principle Type" parent while any values are in use — confirm same block applies
- [ ] Reassign all principles away from "Security", retry delete — it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)