### PR TITLE
feat(detail-pages): add permission-aware edit actions to base item detail pages

### DIFF
--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -64,6 +64,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       roleBadgeClass={ROLE_BADGE_CLASS[role]}
       themeStyle={themeStyle}
       isDev={isInstanceAdmin(session.user)}
+      isInstanceAdmin={isInstanceAdmin(session.user)}
       enabledModules={enabledModules}
       signOutSlot={signOutSlot}
     >

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -171,6 +171,7 @@ interface AppShellProps {
   roleBadgeClass: string
   themeStyle: string
   isDev: boolean
+  isInstanceAdmin: boolean
   enabledModules: Record<string, boolean>
   signOutSlot: ReactNode
   children: ReactNode
@@ -182,6 +183,7 @@ export function AppShell({
   roleBadgeClass,
   themeStyle,
   isDev,
+  isInstanceAdmin,
   enabledModules,
   signOutSlot,
   children,
@@ -337,6 +339,14 @@ export function AppShell({
 
           {/* User info */}
           <div className="flex items-center gap-3">
+            {isInstanceAdmin && (
+              <Link
+                href="/instance"
+                className="hidden sm:inline-flex items-center rounded-md border border-violet-400/40 bg-violet-500/20 px-2.5 py-1 text-xs font-medium text-violet-200 hover:bg-violet-500/30 transition-colors"
+              >
+                Platform Admin
+              </Link>
+            )}
             <span className="hidden sm:block text-sm text-white/70">{email}</span>
             <span
               data-tour="role-badge"


### PR DESCRIPTION
## Summary

- Adds inline **Edit** buttons to Services, Value Streams, Glossary, and Principles detail pages, following the `PersonaEditButton` pattern already established — same card-style inline form, same `canMutate` permission gate
- Edit controls are only shown to Admin/Contributor users who own the item; Viewer users see none
- Adds a **name search input** to the Value Streams list toolbar, matching the layout already used by Services, Glossary, and Applications
- Fixes a pre-existing crash in `getService` caused by a 3-level-deep Drizzle relation join (`capability → applicationCapabilities → application`) that Drizzle can't execute without `LATERAL`; replaced with a separate flat query — this was breaking Fast Refresh and crashing all dev server routes when any services detail page was visited

## Test plan

- [ ] Open a Service detail page as admin → "Edit service" button appears; click → inline form expands pre-populated; save → page refreshes with updated data
- [ ] Open a Service detail page as viewer → no edit button visible
- [ ] Same for Value Stream, Glossary term, and Principle detail pages
- [ ] Value Streams list: search input filters by name
- [ ] Services detail page no longer crashes the dev server

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)