### PR TITLE
docs(devx): warn contributors not to mix Podman compose providers on named volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,27 @@ podman compose version   # bundled with Podman Desktop
 pip install podman-compose
 ```
 
+### Named volumes and Podman compose providers
+
+The demo stack persists Postgres data in a named volume (`demo_postgres_data`). With rootless Podman, `podman compose` (bundled with Podman Desktop) and `podman-compose` (the pip/brew package) can manage named volumes differently. If you start the stack with one tool and later switch to the other, you may land on what appears to be an empty database with no error — the data is in a volume the other tool can't see.
+
+**Recommendation:** pick one provider and stick to it. The `container-compose.sh` helper prefers `podman compose` when both are available, so as long as you use `pnpm demo:*` commands you stay on the same provider.
+
+If you deliberately want a clean local database (to re-run seed data from scratch, for example), remove the volume explicitly:
+
+```bash
+# Stop the stack first
+pnpm demo:db:stop          # or pnpm demo:stop for the full stack
+
+# Remove the named volume
+podman volume rm demo_postgres_data   # or: docker volume rm demo_postgres_data
+
+# Start fresh — the volume is recreated automatically
+pnpm demo:db
+pnpm --filter govea db:migrate
+pnpm --filter govea db:seed
+```
+
 ### Azure container builds
 
 Azure deployments build images in the cloud via `az acr build` and do not require a local Docker daemon. See `scripts/azure-dev.sh` for details.

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -37,4 +37,10 @@ services:
       retries: 10
 
 volumes:
+  # Named volume for Postgres data. With rootless Podman, "podman compose" and
+  # "podman-compose" manage named volumes independently — mixing them makes the
+  # database appear empty. Use one provider consistently (the container-compose.sh
+  # helper prefers "podman compose" when both are installed).
+  # To reset: stop the stack, run `podman volume rm demo_postgres_data`, then
+  # restart and re-run db:migrate + db:seed.
   demo_postgres_data:


### PR DESCRIPTION
## Summary

- Adds a **Named volumes and Podman compose providers** section to the Local Containers docs in `README.md`, explaining why mixing `podman compose` and `podman-compose` against the same named volume can silently make the database look empty
- Recommends sticking to one provider (the `container-compose.sh` helper already prefers `podman compose` when both are installed, so `pnpm demo:*` commands stay consistent automatically)
- Documents the intentional DB reset workflow: stop the stack → `podman/docker volume rm demo_postgres_data` → restart → `db:migrate` + `db:seed`
- Adds a short inline comment in `docker-compose.demo.yml` at the `demo_postgres_data` volume definition so contributors reading the compose file get the caveat in context

## Test plan

- [ ] Review README Local Containers section — new subsection renders correctly
- [ ] Review `docker-compose.demo.yml` — comment at named volume definition is accurate and concise
- [ ] No code changes; type check and lint pass without changes

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)