### PR TITLE
[codex] docs: refresh backlog and capability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,17 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Service catalogue: first-class service records linked to personas, capabilities, and value streams, with supporting applications derived through capabilities
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
 - Markdown-rendered long-form detail pages across the portfolio model, with shared prose styling for descriptions and other narrative fields
+- Leadership-friendly application risk portfolio view on the Applications page, highlighting retiring systems that still support active capability work
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
 - Demo-ready planning module: strategic objectives plus initiatives with roadmap grid and executive timeline views
+- Reports hub with generated Architecture Vision output from existing repository content
 - Repository-wide search across the core content model
 - Guided product tour with role-aware coach marks for the main application areas
 - Audit trail: immutable before/after log of all changes
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
 - Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, and audited break-glass sessions
+- TOGAF framework overlay: org-level opt-in toggle, framework mappings on capability/application detail pages, and a TOGAF Application Landscape report
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
@@ -126,18 +129,18 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
-- Hardening multi-org auth, viewer visibility, and glossary-link safety after the latest security findings
-- Closing the taxonomy delete-safety gap for in-use principle types
+- Defining the true instance-level configuration surface for the `/instance` console
+- Turning the new reporting and portfolio foundations into stronger stakeholder-facing decision support
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Resolve the multi-org auth identity model and duplicate-email tenant-boundary risk
-- Fix glossary viewer-publishing and URL-validation gaps
-- Upgrade Next.js to the patched App Router security release
-- Add taxonomy delete safety for in-use principle types
-- Add a markdown editor with preview for long-text fields
+- Define and ship instance-level platform configuration in `/instance`
+- Add an executive dashboard for non-architect leadership audiences
+- Add impact analysis on application and capability detail pages
+- Add heatmap analysis views over existing portfolio data
+- Start lightweight user feedback capture for EA practice fit
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md
@@ -21,6 +21,11 @@ The system must provide a visual portfolio view that helps stakeholders identify
 - The visual must not imply precision the repository does not support; any derived score should be explainable
 - Viewer-facing output should emphasize operational meaning such as `aging`, `replacement underway`, or `high dependency`
 
+## Implementation Status
+
+- **v1:** Implemented as a Portfolio view on the Applications page. It uses existing lifecycle and capability-link data to surface retiring systems, no-capability-link records, and cleaner portfolio cards for leadership-style review.
+- Duplicate-detection, richer scoring, and deeper modernization analysis remain future work.
+
 ## Links
 - Depends on: Portfolio Management — Application Portfolio, Front-end Display — Portfolio Views
 - Related: Planning — Initiatives, Repository & Modelling — Repository Completeness

--- a/business-architecture/capabilities/ea/framework-alignment/fa-framework-mapping.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-framework-mapping.md
@@ -29,7 +29,19 @@ Mappings explain how existing GovEA content relates to external architecture pra
 
 ## Implementation Status
 
-Not implemented.
+Partially implemented.
+
+Current shipped slice:
+
+- Capability and application detail pages support TOGAF Architecture Domain mappings
+- Mappings can carry an optional rationale
+- Mappings are organization-scoped and only visible when the TOGAF overlay is enabled
+
+Not yet shipped:
+
+- Mapping additional entity types
+- Supporting multiple frameworks or richer concept taxonomies
+- Reporting and filtering across arbitrary framework concepts beyond the current TOGAF domain slice
 
 ## Links
 

--- a/business-architecture/capabilities/ea/framework-alignment/fa-framework-overlay-configuration.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-framework-overlay-configuration.md
@@ -27,7 +27,19 @@ The system must allow administrators to enable, disable, and configure optional 
 
 ## Implementation Status
 
-Not implemented.
+Partially implemented.
+
+Current shipped slice:
+
+- Org admins can enable or disable the TOGAF framework overlay from settings
+- The overlay is off by default for new organizations
+- Disabling the overlay hides framework UI without deleting saved mapping data
+
+Not yet shipped:
+
+- Per-framework options beyond the single TOGAF toggle
+- Per-entity or per-report overlay controls
+- Admin-defined framework bundles or reference sources
 
 ## Links
 

--- a/business-architecture/capabilities/ea/framework-alignment/fa-framework-reference-management.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-framework-reference-management.md
@@ -29,7 +29,7 @@ Reference material is not authoritative GovEA product definition. It is an input
 
 ## Implementation Status
 
-Not implemented. GovEA has glossary source-definition support today, but not a general framework reference-management surface.
+Not implemented. GovEA has glossary source-definition support today and a shipped TOGAF overlay slice, but there is still no general framework reference-management surface for admins.
 
 ## Links
 

--- a/business-architecture/capabilities/ea/framework-alignment/fa-togaf-reporting.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-togaf-reporting.md
@@ -27,7 +27,20 @@ The system must generate TOGAF-friendly reports from GovEA content for organizat
 
 ## Implementation Status
 
-Not implemented.
+Partially implemented.
+
+Current shipped slice:
+
+- `Architecture Vision` report generates a plain-language architecture summary from existing GovEA records
+- `Application Landscape` report is available under Reports when the TOGAF overlay is enabled
+- Reports disclose repository gaps rather than hiding them
+- Reports link back to the underlying GovEA records
+
+Not yet shipped:
+
+- Additional TOGAF-style outputs beyond the current Architecture Vision and Application Landscape reports
+- Reporting driven by richer framework mappings or ADM phase labels
+- A broader configurable reporting surface for multiple frameworks
 
 ## Links
 

--- a/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
+++ b/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
@@ -9,17 +9,17 @@ The system must allow organizations to align GovEA content to external architect
 - **CMS Administrator** — needs to enable, configure, and maintain framework overlays without code changes
 - **Department Director** — benefits from clearer reports and better-governed architecture content, but should not need to understand TOGAF terminology
 
-> ⚠️ Enterprise Architect, Agency EA Coordinator, CMS Administrator, and Department Director are currently **Assumed** personas. Framework-alignment implementation should wait until the relevant needs are validated through direct user research.
+> ⚠️ Enterprise Architect, Agency EA Coordinator, CMS Administrator, and Department Director are currently **Assumed** personas. GovEA has still shipped a narrow TOGAF-alignment slice to reduce procurement and demo friction, but broader framework work should remain gated by real user validation.
 
 ## Sub-Capabilities
 
 | Capability | File | Status | Description |
 |---|---|---|---|
 | Framework Reference Management | [fa-framework-reference-management.md](./fa-framework-reference-management.md) | Not implemented | Store external framework references separately from GovEA's authoritative capability definitions |
-| Framework Mapping | [fa-framework-mapping.md](./fa-framework-mapping.md) | Not implemented | Map GovEA records to framework concepts, domains, content types, or reference categories |
+| Framework Mapping | [fa-framework-mapping.md](./fa-framework-mapping.md) | Partially implemented | Map capability and application records to TOGAF Architecture Domains; broader framework concept mapping remains future work |
 | ADM Phase Alignment | [fa-adm-phase-alignment.md](./fa-adm-phase-alignment.md) | Not implemented | Optionally tag architecture work to TOGAF ADM phases for TOGAF-aware teams |
-| TOGAF-Aligned Reporting | [fa-togaf-reporting.md](./fa-togaf-reporting.md) | Not implemented | Generate TOGAF-friendly reports from existing GovEA content |
-| Framework Overlay Configuration | [fa-framework-overlay-configuration.md](./fa-framework-overlay-configuration.md) | Not implemented | Allow admins to enable, disable, and configure framework overlays per organization |
+| TOGAF-Aligned Reporting | [fa-togaf-reporting.md](./fa-togaf-reporting.md) | Partially implemented | Generate TOGAF-friendly reports from existing GovEA content |
+| Framework Overlay Configuration | [fa-framework-overlay-configuration.md](./fa-framework-overlay-configuration.md) | Partially implemented | Allow admins to enable, disable, and configure optional framework overlays per organization |
 
 ## Reference Sources
 
@@ -45,3 +45,19 @@ Framework reference sources are inputs to capability design, not GovEA capabilit
 ## Design Principle
 
 Framework support should increase credibility without increasing friction. A TOGAF-trained architect should be able to recognize the structure of the work, while an agency practitioner should still experience GovEA as a simple mission-to-technology repository.
+
+## Current State
+
+GovEA now ships the first framework-alignment slice:
+
+- The `framework-overlay` module is org-scoped, opt-in, and off by default
+- Capability and application detail pages support TOGAF Architecture Domain mappings with optional rationale
+- The Reports area includes a TOGAF Application Landscape report when the overlay is enabled
+- The generic Architecture Vision report also now provides a framework-friendly summary built from existing repository content
+
+Still not shipped:
+
+- ADM phase tagging
+- Admin-managed framework reference records
+- Broader framework mappings beyond the current TOGAF domain slice
+- Per-framework configuration deeper than a single overlay toggle

--- a/capabilities.md
+++ b/capabilities.md
@@ -18,7 +18,7 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 | 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
 | 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Prototype |
 | 8 | [Repository & Modelling](#8-repository--modelling) | Scaffolded |
-| 9 | [Framework Alignment](#9-framework-alignment) | Not implemented |
+| 9 | [Framework Alignment](#9-framework-alignment) | Partially implemented |
 
 ---
 
@@ -136,7 +136,7 @@ How content is presented to authenticated users and, optionally, the public.
 | Product Tour | Implemented | Role-aware guided tour covering the main dashboard, architecture, portfolio, strategy, search, and role-specific workflows |
 | Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
 | Repository Confidence Summary | Not implemented | Plain-language freshness and trust cue for stakeholder-facing views |
-| Application Risk Portfolio | Not implemented | Leadership-oriented view of lifecycle, dependency, duplication, and modernization risk across applications |
+| Application Risk Portfolio | Implemented | Leadership-oriented portfolio card view on the Applications page, with lifecycle and dependency risk cues derived from existing data |
 | Responsive Layout | Partially implemented | Desktop-first; mobile not a v1 priority |
 | Theming | Implemented | Organization-selected predefined themes applied through settings |
 
@@ -210,10 +210,12 @@ Optional alignment to external architecture frameworks such as TOGAF without rep
 | Capability | Status | Description |
 |---|---|---|
 | Framework Reference Management | Not implemented | Store external framework references separately from GovEA's authoritative capability definitions |
-| Framework Mapping | Not implemented | Map GovEA records to framework concepts, domains, content types, or reference categories |
+| Framework Mapping | Partially implemented | Capability and application detail pages support TOGAF Architecture Domain mappings with optional rationale; broader framework concept mapping remains future work |
 | ADM Phase Alignment | Not implemented | Optionally tag architecture work to TOGAF ADM phases for TOGAF-aware teams |
-| TOGAF-Aligned Reporting | Not implemented | Generate TOGAF-friendly outputs from existing GovEA content and mappings |
-| Framework Overlay Configuration | Not implemented | Enable, disable, and configure optional framework overlays per organization |
+| TOGAF-Aligned Reporting | Partially implemented | Reports hub ships an Architecture Vision summary for all orgs and a TOGAF Application Landscape report when the overlay is enabled |
+| Framework Overlay Configuration | Partially implemented | Org admins can enable or disable the TOGAF overlay module; richer per-framework configuration remains future work |
+
+Current reality: GovEA now ships the first framework-alignment slice. The TOGAF overlay is opt-in and off by default, application and capability records can carry TOGAF Architecture Domain mappings, and the Reports area includes a TOGAF Application Landscape report. ADM phase tagging, admin-managed framework references, and broader mapping depth remain future work.
 
 **Design principle:** Framework support should increase credibility without increasing friction. TOGAF-aware architects should be able to recognize familiar concepts and reporting structures, while ordinary GovEA users continue working with plain-language personas, capabilities, services, applications, objectives, initiatives, principles, and decisions.
 
@@ -223,7 +225,7 @@ Framework alignment is distinct from formal modelling notation. GovEA can map co
 
 ## Capability Target Surface
 
-GovEA's long-term capability surface spans 9 groups, each defined through the EasyEA workflow: persona validation -> capability definition -> ARB review -> implementation issues.
+GovEA's longer-horizon capability direction spans the major themes below, each defined through the EasyEA workflow: persona validation -> capability definition -> ARB review -> implementation issues.
 
 | Group | Near-term priorities |
 |---|---|

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,57 +1,50 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-04-23
+Last groomed: 2026-04-28
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
 ## Current Signal
 
-Recent merges strengthened the product in seven areas:
+Recent merges materially changed the product surface:
 
-- The second municipal demo organization is now merged, so GovEA has a stronger multi-org and instance-admin demo base.
-- Guided stakeholder answers are now shipped through `/answers?q=`, connected from search results, and filtered by viewer publication rules.
-- The roadmap now has an executive timeline view in addition to the existing grid, and the viewer filter bug on roadmap data was fixed.
-- Dialog naming and ADR tooltip consistency have merged, closing the last visible UX cleanup item from the prior shortlist.
-- PR #268 merged the typed-principle and markdown-rendering slice, so principle sets and prose rendering are now part of the shipped baseline.
-- Mission-to-technology traceability, repository-wide search, and viewer visibility rules remain core shipped foundations.
-- Instance administration is a usable console with org inventory, user management, audit view, org suspension, and audited break-glass sessions.
-- Framework Alignment is documented as an optional overlay, but implementation has not started.
+- PR #304 shipped the Application Portfolio risk view, giving GovEA a stronger leadership-facing application surface built from existing lifecycle and capability-link data.
+- PR #299 shipped the Reports hub and Architecture Vision output, proving GovEA can generate executive summaries directly from repository content rather than requiring duplicate documentation.
+- PR #301 shipped the first TOGAF overlay slice: org-level enablement, framework mappings on capability/application records, and a TOGAF Application Landscape report.
+- PR #303 documented the TOGAF/ADM boundary clearly: optional overlay in, ADM workflow enforcement out for v1/v2.
+- PR #309 clarified the instance-admin product boundary and made the persona/capability model match the already-shipped `/instance` console.
+- PR #310 reconciled several business-architecture docs, but a follow-up pass is still needed because top-level docs had drifted behind the newest product work.
 
-New signal since the prior grooming pass:
+What this means for prioritization:
 
-- PR #268 merged and superseded PR #265, so #262 is now shipped and docs should treat taxonomy-backed principle sets as implemented.
-- Issue #266 is now a true post-merge integrity gap: deleting a Principle Type can orphan existing principles because the reference is stored as plain text.
-- Four fresh security and tenancy issues now dominate near-term priority: bare-email auth lookup across orgs (#269), viewer access to unpublished glossary content (#270), the Next.js App Router DoS advisory (#271), and unsafe glossary source URLs (#272).
-- Issue #273 is the clear UX follow-up to the markdown-rendering merge: authoring still uses plain textareas even though display now supports markdown.
-- Issue #258 still appears open even though its body says it was fixed in PR #257; close it after merge verification if no regression remains.
-- Stakeholder-facing visuals are now useful enough for demos, but the immediate backlog should favor security, tenant-boundary correctness, and content-integrity fixes before more demo-surface expansion.
-
-The next work should first harden security and tenancy boundaries around the now-richer content model, then close the taxonomy-integrity gap introduced by the shipped principle-type work.
+- GovEA now has stronger admin, reporting, and leadership-demo foundations than it did a week ago.
+- The next best work is less about another isolated CRUD slice and more about turning the existing repository into decision support for platform admins, leadership audiences, and real-user feedback loops.
+- The repo still has important long-range ARB and market-research issues open, but the highest-leverage next moves are the ones that compound the product areas strengthened by the latest merges.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) / PR |
 |---|---|---|---|
-| 1 | Fix multi-org auth identity binding | #269 is the highest-risk tenant-boundary issue in the repo: auth and SSO resolve users by bare email even though uniqueness is only guaranteed per organization | #269 |
-| 2 | Enforce published-only glossary access for viewers | #270 breaks the Viewer contract and leaks unpublished shared-reference content, which is especially visible now that glossary content is more central to stakeholder-facing views | #270 |
-| 3 | Patch the Next.js App Router security advisory | #271 is a framework-level DoS fix with a known patched target release, so it is a straightforward security-hardening move with broad platform value | #271 |
-| 4 | Validate glossary source URLs on write | #272 is a stored click-through script-injection vector; it should be closed before glossary usage expands further | #272 |
-| 5 | Add taxonomy delete safety for in-use principle types | #266 is the main post-merge integrity gap from the shipped principle-set work and should be fixed before admins manage principle vocabularies more aggressively | #266 |
+| 1 | Define and ship instance-level platform configuration | The `/instance` console is now real, documented, and clearly separated from org admin scope. #308 is the immediate product follow-on that turns instance admin from an audit/provisioning console into a real platform-management surface. | #308, PR #309 |
+| 2 | Build the Executive Dashboard for non-architects | PR #304 and PR #299 already proved the underlying summary data and leadership framing. #84 is the clearest next stakeholder-facing screen and the strongest adoption move in the open backlog. | #84, PR #304, PR #299 |
+| 3 | Add Impact Analysis on application and capability detail pages | GovEA already has the traceability graph and now has better portfolio/risk storytelling. #83 is the next decision-support feature that helps users act on lifecycle and modernization questions instead of just viewing linked records. | #83 |
+| 4 | Add Heatmap Analysis views | With the application risk portfolio shipped, #82 becomes a natural companion view for portfolio exposure, maturity, and domain-level pattern detection using the same core data. | #82, PR #304 |
+| 5 | Start lightweight user feedback capture for practice fit | The product now has enough breadth that wrong assumptions will compound unless feedback is captured systematically. #103 has a low-cost Phase 1 that can start immediately without waiting for a full in-app workflow. | #103 |
 
 ## Product Manager Notes
 
-- Treat #269 as the main product decision item, not just a bug. The team needs to choose between global unique identity and org-qualified sign-in, then make schema, login UX, and docs agree.
-- Treat #270 and #272 as trust-and-safety fixes for the glossary slice. The glossary is now shared reference content, so visibility and outbound-link hygiene need to be explicit.
-- Treat #271 as the cleanest platform-hardening task: patch, refresh lockfile, and run build/lint plus targeted auth and server-action regression checks.
-- Treat #266 as the principal non-security follow-up. Blocking deletion for in-use taxonomy terms is safer than silently clearing or rewriting principle types.
-- Keep #273 close behind the top five. Markdown display shipped, but better authoring should wait until the current security and integrity work is closed.
-- If #258 was verified through PR #257, close it as fixed so open bugs reflect current reality.
+- Treat #308 as the most concrete next product-management task. The repo now has a documented instance-admin boundary but not yet a clearly owned platform-config surface.
+- #84, #83, and #82 form a coherent sequence, not three isolated ideas: executive summary -> decision-support drill-down -> portfolio pattern visualization.
+- #306 is worth keeping warm as an input to future analysis and reporting work, but it is narrower than the five items above unless real users confirm it is blocking capability modelling today.
+- The ARB/research issues in the 90s and 130s still matter, but many are capability-definition or scope-decision work. The shortlist above favors moves that build directly on what the latest merged code already made possible.
+- Ship the Phase 1 manual feedback log from #103 before designing a full feedback table/UI. The process signal is more urgent than the schema.
 
 ## Documentation Follow-up
 
-This grooming pass also keeps public docs aligned with current repo state:
+This grooming pass also updates product docs to match current repo reality:
 
-- `docs/product-priorities.md`: replaces the stale PR-#265 review framing with the post-#268 security and integrity shortlist.
-- `README.md`: treats taxonomy-backed principle sets and markdown-rendered detail pages as shipped, and updates active work to the new hardening priorities.
-- `capabilities.md`: marks principles as taxonomy-backed and content display as markdown-rendered so the product summary matches the merged implementation.
-- `docs/data-model.md`: documents that `principles.principle_type` is taxonomy-backed text and therefore depends on application-level integrity checks.
+- `docs/product-priorities.md`: replaced the stale hardening shortlist with the current product-development sequence.
+- `README.md`: now reflects the shipped application risk portfolio, reports hub, and TOGAF overlay/reporting slice.
+- `capabilities.md`: now marks Application Risk Portfolio and the first framework-alignment slice accurately.
+- `business-architecture/capabilities/ea/framework-alignment/*.md`: implementation status now matches the shipped TOGAF overlay, mapping, and reporting behavior.
+- `business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md`: now explicitly records the shipped v1 implementation status.


### PR DESCRIPTION
## Summary

Updates the backlog and product documentation to match the current GovEA repo state after the latest merged product work.

## What changed

- Re-ranked the top five next product priorities around the current repo momentum
- Updated top-level product docs to reflect the shipped application risk portfolio, reports hub, and TOGAF overlay slice
- Reconciled framework-alignment capability docs so their implementation status matches the shipped overlay, mapping, and reporting behavior
- Added explicit implementation-status language to the application risk portfolio capability doc

## Why

Recent merged PRs changed the product surface materially, but several documents still described those areas as unimplemented or not started. That created drift between the repo, the capability model, and the current backlog narrative.

## User and developer impact

- Product planning now points at the most leveraged next five items from the current repo state
- Contributors reading `README.md`, `capabilities.md`, or the business-architecture specs now get an accurate picture of what is already shipped
- Framework-alignment docs no longer understate the current TOGAF overlay/reporting behavior

## Validation

- Reviewed open issues and recent merged PRs
- Checked current implementation signals in the repo before updating docs
- No automated tests run; documentation-only change
