### PR TITLE
feat(nav): add Platform Admin link in header for instance admins

### DIFF
--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -64,6 +64,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       roleBadgeClass={ROLE_BADGE_CLASS[role]}
       themeStyle={themeStyle}
       isDev={isInstanceAdmin(session.user)}
+      isInstanceAdmin={isInstanceAdmin(session.user)}
       enabledModules={enabledModules}
       signOutSlot={signOutSlot}
     >

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -171,6 +171,7 @@ interface AppShellProps {
   roleBadgeClass: string
   themeStyle: string
   isDev: boolean
+  isInstanceAdmin: boolean
   enabledModules: Record<string, boolean>
   signOutSlot: ReactNode
   children: ReactNode
@@ -182,6 +183,7 @@ export function AppShell({
   roleBadgeClass,
   themeStyle,
   isDev,
+  isInstanceAdmin,
   enabledModules,
   signOutSlot,
   children,
@@ -337,6 +339,14 @@ export function AppShell({
 
           {/* User info */}
           <div className="flex items-center gap-3">
+            {isInstanceAdmin && (
+              <Link
+                href="/instance"
+                className="hidden sm:inline-flex items-center rounded-md border border-violet-400/40 bg-violet-500/20 px-2.5 py-1 text-xs font-medium text-violet-200 hover:bg-violet-500/30 transition-colors"
+              >
+                Platform Admin
+              </Link>
+            )}
             <span className="hidden sm:block text-sm text-white/70">{email}</span>
             <span
               data-tour="role-badge"


### PR DESCRIPTION
Closes part of #341 (discoverability gap)

## Summary

Instance admins land on `/dashboard` after login with no visible way to reach the `/instance` panel. Adds a **Platform Admin** badge-link in the top header, visible only to users with `instanceRole = instance_admin`.

## Test plan

- [ ] Log in as instance admin → see violet "Platform Admin" link in header
- [ ] Click it → lands on `/instance` dashboard
- [ ] Log in as regular org admin → link is not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)