### PR TITLE
research: stakeholder interview guides and assumption register (#216)

### DIFF
--- a/docs/research/stakeholder-assumption-register.md
+++ b/docs/research/stakeholder-assumption-register.md
@@ -1,0 +1,59 @@
+# Stakeholder Feature Assumption Register
+
+**Purpose:** Map each stakeholder-facing feature to the specific assumptions it depends on, ranked by consequence if the assumption is wrong. Use to prioritize which interview answers matter most before the next build.
+
+**Features covered:** Repository Confidence Summary, Roadmap Timeline, Guided Answers
+**Related issue:** [#216](https://github.com/roballred/GovEA/issues/216)
+
+**Priority ratings:**
+- **P1** — wrong assumption likely breaks the feature's value proposition entirely
+- **P2** — wrong assumption degrades usefulness but the feature survives
+- **P3** — wrong assumption creates friction but doesn't invalidate the feature
+
+---
+
+## Repository Confidence Summary
+
+| ID | Assumption | Persona | If wrong | Priority |
+|----|-----------|---------|----------|----------|
+| RC-1 | Stakeholders check freshness before acting on data — a staleness signal changes behavior | Elected Official, Budget Analyst | The label is ignored; no one reads metadata before using a view | P1 |
+| RC-2 | "Actively maintained / under development / getting started" labels are legible without a definition | Elected Official | Labels are opaque or feel like jargon ("maintained by whom? for what?") | P1 |
+| RC-3 | A percentage score mapped to a label is more trustworthy than a raw number | Budget Analyst | Analysts want the number and the methodology, not an abstracted label | P2 |
+| RC-4 | Stakeholders attribute the confidence rating to the IT team, which is sufficient for their purposes | Both | They need to know which human is accountable — a label without a name carries no weight in oversight | P2 |
+| RC-5 | The narrative field (admin-authored) will be filled in and kept current | Both | Feature silently degrades into label-only; optional fields in practice become empty fields | P3 |
+
+**Riskiest assumption:** RC-1. If no one reads freshness labels before acting, the entire feature is decorative.
+
+---
+
+## Roadmap Timeline
+
+| ID | Assumption | Persona | If wrong | Priority |
+|----|-----------|---------|----------|----------|
+| RT-1 | Elected officials want to see initiative sequence over time, not status counts or budget totals | Elected Official | The timeline view answers a question they don't ask; they want "how much" before "when" | P1 |
+| RT-2 | A 1–3 year horizon is the right window; shorter (current fiscal year) or longer (capital plan) is less useful | Both | Elected officials think in fiscal years; budget analysts think in multi-year CIP cycles — neither maps cleanly to a rolling 3-year view | P1 |
+| RT-3 | "Roadmap" is a legible term that implies forward planning, not a completed route | Elected Official | "Roadmap" reads as a finished document or a promise, not a living plan; creates accountability expectations the tool doesn't intend to carry | P2 |
+| RT-4 | Stakeholders will trust initiative data entered by IT staff without external corroboration | Budget Analyst | Budget analysts expect to reconcile this against the capital budget or CIP — mismatches make IT look unreliable, not the tool | P2 |
+| RT-5 | Seeing which capabilities each initiative affects is useful context, not noise | Both | At the stakeholder level, capability linkages are inside baseball; what matters is which departments or services are affected | P3 |
+
+**Riskiest assumption:** RT-2. If the time horizon is wrong, the view answers a question no one is asking at the moment they need an answer.
+
+---
+
+## Guided Answers
+
+| ID | Assumption | Persona | If wrong | Priority |
+|----|-----------|---------|----------|----------|
+| GA-1 | Elected officials and budget staff will ask questions directly, without staff intermediation | Elected Official | The actual user is a chief of staff or budget analyst using the tool on behalf of the principal — the UX needs to work for the proxy, not the elected official | P1 |
+| GA-2 | Plain-language answers reduce the need for staff interpretation | Both | Plain language lowers the reading burden but doesn't eliminate the trust deficit — stakeholders still want a human name attached to the answer | P1 |
+| GA-3 | The questions stakeholders ask map to the entity types GovEA stores (capabilities, applications, personas) | Budget Analyst | Budget staff ask about cost centers, FTEs, and contract vehicles — none of which are in GovEA's data model | P2 |
+| GA-4 | A direct question-answer format is preferred over a dashboard for this audience | Both | Some users want an overview first and drill down; others want to ask a specific question and stop — the right default is unknown | P2 |
+| GA-5 | Stakeholders will know enough to ask a useful question without prompting | Elected Official | Without suggested questions or examples, a blank prompt box is a blank stare; the discovery problem is upstream of the answer quality | P3 |
+
+**Riskiest assumption:** GA-3. Budget analysts work in a financial data model that doesn't overlap with EA data. If their real questions — "what does this system cost in FTE time?" "which contract expires next year?" — can't be answered, guided answers is useful only to architects, not to the personas it's targeting.
+
+---
+
+## Cross-cutting risk
+
+GA-1 and RT-1 share a structural assumption: that elected officials and budget staff use the tool themselves, not through a staff proxy. If the actual user is always a chief of staff or a budget aide, the UX decisions (reading level, question prompts, confidence labels) need to optimize for a different person than the named persona. This is the single most consequential thing to confirm or refute in interviews.

--- a/docs/research/stakeholder-interview-guide.md
+++ b/docs/research/stakeholder-interview-guide.md
@@ -1,0 +1,96 @@
+# Stakeholder Persona Interview Guide
+
+**Purpose:** Validate the `Elected Official` and `Budget & Performance Analyst` personas before driving further stakeholder-facing UI decisions. Closes acceptance criteria for [#216](https://github.com/roballred/GovEA/issues/216).
+
+**How to use:** Each guide is a 30–45 minute structured conversation. A video call with one person who fits the profile counts as a session. Take notes on surprises — confirming an assumption is useful, but disconfirming one is more valuable.
+
+---
+
+## Guide A: Elected Official / City Council Member
+
+### Who to recruit
+A sitting or former city/county council member, a council chief of staff, or a legislative aide who regularly briefs an elected official on technology or budget matters. One conversation is the minimum; two gives you a signal check.
+
+### Framing (say this to open)
+> "I'm working on a tool that helps government IT teams explain their technology decisions to non-technical audiences — council members, budget staff, the public. I want to understand how you actually get and use that kind of information today, not pitch you anything."
+
+### Warm-up (5 min)
+- Walk me through the last time you had to make a decision or cast a vote that touched technology or software. What information did you have going in?
+- Where does that information come from — staff briefings, documents, dashboards, something else?
+
+### Core validation (20 min)
+
+**Questions they actually ask:**
+- When a department comes to you about a new technology investment or a system being retired, what are the first two or three questions you ask?
+- What would make you vote no on a technology request even if the dollar amount was small?
+
+**Format and trust:**
+- When staff brief you on technology, what format lands best — a one-pager, a slide, a table, a verbal summary, something else?
+- Have you ever seen a chart or visual about technology that you actually trusted enough to reference later? What made it credible?
+- *(If they describe a format):* Would you use that yourself, or do you need staff to interpret it for you first?
+
+**Terminology:**
+- I'm going to say some words we use in IT planning. Tell me what comes to mind, if anything: *capability, lifecycle, roadmap, decommissioned, architecture*.
+- Which of those would you feel comfortable using in a public meeting? Which would you want defined first?
+
+**Confidence and freshness:**
+- If a staff member showed you a summary of the city's technology portfolio, what would you need to see to trust that it was current and not outdated?
+- Would a label like "actively maintained" or "last updated 3 months ago" change how you used the information?
+
+### Feature probes (10 min)
+
+**Guided answers:** "Imagine you could type a plain-English question — 'What applications does the city use for permitting?' — and get a direct answer instead of a report. Would you use that, or would you still want staff to pull the information for you? What questions would you actually ask?"
+
+**Roadmap timeline:** "If you saw a visual showing which technology projects are planned over the next 1–3 years, in what order, what would you want to know that the visual doesn't show? What would make you distrust it?"
+
+**Repository confidence:** "If a technology summary page had a label that said 'actively maintained' or 'under development,' would that change how you used or shared the information? What would you need to know about how that label was determined?"
+
+### Closing (5 min)
+- Is there anything about how your office currently gets technology information that I haven't asked about that you think I should know?
+- Who else in your orbit would have strong opinions about this — staff, colleagues, department directors?
+
+---
+
+## Guide B: Budget & Performance Analyst
+
+### Who to recruit
+Someone in a municipal or county budget office, an OMB analyst, a performance management staffer, or a consultant who regularly works with those offices. This persona does not currently exist as a record in GovEA — treat this conversation as foundational, not confirmatory.
+
+### Framing (say this to open)
+> "I'm building a tool that helps IT teams document and explain their technology portfolio. I want to understand how budget and performance staff currently interact with technology information — what you need, what's missing, and what gets in the way."
+
+### Warm-up (5 min)
+- Tell me about a recent budget cycle where technology spend was a notable item. What did you have to figure out, and where did you go to figure it out?
+- Do you have a go-to source for understanding what technology a department uses? What is it, and how much do you trust it?
+
+### Core validation (20 min)
+
+**Questions they actually ask:**
+- When you're reviewing a department's technology budget request, what are the first things you check or challenge?
+- What information about an application or system do you wish you had that you typically don't?
+- Have you ever had to reconcile what IT says a system costs with what a department says it delivers? What does that process look like?
+
+**Format and trust:**
+- Do you work primarily in spreadsheets, dashboards, documents, or something else when analyzing technology spend?
+- What makes a technology summary credible to you — who produced it, how recent it is, what it cites, something else?
+- *(If they describe a format):* Would a visual like a matrix or a card work, or do you need the underlying numbers?
+
+**Terminology:**
+- Same word exercise: *capability, lifecycle, roadmap, decommissioned, architecture*. Which of these do you use in your work? Which would you have to explain to a department director?
+- What term would you use instead of "decommissioned" when writing a budget justification?
+
+**Confidence and freshness:**
+- If a system showed you that a technology summary was last updated six months ago, would you use it in a budget document? What's your threshold for "too old"?
+- Who do you need to be able to trace a data point back to — the IT director, a specific analyst, an automated system?
+
+### Feature probes (10 min)
+
+**Guided answers:** "If you could ask a question like 'Which applications support the Parks department?' and get a structured answer, would that replace any part of your current process? Or would it create new questions you'd then need to chase down?"
+
+**Roadmap timeline:** "If you saw a 3-year initiative timeline that showed which systems are being replaced or retired, and you were reviewing a department's capital budget request, would that change your questions? What's missing from a timeline that you'd need for a budget context?"
+
+**Repository confidence:** "A label that says 'actively maintained — last updated January 2026.' Is that useful to you in a budget document or oversight memo, or does it raise more questions than it answers?"
+
+### Closing (5 min)
+- Is there a standard format — a report, a template, a state requirement — that governs how your office receives technology information? Can you share a sanitized example?
+- Who in the city or county tends to produce the technology information you actually trust?


### PR DESCRIPTION
## Summary

- Adds `docs/research/stakeholder-interview-guide.md` — structured interview guides for the Elected Official and Budget & Performance Analyst personas, with warm-up, core validation questions, and feature probes for the three live stakeholder features
- Adds `docs/research/stakeholder-assumption-register.md` — maps each stakeholder-facing feature to the assumptions it depends on, rated P1–P3 by consequence if wrong

No code changes. This is the prerequisite research artifact for #216.

## Why

Guided answers, roadmap timeline, and repository confidence are live. The next stakeholder-facing build should be grounded in validation signals rather than assumed needs. These documents give whoever conducts outreach a structured instrument and a clear picture of what's at stake per assumption.

Closes #216 (acceptance criteria: research artifacts produced; persona updates and capability wording revisions to follow after interviews are complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)