### PR TITLE
fix(container): add migration entrypoint and first-run setup to production image

### DIFF
--- a/docker/Containerfile
+++ b/docker/Containerfile
@@ -21,7 +21,21 @@ RUN cd apps/govea && node node_modules/next/dist/bin/next build
 FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+# Standalone Next.js build
 COPY --from=builder /app/apps/govea/.next/standalone ./
 COPY --from=builder /app/apps/govea/.next/static ./apps/govea/.next/static
+
+# Migration tooling — isolated in /app/db-tools so it doesn't conflict with the standalone bundle.
+# Uses plain npm (not pnpm) to avoid symlink issues when copying from the deps stage.
+WORKDIR /app/db-tools
+COPY apps/govea/src/db/migrations ./migrations/
+COPY docker/migrate.mjs docker/create-admin.mjs ./
+RUN npm init -y --quiet && npm install --save-exact --quiet postgres drizzle-orm bcryptjs
+
+WORKDIR /app
+COPY docker/entrypoint.prod.sh /entrypoint.prod.sh
+RUN chmod +x /entrypoint.prod.sh
+
 EXPOSE 3000
-CMD ["node", "apps/govea/server.js"]
+ENTRYPOINT ["/entrypoint.prod.sh"]

--- a/docker/create-admin.mjs
+++ b/docker/create-admin.mjs
@@ -1,0 +1,42 @@
+/**
+ * First-run setup: creates an org + initial instance admin if no users exist yet.
+ * Controlled by GOVEA_SETUP_EMAIL and GOVEA_SETUP_PASSWORD env vars.
+ * Safe to leave in env on subsequent runs — no-ops when users already exist.
+ */
+import postgres from 'postgres'
+import bcrypt from 'bcryptjs'
+
+const email = process.env.GOVEA_SETUP_EMAIL
+const password = process.env.GOVEA_SETUP_PASSWORD
+const orgName = process.env.GOVEA_SETUP_ORG_NAME ?? 'My Organization'
+
+if (!email || !password) {
+  console.error('    GOVEA_SETUP_EMAIL and GOVEA_SETUP_PASSWORD are required.')
+  process.exit(1)
+}
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1 })
+
+const [{ count }] = await sql`SELECT count(*)::int FROM users`
+if (parseInt(count) > 0) {
+  console.log('    Users already exist — skipping first-run setup.')
+  await sql.end()
+  process.exit(0)
+}
+
+const slug = orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+const [org] = await sql`
+  INSERT INTO organizations (name, slug)
+  VALUES (${orgName}, ${slug})
+  RETURNING id
+`
+
+const passwordHash = await bcrypt.hash(password, 12)
+await sql`
+  INSERT INTO users (organization_id, email, name, password_hash, role, instance_role, is_active)
+  VALUES (${org.id}, ${email}, 'Admin', ${passwordHash}, 'admin', 'instance_admin', 'true')
+`
+
+console.log(`    Created org: ${orgName}`)
+console.log(`    Created instance admin: ${email}`)
+await sql.end()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,20 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/govea
+      NODE_ENV: production
+
+      # Required — generate with: openssl rand -base64 32
+      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required. Run: export AUTH_SECRET=$(openssl rand -base64 32)}
+
+      # Required — set to the URL where the app is reachable
+      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+
+      # First-run setup — creates an org + instance admin on first boot if no users exist.
+      # Safe to leave set on subsequent runs (no-ops when users already exist).
+      GOVEA_SETUP_EMAIL: ${GOVEA_SETUP_EMAIL:-}
+      GOVEA_SETUP_PASSWORD: ${GOVEA_SETUP_PASSWORD:-}
+      GOVEA_SETUP_ORG_NAME: ${GOVEA_SETUP_ORG_NAME:-My Organization}
+
     depends_on:
       db:
         condition: service_healthy

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Production startup: wait for Postgres → run migrations → optional first-run setup → start server.
+set -e
+
+echo ""
+echo "==> Waiting for database..."
+until node -e "
+  const n = require('net')
+  const u = new URL(process.env.DATABASE_URL)
+  const s = n.createConnection(parseInt(u.port) || 5432, u.hostname)
+  s.on('connect', () => { s.destroy(); process.exit(0) })
+  s.on('error', () => process.exit(1))
+" 2>/dev/null; do
+  sleep 2
+done
+echo "    Database ready."
+
+echo ""
+echo "==> Running migrations..."
+node /app/db-tools/migrate.mjs
+
+if [ -n "${GOVEA_SETUP_EMAIL}" ]; then
+  echo ""
+  echo "==> Running first-run setup..."
+  node /app/db-tools/create-admin.mjs
+fi
+
+echo ""
+echo "==> Starting server..."
+exec node /app/apps/govea/server.js

--- a/docker/migrate.mjs
+++ b/docker/migrate.mjs
@@ -1,0 +1,15 @@
+import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
+import postgres from 'postgres'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const migrationsFolder = join(dirname(fileURLToPath(import.meta.url)), 'migrations')
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1 })
+const db = drizzle(sql)
+
+await migrate(db, { migrationsFolder })
+await sql.end()
+
+console.log('    Migrations complete.')

--- a/docker/podman-compose.yml
+++ b/docker/podman-compose.yml
@@ -7,6 +7,21 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/govea
+      NODE_ENV: production
+
+      # Required — generate with: openssl rand -base64 32
+      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required. Run: export AUTH_SECRET=$(openssl rand -base64 32)}
+
+      # Required — set to the URL where the app is reachable
+      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+
+      # First-run setup — creates an org + instance admin on first boot if no users exist.
+      # Safe to leave set on subsequent runs (no-ops when users already exist).
+      # Remove or leave blank after initial setup if preferred.
+      GOVEA_SETUP_EMAIL: ${GOVEA_SETUP_EMAIL:-}
+      GOVEA_SETUP_PASSWORD: ${GOVEA_SETUP_PASSWORD:-}
+      GOVEA_SETUP_ORG_NAME: ${GOVEA_SETUP_ORG_NAME:-My Organization}
+
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- **`entrypoint.prod.sh`** — waits for Postgres, runs migrations, optionally creates the first admin, starts `node server.js`
- **`migrate.mjs`** — drizzle-orm migration runner, isolated in `/app/db-tools` to avoid conflicts with the standalone bundle
- **`create-admin.mjs`** — first-run org + instance admin creation via `GOVEA_SETUP_EMAIL` / `GOVEA_SETUP_PASSWORD`; no-ops if users already exist so it's safe to leave in env permanently
- **`Containerfile`** — runner stage installs `postgres`, `drizzle-orm`, `bcryptjs` via npm (not pnpm, to avoid symlink issues), copies migration SQL files, uses new entrypoint
- **`podman-compose.yml` / `docker-compose.yml`** — `AUTH_SECRET` (required, fails fast if missing), `NEXT_PUBLIC_APP_URL`, and first-run env vars with inline comments

Closes #335

## Local run (Podman)

```bash
# Install podman-compose once
pip3 install podman-compose

# From repo root
export AUTH_SECRET=$(openssl rand -base64 32)
export GOVEA_SETUP_EMAIL=admin@example.com
export GOVEA_SETUP_PASSWORD=yourpassword

podman-compose -f docker/podman-compose.yml up --build
```

Then open http://localhost:3000 and log in with the email/password above.

## Test plan

- [ ] `podman-compose up --build` completes without errors
- [ ] Container logs show: Postgres ready → Migrations complete → first admin created → server started
- [ ] http://localhost:3000 shows login page
- [ ] Login with `GOVEA_SETUP_EMAIL` / `GOVEA_SETUP_PASSWORD` succeeds
- [ ] Second `podman-compose up` (no `--build`) shows "Users already exist — skipping" and starts normally
- [ ] `AUTH_SECRET` missing → compose fails immediately with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)