### PR TITLE
fix(spec): security_sensitive flag and classification guidance for debt items (#135)

### DIFF
--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -1,0 +1,476 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { db } from '@/db/client'
+import {
+  capabilities, applications, applicationCapabilities,
+  initiatives, strategicObjectives, organizations,
+} from '@/db/schema'
+import { and, count, desc, eq, isNull, lt } from 'drizzle-orm'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
+import { cn } from '@/lib/utils'
+import Link from 'next/link'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const STALE_MONTHS = 12
+const APP_LIFECYCLE_ORDER = ['active', 'planned', 'sunset', 'decommissioned'] as const
+
+const LIFECYCLE_LABELS: Record<string, string> = {
+  active: 'Active',
+  planned: 'Planned',
+  sunset: 'Sunsetting',
+  decommissioned: 'Decommissioned',
+}
+
+const LIFECYCLE_STYLES: Record<string, string> = {
+  active:         'bg-emerald-500',
+  planned:        'bg-blue-400',
+  sunset:         'bg-amber-400',
+  decommissioned: 'bg-slate-300 dark:bg-slate-600',
+}
+
+const INITIATIVE_STATUS_LABELS: Record<string, string> = {
+  proposed: 'Proposed',
+  active:   'Active',
+  'on-hold':'On Hold',
+  complete: 'Complete',
+  cancelled:'Cancelled',
+}
+
+const INITIATIVE_STATUS_STYLES: Record<string, string> = {
+  proposed: 'text-blue-700 bg-blue-50 border-blue-200 dark:text-blue-300 dark:bg-blue-950/30 dark:border-blue-800',
+  active:   'text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-300 dark:bg-emerald-950/30 dark:border-emerald-800',
+  'on-hold':'text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-950/30 dark:border-amber-800',
+  complete: 'text-slate-600 bg-slate-50 border-slate-200 dark:text-slate-400 dark:bg-slate-800 dark:border-slate-700',
+  cancelled:'text-slate-500 bg-slate-50 border-slate-200 dark:text-slate-500 dark:bg-slate-800 dark:border-slate-700',
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+  href,
+  warn,
+}: {
+  label: string
+  value: string | number
+  sub?: string
+  href?: string
+  warn?: boolean
+}) {
+  const inner = (
+    <div className={cn(
+      'rounded-xl border p-5 space-y-1',
+      warn ? 'border-amber-300 bg-amber-50 dark:bg-amber-950/20' : 'bg-card',
+      href && 'hover:bg-muted/50 transition-colors cursor-pointer'
+    )}>
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</p>
+      <p className={cn('text-3xl font-bold tabular-nums', warn && 'text-amber-700 dark:text-amber-400')}>{value}</p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  )
+  return href ? <Link href={href}>{inner}</Link> : inner
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">{children}</p>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function ExecutiveDashboardPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const orgId = session.user.organizationId!
+  const enabledModules = await getEnabledModules()
+
+  const hasApps        = isModuleEnabled(enabledModules, 'applications')
+  const hasCapabilities= isModuleEnabled(enabledModules, 'capabilities')
+  const hasInitiatives = isModuleEnabled(enabledModules, 'initiatives')
+  const hasObjectives  = isModuleEnabled(enabledModules, 'objectives')
+
+  // eslint-disable-next-line react-hooks/purity -- server component, Date.now() is intentional
+  const staleThreshold = new Date(Date.now() - STALE_MONTHS * 30 * 24 * 60 * 60 * 1000)
+
+  // ── Parallel data fetch ───────────────────────────────────────────────────
+
+  const [
+    org,
+    // Applications: lifecycle breakdown (published only)
+    appLifecycleRows,
+    appStaleRow,
+    // Capabilities: total published + gap count (no application link)
+    capTotalRow,
+    capGapRow,
+    // Initiatives: status breakdown
+    initiativeStatusRows,
+    // Strategic objectives: count
+    objectivesPublishedRow,
+    // Recent updates: last 5 published records per type, merged in JS
+    recentApps,
+    recentCaps,
+    recentInitiatives,
+    recentObjectives,
+  ] = await Promise.all([
+    db.query.organizations.findFirst({ where: eq(organizations.id, orgId) }),
+
+    // App lifecycle counts for published apps
+    hasApps
+      ? db.select({ lifecycleStatus: applications.lifecycleStatus, count: count() })
+          .from(applications)
+          .where(and(eq(applications.organizationId, orgId), eq(applications.status, 'published')))
+          .groupBy(applications.lifecycleStatus)
+      : Promise.resolve([]),
+
+    // Apps not updated in >12 months
+    hasApps
+      ? db.select({ count: count() })
+          .from(applications)
+          .where(and(
+            eq(applications.organizationId, orgId),
+            eq(applications.status, 'published'),
+            lt(applications.updatedAt, staleThreshold),
+          ))
+      : Promise.resolve([{ count: 0 }]),
+
+    // Total published capabilities
+    hasCapabilities
+      ? db.select({ count: count() })
+          .from(capabilities)
+          .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'published')))
+      : Promise.resolve([{ count: 0 }]),
+
+    // Capabilities with no application link (gap)
+    hasCapabilities && hasApps
+      ? db.select({ count: count() })
+          .from(capabilities)
+          .leftJoin(applicationCapabilities, eq(applicationCapabilities.capabilityId, capabilities.id))
+          .where(and(
+            eq(capabilities.organizationId, orgId),
+            eq(capabilities.status, 'published'),
+            isNull(applicationCapabilities.capabilityId),
+          ))
+      : Promise.resolve([{ count: 0 }]),
+
+    // Initiative status counts
+    hasInitiatives
+      ? db.select({ status: initiatives.status, count: count() })
+          .from(initiatives)
+          .where(eq(initiatives.organizationId, orgId))
+          .groupBy(initiatives.status)
+      : Promise.resolve([]),
+
+    // Published objectives
+    hasObjectives
+      ? db.select({ count: count() })
+          .from(strategicObjectives)
+          .where(and(
+            eq(strategicObjectives.organizationId, orgId),
+            eq(strategicObjectives.status, 'published'),
+          ))
+      : Promise.resolve([{ count: 0 }]),
+
+    // Recent published apps
+    hasApps
+      ? db.select({ id: applications.id, name: applications.name, updatedAt: applications.updatedAt })
+          .from(applications)
+          .where(and(eq(applications.organizationId, orgId), eq(applications.status, 'published')))
+          .orderBy(desc(applications.updatedAt))
+          .limit(5)
+      : Promise.resolve([]),
+
+    // Recent published capabilities
+    hasCapabilities
+      ? db.select({ id: capabilities.id, name: capabilities.name, updatedAt: capabilities.updatedAt })
+          .from(capabilities)
+          .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'published')))
+          .orderBy(desc(capabilities.updatedAt))
+          .limit(5)
+      : Promise.resolve([]),
+
+    // Recent initiatives (any active status)
+    hasInitiatives
+      ? db.select({ id: initiatives.id, name: initiatives.name, updatedAt: initiatives.updatedAt })
+          .from(initiatives)
+          .where(eq(initiatives.organizationId, orgId))
+          .orderBy(desc(initiatives.updatedAt))
+          .limit(5)
+      : Promise.resolve([]),
+
+    // Recent objectives
+    hasObjectives
+      ? db.select({ id: strategicObjectives.id, name: strategicObjectives.name, updatedAt: strategicObjectives.updatedAt })
+          .from(strategicObjectives)
+          .where(and(
+            eq(strategicObjectives.organizationId, orgId),
+            eq(strategicObjectives.status, 'published'),
+          ))
+          .orderBy(desc(strategicObjectives.updatedAt))
+          .limit(5)
+      : Promise.resolve([]),
+  ])
+
+  // ── Derived values ────────────────────────────────────────────────────────
+
+  // Application portfolio
+  const appByLifecycle = new Map<string, number>()
+  let totalPublishedApps = 0
+  for (const row of appLifecycleRows) {
+    const n = Number(row.count)
+    appByLifecycle.set(row.lifecycleStatus, n)
+    totalPublishedApps += n
+  }
+  const activeApps     = appByLifecycle.get('active')     ?? 0
+  const staleAppCount  = Number(appStaleRow[0]?.count ?? 0)
+  const currentApps    = totalPublishedApps - staleAppCount
+
+  // Capabilities
+  const totalCaps = Number(capTotalRow[0]?.count ?? 0)
+  const gapCaps   = Number(capGapRow[0]?.count  ?? 0)
+
+  // Initiatives
+  const initiativeByStatus = new Map<string, number>()
+  let totalInitiatives = 0
+  for (const row of initiativeStatusRows) {
+    const n = Number(row.count)
+    initiativeByStatus.set(row.status, n)
+    totalInitiatives += n
+  }
+  const activeInitiatives = initiativeByStatus.get('active') ?? 0
+
+  // Objectives
+  const objectivesCount = Number(objectivesPublishedRow[0]?.count ?? 0)
+
+  // Freshness stat: only show if apps are enabled and there are apps
+  const freshnessLabel = totalPublishedApps > 0
+    ? `${currentApps} of ${totalPublishedApps} updated in past ${STALE_MONTHS} months`
+    : null
+
+  // Recent changes: merge and sort, top 5
+  const recentChanges = [
+    ...recentApps.map(r => ({ id: r.id, name: r.name, updatedAt: r.updatedAt, type: 'Application', href: `/applications/${r.id}` })),
+    ...recentCaps.map(r => ({ id: r.id, name: r.name, updatedAt: r.updatedAt, type: 'Capability',  href: `/capabilities/${r.id}` })),
+    ...recentInitiatives.map(r => ({ id: r.id, name: r.name, updatedAt: r.updatedAt, type: 'Initiative', href: `/initiatives/${r.id}` })),
+    ...recentObjectives.map(r => ({ id: r.id, name: r.name, updatedAt: r.updatedAt, type: 'Objective',   href: `/objectives/${r.id}` })),
+  ]
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+    .slice(0, 5)
+
+  // App lifecycle bar segments (ordered, non-zero only)
+  const lifecycleSegments = APP_LIFECYCLE_ORDER
+    .map(k => ({ key: k, label: LIFECYCLE_LABELS[k] ?? k, count: appByLifecycle.get(k) ?? 0 }))
+    .filter(s => s.count > 0)
+
+  const generatedDate = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+
+  return (
+    <div className="space-y-8 max-w-4xl">
+
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Executive Summary</h1>
+        <p className="text-muted-foreground mt-1">
+          {org?.name ?? 'Your organisation'} · {generatedDate}
+        </p>
+      </div>
+
+      {/* ── Hero stats ─────────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {hasApps && (
+          <StatCard
+            label="Active applications"
+            value={activeApps}
+            sub={totalPublishedApps > 0 ? `${totalPublishedApps} total` : undefined}
+            href="/applications"
+          />
+        )}
+        {hasInitiatives && (
+          <StatCard
+            label="Active projects"
+            value={activeInitiatives}
+            sub={totalInitiatives > 0 ? `${totalInitiatives} total` : undefined}
+            href="/initiatives"
+          />
+        )}
+        {hasObjectives && (
+          <StatCard
+            label="Strategic objectives"
+            value={objectivesCount}
+            href="/objectives"
+          />
+        )}
+        {hasCapabilities && hasApps && (
+          <StatCard
+            label="Coverage gaps"
+            value={gapCaps}
+            sub={gapCaps > 0 ? 'capabilities need technology coverage' : 'all capabilities covered'}
+            href="/capabilities"
+            warn={gapCaps > 0}
+          />
+        )}
+        {hasCapabilities && !hasApps && (
+          <StatCard
+            label="Capabilities"
+            value={totalCaps}
+            href="/capabilities"
+          />
+        )}
+        {hasApps && freshnessLabel && (
+          <StatCard
+            label="Portfolio currency"
+            value={`${totalPublishedApps > 0 ? Math.round((currentApps / totalPublishedApps) * 100) : 0}%`}
+            sub={freshnessLabel}
+            warn={totalPublishedApps > 0 && staleAppCount > 0}
+          />
+        )}
+      </div>
+
+      {/* ── Application portfolio ───────────────────────────────────────────── */}
+      {hasApps && totalPublishedApps > 0 && (
+        <div>
+          <SectionLabel>Application Portfolio</SectionLabel>
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+
+            {/* Proportional bar */}
+            <div className="flex rounded-full overflow-hidden h-3 gap-0.5">
+              {lifecycleSegments.map(seg => (
+                <div
+                  key={seg.key}
+                  className={cn('h-full', LIFECYCLE_STYLES[seg.key] ?? 'bg-slate-400')}
+                  style={{ width: `${(seg.count / totalPublishedApps) * 100}%` }}
+                  title={`${seg.label}: ${seg.count}`}
+                />
+              ))}
+            </div>
+
+            {/* Legend */}
+            <div className="flex flex-wrap gap-x-6 gap-y-2">
+              {lifecycleSegments.map(seg => (
+                <div key={seg.key} className="flex items-center gap-2 text-sm">
+                  <div className={cn('h-2.5 w-2.5 rounded-full shrink-0', LIFECYCLE_STYLES[seg.key] ?? 'bg-slate-400')} />
+                  <span className="text-muted-foreground">{seg.label}</span>
+                  <span className="font-semibold tabular-nums">{seg.count}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* Freshness */}
+            {staleAppCount > 0 && (
+              <p className="text-xs text-amber-700 dark:text-amber-400 border-t pt-3">
+                {staleAppCount} application{staleAppCount !== 1 ? 's' : ''} not updated in over {STALE_MONTHS} months —
+                {' '}<Link href="/applications" className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200">review portfolio →</Link>
+              </p>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              <Link href="/applications" className="underline underline-offset-2 hover:text-foreground">
+                View full application inventory →
+              </Link>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Transformation progress ─────────────────────────────────────────── */}
+      {hasInitiatives && totalInitiatives > 0 && (
+        <div>
+          <SectionLabel>Transformation Progress</SectionLabel>
+          <div className="rounded-xl border bg-card divide-y">
+            {Object.entries(INITIATIVE_STATUS_LABELS).map(([key, label]) => {
+              const c = initiativeByStatus.get(key) ?? 0
+              if (c === 0) return null
+              return (
+                <div key={key} className="flex items-center justify-between px-5 py-3">
+                  <div className="flex items-center gap-3">
+                    <span className={cn(
+                      'inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium',
+                      INITIATIVE_STATUS_STYLES[key] ?? INITIATIVE_STATUS_STYLES.proposed
+                    )}>
+                      {label}
+                    </span>
+                  </div>
+                  <span className="text-lg font-semibold tabular-nums">{c}</span>
+                </div>
+              )
+            })}
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            <Link href="/roadmap" className="underline underline-offset-2 hover:text-foreground">
+              View roadmap →
+            </Link>
+          </p>
+        </div>
+      )}
+
+      {/* ── Capability coverage gap ─────────────────────────────────────────── */}
+      {hasCapabilities && hasApps && gapCaps > 0 && (
+        <div>
+          <SectionLabel>Architecture Gaps</SectionLabel>
+          <div className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/20 px-5 py-4 space-y-1">
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+              {gapCaps} capability{gapCaps !== 1 ? 'ies' : 'y'} without supporting technology
+            </p>
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              These business capabilities have no application recorded as delivering them.
+              The gap may reflect missing documentation or a genuine technology need.{' '}
+              <Link href="/capabilities" className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200">
+                Review capabilities →
+              </Link>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Recent updates ──────────────────────────────────────────────────── */}
+      {recentChanges.length > 0 && (
+        <div>
+          <SectionLabel>Recent Updates</SectionLabel>
+          <div className="rounded-xl border bg-card divide-y">
+            {recentChanges.map(item => (
+              <div key={`${item.type}-${item.id}`} className="flex items-center gap-4 px-5 py-3">
+                <span className="inline-flex shrink-0 items-center rounded border border-border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground w-24 justify-center">
+                  {item.type}
+                </span>
+                <Link
+                  href={item.href}
+                  className="flex-1 text-sm font-medium hover:text-primary transition-colors truncate"
+                >
+                  {item.name}
+                </Link>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {item.updatedAt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {totalPublishedApps === 0 && totalCaps === 0 && totalInitiatives === 0 && (
+        <div className="rounded-xl border bg-card px-6 py-12 text-center space-y-2">
+          <p className="text-sm font-medium">No published content yet</p>
+          <p className="text-xs text-muted-foreground">
+            This summary reflects published content only.
+            Add and publish capabilities, applications, and initiatives to see your portfolio health here.
+          </p>
+          <p className="text-xs text-muted-foreground pt-2">
+            <Link href="/dashboard" className="underline underline-offset-2 hover:text-foreground">
+              Go to practitioner dashboard →
+            </Link>
+          </p>
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground border-t pt-4">
+        Reflects published content only. Draft and archived records are excluded.
+      </p>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -86,6 +86,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 export default async function ExecutiveDashboardPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  if (session.user.role === 'viewer') redirect('/dashboard')
 
   const orgId = session.user.organizationId!
   const enabledModules = await getEnabledModules()

--- a/apps/govea/src/app/(admin)/reports/heatmap/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/heatmap/page.tsx
@@ -1,0 +1,424 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { db } from '@/db/client'
+import {
+  applications, applicationCapabilities, capabilities,
+} from '@/db/schema'
+import { and, count, eq } from 'drizzle-orm'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
+import { cn } from '@/lib/utils'
+import Link from 'next/link'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const LIFECYCLE_COLS = ['active', 'planned', 'sunset', 'decommissioned'] as const
+type LifecycleStatus = typeof LIFECYCLE_COLS[number]
+
+const LIFECYCLE_LABELS: Record<LifecycleStatus, string> = {
+  active:         'Active',
+  planned:        'Planned',
+  sunset:         'Sunsetting',
+  decommissioned: 'Decommissioned',
+}
+
+// Cell bg classes indexed [0..3] for intensity buckets: empty, low, mid, high
+const LIFECYCLE_INTENSITY: Record<LifecycleStatus, [string, string, string, string]> = {
+  active:         ['', 'bg-emerald-100 dark:bg-emerald-950/40', 'bg-emerald-300 dark:bg-emerald-800/60', 'bg-emerald-500 dark:bg-emerald-700'],
+  planned:        ['', 'bg-blue-100 dark:bg-blue-950/40',     'bg-blue-300 dark:bg-blue-800/60',     'bg-blue-500 dark:bg-blue-700'],
+  sunset:         ['', 'bg-amber-100 dark:bg-amber-950/40',   'bg-amber-300 dark:bg-amber-800/60',   'bg-amber-500 dark:bg-amber-700'],
+  decommissioned: ['', 'bg-red-100 dark:bg-red-950/40',       'bg-red-300 dark:bg-red-800/60',       'bg-red-500 dark:bg-red-700'],
+}
+
+const LIFECYCLE_TEXT: Record<LifecycleStatus, [string, string, string, string]> = {
+  active:         ['text-muted-foreground', 'text-emerald-800 dark:text-emerald-200', 'text-emerald-900 dark:text-emerald-100', 'text-white'],
+  planned:        ['text-muted-foreground', 'text-blue-800 dark:text-blue-200',       'text-blue-900 dark:text-blue-100',       'text-white'],
+  sunset:         ['text-muted-foreground', 'text-amber-800 dark:text-amber-200',     'text-amber-900 dark:text-amber-100',     'text-white'],
+  decommissioned: ['text-muted-foreground', 'text-red-800 dark:text-red-200',         'text-red-900 dark:text-red-100',         'text-white'],
+}
+
+const HOSTING_STYLES: Record<string, string> = {
+  saas:    'bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-200 border-blue-200 dark:border-blue-800',
+  'on-prem':'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200 border-slate-200 dark:border-slate-700',
+  hybrid:  'bg-violet-100 text-violet-800 dark:bg-violet-950/40 dark:text-violet-200 border-violet-200 dark:border-violet-800',
+  other:   'bg-muted text-muted-foreground border-border',
+}
+
+const HOSTING_LABELS: Record<string, string> = {
+  saas:    'SaaS',
+  'on-prem':'On-Premises',
+  hybrid:  'Hybrid',
+  other:   'Unspecified',
+}
+
+const UNASSIGNED = '(Unassigned)'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function intensityBucket(n: number, rowMax: number): 0 | 1 | 2 | 3 {
+  if (n === 0 || rowMax === 0) return 0
+  const ratio = n / rowMax
+  if (ratio <= 0.25) return 1
+  if (ratio <= 0.6)  return 2
+  return 3
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SectionHeading({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-base font-semibold">{title}</h2>
+      <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+    </div>
+  )
+}
+
+function EmptySection({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border px-6 py-8 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function HeatmapPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (session.user.role === 'viewer') redirect('/dashboard')
+
+  const orgId = session.user.organizationId!
+  const enabledModules = await getEnabledModules()
+
+  const hasApps = isModuleEnabled(enabledModules, 'applications')
+  const hasCaps = isModuleEnabled(enabledModules, 'capabilities')
+
+  // ── Data fetch ────────────────────────────────────────────────────────────
+
+  const [
+    lifecycleDomainRows,
+    hostingRows,
+    capCoverageRows,
+  ] = await Promise.all([
+    // Lifecycle × Domain: apps (published) joined through capabilities to get domain
+    hasApps && hasCaps
+      ? db.select({
+          domain:          capabilities.domain,
+          lifecycleStatus: applications.lifecycleStatus,
+          appCount:        count(applications.id),
+        })
+          .from(applications)
+          .innerJoin(applicationCapabilities, eq(applicationCapabilities.applicationId, applications.id))
+          .innerJoin(capabilities, eq(capabilities.id, applicationCapabilities.capabilityId))
+          .where(and(
+            eq(applications.organizationId, orgId),
+            eq(applications.status, 'published'),
+          ))
+          .groupBy(capabilities.domain, applications.lifecycleStatus)
+      : Promise.resolve([]),
+
+    // Hosting model distribution
+    hasApps
+      ? db.select({ hostingModel: applications.hostingModel, appCount: count() })
+          .from(applications)
+          .where(and(eq(applications.organizationId, orgId), eq(applications.status, 'published')))
+          .groupBy(applications.hostingModel)
+      : Promise.resolve([]),
+
+    // Capability coverage: each published capability with its app link count
+    hasApps && hasCaps
+      ? db.select({
+          id:      capabilities.id,
+          domain:  capabilities.domain,
+          appCount: count(applicationCapabilities.applicationId),
+        })
+          .from(capabilities)
+          .leftJoin(applicationCapabilities, eq(applicationCapabilities.capabilityId, capabilities.id))
+          .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'published')))
+          .groupBy(capabilities.id, capabilities.domain)
+      : Promise.resolve([]),
+  ])
+
+  // ── Derive Lifecycle × Domain matrix ──────────────────────────────────────
+
+  // Build: { domain → { lifecycleStatus → count } }
+  const lifecycleMatrix: Record<string, Partial<Record<LifecycleStatus, number>>> = {}
+  for (const row of lifecycleDomainRows) {
+    const domain = row.domain ?? UNASSIGNED
+    const status = row.lifecycleStatus as LifecycleStatus
+    if (!lifecycleMatrix[domain]) lifecycleMatrix[domain] = {}
+    lifecycleMatrix[domain][status] = (lifecycleMatrix[domain][status] ?? 0) + Number(row.appCount)
+  }
+  const lifecycleDomains = Object.keys(lifecycleMatrix).sort((a, b) =>
+    a === UNASSIGNED ? 1 : b === UNASSIGNED ? -1 : a.localeCompare(b)
+  )
+
+  // Also include apps with no capability link (no domain) in Unassigned
+  // (They won't appear in the innerJoin above — handle by noting this in the UI)
+
+  // ── Derive Hosting model breakdown ────────────────────────────────────────
+
+  const hostingMap: Record<string, number> = {}
+  let totalHosting = 0
+  for (const row of hostingRows) {
+    const key = row.hostingModel?.toLowerCase() ?? 'other'
+    const canonKey = ['saas', 'on-prem', 'hybrid'].includes(key) ? key : 'other'
+    hostingMap[canonKey] = (hostingMap[canonKey] ?? 0) + Number(row.appCount)
+    totalHosting += Number(row.appCount)
+  }
+
+  // ── Derive Capability Coverage by Domain ──────────────────────────────────
+
+  const coverageByDomain: Record<string, { supported: number; unsupported: number }> = {}
+  for (const row of capCoverageRows) {
+    const domain = row.domain ?? UNASSIGNED
+    if (!coverageByDomain[domain]) coverageByDomain[domain] = { supported: 0, unsupported: 0 }
+    if (Number(row.appCount) > 0) {
+      coverageByDomain[domain].supported++
+    } else {
+      coverageByDomain[domain].unsupported++
+    }
+  }
+  const coverageDomains = Object.keys(coverageByDomain).sort((a, b) =>
+    a === UNASSIGNED ? 1 : b === UNASSIGNED ? -1 : a.localeCompare(b)
+  )
+
+  const totalUnsupported = Object.values(coverageByDomain).reduce((s, d) => s + d.unsupported, 0)
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-10 max-w-5xl">
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+            <Link href="/reports" className="hover:text-foreground transition-colors">Reports</Link>
+            <span>›</span>
+            <span>Heatmap Analysis</span>
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight">Heatmap Analysis</h1>
+          <p className="text-muted-foreground mt-1">
+            Portfolio pattern view — at-a-glance signals across lifecycle status, hosting model, and capability coverage.
+          </p>
+        </div>
+      </div>
+
+      {/* ── 1. Lifecycle Health ── */}
+      {hasApps && hasCaps ? (
+        <section>
+          <SectionHeading
+            title="Application Lifecycle by Domain"
+            description="How lifecycle status is distributed across capability domains. Darker cells indicate higher concentration."
+          />
+
+          {lifecycleDomains.length === 0 ? (
+            <EmptySection message="No published applications with capability links found. Link applications to capabilities to see domain breakdown." />
+          ) : (
+            <div className="rounded-lg border border-border overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-border bg-muted/40">
+                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground w-40">Domain</th>
+                    {LIFECYCLE_COLS.map(col => (
+                      <th key={col} className="text-center px-3 py-2.5 font-medium text-muted-foreground min-w-24">
+                        {LIFECYCLE_LABELS[col]}
+                      </th>
+                    ))}
+                    <th className="text-center px-3 py-2.5 font-medium text-muted-foreground min-w-16">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lifecycleDomains.map((domain, i) => {
+                    const row = lifecycleMatrix[domain]
+                    const rowTotal = LIFECYCLE_COLS.reduce((s, c) => s + (row[c] ?? 0), 0)
+                    const rowMax   = Math.max(...LIFECYCLE_COLS.map(c => row[c] ?? 0))
+                    return (
+                      <tr key={domain} className={cn('border-b border-border last:border-0', i % 2 === 0 ? '' : 'bg-muted/20')}>
+                        <td className="px-4 py-2 font-medium text-sm truncate max-w-40" title={domain}>
+                          {domain}
+                        </td>
+                        {LIFECYCLE_COLS.map(col => {
+                          const n      = row[col] ?? 0
+                          const bucket = intensityBucket(n, rowMax)
+                          return (
+                            <td key={col} className={cn('px-3 py-2 text-center tabular-nums font-semibold transition-colors', LIFECYCLE_INTENSITY[col][bucket], LIFECYCLE_TEXT[col][bucket])}>
+                              {n > 0 ? n : <span className="text-muted-foreground/40 font-normal">—</span>}
+                            </td>
+                          )
+                        })}
+                        <td className="px-3 py-2 text-center tabular-nums text-muted-foreground font-medium">
+                          {rowTotal}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+              <p className="px-4 py-2 text-xs text-muted-foreground border-t border-border bg-muted/20">
+                Applications without capability links are excluded. An app spanning multiple domains is counted in each domain.
+              </p>
+            </div>
+          )}
+
+          {/* Attention callout: sunset/decommissioned concentration */}
+          {(() => {
+            const atRiskDomains = lifecycleDomains.filter(d => {
+              const row = lifecycleMatrix[d]
+              return (row.sunset ?? 0) + (row.decommissioned ?? 0) > 0
+            })
+            if (atRiskDomains.length === 0) return null
+            return (
+              <div className="mt-3 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-4 py-3">
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                  Retirement exposure in {atRiskDomains.length} domain{atRiskDomains.length > 1 ? 's' : ''}:{' '}
+                  <span className="font-normal">{atRiskDomains.join(', ')}</span>
+                </p>
+              </div>
+            )
+          })()}
+        </section>
+      ) : !hasApps ? (
+        <section>
+          <SectionHeading title="Application Lifecycle by Domain" description="Requires the Applications module." />
+          <EmptySection message="Enable the Applications module in Settings to see lifecycle analysis." />
+        </section>
+      ) : null}
+
+      {/* ── 2. Hosting Model Distribution ── */}
+      {hasApps ? (
+        <section>
+          <SectionHeading
+            title="Hosting Model Distribution"
+            description="Cloud adoption progress across the published application portfolio."
+          />
+
+          {totalHosting === 0 ? (
+            <EmptySection message="No published applications found." />
+          ) : (
+            <>
+              {/* Proportional bar */}
+              <div className="flex h-8 rounded-lg overflow-hidden border border-border mb-4">
+                {(['saas', 'on-prem', 'hybrid', 'other'] as const).map(key => {
+                  const n = hostingMap[key] ?? 0
+                  if (n === 0) return null
+                  const pct = Math.round((n / totalHosting) * 100)
+                  const barStyle: Record<string, string> = {
+                    saas:     'bg-blue-400 dark:bg-blue-600',
+                    'on-prem':'bg-slate-400 dark:bg-slate-600',
+                    hybrid:   'bg-violet-400 dark:bg-violet-600',
+                    other:    'bg-muted',
+                  }
+                  return (
+                    <div
+                      key={key}
+                      className={cn('flex items-center justify-center text-xs font-semibold text-white', barStyle[key])}
+                      style={{ width: `${pct}%` }}
+                      title={`${HOSTING_LABELS[key]}: ${n} (${pct}%)`}
+                    >
+                      {pct >= 12 ? `${pct}%` : null}
+                    </div>
+                  )
+                })}
+              </div>
+
+              {/* Legend cards */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                {(['saas', 'on-prem', 'hybrid', 'other'] as const).map(key => {
+                  const n   = hostingMap[key] ?? 0
+                  const pct = totalHosting > 0 ? Math.round((n / totalHosting) * 100) : 0
+                  return (
+                    <div key={key} className={cn('rounded-lg border px-4 py-3', HOSTING_STYLES[key])}>
+                      <p className="text-xs font-medium uppercase tracking-wide opacity-70">{HOSTING_LABELS[key]}</p>
+                      <p className="text-2xl font-bold tabular-nums mt-0.5">{n}</p>
+                      <p className="text-xs opacity-60 mt-0.5">{pct}% of portfolio</p>
+                    </div>
+                  )
+                })}
+              </div>
+            </>
+          )}
+        </section>
+      ) : null}
+
+      {/* ── 3. Capability Coverage ── */}
+      {hasApps && hasCaps ? (
+        <section>
+          <SectionHeading
+            title="Capability Coverage by Domain"
+            description="Which domains have capabilities not yet supported by any application."
+          />
+
+          {coverageDomains.length === 0 ? (
+            <EmptySection message="No published capabilities found." />
+          ) : (
+            <>
+              {totalUnsupported > 0 && (
+                <div className="mb-3 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-4 py-3">
+                  <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                    {totalUnsupported} capability{totalUnsupported > 1 ? 'ies' : 'y'} across{' '}
+                    {coverageDomains.filter(d => (coverageByDomain[d]?.unsupported ?? 0) > 0).length} domain{coverageDomains.filter(d => (coverageByDomain[d]?.unsupported ?? 0) > 0).length > 1 ? 's' : ''}{' '}
+                    have no application support.
+                  </p>
+                </div>
+              )}
+
+              <div className="rounded-lg border border-border overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/40">
+                      <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Domain</th>
+                      <th className="text-center px-4 py-2.5 font-medium text-muted-foreground min-w-28">Supported</th>
+                      <th className="text-center px-4 py-2.5 font-medium text-muted-foreground min-w-28">Unsupported</th>
+                      <th className="text-center px-4 py-2.5 font-medium text-muted-foreground min-w-20">Total</th>
+                      <th className="text-center px-4 py-2.5 font-medium text-muted-foreground min-w-24">Coverage</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {coverageDomains.map((domain, i) => {
+                      const { supported, unsupported } = coverageByDomain[domain]
+                      const total    = supported + unsupported
+                      const coverage = total > 0 ? Math.round((supported / total) * 100) : 0
+                      const hasGap   = unsupported > 0
+                      return (
+                        <tr key={domain} className={cn('border-b border-border last:border-0', i % 2 === 0 ? '' : 'bg-muted/20')}>
+                          <td className="px-4 py-2 font-medium truncate max-w-48" title={domain}>{domain}</td>
+                          <td className="px-4 py-2 text-center tabular-nums font-semibold text-emerald-700 dark:text-emerald-400">
+                            {supported > 0 ? supported : <span className="text-muted-foreground/40 font-normal">—</span>}
+                          </td>
+                          <td className={cn('px-4 py-2 text-center tabular-nums font-semibold', hasGap ? 'text-amber-700 dark:text-amber-400' : 'text-muted-foreground/40')}>
+                            {unsupported > 0 ? unsupported : '—'}
+                          </td>
+                          <td className="px-4 py-2 text-center tabular-nums text-muted-foreground">{total}</td>
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-2">
+                              <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                                <div
+                                  className={cn('h-full rounded-full', coverage === 100 ? 'bg-emerald-500' : coverage >= 50 ? 'bg-amber-400' : 'bg-red-400')}
+                                  style={{ width: `${coverage}%` }}
+                                />
+                              </div>
+                              <span className="text-xs text-muted-foreground w-8 text-right">{coverage}%</span>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </section>
+      ) : null}
+
+      {/* Footer */}
+      <p className="text-xs text-muted-foreground pb-4">
+        Reflects published content only. Draft and archived records are excluded.
+      </p>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/reports/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/page.tsx
@@ -31,6 +31,16 @@ export default async function ReportsPage() {
             </div>
             <span className="text-muted-foreground text-sm">→</span>
           </Link>
+          <Link
+            href="/reports/heatmap"
+            className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors group"
+          >
+            <div>
+              <p className="text-sm font-medium group-hover:text-primary transition-colors">Heatmap Analysis</p>
+              <p className="text-xs text-muted-foreground mt-0.5">Portfolio pattern view — lifecycle health by domain, hosting model distribution, and capability coverage gaps at a glance.</p>
+            </div>
+            <span className="text-muted-foreground text-sm">→</span>
+          </Link>
         </div>
       </section>
 

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -12,7 +12,7 @@ import { isModuleEnabled, moduleForPath } from '@/lib/modules'
 
 // ── Nav structure ─────────────────────────────────────────────────────────────
 
-type NavItem = { href: string; label: string; moduleKey?: string }
+type NavItem = { href: string; label: string; moduleKey?: string; contributorOnly?: boolean }
 type NavGroup = { label: string; items: NavItem[]; adminOnly?: boolean }
 
 const NAV_GROUPS: NavGroup[] = [
@@ -45,7 +45,8 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: 'Reports',
     items: [
-      { href: '/reports', label: 'Reports' },
+      { href: '/reports',    label: 'Reports' },
+      { href: '/executive',  label: 'Executive Summary', contributorOnly: true },
     ],
   },
   {
@@ -75,6 +76,7 @@ function SidebarContent({
   onClose?: () => void
 }) {
   const isAdmin = role === 'admin'
+  const isContributor = role === 'admin' || role === 'contributor'
 
   return (
     <nav className="flex flex-col h-full overflow-y-auto py-4 px-3 gap-1">
@@ -93,24 +95,12 @@ function SidebarContent({
         Dashboard
       </Link>
 
-      {/* Executive Summary */}
-      <Link
-        href="/executive"
-        onClick={onClose}
-        className={cn(
-          'rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          pathname === '/executive' || pathname.startsWith('/executive/')
-            ? 'bg-white/15 text-white'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
-        )}
-      >
-        Executive Summary
-      </Link>
-
       <div className="mt-2 space-y-4">
         {NAV_GROUPS.filter(g => !g.adminOnly || isAdmin).map(group => {
           const visibleItems = group.items.filter(
-            item => !item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])
+            item =>
+              (!item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])) &&
+              (!item.contributorOnly || isContributor)
           )
           if (visibleItems.length === 0) return null
           return (

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -93,6 +93,20 @@ function SidebarContent({
         Dashboard
       </Link>
 
+      {/* Executive Summary */}
+      <Link
+        href="/executive"
+        onClick={onClose}
+        className={cn(
+          'rounded-md px-3 py-2 text-sm font-medium transition-colors',
+          pathname === '/executive' || pathname.startsWith('/executive/')
+            ? 'bg-white/15 text-white'
+            : 'text-white/70 hover:bg-white/10 hover:text-white'
+        )}
+      >
+        Executive Summary
+      </Link>
+
       <div className="mt-2 space-y-4">
         {NAV_GROUPS.filter(g => !g.adminOnly || isAdmin).map(group => {
           const visibleItems = group.items.filter(

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -15,7 +15,7 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 
 ## Behaviors
 
-- Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, and optional target resolution date
+- Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, optional target resolution date, and a `security_sensitive` boolean flag
 - Debt types: `lifecycle-risk` (application approaching or past vendor support end), `capability-gap` (capability with no supporting application), `decision-drift` (ADR superseded by practice without formal revision), `known-shortcut` (deliberate technical or architectural compromise), `unreviewed` (object not updated in more than N months)
 - Severity tiers (defined once here; used by this capability and referenced by `rm-end-to-end-traceability` and `rm-repository-completeness`):
   - `critical` — immediate operational or security risk: an application past end-of-life in active use with no remediation plan; a published capability with zero linked personas
@@ -34,11 +34,35 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 
 - Debt items belong to an organization and follow the standard content workflow: draft → published → archived
 - Only published debt items are visible to Viewer-role users — this is intentional; organizations control what they publish about their own architecture challenges
+- **Security exception:** debt items with `security_sensitive: true` are permanently restricted to Admin and Contributor roles regardless of workflow state. Publishing such an item does not expose it to Viewer-role users. The restriction is enforced by the system; it cannot be overridden by role assignment or visibility settings
+- The `security_sensitive` flag defaults to `false`. It must default to `true` when: the debt type is `lifecycle-risk` and the linked technology has a known CVE or an active security advisory on record; or when the item's description or rationale contains the word "CVE", "vulnerability", "exploit", "unpatched", or "advisory" (case-insensitive). The system must surface a prompt at creation time asking the user to confirm the classification; the user may override `true → false` only with an explicit acknowledgment logged to the audit trail
 - `accepted` debt items require a written rationale; the system must not allow acceptance without documentation
+- `accepted` rationale text is subject to the same `security_sensitive` auto-detection rule — if the rationale text contains sensitive indicators, the item is re-flagged and the user must re-acknowledge the classification before saving
 - Auto-flagged debt (lifecycle-based) appears in a separate "system-detected" queue, distinct from human-created debt items; the distinction must be visible
 - Resolving a debt item requires linking it to an initiative or explicitly marking it `accepted` with rationale; it cannot be closed without one or the other
 - When a user attempts to publish an architecture object that has one or more linked `critical` or `high` severity debt items in `open` status, the system must display a warning and require explicit acknowledgment before publishing proceeds — the publish action is not blocked, but the acknowledgment is mandatory and logged in the audit trail; this prevents silent publication of high-risk content without removing the architect's ability to communicate context alongside known problems
 - Debt items must be linked to at least one architecture object; unattached debt items are not permitted
+
+## Security Classification Guidance
+
+This guidance is for architects deciding what debt is safe to publish to Viewer-role users.
+
+**Generally safe to publish:**
+- Lifecycle risk linked to a vendor's published end-of-support date (e.g., "Windows Server 2012 reaches EOS in October 2026")
+- Capability gaps (a capability with no supporting application) — these describe an architectural gap, not a specific exploitable weakness
+- Decision drift (an ADR that has been informally superseded) — describes process debt, not a security exposure
+- Known shortcuts where the shortcut itself is not exploitable (e.g., "we deferred the API gateway implementation")
+
+**Should be marked `security_sensitive: true` before publication is considered:**
+- Any debt item that names a specific CVE, security advisory ID, or CVSS score
+- Patch status of a production system (e.g., "Apache 2.4.49 is unpatched on the permitting server")
+- Configuration weaknesses pending remediation (e.g., "MFA not enforced on the finance portal")
+- Dependency on an unsupported library where the vulnerability details are non-public or under embargo
+- `accepted` rationale that explains why a known vulnerability is being tolerated rather than remediated — this context must never be published
+
+**The test:** would a bad actor learn something useful from this item that they could not already learn from a public vendor advisory? If yes, it is security-sensitive. If the item merely points at a publicly known timeline (end-of-support date, published EOL notice), it may be safe to publish.
+
+**When in doubt, mark it sensitive.** The cost of an unpublished debt item is a slightly less complete public view of the portfolio. The cost of an inadvertently published vulnerability detail in a government system is significantly higher.
 
 ## Federation Behavior
 
@@ -56,6 +80,12 @@ Debt items are always owned by the organization that creates them. Federation do
 **Design principle:** An Enterprise Architect cannot use debt tracking as a surveillance mechanism to discover problems in agencies that have not chosen to share them. The federation model is a professional network, not an audit trail. If agencies know that linking to an enterprise capability automatically exposes their debt to central IT, they will not link — and the entire federation model fails.
 
 **Auto-flagged debt and cross-org objects:** The system-detected debt queue (lifecycle-based flags) only fires against objects the org owns. An agency is never auto-flagged for debt conditions in a cross-org linked object that belongs to another org.
+
+## Implementation Status
+
+Not yet implemented. No architecture debt tracking surface exists in the current product. This document is the design specification for that future build.
+
+The `security_sensitive` flag and the Security Classification Guidance section above were added in response to ARB finding #135 (Omar Singh, Security Architect). These constraints must be incorporated in the initial implementation — retrofitting security classification onto an existing debt store is significantly harder than building it in from the start.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Addresses ARB finding #135 (Omar Singh, Security Architect, severity: medium): the architecture debt capability spec allowed debt items to be published to Viewer-role users with no mechanism to prevent inadvertent exposure of live vulnerability details.

**Changes to `rm-architecture-debt.md`:**

- `security_sensitive` boolean added to the debt item data model (Behaviors)
- **Hard rule:** `security_sensitive: true` permanently restricts the item to Admin and Contributor roles regardless of workflow state — the system enforces this, it cannot be overridden by visibility settings
- **Auto-detection rule:** flag defaults `true` when the debt type is `lifecycle-risk` with a linked CVE/advisory on record, or when the description/rationale contains security-indicator keywords (`CVE`, `vulnerability`, `exploit`, `unpatched`, `advisory`); user override from `true → false` requires explicit acknowledgment logged to the audit trail
- `accepted` rationale text is subject to the same auto-detection on save — sensitive context in a rationale re-triggers the classification prompt
- New **Security Classification Guidance** section with concrete safe-to-publish examples, must-flag examples, and a plain-language test ("would a bad actor learn something they couldn't from a public advisory?")
- **Implementation Status** section noting this capability is not yet built and these constraints must land in the initial implementation — not retrofitted

## Why this matters

Debt tracking is where architects document the most sensitive operational reality of a system. The standard publish workflow has no safety net. This spec change ensures the safety net is designed in before code is written.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)