### PR TITLE
docs: PO audit reconciliation — align business-architecture docs to product reality

### DIFF
--- a/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
@@ -10,9 +10,11 @@ The system must provide administrators with the tools needed to configure, monit
 
 | Capability | File | Description |
 |---|---|---|
-| Site Settings | [ac-site-settings.md](./ac-site-settings.md) | Organization name, URL, timezone, and branding |
+| Site Settings | [ac-site-settings.md](./ac-site-settings.md) | Theme selection and appearance configuration; broader org settings are future work |
+| Persona Type Management | [ac-persona-type-management.md](./ac-persona-type-management.md) | Manage persona type categories as taxonomy terms |
+| Persona Tags | [ac-persona-tags.md](./ac-persona-tags.md) | Manage persona tag values as taxonomy terms |
+| Admin Dashboard | [ac-admin-dashboard.md](./ac-admin-dashboard.md) | Live coverage grid, needs-attention signals, recent activity, and domain summaries |
 | Feature Management | [ac-feature-management.md](./ac-feature-management.md) | Enable and disable optional modules without code |
-| Admin Dashboard | [ac-admin-dashboard.md](./ac-admin-dashboard.md) | System health, content status, and repository completeness |
 | Email Configuration | [ac-email-configuration.md](./ac-email-configuration.md) | SMTP settings for transactional email delivery |
 | Security Settings | [ac-security-settings.md](./ac-security-settings.md) | Password policy, session timeout, and account lockout |
 | Backup & Export | [ac-backup-export.md](./ac-backup-export.md) | Export and import configuration and content |

--- a/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
+++ b/business-architecture/capabilities/cms/content-management/cm-content-search-filtering.md
@@ -22,6 +22,15 @@ The system must allow users to find content items quickly using list-level filte
 - Filters are additive — multiple filters narrow results
 - Empty filters return all content matching the current screen and role context
 
+## Implementation Status
+
+- **Per-entity filtering** — implemented: each list view has its own search bar and filter controls
+- **Taxonomy-driven browsing** — implemented: filter by taxonomy term on taxonomy-backed entity lists
+- **Repository-wide search** — implemented: the shared search surface covers the core EA entity types and does not require an external search service
+- **Search relevance and workflow-state filtering consistency** — maturing: relevance tuning and Viewer-scoped result filtering are still being refined
+
+Per-entity filtering is the most mature surface. The repository-wide search covers key entity types but is not a full-text index with relevance scoring; results are useful but not yet optimized for precision or Viewer role filtering consistency.
+
 ## Links
 - Depends on: Content Authoring, Content Workflow, Taxonomy Management
 - Related: Content Relationships, IAM — Role-Based Access Control

--- a/business-architecture/capabilities/cms/iam/iam.md
+++ b/business-architecture/capabilities/cms/iam/iam.md
@@ -13,10 +13,18 @@ The system must control who can access it, how they authenticate, and what they 
 |---|---|---|
 | User Management | [iam-user-management.md](./iam-user-management.md) | Create, edit, deactivate, and delete user accounts |
 | Role-Based Access Control | [iam-role-based-access-control.md](./iam-role-based-access-control.md) | Enforce Admin / Contributor / Viewer roles and permissions |
+| Instance Administration | — | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, and audited break-glass sessions |
 | Local Authentication | [iam-local-authentication.md](./iam-local-authentication.md) | Email and password login with password reset |
 | SSO Authentication | [iam-sso-authentication.md](./iam-sso-authentication.md) | Microsoft Entra ID sign-in via OpenID Connect with admin-managed pre-provisioned access |
 | IAM Audit Trail | [iam-audit-trail.md](./iam-audit-trail.md) | Immutable log of all identity and access events |
 | First-Run Setup | [iam-first-run-setup.md](./iam-first-run-setup.md) | Bootstrap initial Admin account on first launch |
+| API Auth Decision | [iam-api-auth-decision.md](./iam-api-auth-decision.md) | Auth strategy for API routes (session-based, not token-based in v1) |
+
+## Current State
+
+IAM is one of GovEA's strongest product areas and is credible as a core v1 pillar. Authentication, authorization, audit logging, meaningful E2E test coverage, and the full instance-admin console are all present.
+
+**Remaining gap:** The last-admin edge case (preventing the final admin account from being demoted or deactivated) has a known CI reliability gap. Tracked in [issue #33](https://github.com/roballred/GovEA/issues/33). This is a test-coverage gap, not a missing feature — the behavior is implemented but the test scenario is not consistently exercised in CI.
 
 ## Success Criteria
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -6,6 +6,10 @@ The system must allow architects to identify, record, and track conditions in th
 
 Debt that is named and tracked is manageable. Debt that is invisible becomes the reason EA outputs stop being trusted.
 
+## Implementation Status
+
+**Not yet implemented.** No architecture debt tracking surface exists in the current product. This document is the design specification for a future capability. The severity tier definitions here are referenced by `rm-end-to-end-traceability` and `rm-repository-completeness` as a shared vocabulary for a future unified priority signal.
+
 ## Personas
 
 - **Enterprise Architect (Central IT)** — needs to surface and communicate architectural debt to leadership in plain language; currently has no mechanism to separate "what we know is a problem" from "what we haven't looked at yet"; this conflation erodes trust in EA outputs

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -4,6 +4,10 @@
 
 The system must allow any user to follow a chain of relationships across the full architecture — from strategic objectives through capabilities to applications and technology — in either direction, and must surface where those chains are broken or incomplete.
 
+## Implementation Status
+
+**Not yet implemented.** Read-only traceability views for individual objectives, capabilities, and services exist in the product (see `fd-traceability-views.md`), but the cross-layer impact analysis, reverse traversal UI, broken chain indicators, and cross-agency views described in this document are not yet built. This document is the design specification for that future work.
+
 ## Personas
 
 - **Enterprise Architect (Central IT)** — needs to see the full impact of a proposed change or decommission before it happens; wants to identify which agencies have redundant applications serving the same capability

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -6,6 +6,10 @@ The system must continuously signal the health and completeness of the EA object
 
 A repository where everything appears equally authoritative — regardless of whether it was updated last week or three years ago — is a repository people stop trusting. Completeness signals turn the unknown unknowns into known gaps.
 
+## Implementation Status
+
+**Scaffolded.** Basic coverage signals (entity counts and needs-attention summaries) are surfaced on the Admin Dashboard. The full completeness workflow described in this document — drill-down views, trend lines, domain scoring, publication controls, and staleness thresholds — is not yet implemented. This document is the design specification for that future build.
+
 ## Personas
 
 - **Enterprise Architect (Central IT)** — needs to report the state of the enterprise capability map with honesty; a completeness view allows them to say "we have 80% of capabilities mapped to at least one application" rather than making claims that can be challenged; currently has no mechanism to produce this picture without manual audit


### PR DESCRIPTION
## Summary

Focused documentation reconciliation pass for the five outstanding PO audit issues. `capabilities.md` and `README.md` were already current; the drift was entirely in the individual business-architecture sub-capability docs.

**#148 — IAM as implemented pillar** (`iam.md`)
- Added missing `Instance Administration` and `API Auth Decision` sub-capability rows to the table
- Added a **Current State** section confirming IAM as the strongest product area and explicitly calling out the last-admin CI test gap (issue #33) rather than leaving it implicit

**#149 — Content Management staging** (`cm-content-search-filtering.md`)
- Added **Implementation Status** section distinguishing the three shipped surfaces (per-entity filtering, taxonomy browsing, repo-wide search) from what's still maturing (relevance tuning, Viewer-role filtering consistency)
- `cm-content-workflow.md` was already accurate with its planning-entity state mappings — no change needed

**#152 — Frontend Display / Theming** (no changes needed)
- `fd-theming.md` already has a Current Scope section; `fd-public-authenticated-views.md` already has an Implementation Status section; `frontend-display.md` intro already distinguishes authenticated vs. public experience

**#153 — Admin Configuration** (`admin-configuration.md`)
- Added `Persona Type Management` and `Persona Tags` rows to the sub-capability table (files `ac-persona-type-management.md` / `ac-persona-tags.md` already existed)
- Fixed `Site Settings` description from aspirational ("Organization name, URL, timezone, and branding") to accurate ("Theme selection and appearance configuration; broader org settings are future work")
- Updated `Admin Dashboard` description to match what's actually shipped (coverage grid, needs-attention signals, recent activity)

**#155 — Repository & Modelling** (`rm-repository-completeness.md`, `rm-end-to-end-traceability.md`, `rm-architecture-debt.md`)
- Added **Implementation Status** headers to all three sub-capability spec files, clearly marking them as design specifications rather than shipped product documentation
- `repository-modelling.md` group doc was already accurate with correct statuses in the sub-capability table

## Test plan
- [ ] Read each changed file and verify it accurately describes the current product
- [ ] Confirm no capability is understated or overstated relative to `capabilities.md`
- [ ] Verify issues #148, #149, #152, #153, #155 can be closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)