### PR TITLE
fix: restrict dev toolbar to instance admins only

### DIFF
--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -7,6 +7,7 @@ import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { getTheme, themeToStyleString } from '@/lib/themes'
 import type { Role } from '@/lib/rbac'
+import { isInstanceAdmin } from '@/lib/rbac'
 import { AppShell } from '@/components/app-shell'
 
 const ROLE_BADGE_CLASS: Record<Role, string> = {
@@ -58,7 +59,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       email={session.user.email ?? ''}
       roleBadgeClass={ROLE_BADGE_CLASS[role]}
       themeStyle={themeStyle}
-      isDev={process.env.NODE_ENV === 'development' || process.env.DEMO_MODE === 'true'}
+      isDev={isInstanceAdmin(session.user)}
       enabledModules={enabledModules}
       signOutSlot={signOutSlot}
     >


### PR DESCRIPTION
## Summary

- Dev data toolbar was visible to all users in development mode or when `DEMO_MODE=true`
- Changed the `isDev` prop in the admin layout to use `isInstanceAdmin(session.user)` instead of the env var check
- Toolbar is now gated on the `instanceRole === 'instance_admin'` RBAC check, matching the intended access model

## Changes

- `apps/govea/src/app/(admin)/layout.tsx`: import `isInstanceAdmin` and gate `isDev` prop on it

Closes #235

## Test plan

- [ ] Sign in as a regular admin/contributor/viewer — dev toolbar should not appear
- [ ] Sign in as instance admin — dev toolbar should appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)