### PR TITLE
feat: capability relationship map — first visualization slice (#281)

### DIFF
--- a/apps/govea/src/app/(admin)/capabilities/[id]/map/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/map/page.tsx
@@ -1,0 +1,59 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import { getCapabilityTrace } from '@/actions/traceability'
+import Link from 'next/link'
+import { CapabilityMap } from '@/components/capability-map'
+
+export default async function CapabilityMapPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const trace = await getCapabilityTrace(id)
+  if (!trace) notFound()
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div className="flex items-center justify-between">
+        <Link
+          href={`/capabilities/${id}`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← {trace.name}
+        </Link>
+        <Link
+          href={`/traceability?from=capability&id=${id}`}
+          className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          View traceability →
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{trace.name}</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          1-hop relationship map · objectives, applications, personas
+        </p>
+      </div>
+
+      <CapabilityMap trace={trace} />
+
+      <p className="text-xs text-muted-foreground">
+        Showing direct (1-hop) relationships only. Initiatives, ADRs, and principles are on the{' '}
+        <Link
+          href={`/traceability?from=capability&id=${id}`}
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          traceability view
+        </Link>
+        {' '}or the{' '}
+        <Link
+          href={`/capabilities/${id}`}
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          detail page
+        </Link>.
+      </p>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -91,12 +91,20 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
         <Link href="/capabilities" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
           ← Capabilities
         </Link>
-        <Link
-          href={`/traceability?from=capability&id=${id}`}
-          className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
-        >
-          View traceability →
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link
+            href={`/capabilities/${id}/map`}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View map →
+          </Link>
+          <Link
+            href={`/traceability?from=capability&id=${id}`}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            View traceability →
+          </Link>
+        </div>
       </div>
 
       <div className="space-y-3">

--- a/apps/govea/src/components/capability-map.tsx
+++ b/apps/govea/src/components/capability-map.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { CapabilityTrace } from '@/actions/traceability'
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+const NW  = 170   // satellite node width
+const NH  = 56    // satellite node height
+const FW  = 200   // focal node width
+const FH  = 68    // focal node height
+const GX  = 80    // horizontal gap between columns (edge routing space)
+const GY  = 14    // vertical gap between sibling nodes
+const PY  = 40    // vertical padding top/bottom
+
+const LEFT_X  = 0
+const FOC_X   = NW + GX            // 250
+const RIGHT_X = NW + GX + FW + GX  // 530
+const CVW     = RIGHT_X + NW        // 700 — total canvas width
+
+// ── Color tokens (hex — used directly in SVG attributes) ──────────────────────
+
+const COLORS = {
+  focal: {
+    fill: '#0f172a', stroke: '#0f172a',
+    text: '#ffffff',  sub: '#94a3b8',
+  },
+  objective: {
+    fill: '#f5f3ff', stroke: '#c4b5fd',
+    text: '#5b21b6',  sub: '#7c3aed',
+  },
+  application: {
+    fill: '#f8fafc', stroke: '#e2e8f0',
+    text: '#0f172a',  sub: '#64748b',
+  },
+  persona: {
+    fill: '#eef2ff', stroke: '#c7d2fe',
+    text: '#3730a3',  sub: '#4f46e5',
+  },
+} as const
+
+type NodeType = keyof typeof COLORS
+
+const EDGE_DEFAULT = '#cbd5e1'
+const EDGE_ACTIVE  = '#6366f1'
+const EDGE_DIM     = '#f1f5f9'
+
+const FONT = 'system-ui, -apple-system, sans-serif'
+
+// ── Internal layout types ─────────────────────────────────────────────────────
+
+interface LayoutNode {
+  id: string
+  type: NodeType
+  label: string
+  sub?: string
+  href: string
+  x: number; y: number; w: number; h: number
+}
+
+interface LayoutEdge {
+  id: string
+  sourceId: string
+  targetId: string
+  x1: number; y1: number
+  x2: number; y2: number
+}
+
+// ── Layout computation (pure) ─────────────────────────────────────────────────
+
+function computeLayout(trace: CapabilityTrace): {
+  nodes: LayoutNode[]
+  edges: LayoutEdge[]
+  canvasHeight: number
+} {
+  const leftItems = trace.objectives.map(o => ({
+    id: `obj-${o.id}`,
+    type: 'objective' as NodeType,
+    label: o.name,
+    sub: o.timeHorizon ?? undefined,
+    href: `/objectives/${o.id}`,
+  }))
+
+  const rightItems: Array<Omit<LayoutNode, 'x' | 'y' | 'w' | 'h'>> = [
+    ...trace.applications.map(a => ({
+      id: `app-${a.id}`,
+      type: 'application' as NodeType,
+      label: a.name,
+      sub: a.vendor ?? undefined,
+      href: `/applications/${a.id}`,
+    })),
+    ...trace.personas.map(p => ({
+      id: `per-${p.id}`,
+      type: 'persona' as NodeType,
+      label: p.name,
+      sub: p.type ?? undefined,
+      href: `/personas/${p.id}`,
+    })),
+  ]
+
+  // Canvas height driven by the tallest column
+  const sideCount = Math.max(leftItems.length, rightItems.length, 1)
+  const sideColH  = sideCount * NH + (sideCount - 1) * GY
+  const canvasHeight = Math.max(sideColH, FH) + PY * 2
+
+  const focalY = Math.round((canvasHeight - FH) / 2)
+
+  const nodes: LayoutNode[] = []
+  const edges: LayoutEdge[]  = []
+
+  // Focal node
+  nodes.push({
+    id: 'focal',
+    type: 'focal',
+    label: trace.name,
+    sub: trace.domain ?? undefined,
+    href: `/capabilities/${trace.id}`,
+    x: FOC_X, y: focalY, w: FW, h: FH,
+  })
+
+  // Left column — vertically centred
+  const leftColH    = Math.max(leftItems.length, 1) * NH + (Math.max(leftItems.length, 1) - 1) * GY
+  const leftStartY  = Math.round((canvasHeight - leftColH) / 2)
+
+  leftItems.forEach((item, i) => {
+    const y = leftStartY + i * (NH + GY)
+    nodes.push({ ...item, x: LEFT_X, y, w: NW, h: NH })
+    edges.push({
+      id: `e-${item.id}`,
+      sourceId: item.id,
+      targetId: 'focal',
+      x1: LEFT_X + NW, y1: y + NH / 2,
+      x2: FOC_X,       y2: focalY + FH / 2,
+    })
+  })
+
+  // Right column — vertically centred
+  const rightColH   = Math.max(rightItems.length, 1) * NH + (Math.max(rightItems.length, 1) - 1) * GY
+  const rightStartY = Math.round((canvasHeight - rightColH) / 2)
+
+  rightItems.forEach((item, i) => {
+    const y = rightStartY + i * (NH + GY)
+    nodes.push({ ...item, x: RIGHT_X, y, w: NW, h: NH })
+    edges.push({
+      id: `e-focal-${item.id}`,
+      sourceId: 'focal',
+      targetId: item.id,
+      x1: FOC_X + FW, y1: focalY + FH / 2,
+      x2: RIGHT_X,    y2: y + NH / 2,
+    })
+  })
+
+  return { nodes, edges, canvasHeight }
+}
+
+// ── Bezier path helper ────────────────────────────────────────────────────────
+
+function bezierH(x1: number, y1: number, x2: number, y2: number): string {
+  const mx = x1 + (x2 - x1) * 0.5
+  return `M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`
+}
+
+// ── Truncate helper ───────────────────────────────────────────────────────────
+
+function trunc(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s
+}
+
+// ── Node ──────────────────────────────────────────────────────────────────────
+
+function MapNode({
+  node,
+  hoveredId,
+  onEnter,
+  onLeave,
+  onActivate,
+}: {
+  node: LayoutNode
+  hoveredId: string | null
+  onEnter: (id: string) => void
+  onLeave: () => void
+  onActivate: (href: string) => void
+}) {
+  const c  = COLORS[node.type]
+  const rx = 8
+
+  const isHovered = hoveredId === node.id
+  // Dim satellite nodes when a different satellite is hovered
+  const isDimmed  =
+    hoveredId !== null &&
+    hoveredId !== node.id &&
+    node.id !== 'focal' &&
+    hoveredId !== 'focal'
+
+  const label = trunc(node.label, node.type === 'focal' ? 26 : 22)
+  const sub   = node.sub ? trunc(node.sub, 24) : undefined
+
+  const labelY = node.y + (sub ? node.h / 2 - 9 : node.h / 2)
+  const subY   = node.y + node.h / 2 + 10
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${node.label}${node.sub ? ` — ${node.sub}` : ''}`}
+      style={{ cursor: 'pointer', opacity: isDimmed ? 0.3 : 1, transition: 'opacity 120ms' }}
+      onMouseEnter={() => onEnter(node.id)}
+      onMouseLeave={onLeave}
+      onClick={() => onActivate(node.href)}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onActivate(node.href) } }}
+    >
+      <title>{node.label}{node.sub ? ` (${node.sub})` : ''}</title>
+
+      <rect
+        x={node.x} y={node.y} width={node.w} height={node.h}
+        rx={rx} ry={rx}
+        fill={c.fill}
+        stroke={isHovered ? EDGE_ACTIVE : c.stroke}
+        strokeWidth={isHovered ? 2 : 1}
+        style={{ transition: 'stroke 120ms' }}
+      />
+
+      <text
+        x={node.x + node.w / 2} y={labelY}
+        textAnchor="middle" dominantBaseline="middle"
+        fontSize={node.type === 'focal' ? 13 : 12}
+        fontWeight={node.type === 'focal' ? 600 : 500}
+        fill={c.text}
+        style={{ fontFamily: FONT, userSelect: 'none' }}
+      >
+        {label}
+      </text>
+
+      {sub && (
+        <text
+          x={node.x + node.w / 2} y={subY}
+          textAnchor="middle" dominantBaseline="middle"
+          fontSize={10}
+          fill={c.sub}
+          style={{ fontFamily: FONT, userSelect: 'none' }}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  )
+}
+
+// ── Empty-state placeholder ───────────────────────────────────────────────────
+
+function GapNode({ x, y, message }: { x: number; y: number; message: string }) {
+  return (
+    <g>
+      <rect
+        x={x} y={y} width={NW} height={NH}
+        rx={8} ry={8}
+        fill="#fefce8" stroke="#fde68a" strokeWidth={1}
+        strokeDasharray="4 3"
+      />
+      <text
+        x={x + NW / 2} y={y + NH / 2}
+        textAnchor="middle" dominantBaseline="middle"
+        fontSize={10} fill="#92400e"
+        style={{ fontFamily: FONT, userSelect: 'none' }}
+      >
+        {message}
+      </text>
+    </g>
+  )
+}
+
+// ── Axis label ────────────────────────────────────────────────────────────────
+
+function AxisLabel({ x, y, children }: { x: number; y: number; children: string }) {
+  return (
+    <text
+      x={x} y={y}
+      textAnchor="middle"
+      fontSize={9} fontWeight={600}
+      fill="#94a3b8"
+      letterSpacing={1}
+      style={{ fontFamily: FONT, textTransform: 'uppercase', userSelect: 'none' }}
+    >
+      {children}
+    </text>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function CapabilityMap({ trace }: { trace: CapabilityTrace }) {
+  const router = useRouter()
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
+
+  const onEnter    = useCallback((id: string) => setHoveredId(id), [])
+  const onLeave    = useCallback(() => setHoveredId(null), [])
+  const onActivate = useCallback((href: string) => router.push(href), [router])
+
+  const { nodes, edges, canvasHeight } = computeLayout(trace)
+
+  const hasNoLeft  = trace.objectives.length === 0
+  const hasNoRight = trace.applications.length === 0 && trace.personas.length === 0
+
+  const midY = Math.round(canvasHeight / 2)
+
+  return (
+    <div className="w-full overflow-x-auto rounded-lg border border-border bg-card">
+      <svg
+        viewBox={`0 0 ${CVW} ${canvasHeight}`}
+        width="100%"
+        style={{ minWidth: 420, display: 'block' }}
+        role="img"
+        aria-label={`Relationship map for capability: ${trace.name}`}
+      >
+        <title>Capability relationship map — {trace.name}</title>
+
+        {/* Column axis labels */}
+        <AxisLabel x={LEFT_X + NW / 2} y={14}>Objectives</AxisLabel>
+        <AxisLabel x={FOC_X + FW / 2}  y={14}>Capability</AxisLabel>
+        <AxisLabel x={RIGHT_X + NW / 2} y={14}>Applications & Personas</AxisLabel>
+
+        {/* Empty-state gap nodes */}
+        {hasNoLeft && (
+          <GapNode x={LEFT_X} y={midY - NH / 2} message="No objectives linked" />
+        )}
+        {hasNoRight && (
+          <GapNode x={RIGHT_X} y={midY - NH / 2} message="No apps or personas" />
+        )}
+
+        {/* Edges — rendered behind nodes */}
+        {edges.map(edge => {
+          const adjacent = hoveredId === edge.sourceId || hoveredId === edge.targetId
+          const color =
+            hoveredId === null  ? EDGE_DEFAULT :
+            adjacent            ? EDGE_ACTIVE  : EDGE_DIM
+          return (
+            <path
+              key={edge.id}
+              d={bezierH(edge.x1, edge.y1, edge.x2, edge.y2)}
+              fill="none"
+              stroke={color}
+              strokeWidth={adjacent && hoveredId !== null ? 2 : 1.5}
+              style={{ transition: 'stroke 120ms, stroke-width 120ms' }}
+            />
+          )
+        })}
+
+        {/* Nodes */}
+        {nodes.map(node => (
+          <MapNode
+            key={node.id}
+            node={node}
+            hoveredId={hoveredId}
+            onEnter={onEnter}
+            onLeave={onLeave}
+            onActivate={onActivate}
+          />
+        ))}
+      </svg>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 px-4 py-2.5 border-t border-border text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm bg-violet-50 border border-violet-300" />
+          Objective
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm bg-slate-50 border border-slate-200" />
+          Application
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm bg-indigo-50 border border-indigo-200" />
+          Persona
+        </span>
+        <span className="ml-auto">Click any node to open its detail page</span>
+      </div>
+    </div>
+  )
+}

--- a/docs/design/relationship-visualization.md
+++ b/docs/design/relationship-visualization.md
@@ -1,0 +1,153 @@
+# Relationship Visualization — Design
+
+**Issue:** [#281](https://github.com/roballred/GovEA/issues/281)
+**Status:** First slice implemented (capability focal map)
+
+---
+
+## Decisions
+
+### Rendering: app-native SVG
+
+Relationship maps are rendered as inline SVG in React components. No D3, no external graph library, no PlantUML as the runtime surface.
+
+Rationale:
+- SVG integrates with React state (hover, click) without a separate runtime
+- Layout is deterministic — no force simulation means no jitter or non-reproducible positions
+- Accessible with `role`, `aria-label`, keyboard navigation, and `<title>` elements
+- Scales responsively via `viewBox`
+
+PlantUML and Mermaid remain useful for capability design, ADRs, and issue discussion but are not the in-product visualization layer.
+
+### Layout: deterministic columns
+
+Maps use a left-to-right column layout. Columns are fixed:
+- **Left column** — upstream context (what justifies this object)
+- **Center** — focal object (always rendered prominent)
+- **Right column** — downstream delivery (what this object produces or connects to)
+
+This creates a consistent reading direction: mission → capability → technology/people.
+
+Force-directed layouts are explicitly rejected. They produce different results on each render, make it hard to predict where to look, and degrade with larger node counts.
+
+### Scope: focal-object views only
+
+Each map is centered on one object. The first slice centers on a Capability. There is no "show me everything" graph. This is a product constraint, not a technical one — the data model could support a full graph but readability would collapse.
+
+### Hop limit: 1-hop in v1
+
+The first slice shows only direct relationships (1 hop from the focal node). 2-hop expansion is a follow-on.
+
+### Coexistence with traceability
+
+The relationship map complements the existing traceability view, it does not replace it. The traceability view is better for deep drill-down and gap identification. The map is better for orientation and communication. Both are accessible from the capability detail page.
+
+---
+
+## First slice: Capability focal map
+
+### Surface
+
+`/capabilities/[id]/map` — dedicated route, linked from the capability detail page header.
+
+Chose a dedicated route over an inline panel to:
+- keep the detail page clean
+- allow the map to use more horizontal space (max-w-4xl vs max-w-3xl)
+- follow the same pattern as the existing traceability route
+
+### Data
+
+Reuses `getCapabilityTrace(id)` from `src/actions/traceability.ts`. No new queries needed. The existing trace includes all 1-hop relationships: objectives, applications, personas, initiatives, ADRs, principles.
+
+The map renders: **objectives** (left), **applications + personas** (right). Initiatives, ADRs, and principles are excluded from v1 — they're available via the traceability view.
+
+### Layout algorithm
+
+```
+Canvas width: 700px (viewBox, scales responsively)
+
+Left col:   x=0,   width=170
+Center:     x=250, width=200
+Right col:  x=530, width=170
+
+Horizontal gap between columns: 80px (edge routing space)
+Vertical gap between sibling nodes: 14px
+Vertical padding top/bottom: 32px
+
+Node height (satellite): 56px
+Node height (focal): 68px
+
+Canvas height: PAD*2 + max(leftCount, rightCount, 1) * (NH + GY) - GY
+               minimum: 200px
+```
+
+Edges are cubic bezier curves: `M x1 y1 C mx y1, mx y2, x2 y2` where `mx = x1 + (x2-x1)*0.5`. This creates symmetric S-curves.
+
+### Color coding
+
+| Node type   | Background  | Border       | Text         |
+|-------------|-------------|--------------|--------------|
+| Focal       | slate-900   | slate-900    | white        |
+| Objective   | violet-50   | violet-300   | violet-800   |
+| Application | slate-50    | slate-200    | slate-900    |
+| Persona     | indigo-50   | indigo-200   | indigo-800   |
+
+Edge lines: slate-300 default, indigo-500 on hover of adjacent node, slate-100 (dim) when a different node is hovered.
+
+### Interaction
+
+- **Hover node** — node border turns indigo, adjacent edges turn indigo, non-adjacent edges dim
+- **Click node** — `router.push(href)` navigates to entity detail page
+- **Keyboard** — nodes are `tabIndex={0}` with `onKeyDown` for Enter/Space
+- **Empty state** — when a column has no nodes, a dashed amber placeholder appears with a plain-language message
+
+### Accessibility
+
+- SVG has `role="img"` and `aria-label`
+- `<title>` element inside SVG for screen readers
+- Each node has `role="button"` and `aria-label` with name + sublabel
+- Each node is keyboard-focusable
+
+### Visibility rules
+
+`getCapabilityTrace` already enforces `canReadFederatedEntity` on the focal capability. Nodes in the map are the same relationships already visible via the traceability page — no new visibility logic needed.
+
+---
+
+## Component
+
+`src/components/capability-map.tsx` — client component (`'use client'`).
+
+Props: `{ trace: CapabilityTrace }`
+
+The component:
+1. Computes node and edge layout positions (pure function, no side effects)
+2. Renders SVG with column axis labels, edges (behind nodes), nodes
+3. Manages hover state via `useState`
+4. Navigates on click via `useRouter`
+5. Renders an HTML legend below the SVG
+
+---
+
+## Follow-on slices
+
+These are not in scope for the first implementation but are the natural next steps:
+
+| Slice | Surface | Notes |
+|-------|---------|-------|
+| 2 | Application focal map | Application → Capabilities → Objectives + Personas |
+| 3 | 2-hop expansion toggle | Show neighbors of neighbors on demand |
+| 4 | Service focal map | Persona → Service → Capabilities → Applications |
+| 5 | Objective focal map | Objective → Capabilities → Applications |
+| 6 | Matrix view | Capabilities × Applications heatmap |
+
+Follow-on implementation issues should be opened once the first slice is validated.
+
+---
+
+## Explicit non-goals (permanent)
+
+- No whole-repository "show me everything" graph
+- No force-directed layout as default
+- No formal notation (ArchiMate, BPMN, UML)
+- The map never replaces table/detail access — it complements it


### PR DESCRIPTION
## Summary

First implementation slice for #281. Adds a focused 1-hop SVG relationship map to the capability detail surface.

- **`src/components/capability-map.tsx`** — client component; deterministic 3-column layout (objectives left | capability center | applications + personas right); pure React SVG with hover highlight, edge dimming, click-through navigation, keyboard access, and empty-state gap placeholders
- **`src/app/(admin)/capabilities/[id]/map/page.tsx`** — dedicated route at `/capabilities/:id/map`; reuses `getCapabilityTrace`, no new queries
- **`src/app/(admin)/capabilities/[id]/page.tsx`** — adds "View map →" link alongside "View traceability →" in the header
- **`docs/design/relationship-visualization.md`** — design document covering layout algorithm, color tokens, follow-on slices, and permanent non-goals

## Design decisions

- **Deterministic column layout** — left (objectives) → center (capability) → right (applications + personas). No force-directed layout.
- **1-hop only** — direct relationships only. Initiatives, ADRs, and principles remain on the traceability view.
- **Dedicated route** — `/capabilities/:id/map` keeps the detail page clean and gives the map more horizontal space (`max-w-4xl`)
- **Reuses existing data** — `getCapabilityTrace` already returns everything needed; visibility rules already enforced there

## What's NOT in this slice (by design)

- Application focal map
- Service focal map
- 2-hop expansion toggle
- Objective focal map
- Whole-repo graph (permanent non-goal)

## Test plan

- [ ] Visit any capability detail page — "View map →" link appears in the header
- [ ] Map page renders with 3 columns: objectives left, focal center, apps + personas right
- [ ] Hovering a node highlights its edges and dims unrelated nodes
- [ ] Clicking a node navigates to that entity's detail page
- [ ] Empty columns show amber dashed gap placeholders
- [ ] Keyboard: Tab to each node, Enter/Space navigates

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)