### PR TITLE
fix: add missing Mark as reviewed button to persona detail page

### DIFF
--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getApplication, markApplicationReviewed } from '@/actions/applications'
+import { MarkReviewedForm } from '@/components/mark-reviewed-button'
 import { getCapabilities } from '@/actions/capabilities'
 import { getInitiatives } from '@/actions/initiatives'
 import { getADRs } from '@/actions/adrs'
@@ -194,11 +195,7 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
             : ' · Never reviewed'}
         </p>
         {canMutate && (
-          <form action={markApplicationReviewed.bind(null, id)}>
-            <button type="submit" className="text-xs font-medium text-primary hover:text-primary/80 transition-colors">
-              Mark as reviewed
-            </button>
-          </form>
+          <MarkReviewedForm action={markApplicationReviewed.bind(null, id)} />
         )}
       </div>
     </div>

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getCapability, markCapabilityReviewed } from '@/actions/capabilities'
+import { MarkReviewedForm } from '@/components/mark-reviewed-button'
 import { getApplications } from '@/actions/applications'
 import { getObjectives } from '@/actions/objectives'
 import { getInitiatives } from '@/actions/initiatives'
@@ -249,11 +250,7 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             : ' · Never reviewed'}
         </p>
         {canMutate && (
-          <form action={markCapabilityReviewed.bind(null, id)}>
-            <button type="submit" className="text-xs font-medium text-primary hover:text-primary/80 transition-colors">
-              Mark as reviewed
-            </button>
-          </form>
+          <MarkReviewedForm action={markCapabilityReviewed.bind(null, id)} />
         )}
       </div>
     </div>

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getPersona, markPersonaReviewed } from '@/actions/personas'
+import { MarkReviewedForm } from '@/components/mark-reviewed-button'
 import { getPersonaTypesFromTaxonomy, getPersonaTagsFromTaxonomy } from '@/actions/taxonomy'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
@@ -189,11 +190,7 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
             : ' · Never reviewed'}
         </p>
         {canMutate && (
-          <form action={markPersonaReviewed.bind(null, id)}>
-            <button type="submit" className="text-xs font-medium text-primary hover:text-primary/80 transition-colors">
-              Mark as reviewed
-            </button>
-          </form>
+          <MarkReviewedForm action={markPersonaReviewed.bind(null, id)} />
         )}
       </div>
     </div>

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -181,8 +181,20 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
         revokeAction={revokeCrossOrgLink}
       />
 
-      <div className="text-xs text-muted-foreground pt-4 border-t">
-        Created {new Date(persona.createdAt).toLocaleDateString()} · Updated {new Date(persona.updatedAt).toLocaleDateString()}
+      <div className="pt-4 border-t flex items-center justify-between gap-4">
+        <p className="text-xs text-muted-foreground">
+          Created {new Date(persona.createdAt).toLocaleDateString()} · Modified {new Date(persona.updatedAt).toLocaleDateString()}
+          {persona.lastReviewedAt
+            ? ` · Reviewed ${new Date(persona.lastReviewedAt).toLocaleDateString()}`
+            : ' · Never reviewed'}
+        </p>
+        {canMutate && (
+          <form action={markPersonaReviewed.bind(null, id)}>
+            <button type="submit" className="text-xs font-medium text-primary hover:text-primary/80 transition-colors">
+              Mark as reviewed
+            </button>
+          </form>
+        )}
       </div>
     </div>
   )

--- a/apps/govea/src/components/mark-reviewed-button.tsx
+++ b/apps/govea/src/components/mark-reviewed-button.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useFormStatus } from 'react-dom'
-import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 function SubmitButton() {
   const { pending } = useFormStatus()
@@ -21,16 +22,15 @@ interface MarkReviewedFormProps {
 }
 
 export function MarkReviewedForm({ action }: MarkReviewedFormProps) {
+  const router = useRouter()
   const [confirmed, setConfirmed] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   async function handleAction(formData: FormData) {
     await action(formData)
     setConfirmed(true)
-    timerRef.current = setTimeout(() => setConfirmed(false), 3000)
+    router.refresh()
+    setTimeout(() => setConfirmed(false), 2000)
   }
-
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
 
   if (confirmed) {
     return <span className="text-xs text-emerald-600 font-medium">Marked as reviewed</span>

--- a/apps/govea/src/components/mark-reviewed-button.tsx
+++ b/apps/govea/src/components/mark-reviewed-button.tsx
@@ -2,7 +2,6 @@
 
 import { useFormStatus } from 'react-dom'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
 
 function SubmitButton() {
   const { pending } = useFormStatus()
@@ -23,17 +22,10 @@ interface MarkReviewedFormProps {
 
 export function MarkReviewedForm({ action }: MarkReviewedFormProps) {
   const router = useRouter()
-  const [confirmed, setConfirmed] = useState(false)
 
   async function handleAction(formData: FormData) {
     await action(formData)
-    setConfirmed(true)
     router.refresh()
-    setTimeout(() => setConfirmed(false), 2000)
-  }
-
-  if (confirmed) {
-    return <span className="text-xs text-emerald-600 font-medium">Marked as reviewed</span>
   }
 
   return (

--- a/apps/govea/src/components/mark-reviewed-button.tsx
+++ b/apps/govea/src/components/mark-reviewed-button.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+import { useEffect, useRef, useState } from 'react'
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="text-xs font-medium text-primary hover:text-primary/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? 'Saving…' : 'Mark as reviewed'}
+    </button>
+  )
+}
+
+interface MarkReviewedFormProps {
+  action: (formData: FormData) => Promise<void>
+}
+
+export function MarkReviewedForm({ action }: MarkReviewedFormProps) {
+  const [confirmed, setConfirmed] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  async function handleAction(formData: FormData) {
+    await action(formData)
+    setConfirmed(true)
+    timerRef.current = setTimeout(() => setConfirmed(false), 3000)
+  }
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+
+  if (confirmed) {
+    return <span className="text-xs text-emerald-600 font-medium">Marked as reviewed</span>
+  }
+
+  return (
+    <form action={handleAction}>
+      <SubmitButton />
+    </form>
+  )
+}


### PR DESCRIPTION
Closes #285

## Summary

- `markPersonaReviewed` was imported in the persona detail page but never wired up — no button existed in the UI
- Adds the review footer matching capabilities and applications: review date or "Never reviewed" on the left, "Mark as reviewed" button on the right for Contributors+
- Replaces the bare form on all three entity types (capabilities, applications, personas) with a `MarkReviewedForm` client component that shows "Saving…" while pending and calls `router.refresh()` on completion so the date updates in place

## Test plan

- [ ] Open a persona detail page as Contributor or Admin — footer shows "Never reviewed" and "Mark as reviewed" button
- [ ] Click "Mark as reviewed" — button shows "Saving…", then footer updates to today's date
- [ ] Verify the same behavior on capabilities and applications pages
- [ ] Verify the updated date appears in the 90-day Review Health section on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)