### PR TITLE
Revert Azure container to next dev mode

### DIFF
--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -34,6 +34,9 @@ COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
 COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh
 RUN chmod +x /entrypoint.dev.sh /entrypoint.azure-dev.sh
 
+# Cache-bust: pass --build-arg CACHE_BUST=$(date +%s) to force re-execution.
+ARG CACHE_BUST=1
+
 # Pre-build the Next.js app so server action IDs are stable at runtime.
 # Placeholder env vars are sufficient — all DB queries are request-time only.
 RUN DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/govea \

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -34,16 +34,6 @@ COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
 COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh
 RUN chmod +x /entrypoint.dev.sh /entrypoint.azure-dev.sh
 
-# Cache-bust: pass --build-arg CACHE_BUST=$(date +%s) to force re-execution.
-ARG CACHE_BUST=1
-
-# Pre-build the Next.js app so server action IDs are stable at runtime.
-# Placeholder env vars are sufficient — all DB queries are request-time only.
-RUN DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/govea \
-    AUTH_SECRET=build-placeholder \
-    NEXT_PUBLIC_APP_URL=http://localhost:3000 \
-    pnpm --filter govea build
-
 EXPOSE 3000
 
 ENTRYPOINT ["/entrypoint.dev.sh"]

--- a/docker/entrypoint.azure-dev.sh
+++ b/docker/entrypoint.azure-dev.sh
@@ -30,4 +30,4 @@ pnpm --filter govea db:seed:container
 
 echo ""
 echo "==> Starting server..."
-exec pnpm --filter govea start
+exec pnpm --filter govea dev


### PR DESCRIPTION
## Summary

- Removes the pre-build step (`RUN pnpm build`) and `CACHE_BUST` ARG added in f49bd5a — the container is meant to run `next dev`, not `next start`
- Reverts entrypoint start command from `pnpm start` back to `pnpm dev`
- Keeps `drizzle-kit push --force` replacing `db:migrate` (no migration files exist in pre-production)

## Test plan

- [ ] `./scripts/azure-dev.sh update` builds and deploys successfully
- [ ] Logs show `next dev` starting (not `next start`)
- [ ] App responds at https://govea-dev.wittyocean-795e193a.eastus.azurecontainerapps.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)