### PR TITLE
test(unit): expand unit coverage for rbac, modules, and themes

### DIFF
--- a/apps/govea/tests/unit/modules.test.ts
+++ b/apps/govea/tests/unit/modules.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for module toggle utilities (#118)
+ *
+ * isModuleEnabled — absent key defaults to true (opt-out semantics)
+ * moduleForPath  — maps a pathname to its owning ModuleDef
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isModuleEnabled, moduleForPath } from '@/lib/modules'
+
+// ---------------------------------------------------------------------------
+// isModuleEnabled
+// ---------------------------------------------------------------------------
+
+describe('isModuleEnabled', () => {
+  it('returns true when key is absent (new modules default on)', () => {
+    expect(isModuleEnabled({}, 'personas')).toBe(true)
+  })
+
+  it('returns true when key is explicitly true', () => {
+    expect(isModuleEnabled({ personas: true }, 'personas')).toBe(true)
+  })
+
+  it('returns false when key is explicitly false', () => {
+    expect(isModuleEnabled({ personas: false }, 'personas')).toBe(false)
+  })
+
+  it('does not leak — other keys do not affect the queried key', () => {
+    const map = { capabilities: false, roadmap: false }
+    expect(isModuleEnabled(map, 'personas')).toBe(true)
+  })
+
+  it('handles all module keys consistently', () => {
+    const allOff = {
+      personas: false,
+      'value-streams': false,
+      capabilities: false,
+      services: false,
+      glossary: false,
+      applications: false,
+      adrs: false,
+      principles: false,
+      objectives: false,
+      initiatives: false,
+      roadmap: false,
+    }
+    expect(isModuleEnabled(allOff, 'roadmap')).toBe(false)
+    expect(isModuleEnabled({}, 'roadmap')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// moduleForPath
+// ---------------------------------------------------------------------------
+
+describe('moduleForPath', () => {
+  it('returns the correct def for an exact route match', () => {
+    const mod = moduleForPath('/personas')
+    expect(mod?.key).toBe('personas')
+  })
+
+  it('returns the correct def for a sub-path', () => {
+    const mod = moduleForPath('/personas/abc-123')
+    expect(mod?.key).toBe('personas')
+  })
+
+  it('returns the correct def for a deeply nested sub-path', () => {
+    const mod = moduleForPath('/capabilities/abc/edit')
+    expect(mod?.key).toBe('capabilities')
+  })
+
+  it('returns undefined for an unregistered path', () => {
+    expect(moduleForPath('/dashboard')).toBeUndefined()
+  })
+
+  it('returns undefined for an empty path', () => {
+    expect(moduleForPath('')).toBeUndefined()
+  })
+
+  it('does not match on partial prefix — /adr does not match /adrs', () => {
+    expect(moduleForPath('/adr')).toBeUndefined()
+  })
+
+  it('does not match /application against /applications', () => {
+    expect(moduleForPath('/application')).toBeUndefined()
+  })
+
+  it('matches value-streams correctly', () => {
+    expect(moduleForPath('/value-streams')).toMatchObject({ key: 'value-streams' })
+    expect(moduleForPath('/value-streams/stage/99')).toMatchObject({ key: 'value-streams' })
+  })
+
+  it('matches roadmap', () => {
+    expect(moduleForPath('/roadmap')).toMatchObject({ key: 'roadmap' })
+  })
+
+  it('returns the full ModuleDef shape', () => {
+    const mod = moduleForPath('/adrs')
+    expect(mod).toMatchObject({
+      key: 'adrs',
+      label: expect.any(String),
+      href: '/adrs',
+      group: 'Portfolio',
+    })
+  })
+})

--- a/apps/govea/tests/unit/rbac.test.ts
+++ b/apps/govea/tests/unit/rbac.test.ts
@@ -1,5 +1,129 @@
 import { describe, it, expect } from 'vitest'
-import { isInstanceAdmin } from '@/lib/rbac'
+import {
+  hasPermission,
+  hasRole,
+  canEdit,
+  isAdmin,
+  isInstanceAdmin,
+  type Permission,
+  type Role,
+} from '@/lib/rbac'
+
+// ---------------------------------------------------------------------------
+// hasPermission
+// ---------------------------------------------------------------------------
+
+describe('hasPermission', () => {
+  describe('admin', () => {
+    const permissions: Permission[] = [
+      'content:read',
+      'content:create',
+      'content:edit',
+      'content:delete',
+      'content:publish',
+      'users:manage',
+      'settings:manage',
+    ]
+    it.each(permissions)('has %s', (p) => {
+      expect(hasPermission('admin', p)).toBe(true)
+    })
+  })
+
+  describe('contributor', () => {
+    const allowed: Permission[] = [
+      'content:read',
+      'content:create',
+      'content:edit',
+      'content:publish',
+    ]
+    const denied: Permission[] = ['content:delete', 'users:manage', 'settings:manage']
+
+    it.each(allowed)('has %s', (p) => {
+      expect(hasPermission('contributor', p)).toBe(true)
+    })
+    it.each(denied)('does not have %s', (p) => {
+      expect(hasPermission('contributor', p)).toBe(false)
+    })
+  })
+
+  describe('viewer', () => {
+    const denied: Permission[] = [
+      'content:create',
+      'content:edit',
+      'content:delete',
+      'content:publish',
+      'users:manage',
+      'settings:manage',
+    ]
+
+    it('has content:read', () => {
+      expect(hasPermission('viewer', 'content:read')).toBe(true)
+    })
+    it.each(denied)('does not have %s', (p) => {
+      expect(hasPermission('viewer', p)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hasRole — hierarchy: admin(3) > contributor(2) > viewer(1)
+// ---------------------------------------------------------------------------
+
+describe('hasRole', () => {
+  it.each<[Role, Role, boolean]>([
+    ['admin',       'admin',       true],
+    ['admin',       'contributor', true],
+    ['admin',       'viewer',      true],
+    ['contributor', 'admin',       false],
+    ['contributor', 'contributor', true],
+    ['contributor', 'viewer',      true],
+    ['viewer',      'admin',       false],
+    ['viewer',      'contributor', false],
+    ['viewer',      'viewer',      true],
+  ])('%s meets minimum %s → %s', (role, minimum, expected) => {
+    expect(hasRole({ role }, minimum)).toBe(expected)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// canEdit — requires contributor or higher
+// ---------------------------------------------------------------------------
+
+describe('canEdit', () => {
+  it('returns true for admin', () => {
+    expect(canEdit({ role: 'admin' })).toBe(true)
+  })
+
+  it('returns true for contributor', () => {
+    expect(canEdit({ role: 'contributor' })).toBe(true)
+  })
+
+  it('returns false for viewer', () => {
+    expect(canEdit({ role: 'viewer' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isAdmin
+// ---------------------------------------------------------------------------
+
+describe('isAdmin', () => {
+  it('returns true for admin role', () => {
+    expect(isAdmin({ role: 'admin' })).toBe(true)
+  })
+
+  it('returns false for contributor', () => {
+    expect(isAdmin({ role: 'contributor' })).toBe(false)
+  })
+
+  it('returns false for viewer', () => {
+    expect(isAdmin({ role: 'viewer' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isInstanceAdmin
+// ---------------------------------------------------------------------------
 
 describe('isInstanceAdmin', () => {
   it('returns true for instance_admin role', () => {

--- a/apps/govea/tests/unit/themes.test.ts
+++ b/apps/govea/tests/unit/themes.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for theme utilities (#118)
+ *
+ * getTheme         — look up a theme by id with fallback
+ * themeToStyleString — serialises a ThemeDefinition to inline CSS
+ */
+
+import { describe, it, expect } from 'vitest'
+import { getTheme, themeToStyleString, themes } from '@/lib/themes'
+
+// ---------------------------------------------------------------------------
+// getTheme
+// ---------------------------------------------------------------------------
+
+describe('getTheme', () => {
+  it('returns the govea theme by id', () => {
+    expect(getTheme('govea').id).toBe('govea')
+  })
+
+  it('returns the servicenow theme by id', () => {
+    expect(getTheme('servicenow').id).toBe('servicenow')
+  })
+
+  it('falls back to the first theme for an unknown id', () => {
+    const fallback = getTheme('unknown-theme-id')
+    expect(fallback.id).toBe(themes[0].id)
+  })
+
+  it('returned theme has required shape', () => {
+    const t = getTheme('govea')
+    expect(t).toMatchObject({
+      id: expect.any(String),
+      name: expect.any(String),
+      description: expect.any(String),
+      vars: expect.any(Object),
+      previewColors: {
+        header: expect.any(String),
+        primary: expect.any(String),
+        background: expect.any(String),
+      },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// themeToStyleString
+// ---------------------------------------------------------------------------
+
+describe('themeToStyleString', () => {
+  const govea = getTheme('govea')
+  const css = themeToStyleString(govea)
+
+  it('produces a non-empty string', () => {
+    expect(css.length).toBeGreaterThan(0)
+  })
+
+  it('contains a :root block for brand vars (always-on)', () => {
+    expect(css).toMatch(/:root\s*\{/)
+  })
+
+  it('contains a :root:not(.dark) block for content vars', () => {
+    expect(css).toMatch(/:root:not\(\.dark\)\s*\{/)
+  })
+
+  it('places header-bg in the unconditional :root block', () => {
+    // Split on the :root:not(.dark) boundary
+    const rootBlock = css.split(':root:not(.dark)')[0]
+    expect(rootBlock).toContain('--header-bg')
+  })
+
+  it('places --background in the :root:not(.dark) block only', () => {
+    const [rootBlock, darkBlock] = css.split(':root:not(.dark)')
+    expect(rootBlock).not.toContain('--background')
+    expect(darkBlock).toContain('--background')
+  })
+
+  it('does not put brand vars inside :root:not(.dark)', () => {
+    const notDarkBlock = css.split(':root:not(.dark)')[1] ?? ''
+    expect(notDarkBlock).not.toContain('--header-bg')
+    expect(notDarkBlock).not.toContain('--header-fg')
+    expect(notDarkBlock).not.toContain('--header-border')
+  })
+
+  it('works for the servicenow theme too', () => {
+    const sn = getTheme('servicenow')
+    const snCss = themeToStyleString(sn)
+    expect(snCss).toContain('--header-bg')
+    expect(snCss).toContain(':root:not(.dark)')
+  })
+
+  it('every var in the theme appears somewhere in the output', () => {
+    for (const key of Object.keys(govea.vars)) {
+      expect(css).toContain(key)
+    }
+  })
+})


### PR DESCRIPTION
Closes #118

## Summary

- **`rbac.test.ts`** — expanded from `isInstanceAdmin`-only to cover the full surface: `hasPermission` (all 3 roles × all 7 permissions), `hasRole` (complete 3×3 hierarchy matrix), `canEdit`, and `isAdmin`
- **`modules.test.ts`** — new file covering `isModuleEnabled` (absent-key opt-out default, explicit true/false, multi-key isolation) and `moduleForPath` (exact match, sub-path, deep sub-path, unknown paths, empty string, partial-prefix non-matches)
- **`themes.test.ts`** — new file covering `getTheme` (known ids, unknown-id fallback, shape contract) and `themeToStyleString` (brand vars in unconditional `:root` block, content vars in `:root:not(.dark)`, no cross-contamination, all vars from the theme present in output)

90 unit tests total, all passing locally.

## Test plan

- [x] `vitest run tests/unit` — 90 tests pass, 382ms
- [ ] CI type check, lint, integration tests, and E2E smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)