### PR TITLE
fix(seed): seed capability parent-child relationships for demo orgs

### DIFF
--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -303,6 +303,14 @@ export const DEV_CAPABILITIES = [
   },
 ]
 
+// ─── Capability hierarchy (City of Riverdale) ────────────────────────────────
+export const DEV_CAPABILITY_RELATIONSHIPS: { parentName: string; childName: string }[] = [
+  { parentName: 'Digital Identity & Authentication', childName: 'User and Role Management' },
+  { parentName: 'Digital Identity & Authentication', childName: 'Role-Based Access Control' },
+  { parentName: 'Digital Identity & Authentication', childName: 'SSO and Local Authentication' },
+  { parentName: 'Digital Identity & Authentication', childName: 'IAM Audit Trail' },
+]
+
 // ─── Applications (City of Riverdale) ────────────────────────────────────────
 // Coverage: lifecycleStatus = active ✓, sunset ✓, decommissioned ✓, planned ✓
 //           hostingModel = saas ✓, on-prem ✓, hybrid ✓

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -5,7 +5,7 @@ import {
   DEV_USERS, STATE_USERS, SYSTEM_USERS,
   DEFAULT_PERSONA_TYPES, DEFAULT_PERSONA_TAGS,
   DEV_PERSONA_TAG_ASSIGNMENTS,
-  DEV_PERSONAS, DEV_CAPABILITIES, DEV_APPLICATIONS,
+  DEV_PERSONAS, DEV_CAPABILITIES, DEV_CAPABILITY_RELATIONSHIPS, DEV_APPLICATIONS,
   DEV_OBJECTIVES, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   DEV_PRINCIPLES, DEV_GLOSSARY, DEV_SERVICES,
   STATE_PERSONAS, STATE_CAPABILITIES, STATE_APPLICATIONS,
@@ -223,6 +223,18 @@ async function seed() {
     }
   }
   console.log(`  ✓ ${DEV_CAPABILITIES.length} capabilities`)
+
+  // Capability parent-child relationships
+  for (const rel of DEV_CAPABILITY_RELATIONSHIPS) {
+    const parentId = devCapabilityIds[rel.parentName]
+    const childId = devCapabilityIds[rel.childName]
+    if (!parentId || !childId) continue
+    const exists = await db.query.capabilityRelationships.findFirst({
+      where: (t, { eq: e, and }) => and(e(t.parentId, parentId), e(t.childId, childId)),
+    })
+    if (!exists) await db.insert(capabilityRelationships).values({ parentId, childId })
+  }
+  console.log(`  ✓ ${DEV_CAPABILITY_RELATIONSHIPS.length} capability parent-child relationships`)
 
   // Applications + capability links
   const devApplicationIds: Record<string, string> = {}


### PR DESCRIPTION
## Summary

- Adds `DEV_CAPABILITY_RELATIONSHIPS` to `dev-fixtures.ts` — four IAM sub-capabilities parented under `Digital Identity & Authentication` for City of Riverdale
- Wires the constant into `run.ts` with the same skip-existing guard used for all other junction tables

Closes #330

## Test plan

- [ ] `pnpm --filter govea db:seed` completes and logs `✓ 4 capability parent-child relationships`
- [ ] On the capabilities page (City of Riverdale), `Digital Identity & Authentication` shows a collapse toggle and its four children indent beneath it
- [ ] After `./scripts/azure-dev.sh update`, same tree is visible on the Azure instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)