### PR TITLE
feat(instance): create tenant organisation from instance admin panel

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -11,6 +11,38 @@ import { validatePassword } from '@/lib/password'
 import bcrypt from 'bcryptjs'
 import { themes } from '@/lib/themes'
 
+export async function createOrg(formData: FormData): Promise<{ id: string }> {
+  const session = await requireInstanceAdmin()
+
+  const name = (formData.get('name') as string ?? '').trim()
+  const slug = (formData.get('slug') as string ?? '').trim()
+
+  if (!name) throw new Error('Name is required')
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(slug)) {
+    throw new Error('Slug must be lowercase letters, numbers, and hyphens only')
+  }
+
+  const conflict = await db.query.organizations.findFirst({
+    where: eq(organizations.slug, slug),
+    columns: { id: true },
+  })
+  if (conflict) throw new Error('An organisation with that slug already exists')
+
+  const [org] = await db.insert(organizations).values({ name, slug }).returning()
+
+  await writeAuditLog({
+    action: 'instance.org.create',
+    entityType: 'organization',
+    entityId: org.id,
+    userId: session.user.id,
+    organizationId: null,
+    after: { name, slug },
+  })
+
+  revalidatePath('/instance/orgs')
+  return { id: org.id }
+}
+
 export async function grantBreakGlass(orgId: string, reason: string) {
   const session = await requireInstanceAdmin()
   const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)

--- a/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useState, useTransition, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { createOrg } from '@/actions/instance'
+
+type OrgRow = {
+  id: string
+  name: string
+  slug: string
+  userCount: number
+  createdAt: Date
+  suspendedAt: Date | null
+  isSystemOrg: boolean | null
+}
+
+interface Props {
+  orgs: OrgRow[]
+}
+
+function toSlug(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+export function InstanceOrgsTable({ orgs }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [slugEdited, setSlugEdited] = useState(false)
+  const [slug, setSlug] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!slugEdited) setSlug(toSlug(e.target.value))
+  }
+
+  function handleOpen(val: boolean) {
+    setOpen(val)
+    if (val) {
+      setSlug('')
+      setSlugEdited(false)
+      setError(null)
+    }
+  }
+
+  function handleCreate(formData: FormData) {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result = await createOrg(formData)
+        setOpen(false)
+        router.push(`/instance/orgs/${result.id}`)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Something went wrong')
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Organisations</h1>
+          <p className="text-muted-foreground mt-1">All tenant organisations registered on this instance.</p>
+        </div>
+        <Button size="sm" onClick={() => handleOpen(true)}>+ New organisation</Button>
+      </div>
+
+      <div className="rounded-lg border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Slug</TableHead>
+              <TableHead>Users</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {orgs.map((org) => (
+              <TableRow key={org.id}>
+                <TableCell>
+                  <Link href={`/instance/orgs/${org.id}`} className="font-medium hover:underline">
+                    {org.name}
+                  </Link>
+                  {org.isSystemOrg && (
+                    <span className="ml-2 text-xs text-muted-foreground">(system)</span>
+                  )}
+                </TableCell>
+                <TableCell className="font-mono text-sm text-muted-foreground">{org.slug}</TableCell>
+                <TableCell>{org.userCount}</TableCell>
+                <TableCell className="text-muted-foreground whitespace-nowrap">
+                  {org.createdAt.toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  <span className={cn(
+                    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                    org.suspendedAt
+                      ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400'
+                      : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
+                  )}>
+                    {org.suspendedAt ? 'Suspended' : 'Active'}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+            {orgs.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  No organisations yet — create one to get started.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={open} onOpenChange={handleOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New organisation</DialogTitle>
+          </DialogHeader>
+          <form action={handleCreate} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="org-name">Name</Label>
+              <Input
+                id="org-name"
+                name="name"
+                ref={nameRef}
+                required
+                autoFocus
+                onChange={handleNameChange}
+                placeholder="City of Springfield"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="org-slug">Slug</Label>
+              <Input
+                id="org-slug"
+                name="slug"
+                required
+                value={slug}
+                onChange={(e) => { setSlugEdited(true); setSlug(e.target.value) }}
+                placeholder="city-of-springfield"
+                pattern="^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+                title="Lowercase letters, numbers, and hyphens only"
+                className="font-mono"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used in URLs. Lowercase, letters, numbers, and hyphens only.
+              </p>
+            </div>
+            {error && (
+              <p className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
+                {error}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? 'Creating…' : 'Create organisation'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(instance)/instance/orgs/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/page.tsx
@@ -2,11 +2,7 @@ import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { organizations, users } from '@/db/schema'
 import { count, eq, desc } from 'drizzle-orm'
-import Link from 'next/link'
-import { cn } from '@/lib/utils'
-import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table'
+import { InstanceOrgsTable } from './instance-orgs-table'
 
 export default async function InstanceOrgsPage() {
   await requireInstanceAdmin()
@@ -22,64 +18,16 @@ export default async function InstanceOrgsPage() {
     .orderBy(desc(organizations.createdAt))
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Organisations</h1>
-        <p className="text-muted-foreground mt-1">All tenant organisations registered on this instance.</p>
-      </div>
-
-      <div className="rounded-lg border bg-card">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Slug</TableHead>
-              <TableHead>Users</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead>Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.map(({ org, userCount }) => (
-              <TableRow key={org.id}>
-                <TableCell>
-                  <Link
-                    href={`/instance/orgs/${org.id}`}
-                    className="font-medium hover:underline"
-                  >
-                    {org.name}
-                  </Link>
-                  {org.isSystemOrg && (
-                    <span className="ml-2 text-xs text-muted-foreground">(system)</span>
-                  )}
-                </TableCell>
-                <TableCell className="font-mono text-sm text-muted-foreground">{org.slug}</TableCell>
-                <TableCell>{userCount}</TableCell>
-                <TableCell className="text-muted-foreground whitespace-nowrap">
-                  {org.createdAt.toLocaleDateString()}
-                </TableCell>
-                <TableCell>
-                  <span className={cn(
-                    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                    org.suspendedAt
-                      ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400'
-                      : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
-                  )}>
-                    {org.suspendedAt ? 'Suspended' : 'Active'}
-                  </span>
-                </TableCell>
-              </TableRow>
-            ))}
-            {rows.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
-                  No organisations found
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
-    </div>
+    <InstanceOrgsTable
+      orgs={rows.map(({ org, userCount }) => ({
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        userCount,
+        createdAt: org.createdAt,
+        suspendedAt: org.suspendedAt,
+        isSystemOrg: org.isSystemOrg,
+      }))}
+    />
   )
 }

--- a/docker/podman-compose.yml
+++ b/docker/podman-compose.yml
@@ -10,17 +10,19 @@ services:
       NODE_ENV: production
 
       # Required — generate with: openssl rand -base64 32
-      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required. Run: export AUTH_SECRET=$(openssl rand -base64 32)}
+      AUTH_SECRET: ${AUTH_SECRET}
 
       # Required — set to the URL where the app is reachable
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+
+      # Required in production — tells NextAuth v5 to trust the incoming host header
+      AUTH_TRUST_HOST: "1"
 
       # First-run setup — creates an org + instance admin on first boot if no users exist.
       # Safe to leave set on subsequent runs (no-ops when users already exist).
       # Remove or leave blank after initial setup if preferred.
       GOVEA_SETUP_EMAIL: ${GOVEA_SETUP_EMAIL:-}
       GOVEA_SETUP_PASSWORD: ${GOVEA_SETUP_PASSWORD:-}
-      GOVEA_SETUP_ORG_NAME: ${GOVEA_SETUP_ORG_NAME:-My Organization}
 
     depends_on:
       db:


### PR DESCRIPTION
Closes #341

## Summary

- **`createOrg` server action** — validates name + slug (format and uniqueness), inserts the org, writes an audit log entry, and returns the new org's ID for client-side redirect
- **`InstanceOrgsTable` client component** — replaces the static server-rendered table; adds a "New organisation" dialog where slug auto-derives from the name on each keystroke (user can override); inline error message for duplicate slug or bad format; on success redirects to the new org's detail page
- **Orgs page** — refactored to pass data into the new client component (same data query, same shape)
- Also backports the `podman-compose.yml` YAML fix and `AUTH_TRUST_HOST` from PR #340

## Behaviour

1. Instance admin clicks **+ New organisation**
2. Types org name → slug auto-populates (e.g. `City of Springfield` → `city-of-springfield`)
3. Slug is editable; validated client-side (`pattern` attr) and server-side
4. Submit → org created → redirected to `/instance/orgs/<id>`
5. Duplicate slug returns inline error without crashing

## Test plan

- [ ] Create an org — confirm redirect to org detail page
- [ ] Try a duplicate slug — confirm inline error, no page crash
- [ ] Try a bad slug format (uppercase, spaces) — confirm browser/server validation
- [ ] Confirm audit log entry under `/instance/audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)