### PR TITLE
fix(ci): switch from db:migrate to db:push for pre-production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run database migrations
-        run: pnpm --filter govea db:migrate
+      - name: Push schema to database
+        run: pnpm --filter govea db:push --force
 
       - name: Run integration tests
         run: pnpm --filter govea test:integration
@@ -162,8 +162,8 @@ jobs:
       - name: Install Playwright browsers (Chromium only)
         run: pnpm --filter govea exec playwright install --with-deps chromium
 
-      - name: Run database migrations
-        run: pnpm --filter govea db:migrate
+      - name: Push schema to database
+        run: pnpm --filter govea db:push --force
 
       # The db:seed script uses `tsx --env-file .env.local`.  Create an empty
       # placeholder so tsx does not fail on the missing file.  All real env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,9 @@ SSO users default to Viewer. Admins promote as needed.
 
 ## Database Workflow
 
-**Pre-production (current):** Use `db:push` to sync schema changes directly to the dev database. No migration files needed — run `pnpm --filter govea db:push` after schema edits, then `db:seed` to repopulate.
+**Pre-production (current):** Use `db:push` to sync schema changes directly to the dev database. CI also uses `db:push --force` on a fresh database. No migration files needed — run `pnpm --filter govea db:push` after schema edits, then `db:seed` to repopulate.
 
-**Switch to migrations when:** the first real tenant or persistent data exists that can't be thrown away. At that point, stop using `db:push` and switch to `db:generate` + `db:migrate` for all schema changes. Update this section when the switch happens.
+**Switch to migrations when:** the first real tenant or persistent data exists that can't be thrown away. At that point: squash the schema into a single `0000_initial_schema.sql`, switch CI from `db:push` to `db:migrate`, and use `db:generate` + `db:migrate` for all schema changes going forward. Update this section when the switch happens.
 
 Do not commit migration files generated during pre-production development.
 


### PR DESCRIPTION
## Summary

- Replaces `db:migrate` with `db:push --force` in both the integration and smoke CI jobs
- Updates CLAUDE.md to clarify the pre-production workflow and document what to do when switching to migrations at production time

Migration files create unnecessary coordination overhead (numbering conflicts between concurrent branches, broken snapshot chains) while there's no real tenant data to protect. `db:push` is what the project docs have always said to use; CI just wasn't following it.

**When to revisit:** first real tenant or persistent data → squash to `0000_initial_schema.sql`, flip CI back to `db:migrate`.

## Test plan

- [ ] CI integration tests pass with `db:push`
- [ ] CI E2E smoke tests pass with `db:push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)