### PR TITLE
fix(migrations): add missing migration files for capability_relationships and instance_settings

### DIFF
--- a/apps/govea/src/db/migrations/0026_capability_relationships.sql
+++ b/apps/govea/src/db/migrations/0026_capability_relationships.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "capability_relationships" (
+	"parent_id" uuid NOT NULL,
+	"child_id" uuid NOT NULL,
+	CONSTRAINT "capability_relationships_pkey" PRIMARY KEY("parent_id","child_id")
+);
+--> statement-breakpoint
+ALTER TABLE "capability_relationships" ADD CONSTRAINT "capability_relationships_parent_id_capabilities_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."capabilities"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "capability_relationships" ADD CONSTRAINT "capability_relationships_child_id_capabilities_id_fk" FOREIGN KEY ("child_id") REFERENCES "public"."capabilities"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/govea/src/db/migrations/0027_instance_settings.sql
+++ b/apps/govea/src/db/migrations/0027_instance_settings.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "instance_settings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"disabled_modules" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);


### PR DESCRIPTION
## Summary

- `0026_capability_relationships.sql` — table for the parent-child hierarchy added in #327
- `0027_instance_settings.sql` — table for instance-wide module controls added in #334

Both were merged without migration files. The production container's `migrate.mjs` uses drizzle's SQL migrator, so both tables were absent on a fresh deployment.

Closes #337

## Test plan

- [ ] Fresh `podman-compose up --build` completes and both tables exist in the DB
- [ ] Capabilities page loads and shows the tree (collapse toggle visible for parents)
- [ ] Instance → Feature Controls page loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)