### PR TITLE
docs: define instance admin persona and boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Personas -> Capabilities -> Applications
 - **Strategic Objectives** link to capabilities and value streams. Supporting applications are surfaced through linked capabilities rather than direct objective-to-application joins.
 - **Persona Type** and **Persona Tag** values are managed through **Taxonomy**, not through persona-specific admin tables.
 - **Organization** is the top-level tenant boundary.
-- **Instance Admin** is a separate instance-scoped operating role used for platform administration. It does not automatically make a user the owner or editor of every agency's EA content.
+- **Instance Admin** is a separate instance-scoped operating role used for platform administration. It does not automatically make a user the owner or editor of every agency's EA content, and it should not absorb routine org-scoped settings like themes or module choices.
 - Additional core entities include **Architecture Decision Records (ADRs)**, **Strategic Objectives**, **Initiatives**, **Principles**, and the **Glossary**.
 - Single-org use is still the default operating mode, but GovEA now also ships a prototype multi-organization model with org-scoped visibility and approval-based cross-org links.
 
@@ -110,6 +110,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
 - Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, and audited break-glass sessions
+- Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement

--- a/business-architecture/capabilities/cms/admin-configuration/ac-feature-management.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-feature-management.md
@@ -17,6 +17,7 @@ The system must allow administrators to enable and disable optional modules with
 - Disabling a feature does not delete its data — re-enabling restores full functionality
 - Only Admins can manage features
 - Feature changes take effect without a server restart
+- Feature management in this capability is organization-scoped module visibility, not instance-wide platform configuration
 
 ## Implementation Status
 - **v1:** Org-level module toggles are implemented for the current module set.

--- a/business-architecture/capabilities/cms/admin-configuration/ac-site-settings.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-site-settings.md
@@ -16,6 +16,7 @@ The system must allow administrators to configure the basic identity and appeara
 ## Rules
 - Site settings changes take effect immediately without a restart
 - Only Admins can access or modify site settings
+- Site settings in this capability are organization-scoped, not instance-scoped platform settings
 
 ## Implementation Status
 - **v1:** Theme selection and appearance settings are implemented.

--- a/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
@@ -4,7 +4,7 @@
 The system must provide administrators with the tools needed to configure, monitor, and maintain the site without requiring code changes or server access. In the current product this is an early admin toolkit rather than a complete operations surface.
 
 ## Personas
-- **CMS Administrator** — the sole user of this capability group; configures and maintains the system on behalf of the organization
+- **CMS Administrator** — configures and maintains the system on behalf of their organization
 
 ## Sub-Capabilities
 
@@ -41,6 +41,7 @@ GovEA follows a migration-based upgrade model. This section defines expectations
 - All Admin & Configuration capabilities are accessible to Admins only
 - Configuration changes must not require a server restart
 - No Admin & Configuration function should require CLI or database access
+- Platform governance responsibilities such as tenant lifecycle, instance-admin promotion, and break-glass access belong to IAM Instance Administration, not this capability group
 
 ## Current Scope
 - Implemented today: admin dashboard, user management, audit visibility, taxonomy and persona metadata management, org connections, and theme selection

--- a/business-architecture/capabilities/cms/iam/iam-instance-administration.md
+++ b/business-architecture/capabilities/cms/iam/iam-instance-administration.md
@@ -1,0 +1,32 @@
+# Capability: Instance Administration
+
+## What It Does
+The system must support a distinct instance-scoped operating role for platform administration across the whole GovEA deployment. This role governs tenants, platform access, and cross-org operational controls without automatically becoming the working owner of every organization's EA repository.
+
+## Personas
+- **Instance Administrator** — operates the GovEA instance as a shared platform and needs platform-wide controls with clear guardrails
+
+## Behaviors
+- View a platform dashboard with tenant counts, user counts, active break-glass sessions, and recent instance-level events
+- View all organizations registered on the instance, including status and basic metadata
+- View a cross-org user inventory and grant or remove `instance_admin` from eligible users
+- Suspend and unsuspend organizations with an explicit reason captured in the audit log
+- View instance-level audit events separately from org-scoped audit events
+- Grant time-limited break-glass access to a specific organization for support or incident investigation
+- Revoke break-glass access before expiry when the investigation is complete
+
+## Rules
+- `instance_admin` is stored separately from the org-scoped user role and does not replace it
+- Instance admin does not automatically grant create, edit, publish, or delete rights across every org's EA content
+- Org-scoped configuration such as themes, enabled modules, and framework overlays remains with the organization's Admin role
+- Break-glass access must be time-limited, explicitly granted, and fully audited
+- The system org cannot be suspended through the normal instance-admin UI
+- Instance-level actions must be distinguishable from org-level actions in the audit trail
+
+## Implementation Status
+- **v1:** Platform dashboard, org inventory, org detail, cross-org user view, org suspension, instance-admin promotion/demotion, instance audit view, and audited break-glass sessions are implemented.
+- **Future:** Org creation, platform defaults, endpoint and integration configuration, and richer tenant-governance controls should be added here rather than folded into org-admin settings.
+
+## Links
+- Depends on: User Management, Role-Based Access Control, IAM Audit Trail
+- Related: Multi-Organization Federation

--- a/business-architecture/capabilities/cms/iam/iam-role-based-access-control.md
+++ b/business-architecture/capabilities/cms/iam/iam-role-based-access-control.md
@@ -9,6 +9,7 @@ The system must control what each user can see and do based on their assigned ro
 
 ## Behaviors
 - Enforce three built-in roles: Admin, Contributor, Viewer
+- Enforce `instance_admin` as a separate instance-scoped operating role rather than a fourth org-scoped content role
 - Prevent users from accessing features or content outside their role's permissions
 - Allow an Admin to change a user's role at any time
 - Preserve the role already assigned to a pre-provisioned SSO user account at sign-in
@@ -22,11 +23,14 @@ The system must control what each user can see and do based on their assigned ro
 | Contributor | Create and edit content — no user management, no delete |
 | Viewer | Read-only access to viewer-visible content: published core content, accepted ADRs, and active/complete initiatives |
 
+`instance_admin` is not listed in the table above because it is a separate operating role layered on top of a user's org-scoped role. It exists for platform governance, not as a content-ownership shortcut.
+
 ## Rules
 - Roles are fixed in v1 — custom role creation is out of scope
 - Permission enforcement must occur server-side; UI hiding alone is not sufficient
 - A user can hold only one role per organization at a time
 - Role assignments must be scoped to an organization
+- Org-scoped Admin retains ownership of org settings; instance-scoped authority is defined separately under Instance Administration
 
 ## Links
 - Depends on: User Management

--- a/business-architecture/capabilities/cms/iam/iam.md
+++ b/business-architecture/capabilities/cms/iam/iam.md
@@ -5,6 +5,7 @@ The system must control who can access it, how they authenticate, and what they 
 
 ## Personas
 - **CMS Administrator** — configures and manages all IAM functions
+- **Instance Administrator** — governs platform-level access and tenant operations across the shared instance
 - **Content Viewer** — subject to IAM; authenticates and receives appropriate access
 
 ## Sub-Capabilities
@@ -13,6 +14,7 @@ The system must control who can access it, how they authenticate, and what they 
 |---|---|---|
 | User Management | [iam-user-management.md](./iam-user-management.md) | Create, edit, deactivate, and delete user accounts |
 | Role-Based Access Control | [iam-role-based-access-control.md](./iam-role-based-access-control.md) | Enforce Admin / Contributor / Viewer roles and permissions |
+| Instance Administration | [iam-instance-administration.md](./iam-instance-administration.md) | Govern tenant lifecycle, platform admin access, and audited break-glass operations |
 | Local Authentication | [iam-local-authentication.md](./iam-local-authentication.md) | Email and password login with password reset |
 | SSO Authentication | [iam-sso-authentication.md](./iam-sso-authentication.md) | Microsoft Entra ID sign-in via OpenID Connect with admin-managed pre-provisioned access |
 | IAM Audit Trail | [iam-audit-trail.md](./iam-audit-trail.md) | Immutable log of all identity and access events |
@@ -33,4 +35,5 @@ The following outcomes indicate IAM is working well for a 1–3 person governmen
 - IAM is always active — authentication is required by default; public access to published content is an opt-in configuration controlled by the Admin
 - Local authentication is always available as a fallback, even when SSO is configured
 - SSO sign-in is allowed only for active pre-provisioned users with an organization binding
+- Instance administration is separate from org-scoped administration and must not silently expand into tenant content ownership
 - All IAM events are logged and immutable

--- a/business-architecture/personas/cms-administrator.md
+++ b/business-architecture/personas/cms-administrator.md
@@ -6,11 +6,12 @@
 Internal — Back-end administrator
 
 ## Who They Are
-The CMS Administrator is the person responsible for setting up, configuring, and maintaining the content management system. In a government context this is typically a senior IT staff member or system owner — not a developer, but technically capable. They manage who has access, what content types exist, and how the system behaves. They are accountable for data integrity and system security.
+The CMS Administrator is the person responsible for setting up, configuring, and maintaining GovEA for a single organization. In a government context this is typically a senior IT staff member or system owner — not a developer, but technically capable. They manage who has access, what content types exist, and how the organization's workspace behaves. They are accountable for data integrity and system security inside their own tenant, not for platform-wide operations across every org on the instance.
 
 ## Goals
 - Configure and maintain content types, taxonomies, and workflows without writing code
 - Manage user accounts, roles, and permissions from a single interface
+- Configure organization-scoped settings such as themes, enabled modules, and similar workspace behavior without platform-operator help
 - Connect the system to the agency's identity provider (e.g. Microsoft Entra ID / SSO) without custom development
 - Audit who changed what and when, and be able to roll back or review changes
 - Keep the system running predictably with minimal ongoing maintenance
@@ -19,11 +20,12 @@ The CMS Administrator is the person responsible for setting up, configuring, and
 - Current tools require developer involvement for routine configuration changes
 - No clear audit trail — hard to answer "who changed this and when"
 - User provisioning is manual and error-prone, especially when staff turn over
+- It is often unclear which settings belong to the agency versus the platform operator
 - SSO integration is either unavailable or requires expensive professional services
 - Role and permission models are too coarse (all or nothing) or too complex to manage
 
 ## Critical Insight
-The CMS Administrator is not a developer and should never need to be. If administrative functions require code changes or CLI access, the system has failed this persona. Every configuration action they need to perform must be available through the UI, and every access decision must be auditable.
+The CMS Administrator is not a developer and should never need to be. If ordinary organization administration requires code changes, CLI access, or filing a platform-operator ticket for routine workspace settings, the system has failed this persona. Every org-scoped configuration action they need must be available through the UI, and every access decision must be auditable.
 
 ## Data Stored About This Persona
 
@@ -44,6 +46,7 @@ GovEA stores the following personal data about CMS Administrator accounts:
 
 ## Relevant Capabilities
 - Back-end content administration
+- Organization-scoped configuration and settings
 - User and role management
 - Identity and access management (SSO integration)
 - Audit trail and change history

--- a/business-architecture/personas/instance-administrator.md
+++ b/business-architecture/personas/instance-administrator.md
@@ -1,0 +1,33 @@
+# Persona: Instance Administrator
+
+**Validation Status: Assumed** — drafted from the current platform-operations model in GovEA, not from direct user interviews. Must be validated with a real operator responsible for hosting or administering a shared GovEA instance before it drives major new implementation.
+
+## Role Type
+Internal — Platform operations / shared service administration
+
+## Who They Are
+The Instance Administrator operates GovEA as a shared platform across multiple organizations. This person may sit in central IT, a shared services team, or the hosting provider. They are responsible for tenant governance, platform access, and operational controls that span the whole instance. They are not the day-to-day owner of any one agency's EA content.
+
+## Goals
+- Add, suspend, and oversee organizations on the instance without database access
+- Grant and remove platform-level admin rights intentionally and with auditability
+- Investigate cross-tenant incidents safely without becoming a permanent editor inside every org
+- Distinguish platform governance from agency-owned EA administration
+- Keep the hosted or shared GovEA environment stable, supportable, and low-friction for participating organizations
+
+## Pain Points
+- Multi-tenant products often blur tenant admin and platform admin responsibilities
+- Investigating support issues can require unsafe broad access or direct database work
+- It is hard to answer which changes were platform actions versus agency actions
+- Shared-service operators need guardrails so they do not accidentally take ownership of local agency content
+- Provisioning and suspension are often scattered across scripts, infrastructure tools, and the app UI
+
+## Critical Insight
+The Instance Administrator needs platform-wide authority without platform-wide authorship. They should be able to govern the instance, manage tenants, and respond to incidents, but normal organization content and configuration should remain with the organization's own admins unless a clearly bounded break-glass path is used.
+
+## Relevant Capabilities
+- Instance administration
+- Platform-level audit trail
+- Organization lifecycle governance
+- Break-glass access with expiry and audit
+- Instance-admin promotion and demotion

--- a/capabilities.md
+++ b/capabilities.md
@@ -29,8 +29,8 @@ Controls authentication, authorization, and all identity events.
 | Capability | Status | Description |
 |---|---|---|
 | User Management | Implemented | Create, edit, deactivate, and assign org-scoped roles to user accounts |
-| Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions |
-| Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, and audited break-glass sessions |
+| Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions, with `instance_admin` layered separately for platform operations |
+| Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, and audited break-glass sessions without taking over org-scoped settings |
 | SSO Authentication | Implemented | Microsoft Entra ID sign-in via OpenID Connect (OIDC) with admin-managed pre-provisioned access |
 | Local Authentication | Implemented | Email and password login; always available as SSO fallback |
 | IAM Audit Trail | Implemented | Immutable log of all identity and access events, including instance-scoped platform events |


### PR DESCRIPTION
## Summary

Document the product boundary clarified in #307 and carried into #308:
- add a dedicated `Instance Administrator` persona
- add an `iam-instance-administration` capability
- clarify that org admins keep org-scoped settings
- clarify that instance admins own shared-platform governance, not tenant content/settings ownership

## Why

The repo already had an implemented `/instance` console, but the EasyEA artifacts still centered everything on `CMS Administrator`. That left the product boundary blurry: instance admin existed in code, but not as a first-class persona/capability definition.

This PR makes the business architecture explicit before implementation work continues on true instance-level configuration.

## Changes

- Added `business-architecture/personas/instance-administrator.md`
- Added `business-architecture/capabilities/cms/iam/iam-instance-administration.md`
- Updated IAM summaries and RBAC docs to treat `instance_admin` as a separate operating role
- Updated CMS Administrator and admin-configuration docs so org settings remain org-scoped
- Updated top-level docs (`README.md`, `capabilities.md`) to reflect the boundary

## Validation

- Documentation-only change
- No tests run

Refs #308
Capability: iam-instance-administration