### PR TITLE
docs: refresh product status and backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,18 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Contributor-friendly relationship panels across detail pages, including in-context persona editing
 - Markdown-rendered long-form detail pages across the portfolio model, with shared prose styling for descriptions and other narrative fields
 - Leadership-friendly application risk portfolio view on the Applications page, highlighting retiring systems that still support active capability work
+- Application custom fields with CSV import/export so agencies can extend and load portfolio metadata without schema changes
+- Impact analysis on application and capability detail pages to surface decommission and change consequences from existing relationship data
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
 - Demo-ready planning module: strategic objectives plus initiatives with roadmap grid and executive timeline views
-- Reports hub with generated Architecture Vision output from existing repository content
+- Reports hub with generated Architecture Vision, Executive Summary, Heatmap Analysis, and TOGAF Application Landscape outputs from existing repository content
+- Capability relationship map with both focused SVG navigation and Mermaid diagram views
 - Repository-wide search across the core content model
 - Guided product tour with role-aware coach marks for the main application areas
 - Audit trail: immutable before/after log of all changes
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
-- Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, and audited break-glass sessions
+- Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, audited break-glass sessions, and instance-level platform configuration
 - Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
@@ -236,18 +239,19 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
-- Defining the true instance-level configuration surface for the `/instance` console
-- Turning the new reporting and portfolio foundations into stronger stakeholder-facing decision support
+- Turning early repository signals into fuller completeness and confidence workflows
+- Maturing ADRs and decision support into stronger architecture-debt and tradeoff visibility
+- Defining the first operational integration slices so repository data stays current without manual reconciliation
 - Expanding automated test coverage
 - Improving local bootstrap and demo workflows
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Define and ship instance-level platform configuration in `/instance`
-- Add an executive dashboard for non-architect leadership audiences
-- Add impact analysis on application and capability detail pages
-- Add heatmap analysis views over existing portfolio data
-- Start lightweight user feedback capture for EA practice fit
+- Ship repository completeness drill-downs and a stakeholder-facing confidence summary
+- Add architecture debt tracking tied to ADRs, impact analysis, and reporting
+- Start the integration foundation with a REST API plus the first Tier 1 operational sync slice
+- Generalize shared item/taxonomy behavior beyond the current per-entity wiring
+- Start lightweight user feedback capture and persona validation for the new analysis surfaces
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
+++ b/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
@@ -14,7 +14,7 @@ The system must maintain a reliable, navigable, and self-auditing store of all a
 
 | Capability | File | Status | Description |
 |---|---|---|---|
-| End-to-End Traceability | [rm-end-to-end-traceability.md](./rm-end-to-end-traceability.md) | Not implemented | Cross-layer impact analysis from strategic goals through capabilities to applications |
+| End-to-End Traceability | [rm-end-to-end-traceability.md](./rm-end-to-end-traceability.md) | Partially implemented | Objective, capability, and service trace views exist, and application/capability impact analysis is shipped; broader cross-layer and cross-agency traversal remains future work |
 | Architecture Debt Tracking | [rm-architecture-debt.md](./rm-architecture-debt.md) | Not implemented | Surface and track decisions and conditions that constrain future options |
 | Repository Completeness | [rm-repository-completeness.md](./rm-repository-completeness.md) | Scaffolded | Early signals and dashboards showing where the EA object store has gaps |
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md
@@ -6,7 +6,7 @@ The system must allow any user to follow a chain of relationships across the ful
 
 ## Implementation Status
 
-**Not yet implemented.** Read-only traceability views for individual objectives, capabilities, and services exist in the product (see `fd-traceability-views.md`), but the cross-layer impact analysis, reverse traversal UI, broken chain indicators, and cross-agency views described in this document are not yet built. This document is the design specification for that future work.
+**Partially implemented.** GovEA already ships read-only traceability views for objectives, capabilities, and services, plus impact-analysis panels on application and capability detail pages. What remains unbuilt is the fuller cross-layer traversal surface described here: reverse traversal UI, broken-chain indicators, cross-agency views, and a unified repository-wide impact workflow.
 
 ## Personas
 
@@ -59,7 +59,8 @@ Traversal respects content visibility at every hop. A relationship link is only 
 ## Implementation Notes
 
 - The core chain (Personas → Capabilities → Applications) is already enforced in the data model and publish workflow
-- What is not yet implemented: reverse traversal UI, impact panel, broken chain indicators, cross-agency views
+- Shipped today: read-only traceability routes for objectives, capabilities, and services, plus application/capability impact panels for change and decommission analysis
+- What is not yet implemented: repository-wide reverse traversal UI, broken chain indicators, cross-agency views, and a unified impact workspace across all object types
 - Technology layer (infrastructure, platforms) is a natural extension of this chain but is not in scope until the Technology Lifecycle capability set is defined
 - The traversal visibility gate must be validated with a security test matrix covering all role × visibility combinations before the impact panel ships (see ARB finding #129)
 - **Query performance:** Traversal depth is bounded at configurable depth (default 3, hard cap 5). Required indexes on relationship tables and a visited-node guard against cycles are pre-ship requirements. See `rm-query-performance-decision.md` for the full performance ADR (resolves ARB finding #134).

--- a/capabilities.md
+++ b/capabilities.md
@@ -152,7 +152,7 @@ Organization-level settings and administrative tools.
 | Persona Type Management | Implemented | Manage persona type categories as taxonomy terms under the `Persona Type` branch |
 | Persona Tags | Implemented | Manage persona tag values as taxonomy terms under the `Persona Tag` branch |
 | Admin Dashboard | Implemented | Live practitioner dashboard with repository activity, coverage signals, and navigation shortcuts |
-| Feature Management | Not implemented | Enable/disable optional product features per org |
+| Feature Management | Partially implemented | Org-level module toggles and instance-wide global disables are shipped; richer dependency and feature-flag behavior remains future work |
 | Email Configuration | Not implemented | SMTP setup for notifications and password reset |
 | Backup & Export | Not implemented | Data export and backup tooling |
 | Security Settings | Not implemented | Session timeouts, password policy, IP restrictions |
@@ -231,12 +231,12 @@ GovEA's longer-horizon capability direction spans the major themes below, each d
 |---|---|
 | Identity & Access Management | Tenant-boundary tests, production hardening for instance-admin operations |
 | Repository & Modelling | End-to-end traceability, architecture debt tracking, repository confidence summary |
-| Application & IT Portfolio | Technology lifecycle tracking, rationalization views, application risk portfolio |
-| Business & Capability Architecture | Capability heat maps, operating model views, typed principle sets |
+| Application & IT Portfolio | Technology lifecycle tracking, custom-field reuse, import/export maturation, richer rationalization views |
+| Business & Capability Architecture | Operating model views, typed principle sets, stronger cross-entity classification and relationship visualisation |
 | Planning & Analysis | Scenario planning, value stream analytics |
 | Governance & Compliance | ARB review workflow, regulatory mapping |
 | Integration | Tier 1: ITSM/CMDB sync, DevOps pipeline links, cloud discovery — Tier 2 (critical gaps): PPM/project portfolio, ERP/financial, HR/org design — Tier 3: data governance platform, API management platform, BI analytics feed — Tier 4 (emerging): IaC, AI/ML registry, low-code platforms — Foundational: REST API |
-| Collaboration & Stakeholder Engagement | Stakeholder validation, repository confidence summaries, stakeholder-facing plain-language views |
+| Collaboration & Stakeholder Engagement | Stakeholder validation, repository confidence summaries, stakeholder-facing plain-language views, feedback capture |
 | Reporting & Documentation | Configurable reports, KPI tracking, elected-official summaries |
 | Framework Alignment | Optional TOGAF mapping, ADM phase alignment, and framework-aware reporting |
 

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-04-28
+Last groomed: 2026-05-04
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -8,43 +8,43 @@ This note summarizes the top next product moves from the current capability inve
 
 Recent merges materially changed the product surface:
 
-- PR #304 shipped the Application Portfolio risk view, giving GovEA a stronger leadership-facing application surface built from existing lifecycle and capability-link data.
-- PR #299 shipped the Reports hub and Architecture Vision output, proving GovEA can generate executive summaries directly from repository content rather than requiring duplicate documentation.
-- PR #301 shipped the first TOGAF overlay slice: org-level enablement, framework mappings on capability/application records, and a TOGAF Application Landscape report.
-- PR #303 documented the TOGAF/ADM boundary clearly: optional overlay in, ADM workflow enforcement out for v1/v2.
-- PR #309 clarified the instance-admin product boundary and made the persona/capability model match the already-shipped `/instance` console.
-- PR #310 reconciled several business-architecture docs, but a follow-up pass is still needed because top-level docs had drifted behind the newest product work.
+- PR #312 shipped the first instance-level platform configuration surface, turning `/instance` into a real operating console rather than only an audit/provisioning shell.
+- PR #314 and PR #316 shipped the Executive Summary and Heatmap Analysis reports, giving GovEA stronger stakeholder-facing reporting on top of the existing repository.
+- PR #357 shipped application and capability impact analysis, moving traceability from passive navigation toward real decision support.
+- PR #356 shipped application custom fields plus CSV import/export, reducing one of the biggest practical barriers to getting real portfolio data into the product.
+- PR #376 shipped a Mermaid-based diagram view on the capability map page, broadening how users can understand repository relationships without changing the underlying model.
+- PR #370 and the recent persona documentation passes strengthened the roadmap definition for integration and real government-practice fit, even where product implementation has not started yet.
 
 What this means for prioritization:
 
-- GovEA now has stronger admin, reporting, and leadership-demo foundations than it did a week ago.
-- The next best work is less about another isolated CRUD slice and more about turning the existing repository into decision support for platform admins, leadership audiences, and real-user feedback loops.
-- The repo still has important long-range ARB and market-research issues open, but the highest-leverage next moves are the ones that compound the product areas strengthened by the latest merges.
+- GovEA has now shipped most of the shortlist that was current at the end of April. The next best work is no longer "add the first report" or "define the instance surface" because those slices now exist.
+- The highest-leverage gap has shifted from feature presence to repository trust: completeness, confidence, decision traceability, and data freshness.
+- The repo also now has enough stakeholder-facing surface area that weak data quality or weak persona validation will be more damaging than another isolated demo-friendly page.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) / PR |
 |---|---|---|---|
-| 1 | Define and ship instance-level platform configuration | The `/instance` console is now real, documented, and clearly separated from org admin scope. #308 is the immediate product follow-on that turns instance admin from an audit/provisioning console into a real platform-management surface. | #308, PR #309 |
-| 2 | Build the Executive Dashboard for non-architects | PR #304 and PR #299 already proved the underlying summary data and leadership framing. #84 is the clearest next stakeholder-facing screen and the strongest adoption move in the open backlog. | #84, PR #304, PR #299 |
-| 3 | Add Impact Analysis on application and capability detail pages | GovEA already has the traceability graph and now has better portfolio/risk storytelling. #83 is the next decision-support feature that helps users act on lifecycle and modernization questions instead of just viewing linked records. | #83 |
-| 4 | Add Heatmap Analysis views | With the application risk portfolio shipped, #82 becomes a natural companion view for portfolio exposure, maturity, and domain-level pattern detection using the same core data. | #82, PR #304 |
-| 5 | Start lightweight user feedback capture for practice fit | The product now has enough breadth that wrong assumptions will compound unless feedback is captured systematically. #103 has a low-cost Phase 1 that can start immediately without waiting for a full in-app workflow. | #103 |
+| 1 | Ship repository completeness drill-downs and a plain-language confidence summary | Reporting, heatmaps, impact views, and executive summaries now depend on users trusting the underlying repository. GovEA has early coverage signals, but not yet the fuller completeness workflow or stakeholder-facing confidence cues described in the repository-modelling capability docs. | `rm-repository-completeness`, `fd-repository-confidence-summary`, PR #357, PR #316, PR #314 |
+| 2 | Add architecture debt tracking and make ADRs a stronger decision-support surface | Impact analysis now surfaces consequences, but GovEA still lacks a first-class way to record persistent constraints, debt, and tradeoff accumulation. That leaves a gap between "what is affected" and "what should leadership worry about next." | `rm-architecture-debt`, `po-architecture-decisions`, PR #357 |
+| 3 | Start the operational integration foundation: REST API plus the first Tier 1 sync slice | Custom fields and CSV import/export help initial data load, but they do not solve staleness. The integration roadmap is now better defined, and the next meaningful trust move is to reduce manual reconciliation with operational systems. | `int-rest-api`, `integration/`, PR #356, PR #370 |
+| 4 | Generalize the shared item/taxonomy foundation beyond the current application-only extension points | GovEA now has proof that configurable fields are useful, but the current model still requires entity-specific wiring. The base-item/taxonomy direction is the platform move that prevents every future classification or metadata request from becoming bespoke per-entity work. | `docs/design/base-item-foundation.md`, PR #356, PR #350 |
+| 5 | Validate assumed personas and start a lightweight product feedback loop for the new analysis surfaces | Repository modelling and integration are still driven by assumed personas in several capability files. With executive reporting, impact analysis, and map views now shipped, the cost of building the wrong next analytic feature has gone up. Validate before compounding. | Persona docs, `docs/research/`, issue #103, PR #314, PR #357, PR #376 |
 
 ## Product Manager Notes
 
-- Treat #308 as the most concrete next product-management task. The repo now has a documented instance-admin boundary but not yet a clearly owned platform-config surface.
-- #84, #83, and #82 form a coherent sequence, not three isolated ideas: executive summary -> decision-support drill-down -> portfolio pattern visualization.
-- #306 is worth keeping warm as an input to future analysis and reporting work, but it is narrower than the five items above unless real users confirm it is blocking capability modelling today.
-- The ARB/research issues in the 90s and 130s still matter, but many are capability-definition or scope-decision work. The shortlist above favors moves that build directly on what the latest merged code already made possible.
-- Ship the Phase 1 manual feedback log from #103 before designing a full feedback table/UI. The process signal is more urgent than the schema.
+- The old shortlist is materially stale: platform configuration, executive reporting, heatmaps, and impact analysis are already shipped in `main`.
+- The new priority stack is intentionally trust-heavy. GovEA has crossed the point where more views are less valuable than better confidence in what those views are saying.
+- The most pragmatic sequence is: repository confidence -> debt/decision capture -> integration freshness. That is the shortest path from "useful demo" to "credible working repository."
+- Treat the shared item/taxonomy foundation as a platform multiplier, not a side quest. Recent custom-field work proved the demand; the next step is making reuse systematic.
+- Keep persona validation attached to these roadmap items, especially for repository-modelling and integration, where several capabilities still explicitly carry assumed-persona risk.
 
 ## Documentation Follow-up
 
 This grooming pass also updates product docs to match current repo reality:
 
-- `docs/product-priorities.md`: replaced the stale hardening shortlist with the current product-development sequence.
-- `README.md`: now reflects the shipped application risk portfolio, reports hub, and TOGAF overlay/reporting slice.
-- `capabilities.md`: now marks Application Risk Portfolio and the first framework-alignment slice accurately.
-- `business-architecture/capabilities/ea/framework-alignment/*.md`: implementation status now matches the shipped TOGAF overlay, mapping, and reporting behavior.
-- `business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md`: now explicitly records the shipped v1 implementation status.
+- `docs/product-priorities.md`: replaced the stale late-April shortlist with a post-PR-#376 sequence based on what is actually shipped in `main`.
+- `README.md`: updated active work and near-term priorities so they stop pointing at already-completed items.
+- `capabilities.md`: refreshed the target-surface table so near-term priorities reflect the current product baseline.
+- `business-architecture/capabilities/ea/repository-modelling/repository-modelling.md`: end-to-end traceability now reads as partially implemented rather than absent.
+- `business-architecture/capabilities/ea/repository-modelling/rm-end-to-end-traceability.md`: implementation status now acknowledges the shipped application/capability impact analysis slice while preserving the remaining roadmap.


### PR DESCRIPTION
## Summary
- refresh README shipped/active/near-term status to match current product reality
- replace the stale product-priorities shortlist with a new top-5 backlog based on shipped work in `main`
- mark repository-modelling traceability and feature-management summaries accurately in capability docs

## Testing
- not run (documentation-only changes)
