### PR TITLE
fix(migrations): add missing platform_config migration

### DIFF
--- a/apps/govea/src/db/migrations/0028_platform_config.sql
+++ b/apps/govea/src/db/migrations/0028_platform_config.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "platform_config" (
+	"id" text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+	"instance_name" text DEFAULT 'GovEA' NOT NULL,
+	"default_theme" text DEFAULT 'govea' NOT NULL,
+	"allow_local_auth" boolean DEFAULT true NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"updated_by" uuid
+);
+--> statement-breakpoint
+ALTER TABLE "platform_config" ADD CONSTRAINT "platform_config_updated_by_users_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1777300001000,
       "tag": "0027_instance_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1777300002000,
+      "tag": "0028_platform_config",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #343

## Summary

Adds the missing `0028_platform_config.sql` migration and `_journal.json` entry. The `platform_config` table was created only via `db:push` and never had a proper migration file, causing production containers to crash on any page that queries it.

## Test plan

- [ ] Fresh container start — no `relation "platform_config" does not exist` error
- [ ] Instance config page loads at `/instance/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)