### PR TITLE
fix: pre-bake pnpm in dev image to prevent startup hang

### DIFF
--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -15,6 +15,12 @@ RUN pnpm install --frozen-lockfile
 FROM base AS dev
 WORKDIR /app
 
+# Pre-download pnpm so corepack doesn't fetch it at container startup.
+# The deps stage downloads it too, but its cache lives in /root/.cache
+# which is not copied across stages, causing a runtime download on every
+# pnpm invocation in the entrypoint (migrate, seed, dev).
+RUN corepack prepare pnpm@9.0.0 --activate
+
 # Copy installed node_modules from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/govea/node_modules ./apps/govea/node_modules


### PR DESCRIPTION
## Summary

- `RUN corepack prepare pnpm@9.0.0 --activate` added to the `dev` stage of `Containerfile.dev`

**Root cause:** The multi-stage build copies `node_modules` from the `deps` stage but not `/root/.cache/node/corepack`. Each pnpm invocation in the entrypoint (`db:migrate`, `db:seed`, `next dev`) triggered a fresh corepack download from npmjs.org at container startup. When the download was slow or failed, the container hung past the ACA provisioning timeout and was marked unhealthy — with zero console logs to indicate why.

Surfaced when upgrading drizzle-kit 0.28→0.31 because it added a new pnpm invocation to the startup sequence. The old image happened to succeed; the new one timed out.

## Test plan
- [ ] Deploy new image, confirm revision becomes Healthy within 3 minutes
- [ ] Confirm markdown editors appear in edit dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)