### PR TITLE
feat(taxonomy): base-item foundation — reusable taxonomy types across item types

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { applications, applicationCapabilities, objectiveCapabilities } from '@/db/schema'
+import { applications, applicationCapabilities, objectiveCapabilities, entityTaxonomyValues } from '@/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
@@ -9,6 +9,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
+import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from './taxonomy'
 
 async function requireContributor() {
   const session = await auth()
@@ -50,14 +51,18 @@ export async function getApplication(id: string) {
 
   // Fetch objectives linked through this application's capabilities as a flat query.
   const capabilityIds = application.applicationCapabilities.map(ac => ac.capabilityId)
-  const capabilityObjectives = capabilityIds.length > 0
-    ? await db.query.objectiveCapabilities.findMany({
-        where: inArray(objectiveCapabilities.capabilityId, capabilityIds),
-        with: { objective: true },
-      })
-    : []
+  const [capabilityObjectives, taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    capabilityIds.length > 0
+      ? db.query.objectiveCapabilities.findMany({
+          where: inArray(objectiveCapabilities.capabilityId, capabilityIds),
+          with: { objective: true },
+        })
+      : Promise.resolve([]),
+    getEntityTaxonomyValues(application.organizationId, 'application', id),
+    getEntityTaxonomyDefinitions(application.organizationId, 'application'),
+  ])
 
-  return { ...application, capabilityObjectives }
+  return { ...application, capabilityObjectives, taxonomyValues, taxonomyDefinitions }
 }
 
 export async function getApplications(organizationId: string, role?: string) {
@@ -95,6 +100,7 @@ export async function createApplication(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const capabilityIds = formData.getAll('capabilityIds') as string[]
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
   const [application] = await db.insert(applications).values({
     name,
@@ -114,6 +120,10 @@ export async function createApplication(formData: FormData) {
     await db.insert(applicationCapabilities).values(
       capabilityIds.map(capabilityId => ({ applicationId: application.id, capabilityId }))
     )
+  }
+
+  if (taxonomyTermIds.length > 0) {
+    await syncEntityTaxonomyValues(orgId, 'application', application.id, taxonomyTermIds)
   }
 
   await writeAuditLog({
@@ -139,6 +149,7 @@ export async function editApplication(applicationId: string, formData: FormData)
   const status = formData.get('status') as 'draft' | 'published' | 'archived'
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
   const capabilityIds = formData.getAll('capabilityIds') as string[]
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
   const before = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
   assertOwnership(before?.organizationId, orgId)
@@ -164,6 +175,9 @@ export async function editApplication(applicationId: string, formData: FormData)
     )
   }
 
+  // Replace taxonomy values
+  await syncEntityTaxonomyValues(orgId, 'application', applicationId, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'application.edit',
     entityType: 'application',
@@ -181,6 +195,14 @@ export async function deleteApplication(applicationId: string) {
 
   const before = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(
+      eq(entityTaxonomyValues.organizationId, orgId),
+      eq(entityTaxonomyValues.entityType, 'application'),
+      eq(entityTaxonomyValues.entityId, applicationId),
+    )
+  )
 
   await db.delete(applications).where(
     and(eq(applications.id, applicationId), eq(applications.organizationId, orgId))

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { taxonomyTerms, principles } from '@/db/schema'
+import { taxonomyTerms, principles, entityTaxonomyDefinitions, entityTaxonomyValues } from '@/db/schema'
 import { eq, and, isNull, inArray, count } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -279,6 +279,169 @@ export async function getPersonaTagsFromTaxonomy(organizationId: string) {
       and(eq(t.organizationId, organizationId), eq(t.parentId, type.id)),
     orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
   })
+}
+
+// ── Entity Taxonomy Definitions ──────────────────────────────────────────────
+
+/**
+ * Returns definitions for a given entity type, including the type name and its values.
+ * Used by create/edit forms to render dynamic taxonomy inputs.
+ */
+export async function getEntityTaxonomyDefinitions(organizationId: string, entityType: string) {
+  const defs = await db.query.entityTaxonomyDefinitions.findMany({
+    where: (d, { eq, and }) =>
+      and(eq(d.organizationId, organizationId), eq(d.entityType, entityType)),
+    orderBy: (d, { asc }) => [asc(d.sortOrder)],
+  })
+
+  if (defs.length === 0) return []
+
+  const typeIds = defs.map(d => d.taxonomyTypeId)
+  const types = await db.query.taxonomyTerms.findMany({
+    where: (t, { inArray }) => inArray(t.id, typeIds),
+  })
+  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
+
+  const values = await db.query.taxonomyTerms.findMany({
+    where: (t, { eq, and, inArray }) =>
+      and(eq(t.organizationId, organizationId), inArray(t.parentId, typeIds)),
+    orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
+  })
+
+  return defs.map(def => ({
+    ...def,
+    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
+    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
+    values: values.filter(v => v.parentId === def.taxonomyTypeId),
+  }))
+}
+
+/**
+ * Returns all definitions grouped by entity type, with type names.
+ * Used by the taxonomy admin page to show which types are wired to which entity types.
+ */
+export async function getAllEntityTaxonomyDefinitions(organizationId: string) {
+  const defs = await db.query.entityTaxonomyDefinitions.findMany({
+    where: (d, { eq }) => eq(d.organizationId, organizationId),
+    orderBy: (d, { asc }) => [asc(d.entityType), asc(d.sortOrder)],
+  })
+
+  if (defs.length === 0) return []
+
+  const typeIds = [...new Set(defs.map(d => d.taxonomyTypeId))]
+  const types = await db.query.taxonomyTerms.findMany({
+    where: (t, { inArray }) => inArray(t.id, typeIds),
+  })
+  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
+
+  return defs.map(def => ({
+    ...def,
+    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
+    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
+  }))
+}
+
+export async function addEntityTaxonomyDefinition(formData: FormData) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const entityType = (formData.get('entityType') as string).trim()
+  const taxonomyTypeId = (formData.get('taxonomyTypeId') as string).trim()
+  const selectionMode = (formData.get('selectionMode') as string) || 'single'
+  const required = formData.get('required') === 'true'
+  const sortOrder = parseInt((formData.get('sortOrder') as string) || '0', 10)
+
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: orgId,
+    entityType,
+    taxonomyTypeId,
+    selectionMode,
+    required,
+    sortOrder,
+  }).onConflictDoNothing()
+}
+
+export async function removeEntityTaxonomyDefinition(definitionId: string) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  await db.delete(entityTaxonomyDefinitions)
+    .where(and(
+      eq(entityTaxonomyDefinitions.id, definitionId),
+      eq(entityTaxonomyDefinitions.organizationId, orgId),
+    ))
+}
+
+// ── Entity Taxonomy Values ────────────────────────────────────────────────────
+
+/** Returns selected taxonomy values for a single entity record, grouped by type. */
+export async function getEntityTaxonomyValues(organizationId: string, entityType: string, entityId: string) {
+  const rows = await db.query.entityTaxonomyValues.findMany({
+    where: (v, { eq, and }) =>
+      and(
+        eq(v.organizationId, organizationId),
+        eq(v.entityType, entityType),
+        eq(v.entityId, entityId),
+      ),
+  })
+  return rows
+}
+
+/**
+ * Replaces all taxonomy values for an entity record.
+ * Deletes current selections and inserts the new set atomically.
+ */
+export async function syncEntityTaxonomyValues(
+  organizationId: string,
+  entityType: string,
+  entityId: string,
+  termIds: string[],
+) {
+  await db.delete(entityTaxonomyValues)
+    .where(and(
+      eq(entityTaxonomyValues.organizationId, organizationId),
+      eq(entityTaxonomyValues.entityType, entityType),
+      eq(entityTaxonomyValues.entityId, entityId),
+    ))
+
+  if (termIds.length > 0) {
+    await db.insert(entityTaxonomyValues).values(
+      termIds.map(termId => ({
+        organizationId,
+        entityType,
+        entityId,
+        taxonomyTermId: termId,
+      }))
+    )
+  }
+}
+
+/**
+ * Returns taxonomy values for multiple entity records of the same type.
+ * Returns a map of entityId → array of term rows.
+ */
+export async function getEntityTaxonomyValuesForMany(
+  organizationId: string,
+  entityType: string,
+  entityIds: string[],
+): Promise<Record<string, typeof entityTaxonomyValues.$inferSelect[]>> {
+  if (entityIds.length === 0) return {}
+
+  const rows = await db.query.entityTaxonomyValues.findMany({
+    where: (v, { eq, and, inArray }) =>
+      and(
+        eq(v.organizationId, organizationId),
+        eq(v.entityType, entityType),
+        inArray(v.entityId, entityIds),
+      ),
+  })
+
+  const result: Record<string, typeof entityTaxonomyValues.$inferSelect[]> = {}
+  for (const row of rows) {
+    if (!result[row.entityId]) result[row.entityId] = []
+    result[row.entityId].push(row)
+  }
+  return result
 }
 
 /**

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -130,6 +130,32 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
         </div>
       </div>
 
+      {/* Taxonomy classification chips */}
+      {application.taxonomyDefinitions.length > 0 && (
+        <div className="flex flex-wrap gap-x-6 gap-y-2">
+          {application.taxonomyDefinitions.map(def => {
+            const selectedTermIds = new Set(application.taxonomyValues.map(v => v.taxonomyTermId))
+            const selectedValues = def.values.filter(v => selectedTermIds.has(v.id))
+            if (selectedValues.length === 0) return null
+            return (
+              <div key={def.id} className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">{def.typeName}:</span>
+                <div className="flex flex-wrap gap-1">
+                  {selectedValues.map(v => (
+                    <span
+                      key={v.id}
+                      className="inline-flex items-center rounded-full border bg-violet-50 text-violet-700 border-violet-200 px-2 py-0.5 text-xs font-medium"
+                    >
+                      {v.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
       <hr />
 
       {isModuleEnabled(enabledModules, 'capabilities') && (

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import type { Application, Capability } from '@/db/schema'
+import type { Application, Capability, EntityTaxonomyValue, TaxonomyTerm } from '@/db/schema'
 import { createApplication, editApplication, deleteApplication } from '@/actions/applications'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -24,11 +24,25 @@ type ApplicationRow = Pick<Application, 'id' | 'name' | 'description' | 'vendor'
   applicationCapabilities: { capability: Pick<Capability, 'id' | 'name' | 'domain'> }[]
 }
 
+type EnrichedTaxonomyDefinition = {
+  id: string
+  entityType: string
+  taxonomyTypeId: string
+  selectionMode: string
+  required: boolean
+  sortOrder: number
+  typeName: string
+  typeSlug: string
+  values: TaxonomyTerm[]
+}
+
 interface Props {
   applications: ApplicationRow[]
   capabilities: Pick<Capability, 'id' | 'name'>[]
   role: Role
   currentOrgId: string
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -236,7 +250,7 @@ function PortfolioCard({
 
 type ViewMode = 'table' | 'portfolio'
 
-export function ApplicationTable({ applications, capabilities, role, currentOrgId }: Props) {
+export function ApplicationTable({ applications, capabilities, role, currentOrgId, taxonomyDefinitions, taxonomyValueMap }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -247,6 +261,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
   const [domainFilter, setDomainFilter] = useState('all')
   const [hostingFilter, setHostingFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
 
   const orgOptions = Array.from(new Map(
     applications.map(a => [a.organizationId, a.organization?.name ?? 'Unknown'])
@@ -281,7 +296,11 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
     const matchDomain = domainFilter === 'all' || a.applicationCapabilities.some(ac => ac.capability.domain === domainFilter)
     const matchHosting = hostingFilter === 'all' || a.hostingModel === hostingFilter
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? a.organizationId === currentOrgId : a.organizationId === orgFilter)
-    return matchSearch && matchLifecycle && matchStatus && matchDomain && matchHosting && matchOrg
+    const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) => {
+      if (termId === 'all') return true
+      return (taxonomyValueMap[a.id] ?? []).some(v => v.taxonomyTermId === termId)
+    })
+    return matchSearch && matchLifecycle && matchStatus && matchDomain && matchHosting && matchOrg && matchTaxonomy
   })
 
   // Portfolio sort: attention items first, then alphabetical
@@ -382,6 +401,17 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
             ))}
           </select>
         )}
+        {taxonomyDefinitions.map(def => def.values.length > 0 && (
+          <select
+            key={def.id}
+            value={taxonomyFilters[def.id] ?? 'all'}
+            onChange={e => setTaxonomyFilters(prev => ({ ...prev, [def.id]: e.target.value }))}
+            className={selectClass}
+          >
+            <option value="all">All {def.typeName}</option>
+            {def.values.map(v => <option key={v.id} value={v.id}>{v.name}</option>)}
+          </select>
+        ))}
         {orgOptions.length > 1 && (
           <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className={selectClass}>
             <option value="all">All organizations</option>
@@ -586,7 +616,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
 
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
           <DialogHeader><DialogTitle>New Application</DialogTitle></DialogHeader>
           <form action={handleCreate} className="space-y-3">
             <FormField label="Name" name="name" required />
@@ -637,6 +667,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
                 </select>
               </div>
             </div>
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <div className="space-y-1.5">
               <Label>Visibility</Label>
               <select name="visibility" defaultValue="org" className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
@@ -655,7 +686,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
 
       {/* Edit Dialog */}
       <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
           <DialogHeader><DialogTitle>Edit Application</DialogTitle></DialogHeader>
           <form action={handleEdit} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
@@ -712,6 +743,10 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
                 </select>
               </div>
             </div>
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
+            />
             <div className="space-y-1.5">
               <Label>Visibility</Label>
               <select name="visibility" defaultValue={editTarget?.visibility ?? 'org'} className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
@@ -753,5 +788,60 @@ function FormField({ label, ...props }: { label: string } & React.InputHTMLAttri
       <Label>{label}</Label>
       <Input {...props} />
     </div>
+  )
+}
+
+function TaxonomyInputs({
+  defs,
+  currentValues,
+}: {
+  defs: EnrichedTaxonomyDefinition[]
+  currentValues: EntityTaxonomyValue[]
+}) {
+  if (defs.length === 0) return null
+  const currentTermIds = new Set(currentValues.map(v => v.taxonomyTermId))
+
+  return (
+    <>
+      {defs.map(def => (
+        <div key={def.id} className="space-y-1.5">
+          <Label>
+            {def.typeName}
+            {def.required && <span className="text-destructive ml-0.5">*</span>}
+          </Label>
+          {def.selectionMode === 'multi' ? (
+            <div className="rounded-md border border-input bg-transparent px-3 py-2 max-h-36 overflow-y-auto space-y-1">
+              {def.values.length === 0
+                ? <p className="text-sm text-muted-foreground">No values defined yet.</p>
+                : def.values.map(v => (
+                  <label key={v.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      name="taxonomyTermIds"
+                      value={v.id}
+                      defaultChecked={currentTermIds.has(v.id)}
+                      className="rounded"
+                    />
+                    {v.name}
+                  </label>
+                ))
+              }
+            </div>
+          ) : (
+            <select
+              name="taxonomyTermIds"
+              defaultValue={def.values.find(v => currentTermIds.has(v.id))?.id ?? ''}
+              required={def.required}
+              className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {!def.required && <option value="">— None —</option>}
+              {def.values.map(v => (
+                <option key={v.id} value={v.id}>{v.name}</option>
+              ))}
+            </select>
+          )}
+        </div>
+      ))}
+    </>
   )
 }

--- a/apps/govea/src/app/(admin)/applications/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/page.tsx
@@ -2,7 +2,9 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getApplications } from '@/actions/applications'
 import { getCapabilities } from '@/actions/capabilities'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { ApplicationTable } from './application-table'
+
 export default async function ApplicationsPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
@@ -10,10 +12,14 @@ export default async function ApplicationsPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [applicationList, capabilityList] = await Promise.all([
+  const [applicationList, capabilityList, taxonomyDefinitions] = await Promise.all([
     getApplications(orgId, role),
     getCapabilities(orgId, role),
+    getEntityTaxonomyDefinitions(orgId, 'application'),
   ])
+
+  const applicationIds = applicationList.map(a => a.id)
+  const taxonomyValueMap = await getEntityTaxonomyValuesForMany(orgId, 'application', applicationIds)
 
   return (
     <div className="space-y-6">
@@ -21,7 +27,14 @@ export default async function ApplicationsPage() {
         <h1 className="text-2xl font-bold tracking-tight">Applications</h1>
         <p className="text-muted-foreground mt-1">Your application portfolio, linked to the capabilities they support.</p>
       </div>
-      <ApplicationTable applications={applicationList} capabilities={capabilityList} role={role} currentOrgId={orgId} />
+      <ApplicationTable
+        applications={applicationList}
+        capabilities={capabilityList}
+        role={role}
+        currentOrgId={orgId}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
+      />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -5,7 +5,7 @@ import {
   capabilities, applications, applicationCapabilities,
   initiatives, strategicObjectives, organizations,
 } from '@/db/schema'
-import { and, count, desc, eq, isNull, lt } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { cn } from '@/lib/utils'
@@ -86,9 +86,9 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 export default async function ExecutiveDashboardPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
-  if (session.user.role === 'viewer') redirect('/dashboard')
 
   const orgId = session.user.organizationId!
+  const isViewer = session.user.role === 'viewer'
   const enabledModules = await getEnabledModules()
 
   const hasApps        = isModuleEnabled(enabledModules, 'applications')
@@ -159,11 +159,14 @@ export default async function ExecutiveDashboardPage() {
           ))
       : Promise.resolve([{ count: 0 }]),
 
-    // Initiative status counts
+    // Initiative status counts (viewers: active + complete only, per #202)
     hasInitiatives
       ? db.select({ status: initiatives.status, count: count() })
           .from(initiatives)
-          .where(eq(initiatives.organizationId, orgId))
+          .where(and(
+            eq(initiatives.organizationId, orgId),
+            ...(isViewer ? [inArray(initiatives.status, ['active', 'complete'])] : []),
+          ))
           .groupBy(initiatives.status)
       : Promise.resolve([]),
 
@@ -195,11 +198,14 @@ export default async function ExecutiveDashboardPage() {
           .limit(5)
       : Promise.resolve([]),
 
-    // Recent initiatives (any active status)
+    // Recent initiatives (viewers: active + complete only, per #202)
     hasInitiatives
       ? db.select({ id: initiatives.id, name: initiatives.name, updatedAt: initiatives.updatedAt })
           .from(initiatives)
-          .where(eq(initiatives.organizationId, orgId))
+          .where(and(
+            eq(initiatives.organizationId, orgId),
+            ...(isViewer ? [inArray(initiatives.status, ['active', 'complete'])] : []),
+          ))
           .orderBy(desc(initiatives.updatedAt))
           .limit(5)
       : Promise.resolve([]),

--- a/apps/govea/src/app/(admin)/taxonomy/page.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { getTaxonomyTermsWithChildren, getPrincipleTypeValueUsage } from '@/actions/taxonomy'
+import { getTaxonomyTermsWithChildren, getPrincipleTypeValueUsage, getAllEntityTaxonomyDefinitions } from '@/actions/taxonomy'
 import { TaxonomyTable } from './taxonomy-table'
 
 export default async function TaxonomyPage() {
@@ -10,9 +10,10 @@ export default async function TaxonomyPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [{ types, values }, principleTypeUsage] = await Promise.all([
+  const [{ types, values }, principleTypeUsage, definitions] = await Promise.all([
     getTaxonomyTermsWithChildren(orgId),
     getPrincipleTypeValueUsage(orgId),
+    getAllEntityTaxonomyDefinitions(orgId),
   ])
 
   return (
@@ -23,7 +24,7 @@ export default async function TaxonomyPage() {
           Classification types and their values — used to organize capabilities, glossary entries, personas, and principles.
         </p>
       </div>
-      <TaxonomyTable types={types} values={values} role={role} principleTypeUsage={principleTypeUsage} />
+      <TaxonomyTable types={types} values={values} role={role} principleTypeUsage={principleTypeUsage} definitions={definitions} />
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
@@ -2,8 +2,11 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import type { TaxonomyTerm } from '@/db/schema'
-import { createTaxonomyTerm, editTaxonomyTerm, deleteTaxonomyTerm } from '@/actions/taxonomy'
+import type { TaxonomyTerm, EntityTaxonomyDefinition } from '@/db/schema'
+import {
+  createTaxonomyTerm, editTaxonomyTerm, deleteTaxonomyTerm,
+  addEntityTaxonomyDefinition, removeEntityTaxonomyDefinition,
+} from '@/actions/taxonomy'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -12,18 +15,33 @@ import {
 } from '@/components/ui/dialog'
 import type { Role } from '@/lib/rbac'
 
+type EnrichedDefinition = EntityTaxonomyDefinition & { typeName: string; typeSlug: string }
+
+const ENTITY_TYPES: { value: string; label: string }[] = [
+  { value: 'application', label: 'Application' },
+  { value: 'capability', label: 'Capability' },
+  { value: 'persona', label: 'Persona' },
+  { value: 'service', label: 'Service' },
+  { value: 'value-stream', label: 'Value Stream' },
+  { value: 'initiative', label: 'Initiative' },
+  { value: 'adr', label: 'ADR' },
+  { value: 'principle', label: 'Principle' },
+  { value: 'glossary-term', label: 'Glossary Term' },
+]
+
 interface Props {
   types: TaxonomyTerm[]
   values: TaxonomyTerm[]
   role: Role
   /** termId → number of principles that reference that term's slug as their principleType */
   principleTypeUsage: Record<string, number>
+  definitions: EnrichedDefinition[]
 }
 
 type EditTarget = { term: TaxonomyTerm; kind: 'type' | 'value' }
 type DeleteTarget = { term: TaxonomyTerm; valueCount: number; principleCount: number }
 
-export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props) {
+export function TaxonomyTable({ types, values, role, principleTypeUsage, definitions }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -31,10 +49,18 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props
   const [createValueTarget, setCreateValueTarget] = useState<TaxonomyTerm | null>(null)
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
+  const [wireTarget, setWireTarget] = useState<TaxonomyTerm | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
+
+  // Group definitions by taxonomyTypeId
+  const defsByType = definitions.reduce<Record<string, EnrichedDefinition[]>>((acc, d) => {
+    acc[d.taxonomyTypeId] = acc[d.taxonomyTypeId] ?? []
+    acc[d.taxonomyTypeId].push(d)
+    return acc
+  }, {})
 
   // Group values by parentId
   const valuesByType = values.reduce<Record<string, TaxonomyTerm[]>>((acc, v) => {
@@ -74,6 +100,23 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props
     startTransition(async () => {
       await deleteTaxonomyTerm(deleteTarget.term.id)
       setDeleteTarget(null)
+      refresh()
+    })
+  }
+
+  async function handleWire(fd: FormData) {
+    if (!wireTarget) return
+    startTransition(async () => {
+      fd.set('taxonomyTypeId', wireTarget.id)
+      await addEntityTaxonomyDefinition(fd)
+      setWireTarget(null)
+      refresh()
+    })
+  }
+
+  async function handleUnwire(definitionId: string) {
+    startTransition(async () => {
+      await removeEntityTaxonomyDefinition(definitionId)
       refresh()
     })
   }
@@ -166,6 +209,55 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props
                   </div>
                 )}
               </div>
+
+              {/* Used on */}
+              {(() => {
+                const typeDefs = defsByType[type.id] ?? []
+                const usedEntityTypes = typeDefs.map(d => d.entityType)
+                const availableToAdd = ENTITY_TYPES.filter(e => !usedEntityTypes.includes(e.value))
+                if (!canDelete && typeDefs.length === 0) return null
+                return (
+                  <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b bg-muted/20">
+                    <span className="text-xs text-muted-foreground shrink-0">Used on:</span>
+                    {typeDefs.length === 0 && (
+                      <span className="text-xs text-muted-foreground/50 italic">not wired to any entity type</span>
+                    )}
+                    {typeDefs.map(def => {
+                      const label = ENTITY_TYPES.find(e => e.value === def.entityType)?.label ?? def.entityType
+                      return (
+                        <span
+                          key={def.id}
+                          className="inline-flex items-center gap-1 rounded-full bg-violet-100 text-violet-700 border border-violet-200 px-2 py-0.5 text-xs font-medium"
+                        >
+                          {label}
+                          {def.selectionMode === 'multi' && <span className="opacity-60">(multi)</span>}
+                          {def.required && <span className="opacity-60">*</span>}
+                          {canDelete && (
+                            <button
+                              type="button"
+                              className="ml-0.5 hover:text-violet-900 transition-colors"
+                              onClick={() => handleUnwire(def.id)}
+                              disabled={isPending}
+                              title={`Remove ${label} wiring`}
+                            >
+                              ×
+                            </button>
+                          )}
+                        </span>
+                      )
+                    })}
+                    {canDelete && availableToAdd.length > 0 && (
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+                        onClick={() => setWireTarget(type)}
+                      >
+                        + Wire to entity type
+                      </button>
+                    )}
+                  </div>
+                )
+              })()}
 
               {/* Values */}
               {typeValues.length === 0 ? (
@@ -270,6 +362,56 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage }: Props
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Wire to Entity Type Dialog */}
+      <Dialog open={!!wireTarget} onOpenChange={open => { if (!open) setWireTarget(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Wire &ldquo;{wireTarget?.name}&rdquo; to entity type</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground -mt-2">
+            This makes &ldquo;{wireTarget?.name}&rdquo; available as a classification field on the selected entity type.
+          </p>
+          <form action={handleWire} className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="wire-entity-type">Entity type <span className="text-destructive">*</span></Label>
+              <select
+                id="wire-entity-type"
+                name="entityType"
+                required
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="">Select entity type…</option>
+                {ENTITY_TYPES
+                  .filter(e => !(defsByType[wireTarget?.id ?? ''] ?? []).some(d => d.entityType === e.value))
+                  .map(e => (
+                    <option key={e.value} value={e.value}>{e.label}</option>
+                  ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="wire-selection-mode">Selection mode</Label>
+              <select
+                id="wire-selection-mode"
+                name="selectionMode"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="single">Single select</option>
+                <option value="multi">Multi select</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-2">
+              <input type="checkbox" id="wire-required" name="required" value="true" className="rounded" />
+              <Label htmlFor="wire-required">Required</Label>
+            </div>
+            <input type="hidden" name="sortOrder" value="0" />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setWireTarget(null)}>Cancel</Button>
+              <Button type="submit" disabled={isPending}>{isPending ? 'Wiring…' : 'Wire'}</Button>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -46,7 +46,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: 'Reports',
     items: [
       { href: '/reports',    label: 'Reports' },
-      { href: '/executive',  label: 'Executive Summary', contributorOnly: true },
+      { href: '/executive',  label: 'Executive Summary' },
     ],
   },
   {

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -2,7 +2,7 @@ import { relations } from 'drizzle-orm'
 import { capabilities, capabilityPersonas, capabilityRelationships } from './capabilities'
 import { applications, applicationCapabilities } from './applications'
 import { personas, personaTags } from './personas'
-import { taxonomyTerms } from './taxonomy'
+import { taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues } from './taxonomy'
 import { organizations } from './organizations'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas } from './value-streams'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from './objectives'
@@ -386,6 +386,47 @@ export const serviceValueStreamsRelations = relations(serviceValueStreams, ({ on
   valueStream: one(valueStreams, {
     fields: [serviceValueStreams.valueStreamId],
     references: [valueStreams.id],
+  }),
+}))
+
+// ─── Taxonomy ─────────────────────────────────────────────────────────────────
+
+export const taxonomyTermsRelations = relations(taxonomyTerms, ({ one, many }) => ({
+  organization: one(organizations, {
+    fields: [taxonomyTerms.organizationId],
+    references: [organizations.id],
+  }),
+  parent: one(taxonomyTerms, {
+    fields: [taxonomyTerms.parentId],
+    references: [taxonomyTerms.id],
+    relationName: 'term_parent_child',
+  }),
+  children: many(taxonomyTerms, {
+    relationName: 'term_parent_child',
+  }),
+  entityDefinitions: many(entityTaxonomyDefinitions),
+  entityValues: many(entityTaxonomyValues),
+}))
+
+export const entityTaxonomyDefinitionsRelations = relations(entityTaxonomyDefinitions, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [entityTaxonomyDefinitions.organizationId],
+    references: [organizations.id],
+  }),
+  taxonomyType: one(taxonomyTerms, {
+    fields: [entityTaxonomyDefinitions.taxonomyTypeId],
+    references: [taxonomyTerms.id],
+  }),
+}))
+
+export const entityTaxonomyValuesRelations = relations(entityTaxonomyValues, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [entityTaxonomyValues.organizationId],
+    references: [organizations.id],
+  }),
+  term: one(taxonomyTerms, {
+    fields: [entityTaxonomyValues.taxonomyTermId],
+    references: [taxonomyTerms.id],
   }),
 }))
 

--- a/apps/govea/src/db/schema/taxonomy.ts
+++ b/apps/govea/src/db/schema/taxonomy.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { boolean, integer, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
 import { organizations } from './organizations'
 
 export const taxonomyTerms = pgTable('taxonomy_terms', {
@@ -14,5 +14,39 @@ export const taxonomyTerms = pgTable('taxonomy_terms', {
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })
 
+// Which taxonomy types are configured for which entity types (per org)
+export const entityTaxonomyDefinitions = pgTable(
+  'entity_taxonomy_definitions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    entityType: text('entity_type').notNull(), // 'application' | 'capability' | etc.
+    taxonomyTypeId: uuid('taxonomy_type_id').notNull().references(() => taxonomyTerms.id, { onDelete: 'cascade' }),
+    selectionMode: text('selection_mode').notNull().default('single'), // 'single' | 'multi'
+    required: boolean('required').notNull().default(false),
+    sortOrder: integer('sort_order').notNull().default(0),
+  },
+  (t) => [
+    uniqueIndex('etd_org_entity_type_uniq').on(t.organizationId, t.entityType, t.taxonomyTypeId),
+  ]
+)
+
+// Selected taxonomy values per record
+export const entityTaxonomyValues = pgTable(
+  'entity_taxonomy_values',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    entityType: text('entity_type').notNull(),
+    entityId: uuid('entity_id').notNull(),
+    taxonomyTermId: uuid('taxonomy_term_id').notNull().references(() => taxonomyTerms.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    uniqueIndex('etv_entity_term_uniq').on(t.entityType, t.entityId, t.taxonomyTermId),
+  ]
+)
+
 export type TaxonomyTerm = typeof taxonomyTerms.$inferSelect
 export type NewTaxonomyTerm = typeof taxonomyTerms.$inferInsert
+export type EntityTaxonomyDefinition = typeof entityTaxonomyDefinitions.$inferSelect
+export type EntityTaxonomyValue = typeof entityTaxonomyValues.$inferSelect

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -35,7 +35,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
   principles, principleAdrs, principleCapabilities,
   glossaryTerms, glossaryTermSources,
-  taxonomyTerms,
+  taxonomyTerms, entityTaxonomyDefinitions,
   services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
 } from '../schema'
@@ -644,6 +644,43 @@ async function seed() {
     }
   }
   console.log(`  ✓ ${DEV_SERVICES.length} services with capability, persona, and value stream links`)
+
+  // Application Type taxonomy + entity definition (pilot for base-item taxonomy foundation)
+  let appTypeTermId: string
+  const existingAppTypeType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'application-type')),
+  })
+  if (existingAppTypeType) {
+    appTypeTermId = existingAppTypeType.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Application Type',
+      slug: 'application-type',
+      description: 'Classification of applications by their primary purpose or delivery model.',
+      sortOrder: '50',
+    }).returning()
+    appTypeTermId = inserted.id
+  }
+  const APP_TYPE_VALUES = ['Core Business System', 'Shared Service', 'Integration Platform', 'Reporting & Analytics', 'Public-Facing Service', 'Internal Tool']
+  for (const name of APP_TYPE_VALUES) {
+    await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      parentId: appTypeTermId,
+      name,
+      slug: toSlug(name),
+    }).onConflictDoNothing()
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'application',
+    taxonomyTypeId: appTypeTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Application Type taxonomy type + entity definition')
 
   // ── Org 2: Office of Digital Services (state agency) ────────────────────
 

--- a/business-architecture/capabilities/cms/planning/pl-initiatives.md
+++ b/business-architecture/capabilities/cms/planning/pl-initiatives.md
@@ -30,4 +30,4 @@ The system must allow organizations to document change programmes (initiatives, 
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships
 - Related: Strategic Objectives, Capabilities, Roadmap
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder

--- a/business-architecture/capabilities/cms/planning/pl-roadmap.md
+++ b/business-architecture/capabilities/cms/planning/pl-roadmap.md
@@ -29,4 +29,4 @@ The roadmap is a view over existing planning content, not a standalone data stor
 ## Links
 - Depends on: Initiatives, Strategic Objectives, Capabilities
 - Related: Portfolio Views, Front-End Display
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder, Early-Maturity Practice Lead

--- a/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
+++ b/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
@@ -27,4 +27,4 @@ The system must allow organizations to define strategic business objectives, lin
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships
 - Related: Capabilities, Value Streams, Initiatives, Roadmap
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder, Early-Maturity Practice Lead

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -95,4 +95,4 @@ The `security_sensitive` flag and the Security Classification Guidance section a
 
 - Depends on: `po-application-portfolio`, `po-capability-map`, `po-architecture-decisions`, `pl-initiatives`, `mo-content-visibility`, `mo-cross-org-linking`
 - Related: `rm-repository-completeness`, `rm-end-to-end-traceability`
-- Personas served: Enterprise Architect, Agency EA Coordinator
+- Personas served: Enterprise Architect, Agency EA Coordinator, Junior EA Analyst, Domain Architect

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -68,4 +68,4 @@ Traversal respects content visibility at every hop. A relationship link is only 
 
 - Depends on: `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`, `mo-content-visibility`, `mo-cross-org-linking`, `mo-org-connections`
 - Related: `rm-repository-completeness`, `pl-strategic-objectives`, `pl-initiatives`, `pl-roadmap`
-- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Domain Architect, Business Stakeholder

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -62,6 +62,7 @@ Traversal respects content visibility at every hop. A relationship link is only 
 - What is not yet implemented: reverse traversal UI, impact panel, broken chain indicators, cross-agency views
 - Technology layer (infrastructure, platforms) is a natural extension of this chain but is not in scope until the Technology Lifecycle capability set is defined
 - The traversal visibility gate must be validated with a security test matrix covering all role × visibility combinations before the impact panel ships (see ARB finding #129)
+- **Query performance:** Traversal depth is bounded at configurable depth (default 3, hard cap 5). Required indexes on relationship tables and a visited-node guard against cycles are pre-ship requirements. See `rm-query-performance-decision.md` for the full performance ADR (resolves ARB finding #134).
 
 ## Links
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-query-performance-decision.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-query-performance-decision.md
@@ -1,0 +1,99 @@
+# Architecture Decision: Query Performance for Traversal and Completeness (v1)
+
+## Decision
+
+1. **Traversal depth** — Impact panel traversal is bounded at a configurable depth, default 3 hops, hard cap 5.
+2. **Completeness calculation** — Completeness snapshots are pre-computed and stored. A snapshot is triggered asynchronously on any EA object mutation; a nightly scheduled job is a safety-net fallback. The dashboard reads from the snapshot table, never from live joins.
+3. **Historical snapshot storage** — One snapshot row per organization per day. Each row stores aggregate counts only (no individual object data). Retention is 36 months by default, configurable.
+4. **Response time SLOs** — Impact panel traversal: < 2 s at default depth, hard timeout at 5 s with partial-results degradation. Completeness dashboard: < 500 ms. Historical trend line: < 1 s.
+
+---
+
+## Context
+
+ARB review (issue #134) flagged that neither `rm-end-to-end-traceability` nor `rm-repository-completeness` defined a query performance strategy before implementation. At the target scale of 100–500 applications with a full capability map, naive implementations of unbounded traversal and live multi-table completeness joins will be too slow to be usable.
+
+The four decisions above must be resolved before implementation issues are opened for either capability.
+
+---
+
+## Rationale
+
+### Decision 1 — Traversal depth
+
+The core EA chain (Objective → Initiative → Capability → Application → Persona) spans 4 hops. The vast majority of meaningful impact traces are within this range. Beyond 5 hops the traversal graph expands exponentially and the results become noise rather than signal — every object in a well-connected repository becomes reachable. A hard cap at 5 prevents runaway queries. The default of 3 keeps the common case fast and focused without requiring configuration.
+
+Depth is configurable at the org level so agencies with deeper chains (e.g. multi-tier capability hierarchies) can raise the limit intentionally. The hard cap is not configurable — it is a performance and security boundary, not a preference.
+
+### Decision 2 — Completeness calculation strategy
+
+Completeness calculations join across all object types and their relationship tables. Running these as live queries on every dashboard load is O(n) per org and will degrade as the repository grows. On-demand caching with a TTL introduces a separate invalidation problem: a cache that survives a publish event shows stale data at exactly the moment architects need current information.
+
+Pre-computing on write avoids both problems. When any EA object is created, updated, published, or deleted, an async job recomputes the org's snapshot. The dashboard always reads a single row. The nightly fallback ensures snapshot freshness even for orgs that go days between edits (rare but possible).
+
+Write-triggered recomputation is preferred over pure nightly scheduling because the dashboard must reflect the current state immediately after an architect publishes content — not at the next midnight run.
+
+### Decision 3 — Historical snapshot storage
+
+The trend line feature requires time-series data. Storing one aggregate row per org per day is sufficient granularity for monthly and quarterly trend views, and the storage cost is negligible:
+
+| Orgs | Retention | Row size | Total |
+|------|-----------|----------|-------|
+| 100  | 12 months | ~500 B   | ~1.8 MB |
+| 100  | 36 months | ~500 B   | ~5.4 MB |
+| 1000 | 36 months | ~500 B   | ~54 MB  |
+
+Each snapshot row stores aggregate counts per object type (total, published count, complete-relationship count, within-staleness-window count) and the org ID and date. No individual object references are stored in the snapshot — those are resolved at drill-down time from live tables.
+
+### Decision 4 — Response time SLOs
+
+These targets are achievable with the pre-computed snapshot strategy and the index strategy below, and are grounded in what government users will tolerate for analytical views (not real-time operations):
+
+| Operation | Target | Degradation behaviour |
+|-----------|--------|-----------------------|
+| Impact panel traversal (default depth 3) | < 2 s | Hard timeout at 5 s; return partial results with indicator |
+| Completeness dashboard | < 500 ms | Read from snapshot row — no join required |
+| Historical trend line | < 1 s | Time-series query on snapshot table with index |
+
+If a traversal query exceeds the 5 s timeout, the panel returns whatever hops completed with a "results may be incomplete — try a shallower depth" indicator. It does not block or error.
+
+---
+
+## Required Indexes
+
+The following indexes must be created before either capability ships. These are not optional — without them, completeness counts and traversal joins will table-scan at realistic object counts.
+
+**Relationship tables** (all tables implementing many-to-many EA object links):
+- `(organization_id, source_id)` — forward traversal
+- `(organization_id, target_id)` — reverse traversal
+
+**Content tables** (capabilities, applications, personas, objectives, initiatives, ADRs):
+- `(organization_id, status)` — completeness counts by publish status
+- `(organization_id, updated_at)` — staleness window queries
+
+**Completeness snapshot table** (new):
+- `(organization_id, snapshot_date DESC)` — trend line queries
+- Primary key on `(organization_id, snapshot_date)` — prevents duplicate daily snapshots
+
+---
+
+## Consequences
+
+- The completeness dashboard is eventually consistent with live data — a mutation triggers an async recompute, so there is a brief window (typically < 1 s on a lightly loaded system) where the dashboard reflects the state before the last write. This is acceptable for an analytics view.
+- The trend line has daily granularity. Sub-daily changes are not tracked in the history; only the day's final computed snapshot is stored.
+- Traversal results at depth 3 may omit objects that are only reachable via 4+ hops. The UI must communicate the active depth to the user and offer a depth control.
+- The 5 s traversal timeout means very large or circular graphs return partial results rather than erroring. Circular traversal must be guarded with a visited-node set regardless — this is a correctness requirement, not just a performance one.
+- Implementation must create the completeness snapshot table and the write-trigger job before the completeness dashboard can ship.
+
+---
+
+## Status
+
+Accepted — pre-implementation requirement for `rm-end-to-end-traceability` and `rm-repository-completeness`
+
+## Related
+
+- ARB finding: roballred/GovEA#134
+- Closes: roballred/GovEA#134
+- Capabilities affected: `rm-end-to-end-traceability`, `rm-repository-completeness`
+- Personas served: Enterprise Architect (Central IT), Agency EA Coordinator, CMS Administrator

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -49,8 +49,7 @@ A repository where everything appears equally authoritative — regardless of wh
 ## Implementation Notes
 
 - The admin dashboard (`ac-admin-dashboard`) already surfaces system health and basic content counts; this capability extends it with EA-specific completeness signals
-- Completeness calculations require joining across object types and their relationship tables — performance implications should be evaluated before implementation
-- The trend line feature requires storing historical completeness snapshots; decide before implementation whether these are computed at query time or stored at a scheduled interval
+- **Query performance:** Completeness calculations use pre-computed snapshots triggered on write, not live joins. The dashboard reads a single snapshot row (< 500 ms SLO). The trend line reads from a time-series snapshot table with one row per org per day (36-month default retention). Required indexes on content and relationship tables are a pre-ship requirement. See `rm-query-performance-decision.md` for the full performance ADR (resolves ARB finding #134).
 
 ## Links
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md
@@ -55,4 +55,4 @@ A repository where everything appears equally authoritative — regardless of wh
 
 - Depends on: `ac-admin-dashboard`, `cm-content-relationships`, `po-capability-map`, `po-application-portfolio`
 - Related: `rm-architecture-debt`, `rm-end-to-end-traceability`
-- Personas served: Enterprise Architect, Agency EA Coordinator, CMS Administrator
+- Personas served: Enterprise Architect, Agency EA Coordinator, CMS Administrator, Junior EA Analyst, Early-Maturity Practice Lead

--- a/business-architecture/personas/business-stakeholder.md
+++ b/business-architecture/personas/business-stakeholder.md
@@ -1,0 +1,36 @@
+# Persona: Business Stakeholder (EA Consumer)
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real programme or project managers who consume EA outputs in a state or local government context.
+
+## Role Type
+Internal — Programme / Project Management (non-architect consumer)
+
+## Who They Are
+The Business Stakeholder is a programme manager, IT investment manager, or senior project lead who runs a specific technology programme or modernisation initiative. They have no architecture background and no interest in EA methodology — but they depend on EA outputs to sequence delivery correctly, manage dependencies, and avoid building on technology that is already earmarked for retirement.
+
+In government, this persona commonly holds titles like IT Programme Manager, Digital Transformation Lead, or Senior Project Officer. They sit between the technical delivery teams and department or agency leadership. They are not the same as the Department Director (who makes investment decisions at a strategic level) — they are operational, focused on delivery, and blocked when architecture information is unavailable or inaccessible.
+
+## Goals
+- Understand application and capability dependencies before committing to a delivery sequence in their programme plan
+- Identify which systems their programme will touch — and which are at risk of decommission — before design work begins
+- Get answers to questions like "what does this system connect to?" or "what capability does this application support?" without raising a ticket to the EA team
+- See whether their programme's intended changes overlap with other active initiatives — to find conflicts or opportunities to share
+- Engage with architecture reviews as a support mechanism, not a compliance gate
+
+## Pain Points
+- EA outputs are too technical and too incomplete to support programme delivery decisions — they spend time decoding diagrams rather than using them
+- Architecture views are locked inside tools they cannot access or navigate — they receive static exports, not live, queryable information
+- The EA team is a bottleneck: every architecture question requires a meeting or a ticket, which adds days or weeks to a programme that cannot afford to wait
+- The EA repository and the programme's own records rarely match — they have learned not to trust either source fully
+- When the EA view is wrong or outdated, they do not find out until delivery is already underway and a dependency has been broken
+- Architecture review outputs are written in framework language — they receive artefacts, not decision briefs
+
+## Critical Insight
+The Business Stakeholder is the most direct test of whether an EA practice is delivering value. If they cannot get answers from the EA repository without help from an architect, the practice has failed to operationalise its outputs. Self-service access to accurate, current, plain-language architecture data — especially dependency and lifecycle information — is the single highest-value capability for this persona.
+
+## Relevant Capabilities
+- Read-only navigation and portfolio views (application portfolio, capability map)
+- End-to-end traceability and dependency lookup
+- Initiative and roadmap views (cross-programme dependency visibility)
+- Strategic objectives and alignment views
+- Plain-language content display

--- a/business-architecture/personas/consultant-si.md
+++ b/business-architecture/personas/consultant-si.md
@@ -1,0 +1,35 @@
+# Persona: Consultant / Systems Integrator
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real consultants or SI staff who implement or support EA tools in state or local government engagements.
+
+## Role Type
+External — Independent consultant or Systems Integrator working under contract to a government agency
+
+## Who They Are
+The Consultant or SI practitioner is an external architect working under contract to a state or local government agency. They may be an independent EA consultant running a small number of concurrent client engagements, or a member of a systems integration firm managing a larger implementation. They bring their own EA methodology and templates, adapt to whichever tooling the client has procured, and are expected to leave the client with a working, maintainable repository when the engagement ends.
+
+In government, consultants and SIs are disproportionately involved in EA work. Many agencies lack the internal staffing to build and maintain an EA practice without external support, and procurement vehicles like GSA schedules and state IT contract vehicles make consultant-led EA work common. The consultant's footprint in GovEA may span initial configuration, content population, stakeholder training, and handover to an internal team.
+
+## Goals
+- Onboard to a client's GovEA instance quickly and produce useful work within the first week of an engagement
+- Bring pre-built content — capability map starters, application inventory templates, persona libraries — into the client's repository without manual re-entry
+- Produce handover documentation and exports that the client can maintain after the engagement ends without retaining the consultant
+- Adapt GovEA's structure to the client's existing terminology and architecture approach without rebuilding from scratch
+- Stay current across the EA tool market to provide credible vendor recommendations to clients evaluating their options
+
+## Pain Points
+- Data portability is poor across most EA tools — extracting a client's existing architecture content in a structured, relationship-preserving format for import into GovEA is rarely straightforward
+- Licensing models are not designed for short-term external contributors — accessing a client's GovEA instance as a non-permanent user creates friction in procurement and user management
+- Most tools have no mechanism for bringing in pre-built artefacts — templates, starter content, reference capability maps — without manual entry that consumes engagement time
+- Client repositories that have been partially built by previous consultants or internal staff are often incomplete, inconsistent, or structured in ways that require archaeology before new work can begin
+- The first deliverable of an engagement is often blocked on getting access, understanding the current repository state, and deciding what to migrate or discard — weeks of billable time before visible progress
+
+## Critical Insight
+Consultants and SIs are disproportionately influential in GovEA adoption: they recommend tools, configure initial environments, and train client teams. Supporting this persona well is an indirect path to broader adoption. The most impactful capabilities are those that reduce engagement ramp-up time — fast onboarding, structured exports, and the ability to bring pre-built content into a new client environment.
+
+## Relevant Capabilities
+- Data export and backup (structured, relationship-preserving exports for handover and migration)
+- Content authoring at contributor level (creating and populating content within the client's org)
+- Site configuration and organisation settings (establishing the environment for a client)
+- Audit trail access (understanding the history of a repository before taking over)
+- Role-based access control (operating within contributor scope without requiring admin access)

--- a/business-architecture/personas/domain-architect.md
+++ b/business-architecture/personas/domain-architect.md
@@ -1,0 +1,35 @@
+# Persona: Domain Architect
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real domain architects (data, security, network, integration) in a state or local government context.
+
+## Role Type
+Internal — Agency IT or Central IT (specialist contributor)
+
+## Who They Are
+The Domain Architect is a specialist — a Data Architect, Security Architect, Network Architect, or Integration Architect — who contributes to the EA repository for their specific domain. They are not the owner of the overall EA practice; that responsibility belongs to the Enterprise Architect or Agency EA Coordinator. They are a domain expert contributing accurate, current records for their slice of the architecture.
+
+In government, this role is most common in large agencies, central IT shops, or shared services organisations where the EA team has enough depth to assign domain ownership. A Security Architect documenting security capabilities and their application dependencies, or a Data Architect maintaining a record of data flows and ownership, fits this profile.
+
+## Goals
+- Keep the domain layer of the EA repository current and accurate without requiring constant coordination with the lead architect
+- Connect domain artefacts (security controls, data flows, network boundaries) to applications and business capabilities maintained by other architects
+- Ensure that delivery teams consult the EA repository before making design decisions that affect their domain — reducing the number of post-hoc surprises
+- Surface domain risks (unowned data, ungoverned integrations, obsolete security controls) through the EA model rather than through ad-hoc escalation
+- Reduce the time spent re-explaining the same architectural constraints to different delivery teams independently
+
+## Pain Points
+- The EA model is structured around application and business capability architecture; specialist domains (data, security, network) are secondary citizens with no clear home
+- Connecting domain objects to application and capability objects requires manual effort that quickly becomes stale as the rest of the model evolves
+- Delivery teams do not check the EA repository before starting work in the domain — by the time the domain architect finds out a new data store or integration has been created, it is already in production
+- Changes in adjacent domains (a new application, a capability retirement) do not notify the domain architect whose records are now inaccurate
+- Other contributors can inadvertently overwrite or misclassify domain records, with no notification to the domain owner
+
+## Critical Insight
+Domain architects are the primary contributors to EA repository data quality in established practices, but they are rarely the primary audience in product design or vendor sales. Building contribution workflows, change notifications, and cross-domain relationship navigation for this persona is the most direct path to a repository that stays accurate and useful as the practice matures.
+
+## Relevant Capabilities
+- Content authoring and editing within a defined domain scope
+- Cross-domain relationship navigation and traceability
+- Content workflow (ensuring domain records go through review before publication)
+- Repository completeness signals scoped to domain
+- Role-based access control with domain-level contribution rights

--- a/business-architecture/personas/early-maturity-practice-lead.md
+++ b/business-architecture/personas/early-maturity-practice-lead.md
@@ -1,0 +1,36 @@
+# Persona: Early-Maturity EA Practice Lead
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption in mid-market and early-stage government EA practices. Must not drive implementation until validated through interviews with real EA leads building a practice from scratch in a state or local government context.
+
+## Role Type
+Internal — Agency IT or Central IT (practice founder / solo practitioner)
+
+## Who They Are
+The Early-Maturity EA Practice Lead is the first dedicated enterprise architect in their organisation — or the lead of a very small team (1–3 people) building an EA practice from the ground up. They have experience in solution architecture, IT management, or a related field, but this is their first formal EA leadership role. They are building the practice simultaneously with doing the work: selecting a tool, establishing a methodology, convincing stakeholders of EA's value, and producing early outputs — all at the same time.
+
+In government, this persona is increasingly common as state and local governments respond to technology modernisation pressures, federal guidance on digital transformation, and increasing scrutiny of IT investment. Many agencies are in the first 1–3 years of a formal EA practice and lack the funding, staffing, or organisational patience for a complex enterprise rollout.
+
+## Goals
+- Establish a working EA repository within the first 90 days without over-engineering it — visible early wins matter more than comprehensive coverage
+- Demonstrate value to senior leadership (CIO, Deputy Secretary, agency director) with concrete outputs before organisational patience runs out
+- Choose an approach that the organisation can sustain without a large dedicated team or a large recurring budget
+- Focus on 2–3 high-value use cases (application rationalisation, capability gap identification, investment alignment) and deliver them fast
+- Build enough credibility and buy-in to justify growing the practice — whether that means hiring additional staff, securing tool budget, or expanding scope
+
+## Pain Points
+- Most EA tools and methodologies are designed for established enterprise practices with large teams and funded governance programmes — the blank-canvas problem is acute when there is no team to share the load
+- Stakeholders want results immediately; most tools require substantial setup before anything useful can be published
+- TOGAF, FEAF, and similar frameworks are overwhelming starting points for an organisation that has never done EA — the framework overhead makes it harder to show early value, not easier
+- There is no clear guidance on what to build first — capability map? application inventory? personas? starting from scratch means every decision is made without a reference point
+- Procurement and onboarding cycles for major EA tools often take longer than the window of organisational patience
+- When early outputs are incomplete — which they always are — stakeholders interpret incompleteness as the tool's failure rather than as a normal first step
+
+## Critical Insight
+The Early-Maturity EA Practice Lead will adopt and champion GovEA only if it lets them show something to leadership within weeks, not months. The first deliverable does not need to be complete — it needs to be credible and useful enough to justify the next step. Progressive disclosure of complexity, and the ability to publish partial content as "in progress" without misrepresenting it as complete, is the difference between a practice that builds momentum and one that stalls before it starts.
+
+## Relevant Capabilities
+- Quick-start content population (starter patterns, example capability maps)
+- Lightweight stakeholder publication with completeness caveats
+- Repository completeness dashboard (to show progress honestly, not just the gaps)
+- Content workflow (draft → published, with clear publication controls)
+- Admin configuration and site settings (establishing the practice environment)

--- a/business-architecture/personas/junior-ea-analyst.md
+++ b/business-architecture/personas/junior-ea-analyst.md
@@ -1,0 +1,36 @@
+# Persona: Junior EA / EA Analyst
+
+**Validation Status: Assumed** — derived from cross-tool market research (2026) and patterns observed across EA tool adoption studies. Must not drive implementation until validated through interviews with real junior architects or EA analysts in a state or local government context.
+
+## Role Type
+Internal — Agency IT / Central IT (junior contributor)
+
+## Who They Are
+The Junior EA Analyst is typically 1–3 years into an architecture role, often having transitioned from business analysis, project management, or application support. They work within an established EA team — often a team of 2–5 led by a more senior architect — and are responsible for the day-to-day maintenance of the EA repository: updating the capability map, adding new applications, recording relationship links, and producing views for stakeholder reviews.
+
+In government, this role is common in medium-to-large agencies and central IT shops that have made an EA practice investment. The analyst handles the operational layer of EA work that senior architects and coordinators do not have time for.
+
+## Goals
+- Maintain and update the EA repository accurately without introducing errors or breaking existing relationships
+- Produce capability maps, application inventories, and stakeholder views that the lead architect can present without rework
+- Understand the EA methodology well enough to apply it independently — not just follow instructions
+- Build credibility with delivery teams, who are often sceptical of EA's value and unlikely to engage voluntarily
+- Develop skills that move them toward a senior EA or solution architect role
+
+## Pain Points
+- There are no guardrails — it is easy to overwrite or misclassify data in ways that are hard to detect until damage is already done in the repository
+- It is difficult to know whether a relationship change or status update is correct, or whether it silently breaks a chain elsewhere in the model
+- Onboarding documentation and help resources are written for experienced architects, not for analysts learning on the job
+- Senior architects review work infrequently; there is no way to self-validate quality before a mistake propagates
+- Getting context from delivery teams is slow and awkward — engineers and project managers expect the analyst to come to them, not the other way around
+- Contributing to the wrong capability domain or duplicating an existing record is a common error with no warning mechanism
+
+## Critical Insight
+The Junior EA Analyst is the fastest-growing segment of EA tool users as practices mature and repository maintenance scales beyond what a single senior architect can manage alone. They are also the group most likely to degrade repository quality if the tool does not provide guidance, validation, and soft guardrails. Designing for this persona is not about simplification — it is about making correct contribution the path of least resistance.
+
+## Relevant Capabilities
+- Content authoring and editing with relationship validation
+- Content workflow (draft → review → publish) as a quality gate
+- Repository completeness signals (to know what is missing before being asked)
+- Relationship navigation (to understand downstream impact before making changes)
+- Role-based access control (limits blast radius without blocking contribution)

--- a/docs/design/base-item-foundation.md
+++ b/docs/design/base-item-foundation.md
@@ -1,0 +1,461 @@
+# Base Item Foundation for Reusable Taxonomy and Shared Content Behavior
+
+**Related issue:** [#349](https://github.com/roballred/GovEA/issues/349)  
+**Status:** Proposed for review
+
+---
+
+## Summary
+
+GovEA currently supports taxonomy-backed fields only where a specific entity has been wired for them in code. That works for today's hardcoded cases, but it does not scale to the broader product direction where administrators can define reusable classification structures and apply them across multiple item types without developer intervention.
+
+This document proposes a **base item foundation** for GovEA. The key idea is:
+
+- treat core content records as a shared family of **items**
+- move reusable concerns such as taxonomy assignment onto that shared layer
+- keep entity-specific tables for entity-specific fields
+
+This is intentionally **foundational**, not a full meta-model rewrite. The near-term goal is to create a shared platform layer that lets applications, capabilities, initiatives, ADRs, and similar records opt into common behaviors without bespoke one-off implementation each time.
+
+---
+
+## Problem
+
+Today, GovEA has two different configuration stories:
+
+1. **Taxonomy UI** lets administrators define Types and Values
+2. **Application code** decides which entities can actually use those values
+
+That creates a real gap:
+
+- a CMS Administrator can create a new taxonomy type
+- but that type does not become usable on applications, capabilities, ADRs, or other records unless a developer adds a field and UI for it
+
+This limits the usefulness of Taxonomy Management and works against the documented direction in `cm-content-types.md`, where taxonomy fields should behave more like reusable building blocks.
+
+There is also a broader structural problem: several cross-cutting concerns are repeatedly implemented per entity rather than modeled once for all content items.
+
+Examples:
+
+- taxonomy-backed classification
+- status / workflow signaling
+- visibility
+- audit metadata
+- common detail rendering sections
+- filter and badge rendering
+
+Without a shared base, every new reusable feature becomes a per-entity retrofit.
+
+---
+
+## Goals
+
+1. Define a shared conceptual model for GovEA content items.
+2. Make taxonomy assignment reusable across supported entity types.
+3. Preserve existing entity-specific tables and workflows where they are still the right fit.
+4. Avoid a disruptive all-at-once meta-model rewrite.
+5. Create a foundation that can support later shared behaviors beyond taxonomy.
+
+---
+
+## Non-Goals
+
+- Replace all existing entity tables with a single polymorphic mega-table.
+- Deliver full user-defined content types in this slice.
+- Standardize every workflow/status model immediately.
+- Rebuild all list pages, reports, and detail pages in one pass.
+- Introduce public plugin-style schema mutation for arbitrary custom entities.
+
+This proposal is about **shared foundations**, not unlimited customization.
+
+---
+
+## Current State
+
+The current model mixes several patterns:
+
+- **Capabilities** store a `domain` text field and use the `Domain` taxonomy type.
+- **Glossary terms** also use the `Domain` taxonomy type.
+- **Personas** store `type` as text and use taxonomy-backed persona tags through a junction table.
+- **Principles** store `principle_type` as taxonomy-backed text.
+- **Applications** do not directly store taxonomy assignment for domain; domain is inferred through linked capabilities.
+
+This means GovEA already has the concept of taxonomy-backed classification, but it is implemented in inconsistent ways:
+
+- direct text field
+- text field plus type-specific lookup
+- junction table
+- derived classification
+
+That inconsistency makes reuse harder and increases implementation cost for every new classification surface.
+
+---
+
+## Proposed Direction
+
+Introduce a logical **base item layer** for core content records.
+
+### What is a base item?
+
+A base item is a GovEA record that:
+
+- belongs to an organization
+- has an identity and title/name
+- participates in visibility and workflow rules
+- can carry taxonomy assignments
+- can appear in shared filtering, badges, and detail rendering patterns
+
+Candidate item types:
+
+- application
+- capability
+- persona
+- service
+- value stream
+- strategic objective
+- initiative
+- ADR
+- principle
+- glossary term
+
+This is primarily a **shared platform contract**, not necessarily a single physical table on day one.
+
+---
+
+## Core Design Decision
+
+### Decision
+
+Adopt a **shared base-item model at the platform layer**, while keeping entity-specific tables for entity-specific data.
+
+### Why
+
+This gives GovEA a reusable foundation without forcing a risky table collapse or inheritance-heavy rewrite.
+
+It means we can add cross-cutting capabilities once, then let item types opt in.
+
+### What this avoids
+
+- a fragile “one table for everything” schema
+- rewriting all server actions at once
+- forcing all entities into identical field semantics too early
+
+---
+
+## Base Item Capabilities
+
+The first capability to move onto the shared layer should be **taxonomy assignment**.
+
+Longer term, the same base can also support:
+
+- common status metadata
+- visibility metadata
+- standardized chips/badges
+- common “about this item” detail sections
+- generic filter configuration
+- shared audit and change-summary rendering
+
+Taxonomy is the best first slice because:
+
+- the problem is visible today
+- the user need is clear
+- the design pressure already exists across multiple entities
+- it creates a reusable pattern for later shared features
+
+---
+
+## Taxonomy on the Base Item Layer
+
+### Supported taxonomy types per item type
+
+Each item type should declare which taxonomy types it supports.
+
+Possible shape:
+
+```sql
+entity_taxonomy_definitions
+- id
+- organization_id
+- entity_type           -- application, capability, initiative, etc.
+- taxonomy_type_id      -- top-level taxonomy type
+- selection_mode        -- single | multi
+- required              -- boolean
+- sort_order
+```
+
+This is the configuration layer.
+
+It answers:
+
+- which taxonomy types can be used on a given item type?
+- is this single-select or multi-select?
+- is it required?
+- what order should the UI render it in?
+
+### Selected taxonomy values per item
+
+Use a shared junction table for actual selections.
+
+Possible shape:
+
+```sql
+entity_taxonomy_values
+- id
+- organization_id
+- entity_type
+- entity_id
+- taxonomy_term_id
+```
+
+This is the assignment layer.
+
+It answers:
+
+- which taxonomy values are selected on this item?
+
+### UI behavior
+
+Create and edit forms should:
+
+- load supported taxonomy definitions for the item type
+- render taxonomy inputs dynamically
+- save selected term IDs through a shared path
+
+Detail pages should:
+
+- display assigned taxonomy values grouped by taxonomy type
+
+List pages should:
+
+- support filtering by those taxonomy values where practical
+
+---
+
+## Important Architectural Constraint
+
+### Base item does not require immediate physical table inheritance
+
+The safest interpretation of “base item” in GovEA is:
+
+- **logical shared abstraction first**
+- **shared infrastructure second**
+- **physical schema convergence only where it clearly helps**
+
+That means we do **not** need to begin by creating an `items` table and migrating every entity onto it.
+
+Instead, we can:
+
+1. define which entity types are treated as base items
+2. build shared cross-cutting features against the base-item contract
+3. evaluate later whether a physical `items` table adds enough value to justify migration cost
+
+This keeps the design approval surface much smaller and reduces implementation risk.
+
+---
+
+## Migration Strategy
+
+### Phase 0 — Design approval
+
+- agree on the base-item concept
+- agree that taxonomy is the first shared capability on that base
+- agree which entity types are in scope for the first rollout
+
+### Phase 1 — Shared taxonomy infrastructure
+
+- add `entity_taxonomy_definitions`
+- add `entity_taxonomy_values`
+- add read/write helpers for shared taxonomy assignment
+- add UI loading for supported taxonomy definitions
+
+### Phase 2 — First entity pilot
+
+Recommended pilot: **applications**
+
+Why applications:
+
+- they currently have no direct reusable taxonomy-backed classification field
+- the user need is easy to understand
+- the surface is important but bounded
+
+Suggested first generic field:
+
+- `Application Type`
+
+### Phase 3 — Display and filtering
+
+- render taxonomy chips on application detail pages
+- support list filtering for the pilot field
+
+### Phase 4 — Migration / coexistence review
+
+Decide how existing hardcoded cases should relate to the new generic model:
+
+- migrate `Domain` for capabilities and glossary
+- migrate `Persona Type`
+- migrate `Principle Type`
+- or allow temporary coexistence while the platform stabilizes
+
+### Phase 5 — Broader rollout
+
+Expand to additional item types once the UX and data model are validated.
+
+---
+
+## Coexistence and Migration Notes
+
+The existing taxonomy-backed fields should not be ripped out immediately.
+
+A safer path is:
+
+- build the generic model
+- prove it on one item type
+- then decide case by case whether to migrate existing fields
+
+This matters because current implementations are not all equivalent:
+
+- some store text labels
+- some store slugs
+- some store term IDs through a junction table
+
+Forcing a universal migration too early would add unnecessary risk and slow adoption of the base-item foundation itself.
+
+---
+
+## Benefits
+
+### Product benefits
+
+- administrators can create reusable classification structures that actually become usable
+- item types gain configurable taxonomy support without bespoke development each time
+- GovEA moves closer to its documented content-type direction
+
+### Engineering benefits
+
+- one shared pattern instead of many field-specific implementations
+- lower marginal cost for new classification fields
+- better consistency across UI, actions, and filters
+- a platform foundation that can later support more than taxonomy
+
+### Governance benefits
+
+- clearer explanation of what is configurable versus what is still code-defined
+- easier approval path for future reusable item behavior
+
+---
+
+## Risks
+
+### Risk: over-generalizing too early
+
+If the base-item abstraction tries to solve every future problem now, it will become vague and hard to implement.
+
+Mitigation:
+
+- keep the first implementation focused on taxonomy assignment only
+- treat other shared capabilities as future extensions, not day-one scope
+
+### Risk: hidden migration complexity
+
+Existing taxonomy-backed fields use different storage patterns.
+
+Mitigation:
+
+- allow coexistence during rollout
+- do not require immediate migration of all existing fields
+
+### Risk: UX becomes too abstract
+
+A generic engine can produce confusing forms if every taxonomy type looks the same regardless of context.
+
+Mitigation:
+
+- support labels, required flags, selection mode, and display order in the definition table
+- pilot on one item type before expanding
+
+### Risk: base-item language gets mistaken for meta-model customization
+
+GovEA explicitly does not promise unrestricted meta-model mutation in v1.
+
+Mitigation:
+
+- keep this positioned as reusable shared behavior for built-in item types
+- do not frame it as user-defined arbitrary entities
+
+---
+
+## Alternatives Considered
+
+### Option A — Keep wiring taxonomy per entity
+
+This is the current model.
+
+Pros:
+
+- low immediate change cost
+
+Cons:
+
+- repeats work
+- does not solve the admin configuration gap
+- keeps taxonomy only partially useful
+
+### Option B — One giant `items` table for all content
+
+Pros:
+
+- extreme uniformity
+
+Cons:
+
+- high migration risk
+- harder to preserve entity-specific semantics
+- unnecessary for the problem we are trying to solve right now
+
+### Option C — Logical base item plus shared feature tables
+
+Pros:
+
+- solves the immediate reuse problem
+- preserves current entity tables
+- creates a path for future shared behaviors
+
+Cons:
+
+- requires some duplication to remain during transition
+
+**Recommended:** Option C
+
+---
+
+## Approval Questions
+
+Before implementation, reviewers should explicitly confirm:
+
+1. Is the logical base-item direction the right level of abstraction for GovEA now?
+2. Is taxonomy assignment the right first shared capability to move onto that base?
+3. Is a pilot on applications the safest first implementation?
+4. Should existing hardcoded taxonomy fields coexist temporarily rather than be migrated immediately?
+5. Is this still consistent with GovEA’s current “fixed meta-model, reusable extensions” direction?
+
+---
+
+## Recommendation
+
+Approve the **base-item foundation** as a platform direction, with the following implementation stance:
+
+- logical base-item contract, not immediate physical table unification
+- taxonomy assignment as the first shared capability
+- application pilot first
+- coexistence with current hardcoded taxonomy-backed fields during rollout
+
+This creates a practical, reviewable foundation for broader configurability without forcing GovEA into an over-generalized architecture too early.
+
+---
+
+## Related
+
+- [#349](https://github.com/roballred/GovEA/issues/349) — reusable taxonomy types across item types
+- [`business-architecture/capabilities/cms/content-management/cm-taxonomy-management.md`](../../business-architecture/capabilities/cms/content-management/cm-taxonomy-management.md)
+- [`business-architecture/capabilities/cms/content-management/cm-content-types.md`](../../business-architecture/capabilities/cms/content-management/cm-content-types.md)
+- [`docs/data-model.md`](../data-model.md)


### PR DESCRIPTION
Closes #349

## Summary

- **Schema**: adds `entity_taxonomy_definitions` (per-org config of which taxonomy types apply to which entity type) and `entity_taxonomy_values` (polymorphic junction table for selected values per record), with unique indexes and Drizzle relations including taxonomyTerms self-reference
- **Actions**: 7 new shared helpers in `taxonomy.ts` — read definitions with values, sync values per record, bulk-fetch for list pages, admin add/remove definition
- **Taxonomy admin page**: each type card now shows a "Used on" row with entity-type chips; admins can wire/unwire entity types with selection mode and required flag
- **Applications pilot**: create/edit dialogs render dynamic taxonomy fields (single-select or multi-select per definition); list toolbar adds per-definition filters; detail page shows selected values as chips grouped by type
- **Dev fixtures**: seeds "Application Type" taxonomy type with 6 example values + entity definition for the Riverdale dev org
- **Design doc**: `docs/design/base-item-foundation.md` captured in the repo

## What's not in this PR (deliberate)

Existing hardcoded taxonomy-backed fields (Domain, Persona Type, Principle Type) are left as-is per the design doc's coexistence strategy. Migration of those to the generic model is a Phase 4 decision.

## Test plan

- [ ] Seed the dev database (`pnpm --filter govea db:seed`) — "Application Type" type should appear in Taxonomy with 6 values and "Application" chip
- [ ] In Taxonomy page, wire a second type to another entity type, verify chip appears; unwire, verify removed
- [ ] In Applications, create a new application — "Application Type" select should appear; save and verify chip on detail page
- [ ] Edit an existing application — previously selected value should be pre-selected
- [ ] In Applications list, filter by Application Type — only matching apps shown
- [ ] Delete an application — verify no orphaned rows in `entity_taxonomy_values`

🤖 Generated with [Claude Code](https://claude.com/claude-code)