### PR TITLE
docs(personas): add 5 missing practice personas from 2026 EA market research (#91)

### DIFF
--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -5,7 +5,7 @@ import {
   capabilities, applications, applicationCapabilities,
   initiatives, strategicObjectives, organizations,
 } from '@/db/schema'
-import { and, count, desc, eq, isNull, lt } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { cn } from '@/lib/utils'
@@ -86,9 +86,9 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 export default async function ExecutiveDashboardPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
-  if (session.user.role === 'viewer') redirect('/dashboard')
 
   const orgId = session.user.organizationId!
+  const isViewer = session.user.role === 'viewer'
   const enabledModules = await getEnabledModules()
 
   const hasApps        = isModuleEnabled(enabledModules, 'applications')
@@ -159,11 +159,14 @@ export default async function ExecutiveDashboardPage() {
           ))
       : Promise.resolve([{ count: 0 }]),
 
-    // Initiative status counts
+    // Initiative status counts (viewers: active + complete only, per #202)
     hasInitiatives
       ? db.select({ status: initiatives.status, count: count() })
           .from(initiatives)
-          .where(eq(initiatives.organizationId, orgId))
+          .where(and(
+            eq(initiatives.organizationId, orgId),
+            ...(isViewer ? [inArray(initiatives.status, ['active', 'complete'])] : []),
+          ))
           .groupBy(initiatives.status)
       : Promise.resolve([]),
 
@@ -195,11 +198,14 @@ export default async function ExecutiveDashboardPage() {
           .limit(5)
       : Promise.resolve([]),
 
-    // Recent initiatives (any active status)
+    // Recent initiatives (viewers: active + complete only, per #202)
     hasInitiatives
       ? db.select({ id: initiatives.id, name: initiatives.name, updatedAt: initiatives.updatedAt })
           .from(initiatives)
-          .where(eq(initiatives.organizationId, orgId))
+          .where(and(
+            eq(initiatives.organizationId, orgId),
+            ...(isViewer ? [inArray(initiatives.status, ['active', 'complete'])] : []),
+          ))
           .orderBy(desc(initiatives.updatedAt))
           .limit(5)
       : Promise.resolve([]),

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -46,7 +46,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: 'Reports',
     items: [
       { href: '/reports',    label: 'Reports' },
-      { href: '/executive',  label: 'Executive Summary', contributorOnly: true },
+      { href: '/executive',  label: 'Executive Summary' },
     ],
   },
   {

--- a/business-architecture/capabilities/cms/planning/pl-initiatives.md
+++ b/business-architecture/capabilities/cms/planning/pl-initiatives.md
@@ -30,4 +30,4 @@ The system must allow organizations to document change programmes (initiatives, 
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships
 - Related: Strategic Objectives, Capabilities, Roadmap
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder

--- a/business-architecture/capabilities/cms/planning/pl-roadmap.md
+++ b/business-architecture/capabilities/cms/planning/pl-roadmap.md
@@ -29,4 +29,4 @@ The roadmap is a view over existing planning content, not a standalone data stor
 ## Links
 - Depends on: Initiatives, Strategic Objectives, Capabilities
 - Related: Portfolio Views, Front-End Display
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder, Early-Maturity Practice Lead

--- a/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
+++ b/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
@@ -27,4 +27,4 @@ The system must allow organizations to define strategic business objectives, lin
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships
 - Related: Capabilities, Value Streams, Initiatives, Roadmap
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder, Early-Maturity Practice Lead

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -95,4 +95,4 @@ The `security_sensitive` flag and the Security Classification Guidance section a
 
 - Depends on: `po-application-portfolio`, `po-capability-map`, `po-architecture-decisions`, `pl-initiatives`, `mo-content-visibility`, `mo-cross-org-linking`
 - Related: `rm-repository-completeness`, `rm-end-to-end-traceability`
-- Personas served: Enterprise Architect, Agency EA Coordinator
+- Personas served: Enterprise Architect, Agency EA Coordinator, Junior EA Analyst, Domain Architect

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -68,4 +68,4 @@ Traversal respects content visibility at every hop. A relationship link is only 
 
 - Depends on: `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `mo-content-visibility`, `mo-cross-org-linking`, `mo-org-connections`
 - Related: `rm-repository-completeness`, `pl-strategic-objectives`, `pl-initiatives`, `pl-roadmap`
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Domain Architect, Business Stakeholder

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -62,6 +62,7 @@ Traversal respects content visibility at every hop. A relationship link is only 
 - What is not yet implemented: reverse traversal UI, impact panel, broken chain indicators, cross-agency views
 - Technology layer (infrastructure, platforms) is a natural extension of this chain but is not in scope until the Technology Lifecycle capability set is defined
 - The traversal visibility gate must be validated with a security test matrix covering all role × visibility combinations before the impact panel ships (see ARB finding #129)
+- **Query performance:** Traversal depth is bounded at configurable depth (default 3, hard cap 5). Required indexes on relationship tables and a visited-node guard against cycles are pre-ship requirements. See `rm-query-performance-decision.md` for the full performance ADR (resolves ARB finding #134).
 
 ## Links
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-query-performance-decision.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-query-performance-decision.md
@@ -1,0 +1,99 @@
+# Architecture Decision: Query Performance for Traversal and Completeness (v1)
+
+## Decision
+
+1. **Traversal depth** — Impact panel traversal is bounded at a configurable depth, default 3 hops, hard cap 5.
+2. **Completeness calculation** — Completeness snapshots are pre-computed and stored. A snapshot is triggered asynchronously on any EA object mutation; a nightly scheduled job is a safety-net fallback. The dashboard reads from the snapshot table, never from live joins.
+3. **Historical snapshot storage** — One snapshot row per organization per day. Each row stores aggregate counts only (no individual object data). Retention is 36 months by default, configurable.
+4. **Response time SLOs** — Impact panel traversal: < 2 s at default depth, hard timeout at 5 s with partial-results degradation. Completeness dashboard: < 500 ms. Historical trend line: < 1 s.
+
+---
+
+## Context
+
+ARB review (issue #134) flagged that neither `rm-end-to-end-traceability` nor `rm-repository-completeness` defined a query performance strategy before implementation. At the target scale of 100–500 applications with a full capability map, naive implementations of unbounded traversal and live multi-table completeness joins will be too slow to be usable.
+
+The four decisions above must be resolved before implementation issues are opened for either capability.
+
+---
+
+## Rationale
+
+### Decision 1 — Traversal depth
+
+The core EA chain (Objective → Initiative → Capability → Application → Persona) spans 4 hops. The vast majority of meaningful impact traces are within this range. Beyond 5 hops the traversal graph expands exponentially and the results become noise rather than signal — every object in a well-connected repository becomes reachable. A hard cap at 5 prevents runaway queries. The default of 3 keeps the common case fast and focused without requiring configuration.
+
+Depth is configurable at the org level so agencies with deeper chains (e.g. multi-tier capability hierarchies) can raise the limit intentionally. The hard cap is not configurable — it is a performance and security boundary, not a preference.
+
+### Decision 2 — Completeness calculation strategy
+
+Completeness calculations join across all object types and their relationship tables. Running these as live queries on every dashboard load is O(n) per org and will degrade as the repository grows. On-demand caching with a TTL introduces a separate invalidation problem: a cache that survives a publish event shows stale data at exactly the moment architects need current information.
+
+Pre-computing on write avoids both problems. When any EA object is created, updated, published, or deleted, an async job recomputes the org's snapshot. The dashboard always reads a single row. The nightly fallback ensures snapshot freshness even for orgs that go days between edits (rare but possible).
+
+Write-triggered recomputation is preferred over pure nightly scheduling because the dashboard must reflect the current state immediately after an architect publishes content — not at the next midnight run.
+
+### Decision 3 — Historical snapshot storage
+
+The trend line feature requires time-series data. Storing one aggregate row per org per day is sufficient granularity for monthly and quarterly trend views, and the storage cost is negligible:
+
+| Orgs | Retention | Row size | Total |
+|------|-----------|----------|-------|
+| 100  | 12 months | ~500 B   | ~1.8 MB |
+| 100  | 36 months | ~500 B   | ~5.4 MB |
+| 1000 | 36 months | ~500 B   | ~54 MB  |
+
+Each snapshot row stores aggregate counts per object type (total, published count, complete-relationship count, within-staleness-window count) and the org ID and date. No individual object references are stored in the snapshot — those are resolved at drill-down time from live tables.
+
+### Decision 4 — Response time SLOs
+
+These targets are achievable with the pre-computed snapshot strategy and the index strategy below, and are grounded in what government users will tolerate for analytical views (not real-time operations):
+
+| Operation | Target | Degradation behaviour |
+|-----------|--------|-----------------------|
+| Impact panel traversal (default depth 3) | < 2 s | Hard timeout at 5 s; return partial results with indicator |
+| Completeness dashboard | < 500 ms | Read from snapshot row — no join required |
+| Historical trend line | < 1 s | Time-series query on snapshot table with index |
+
+If a traversal query exceeds the 5 s timeout, the panel returns whatever hops completed with a "results may be incomplete — try a shallower depth" indicator. It does not block or error.
+
+---
+
+## Required Indexes
+
+The following indexes must be created before either capability ships. These are not optional — without them, completeness counts and traversal joins will table-scan at realistic object counts.
+
+**Relationship tables** (all tables implementing many-to-many EA object links):
+- `(organization_id, source_id)` — forward traversal
+- `(organization_id, target_id)` — reverse traversal
+
+**Content tables** (capabilities, applications, personas, objectives, initiatives, ADRs):
+- `(organization_id, status)` — completeness counts by publish status
+- `(organization_id, updated_at)` — staleness window queries
+
+**Completeness snapshot table** (new):
+- `(organization_id, snapshot_date DESC)` — trend line queries
+- Primary key on `(organization_id, snapshot_date)` — prevents duplicate daily snapshots
+
+---
+
+## Consequences
+
+- The completeness dashboard is eventually consistent with live data — a mutation triggers an async recompute, so there is a brief window (typically < 1 s on a lightly loaded system) where the dashboard reflects the state before the last write. This is acceptable for an analytics view.
+- The trend line has daily granularity. Sub-daily changes are not tracked in the history; only the day's final computed snapshot is stored.
+- Traversal results at depth 3 may omit objects that are only reachable via 4+ hops. The UI must communicate the active depth to the user and offer a depth control.
+- The 5 s traversal timeout means very large or circular graphs return partial results rather than erroring. Circular traversal must be guarded with a visited-node set regardless — this is a correctness requirement, not just a performance one.
+- Implementation must create the completeness snapshot table and the write-trigger job before the completeness dashboard can ship.
+
+---
+
+## Status
+
+Accepted — pre-implementation requirement for `rm-end-to-end-traceability` and `rm-repository-completeness`
+
+## Related
+
+- ARB finding: roballred/GovEA#134
+- Closes: roballred/GovEA#134
+- Capabilities affected: `rm-end-to-end-traceability`, `rm-repository-completeness`
+- Personas served: Enterprise Architect (Central IT), Agency EA Coordinator, CMS Administrator

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -49,8 +49,7 @@ A repository where everything appears equally authoritative — regardless of wh
 ## Implementation Notes
 
 - The admin dashboard (`ac-admin-dashboard`) already surfaces system health and basic content counts; this capability extends it with EA-specific completeness signals
-- Completeness calculations require joining across object types and their relationship tables — performance implications should be evaluated before implementation
-- The trend line feature requires storing historical completeness snapshots; decide before implementation whether these are computed at query time or stored at a scheduled interval
+- **Query performance:** Completeness calculations use pre-computed snapshots triggered on write, not live joins. The dashboard reads a single snapshot row (< 500 ms SLO). The trend line reads from a time-series snapshot table with one row per org per day (36-month default retention). Required indexes on content and relationship tables are a pre-ship requirement. See `rm-query-performance-decision.md` for the full performance ADR (resolves ARB finding #134).
 
 ## Links
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -55,4 +55,4 @@ A repository where everything appears equally authoritative — regardless of wh
 
 - Depends on: `ac-admin-dashboard`, `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`
 - Related: `rm-architecture-debt`, `rm-end-to-end-traceability`
-- Personas served: Enterprise Architect, Agency EA Coordinator, CMS Administrator
+- Personas served: Enterprise Architect, Agency EA Coordinator, CMS Administrator, Junior EA Analyst, Early-Maturity Practice Lead

--- a/business-architecture/personas/business-stakeholder.md
+++ b/business-architecture/personas/business-stakeholder.md
@@ -1,0 +1,36 @@
+# Persona: Business Stakeholder (EA Consumer)
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real programme or project managers who consume EA outputs in a state or local government context.
+
+## Role Type
+Internal — Programme / Project Management (non-architect consumer)
+
+## Who They Are
+The Business Stakeholder is a programme manager, IT investment manager, or senior project lead who runs a specific technology programme or modernisation initiative. They have no architecture background and no interest in EA methodology — but they depend on EA outputs to sequence delivery correctly, manage dependencies, and avoid building on technology that is already earmarked for retirement.
+
+In government, this persona commonly holds titles like IT Programme Manager, Digital Transformation Lead, or Senior Project Officer. They sit between the technical delivery teams and department or agency leadership. They are not the same as the Department Director (who makes investment decisions at a strategic level) — they are operational, focused on delivery, and blocked when architecture information is unavailable or inaccessible.
+
+## Goals
+- Understand application and capability dependencies before committing to a delivery sequence in their programme plan
+- Identify which systems their programme will touch — and which are at risk of decommission — before design work begins
+- Get answers to questions like "what does this system connect to?" or "what capability does this application support?" without raising a ticket to the EA team
+- See whether their programme's intended changes overlap with other active initiatives — to find conflicts or opportunities to share
+- Engage with architecture reviews as a support mechanism, not a compliance gate
+
+## Pain Points
+- EA outputs are too technical and too incomplete to support programme delivery decisions — they spend time decoding diagrams rather than using them
+- Architecture views are locked inside tools they cannot access or navigate — they receive static exports, not live, queryable information
+- The EA team is a bottleneck: every architecture question requires a meeting or a ticket, which adds days or weeks to a programme that cannot afford to wait
+- The EA repository and the programme's own records rarely match — they have learned not to trust either source fully
+- When the EA view is wrong or outdated, they do not find out until delivery is already underway and a dependency has been broken
+- Architecture review outputs are written in framework language — they receive artefacts, not decision briefs
+
+## Critical Insight
+The Business Stakeholder is the most direct test of whether an EA practice is delivering value. If they cannot get answers from the EA repository without help from an architect, the practice has failed to operationalise its outputs. Self-service access to accurate, current, plain-language architecture data — especially dependency and lifecycle information — is the single highest-value capability for this persona.
+
+## Relevant Capabilities
+- Read-only navigation and portfolio views (application portfolio, capability map)
+- End-to-end traceability and dependency lookup
+- Initiative and roadmap views (cross-programme dependency visibility)
+- Strategic objectives and alignment views
+- Plain-language content display

--- a/business-architecture/personas/consultant-si.md
+++ b/business-architecture/personas/consultant-si.md
@@ -1,0 +1,35 @@
+# Persona: Consultant / Systems Integrator
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real consultants or SI staff who implement or support EA tools in state or local government engagements.
+
+## Role Type
+External — Independent consultant or Systems Integrator working under contract to a government agency
+
+## Who They Are
+The Consultant or SI practitioner is an external architect working under contract to a state or local government agency. They may be an independent EA consultant running a small number of concurrent client engagements, or a member of a systems integration firm managing a larger implementation. They bring their own EA methodology and templates, adapt to whichever tooling the client has procured, and are expected to leave the client with a working, maintainable repository when the engagement ends.
+
+In government, consultants and SIs are disproportionately involved in EA work. Many agencies lack the internal staffing to build and maintain an EA practice without external support, and procurement vehicles like GSA schedules and state IT contract vehicles make consultant-led EA work common. The consultant's footprint in GovEA may span initial configuration, content population, stakeholder training, and handover to an internal team.
+
+## Goals
+- Onboard to a client's GovEA instance quickly and produce useful work within the first week of an engagement
+- Bring pre-built content — capability map starters, application inventory templates, persona libraries — into the client's repository without manual re-entry
+- Produce handover documentation and exports that the client can maintain after the engagement ends without retaining the consultant
+- Adapt GovEA's structure to the client's existing terminology and architecture approach without rebuilding from scratch
+- Stay current across the EA tool market to provide credible vendor recommendations to clients evaluating their options
+
+## Pain Points
+- Data portability is poor across most EA tools — extracting a client's existing architecture content in a structured, relationship-preserving format for import into GovEA is rarely straightforward
+- Licensing models are not designed for short-term external contributors — accessing a client's GovEA instance as a non-permanent user creates friction in procurement and user management
+- Most tools have no mechanism for bringing in pre-built artefacts — templates, starter content, reference capability maps — without manual entry that consumes engagement time
+- Client repositories that have been partially built by previous consultants or internal staff are often incomplete, inconsistent, or structured in ways that require archaeology before new work can begin
+- The first deliverable of an engagement is often blocked on getting access, understanding the current repository state, and deciding what to migrate or discard — weeks of billable time before visible progress
+
+## Critical Insight
+Consultants and SIs are disproportionately influential in GovEA adoption: they recommend tools, configure initial environments, and train client teams. Supporting this persona well is an indirect path to broader adoption. The most impactful capabilities are those that reduce engagement ramp-up time — fast onboarding, structured exports, and the ability to bring pre-built content into a new client environment.
+
+## Relevant Capabilities
+- Data export and backup (structured, relationship-preserving exports for handover and migration)
+- Content authoring at contributor level (creating and populating content within the client's org)
+- Site configuration and organisation settings (establishing the environment for a client)
+- Audit trail access (understanding the history of a repository before taking over)
+- Role-based access control (operating within contributor scope without requiring admin access)

--- a/business-architecture/personas/domain-architect.md
+++ b/business-architecture/personas/domain-architect.md
@@ -1,0 +1,35 @@
+# Persona: Domain Architect
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real domain architects (data, security, network, integration) in a state or local government context.
+
+## Role Type
+Internal — Agency IT or Central IT (specialist contributor)
+
+## Who They Are
+The Domain Architect is a specialist — a Data Architect, Security Architect, Network Architect, or Integration Architect — who contributes to the EA repository for their specific domain. They are not the owner of the overall EA practice; that responsibility belongs to the Enterprise Architect or Agency EA Coordinator. They are a domain expert contributing accurate, current records for their slice of the architecture.
+
+In government, this role is most common in large agencies, central IT shops, or shared services organisations where the EA team has enough depth to assign domain ownership. A Security Architect documenting security capabilities and their application dependencies, or a Data Architect maintaining a record of data flows and ownership, fits this profile.
+
+## Goals
+- Keep the domain layer of the EA repository current and accurate without requiring constant coordination with the lead architect
+- Connect domain artefacts (security controls, data flows, network boundaries) to applications and business capabilities maintained by other architects
+- Ensure that delivery teams consult the EA repository before making design decisions that affect their domain — reducing the number of post-hoc surprises
+- Surface domain risks (unowned data, ungoverned integrations, obsolete security controls) through the EA model rather than through ad-hoc escalation
+- Reduce the time spent re-explaining the same architectural constraints to different delivery teams independently
+
+## Pain Points
+- The EA model is structured around application and business capability architecture; specialist domains (data, security, network) are secondary citizens with no clear home
+- Connecting domain objects to application and capability objects requires manual effort that quickly becomes stale as the rest of the model evolves
+- Delivery teams do not check the EA repository before starting work in the domain — by the time the domain architect finds out a new data store or integration has been created, it is already in production
+- Changes in adjacent domains (a new application, a capability retirement) do not notify the domain architect whose records are now inaccurate
+- Other contributors can inadvertently overwrite or misclassify domain records, with no notification to the domain owner
+
+## Critical Insight
+Domain architects are the primary contributors to EA repository data quality in established practices, but they are rarely the primary audience in product design or vendor sales. Building contribution workflows, change notifications, and cross-domain relationship navigation for this persona is the most direct path to a repository that stays accurate and useful as the practice matures.
+
+## Relevant Capabilities
+- Content authoring and editing within a defined domain scope
+- Cross-domain relationship navigation and traceability
+- Content workflow (ensuring domain records go through review before publication)
+- Repository completeness signals scoped to domain
+- Role-based access control with domain-level contribution rights

--- a/business-architecture/personas/early-maturity-practice-lead.md
+++ b/business-architecture/personas/early-maturity-practice-lead.md
@@ -1,0 +1,36 @@
+# Persona: Early-Maturity EA Practice Lead
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption in mid-market and early-stage government EA practices. Must not drive implementation until validated through interviews with real EA leads building a practice from scratch in a state or local government context.
+
+## Role Type
+Internal — Agency IT or Central IT (practice founder / solo practitioner)
+
+## Who They Are
+The Early-Maturity EA Practice Lead is the first dedicated enterprise architect in their organisation — or the lead of a very small team (1–3 people) building an EA practice from the ground up. They have experience in solution architecture, IT management, or a related field, but this is their first formal EA leadership role. They are building the practice simultaneously with doing the work: selecting a tool, establishing a methodology, convincing stakeholders of EA's value, and producing early outputs — all at the same time.
+
+In government, this persona is increasingly common as state and local governments respond to technology modernisation pressures, federal guidance on digital transformation, and increasing scrutiny of IT investment. Many agencies are in the first 1–3 years of a formal EA practice and lack the funding, staffing, or organisational patience for a complex enterprise rollout.
+
+## Goals
+- Establish a working EA repository within the first 90 days without over-engineering it — visible early wins matter more than comprehensive coverage
+- Demonstrate value to senior leadership (CIO, Deputy Secretary, agency director) with concrete outputs before organisational patience runs out
+- Choose an approach that the organisation can sustain without a large dedicated team or a large recurring budget
+- Focus on 2–3 high-value use cases (application rationalisation, capability gap identification, investment alignment) and deliver them fast
+- Build enough credibility and buy-in to justify growing the practice — whether that means hiring additional staff, securing tool budget, or expanding scope
+
+## Pain Points
+- Most EA tools and methodologies are designed for established enterprise practices with large teams and funded governance programmes — the blank-canvas problem is acute when there is no team to share the load
+- Stakeholders want results immediately; most tools require substantial setup before anything useful can be published
+- TOGAF, FEAF, and similar frameworks are overwhelming starting points for an organisation that has never done EA — the framework overhead makes it harder to show early value, not easier
+- There is no clear guidance on what to build first — capability map? application inventory? personas? starting from scratch means every decision is made without a reference point
+- Procurement and onboarding cycles for major EA tools often take longer than the window of organisational patience
+- When early outputs are incomplete — which they always are — stakeholders interpret incompleteness as the tool's failure rather than as a normal first step
+
+## Critical Insight
+The Early-Maturity EA Practice Lead will adopt and champion GovEA only if it lets them show something to leadership within weeks, not months. The first deliverable does not need to be complete — it needs to be credible and useful enough to justify the next step. Progressive disclosure of complexity, and the ability to publish partial content as "in progress" without misrepresenting it as complete, is the difference between a practice that builds momentum and one that stalls before it starts.
+
+## Relevant Capabilities
+- Quick-start content population (starter patterns, example capability maps)
+- Lightweight stakeholder publication with completeness caveats
+- Repository completeness dashboard (to show progress honestly, not just the gaps)
+- Content workflow (draft → published, with clear publication controls)
+- Admin configuration and site settings (establishing the practice environment)

--- a/business-architecture/personas/junior-ea-analyst.md
+++ b/business-architecture/personas/junior-ea-analyst.md
@@ -1,0 +1,36 @@
+# Persona: Junior EA / EA Analyst
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real junior architects or EA analysts in a state or local government context.
+
+## Role Type
+Internal — Agency IT / Central IT (junior contributor)
+
+## Who They Are
+The Junior EA Analyst is typically 1–3 years into an architecture role, often having transitioned from business analysis, project management, or application support. They work within an established EA team — often a team of 2–5 led by a more senior architect — and are responsible for the day-to-day maintenance of the EA repository: updating the capability map, adding new applications, recording relationship links, and producing views for stakeholder reviews.
+
+In government, this role is common in medium-to-large agencies and central IT shops that have made an EA practice investment. The analyst handles the operational layer of EA work that senior architects and coordinators do not have time for.
+
+## Goals
+- Maintain and update the EA repository accurately without introducing errors or breaking existing relationships
+- Produce capability maps, application inventories, and stakeholder views that the lead architect can present without rework
+- Understand the EA methodology well enough to apply it independently — not just follow instructions
+- Build credibility with delivery teams, who are often sceptical of EA's value and unlikely to engage voluntarily
+- Develop skills that move them toward a senior EA or solution architect role
+
+## Pain Points
+- There are no guardrails — it is easy to overwrite or misclassify data in ways that are hard to detect until damage is already done in the repository
+- It is difficult to know whether a relationship change or status update is correct, or whether it silently breaks a chain elsewhere in the model
+- Onboarding documentation and help resources are written for experienced architects, not for analysts learning on the job
+- Senior architects review work infrequently; there is no way to self-validate quality before a mistake propagates
+- Getting context from delivery teams is slow and awkward — engineers and project managers expect the analyst to come to them, not the other way around
+- Contributing to the wrong capability domain or duplicating an existing record is a common error with no warning mechanism
+
+## Critical Insight
+The Junior EA Analyst is the fastest-growing segment of EA tool users as practices mature and repository maintenance scales beyond what a single senior architect can manage alone. They are also the group most likely to degrade repository quality if the tool does not provide guidance, validation, and soft guardrails. Designing for this persona is not about simplification — it is about making correct contribution the path of least resistance.
+
+## Relevant Capabilities
+- Content authoring and editing with relationship validation
+- Content workflow (draft → review → publish) as a quality gate
+- Repository completeness signals (to know what is missing before being asked)
+- Relationship navigation (to understand downstream impact before making changes)
+- Role-based access control (limits blast radius without blocking contribution)


### PR DESCRIPTION
## Summary

Adds the 5 personas identified in issue #91 as missing from the business architecture. All are derived from `ea-research/` source material and adapted to a state/local government context. All carry **Assumed** validation status per the Standards.md requirement.

| File | Persona | Government framing |
|---|---|---|
| `junior-ea-analyst.md` | Junior EA / EA Analyst | IT analyst 1–3 years into an EA role, maintaining the repository day-to-day |
| `domain-architect.md` | Domain Architect | Security, data, or network architect contributing to a specific domain of the EA model |
| `business-stakeholder.md` | Business Stakeholder (EA Consumer) | Programme manager / IT investment manager who needs self-service dependency data for delivery sequencing — distinct from Department Director (executive) and Budget Analyst (finance oversight) |
| `early-maturity-practice-lead.md` | Early-Maturity EA Practice Lead | First EA hire in an agency, building the practice from scratch while demonstrating value before organisational patience runs out |
| `consultant-si.md` | Consultant / Systems Integrator | External contractor implementing or supporting GovEA for a government client under contract |

## Capability updates

Six capability files updated with new personas in `Personas served` where there is a clear primary-audience fit:

| Capability | Added |
|---|---|
| `rm-end-to-end-traceability` | Domain Architect, Business Stakeholder |
| `rm-repository-completeness` | Junior EA Analyst, Early-Maturity Practice Lead |
| `rm-architecture-debt` | Junior EA Analyst, Domain Architect |
| `pl-strategic-objectives` | Business Stakeholder, Early-Maturity Practice Lead |
| `pl-initiatives` | Business Stakeholder |
| `pl-roadmap` | Business Stakeholder, Early-Maturity Practice Lead |

## What this enables

These personas unlock requirements that the current set cannot express — guided contribution (Junior EA), domain-scoped ownership (Domain Architect), stakeholder self-service (Business Stakeholder), early-practice onboarding (Practice Lead), and portability/handover (Consultant/SI). They should be reviewed against upcoming capability work before implementation issues are opened.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)