### PR TITLE
feat(platform): base-item taxonomy foundation — capabilities pilot

### DIFF
--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { db } from '@/db/client'
-import { capabilities, capabilityPersonas, capabilityRelationships } from '@/db/schema'
+import { capabilities, capabilityPersonas, capabilityRelationships, entityTaxonomyValues } from '@/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -67,10 +68,17 @@ export async function getCapability(id: string) {
     : []
   const capNameById = new Map(relatedCaps.map(c => [c.id, c.name]))
 
+  const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    getEntityTaxonomyValues(capability.organizationId, 'capability', id),
+    getEntityTaxonomyDefinitions(capability.organizationId, 'capability'),
+  ])
+
   return {
     ...capability,
     childRelationships: childRels.map(r => ({ ...r, child: { id: r.childId, name: capNameById.get(r.childId) ?? '' } })),
     parentRelationships: parentRels.map(r => ({ ...r, parent: { id: r.parentId, name: capNameById.get(r.parentId) ?? '' } })),
+    taxonomyValues,
+    taxonomyDefinitions,
   }
 }
 
@@ -140,6 +148,7 @@ export async function createCapability(formData: FormData) {
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const personaIds = formData.getAll('personaIds') as string[]
   const parentId = (formData.get('parentId') as string) || null
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
   const [capability] = await db.insert(capabilities).values({
     name,
@@ -163,6 +172,10 @@ export async function createCapability(formData: FormData) {
 
   if (parentId) {
     await db.insert(capabilityRelationships).values({ parentId, childId: capability.id }).onConflictDoNothing()
+  }
+
+  if (taxonomyTermIds.length > 0) {
+    await syncEntityTaxonomyValues(orgId, 'capability', capability.id, taxonomyTermIds)
   }
 
   await writeAuditLog({
@@ -189,6 +202,7 @@ export async function editCapability(capabilityId: string, formData: FormData) {
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
   const personaIds = formData.getAll('personaIds') as string[]
   const parentId = (formData.get('parentId') as string) || null
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
   const before = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
   assertOwnership(before?.organizationId, orgId)
@@ -220,6 +234,8 @@ export async function editCapability(capabilityId: string, formData: FormData) {
     await db.insert(capabilityRelationships).values({ parentId, childId: capabilityId }).onConflictDoNothing()
   }
 
+  await syncEntityTaxonomyValues(orgId, 'capability', capabilityId, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'capability.edit',
     entityType: 'capability',
@@ -244,6 +260,10 @@ export async function deleteCapability(capabilityId: string) {
 
   const before = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(eq(entityTaxonomyValues.entityType, 'capability'), eq(entityTaxonomyValues.entityId, capabilityId))
+  )
 
   await db.delete(capabilities).where(
     and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId))

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -28,6 +28,7 @@ import { MarkdownContent } from '@/components/markdown-content'
 import { getCapabilityImpact } from '@/actions/impact'
 import { CapabilityImpactPanel } from '@/components/impact-panel'
 import { CapabilityEditButton } from '@/components/capability-edit-button'
+import { TaxonomyChips } from '@/components/taxonomy-ui'
 import {
   approveCrossOrgLink,
   getCrossOrgLinkContext,
@@ -147,6 +148,8 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
             personaIds: capability.capabilityPersonas.map(cp => cp.persona.id),
             parentId: capability.parentRelationships[0]?.parentId ?? null,
           }}
+          taxonomyDefinitions={capability.taxonomyDefinitions}
+          currentTaxonomyValues={capability.taxonomyValues}
         />
       )}
 
@@ -180,6 +183,11 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
               : <span className="text-sm text-muted-foreground">No domain assigned</span>
           }
         </div>
+
+        <TaxonomyChips
+          definitions={capability.taxonomyDefinitions}
+          selectedTermIds={capability.taxonomyValues.map(v => v.taxonomyTermId)}
+        />
 
         {children.length > 0 && (
           <div className="pt-2 space-y-1.5">

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import type { Capability, Persona } from '@/db/schema'
+import type { Capability, Persona, EntityTaxonomyValue } from '@/db/schema'
 import { createCapability, editCapability, deleteCapability } from '@/actions/capabilities'
+import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
@@ -32,6 +33,8 @@ interface Props {
   capabilities: CapabilityRow[]
   personas: Pick<Persona, 'id' | 'name'>[]
   domainTerms: { id: string; name: string }[]
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
   role: Role
   currentOrgId: string
 }
@@ -59,7 +62,7 @@ const TYPE_STYLES: Record<string, string> = {
   technical: 'bg-cyan-100 text-cyan-800 border-cyan-200',
 }
 
-export function CapabilityTable({ capabilities, personas, domainTerms, role, currentOrgId }: Props) {
+export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyDefinitions, taxonomyValueMap, role, currentOrgId }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
@@ -68,6 +71,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
   const [typeFilter, setTypeFilter] = useState('all')
   const [domainFilter, setDomainFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
 
   const orgOptions = Array.from(new Map(
@@ -89,7 +93,8 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
 
   const refresh = () => router.refresh()
 
-  const hasFilter = search || statusFilter !== 'all' || typeFilter !== 'all' || domainFilter !== 'all' || orgFilter !== 'all'
+  const hasTaxonomyFilter = Object.values(taxonomyFilters).some(v => v !== 'all')
+  const hasFilter = search || statusFilter !== 'all' || typeFilter !== 'all' || domainFilter !== 'all' || orgFilter !== 'all' || hasTaxonomyFilter
 
   // Build tree from full capability list
   const tree = buildCapabilityTree(capabilities)
@@ -104,7 +109,10 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
         const matchType = typeFilter === 'all' || c.capabilityType === typeFilter
         const matchDomain = domainFilter === 'all' || resolvedDomain === domainFilter
         const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? c.organizationId === currentOrgId : c.organizationId === orgFilter)
-        return matchSearch && matchStatus && matchType && matchDomain && matchOrg
+        const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) =>
+          termId === 'all' || (taxonomyValueMap[c.id] ?? []).some(v => v.taxonomyTermId === termId)
+        )
+        return matchSearch && matchStatus && matchType && matchDomain && matchOrg && matchTaxonomy
       }).map(c => ({ cap: c, depth: 0, children: [] }))
     : flatTree
 
@@ -206,6 +214,11 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
             ))}
           </select>
         )}
+        <TaxonomyFilters
+          defs={taxonomyDefinitions}
+          filters={taxonomyFilters}
+          onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
+        />
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
             + New Capability
@@ -385,6 +398,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
                 }
               </div>
             </div>
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <div className="space-y-1.5">
               <Label>Status</Label>
               <select name="status" defaultValue="draft" className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
@@ -454,6 +468,10 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
                 }
               </div>
             </div>
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
+            />
             <div className="space-y-1.5">
               <Label>Status</Label>
               <select name="status" defaultValue={editTarget?.status} className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">

--- a/apps/govea/src/app/(admin)/capabilities/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getCapabilities } from '@/actions/capabilities'
 import { getPersonas } from '@/actions/personas'
-import { getTaxonomyDomains } from '@/actions/taxonomy'
+import { getTaxonomyDomains, getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { CapabilityTable } from './capability-table'
 export default async function CapabilitiesPage() {
   const session = await auth()
@@ -11,11 +11,17 @@ export default async function CapabilitiesPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [capabilityList, personaList, domainTerms] = await Promise.all([
+  const [capabilityList, personaList, domainTerms, taxonomyDefinitions] = await Promise.all([
     getCapabilities(orgId, role),
     getPersonas(orgId, role),
     getTaxonomyDomains(orgId),
+    getEntityTaxonomyDefinitions(orgId, 'capability'),
   ])
+
+  const capabilityIds = capabilityList.map(c => c.id)
+  const taxonomyValueMap = capabilityIds.length > 0
+    ? await getEntityTaxonomyValuesForMany(orgId, 'capability', capabilityIds)
+    : {}
 
   return (
     <div className="space-y-6">
@@ -23,7 +29,15 @@ export default async function CapabilitiesPage() {
         <h1 className="text-2xl font-bold tracking-tight">Capabilities</h1>
         <p className="text-muted-foreground mt-1">What your organization must be able to do, traced back to persona needs.</p>
       </div>
-      <CapabilityTable capabilities={capabilityList} personas={personaList} domainTerms={domainTerms} role={role} currentOrgId={orgId} />
+      <CapabilityTable
+        capabilities={capabilityList}
+        personas={personaList}
+        domainTerms={domainTerms}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
+        role={role}
+        currentOrgId={orgId}
+      />
     </div>
   )
 }

--- a/apps/govea/src/components/capability-edit-button.tsx
+++ b/apps/govea/src/components/capability-edit-button.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import type { EntityTaxonomyValue } from '@/db/schema'
 
 interface CapabilityEditButtonProps {
   capabilityId: string
@@ -22,9 +24,11 @@ interface CapabilityEditButtonProps {
     personaIds: string[]
     parentId: string | null
   }
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  currentTaxonomyValues: EntityTaxonomyValue[]
 }
 
-export function CapabilityEditButton({ capabilityId, initial }: CapabilityEditButtonProps) {
+export function CapabilityEditButton({ capabilityId, initial, taxonomyDefinitions, currentTaxonomyValues }: CapabilityEditButtonProps) {
   const [editing, setEditing] = useState(false)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
@@ -107,6 +111,12 @@ export function CapabilityEditButton({ capabilityId, initial }: CapabilityEditBu
         <div className="space-y-1 sm:col-span-2">
           <MarkdownEditor label="Rules" name="rules" defaultValue={initial.rules ?? ''} rows={3} placeholder="Markdown supported — use - bullets, **bold**, etc." />
         </div>
+
+        {taxonomyDefinitions.length > 0 && (
+          <div className="sm:col-span-2">
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={currentTaxonomyValues} />
+          </div>
+        )}
 
         <div className="space-y-1">
           <Label>Status</Label>

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -682,6 +682,50 @@ async function seed() {
   }).onConflictDoNothing()
   console.log('  ✓ Application Type taxonomy type + entity definition')
 
+  // Capability Priority taxonomy + entity definition (base-item foundation: second entity pilot)
+  let capPriorityTermId: string
+  const existingCapPriority = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'capability-priority')),
+  })
+  if (existingCapPriority) {
+    capPriorityTermId = existingCapPriority.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Capability Priority',
+      slug: 'capability-priority',
+      description: 'Strategic importance of the capability to the organization.',
+      sortOrder: '60',
+    }).returning()
+    capPriorityTermId = inserted.id
+  }
+  const CAP_PRIORITY_VALUES = ['Critical', 'High', 'Medium', 'Low']
+  for (const name of CAP_PRIORITY_VALUES) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, capPriorityTermId), e(t.slug, slug)),
+    })
+    if (!existing) {
+      await db.insert(taxonomyTerms).values({
+        organizationId: devOrgId,
+        parentId: capPriorityTermId,
+        name,
+        slug,
+      })
+    }
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'capability',
+    taxonomyTypeId: capPriorityTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Capability Priority taxonomy type + entity definition')
+
   // ── Org 2: Office of Digital Services (state agency) ────────────────────
 
   console.log('\n[Org 2] Office of Digital Services')


### PR DESCRIPTION
Closes #383

## Summary

- Wires capabilities as the second entity pilot for the shared `entityTaxonomyDefinitions` / `entityTaxonomyValues` taxonomy system (applications was the first), proving cross-entity reuse
- Seeds a **Capability Priority** taxonomy type (Critical / High / Medium / Low, single-select, required=false) with idempotent `findFirst` guards to prevent duplicate child terms on re-seed
- **List page**: "All Capability Priority" filter dropdown in the toolbar; `getEntityTaxonomyValuesForMany` batch-fetches values for all capabilities in one query
- **Create / edit dialogs**: `TaxonomyInputs` component rendered before the Status field so priority can be set at write time
- **Detail page**: `TaxonomyChips` renders selected values after the domain badge; inline edit form (`CapabilityEditButton`) includes `TaxonomyInputs` with pre-populated current values
- **Server actions**: `syncEntityTaxonomyValues` called on create and edit; orphan cleanup on delete

## Test plan

- [ ] Open `/capabilities` — "All Capability Priority" filter appears in toolbar; filtering by Critical/High/etc. narrows the list
- [ ] Open "+ New Capability" dialog — "Capability Priority" select shows Critical, High, Low, Medium (no duplicates)
- [ ] Create a capability with Priority = High, visit its detail page — "High" chip appears under the domain badge
- [ ] Click "Edit capability" on detail page — Priority field pre-populates with current value; changing it and saving updates the chip
- [ ] Re-run `db:seed` twice — no duplicate taxonomy terms inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)