### PR TITLE
fix(auth): always redirect to /login when authentication is required

### DIFF
--- a/apps/govea/src/app/(auth)/error/page.tsx
+++ b/apps/govea/src/app/(auth)/error/page.tsx
@@ -1,15 +1,10 @@
+import { redirect } from 'next/navigation'
+
 export default async function AuthErrorPage({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string }>
 }) {
   const { error } = await searchParams
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <div className="p-8 text-center">
-        <h1 className="text-xl font-semibold">Authentication error</h1>
-        <p className="mt-2 text-sm text-gray-600">{error ?? 'Something went wrong.'}</p>
-      </div>
-    </main>
-  )
+  redirect(error ? `/login?error=${encodeURIComponent(error)}` : '/login')
 }

--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@ import { AuthError } from 'next-auth'
 import { signIn } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
+import { safeCallbackUrl } from '@/lib/auth-redirect'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -45,7 +46,7 @@ export default async function LoginPage({
                 await signIn('credentials', {
                   email: formData.get('email'),
                   password: formData.get('password'),
-                  redirectTo: params.callbackUrl ?? '/dashboard',
+                  redirectTo: safeCallbackUrl(params.callbackUrl),
                 })
               } catch (error) {
                 if (error instanceof AuthError) {

--- a/apps/govea/src/lib/auth-redirect.ts
+++ b/apps/govea/src/lib/auth-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Auth redirect utilities (#386)
+ *
+ * callbackUrl values arrive from query params and are controlled by NextAuth
+ * or the browser — they should never send users back into auth/error routes
+ * after a successful login.
+ */
+
+const AUTH_DEAD_ENDS = ['/login', '/error', '/api/auth']
+
+/**
+ * Returns a safe post-login destination, falling back to `fallback` if the
+ * supplied URL would trap the user in an auth or error route.
+ *
+ * Rules:
+ *  - Must start with '/' (relative, no external redirects)
+ *  - Must not start with /login, /error, or /api/auth
+ */
+export function safeCallbackUrl(url: string | undefined | null, fallback = '/dashboard'): string {
+  if (!url) return fallback
+  if (!url.startsWith('/') || url.startsWith('//')) return fallback
+  if (AUTH_DEAD_ENDS.some(p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`))) return fallback
+  return url
+}

--- a/apps/govea/tests/e2e/specs/auth-security.spec.ts
+++ b/apps/govea/tests/e2e/specs/auth-security.spec.ts
@@ -1,13 +1,12 @@
 /**
  * Auth security regression tests.
  *
- * Covers the deactivated-user login bug:
- *   - A deactivated user cannot authenticate via local (credentials) login
- *   - A deactivated user's existing session is invalidated within the
- *     re-validation window (5 minutes) — verified immediately via the
- *     jwt callback returning null on the next request after deactivation
+ * Covers:
+ *   - Deactivated-user login (pre-existing)
+ *   - Auth redirect consistency (#386): sign-out always lands on /login;
+ *     /error always redirects to /login; dead-end callbackUrls are rejected
  *
- * Capability: iam-user-management, iam-sso-authentication
+ * Capability: iam-user-management, iam-sso-authentication, iam-local-authentication
  * Persona: CMS Administrator
  */
 
@@ -122,5 +121,50 @@ test.describe('deactivated user cannot log in', () => {
     await expect(userPage).toHaveURL(/\/login/, { timeout: 10_000 })
 
     await userCtx.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth redirect consistency (#386)
+// ---------------------------------------------------------------------------
+
+test.describe('sign-out redirects to /login', () => {
+  test('sign-out from admin area lands on /login', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: 'tests/e2e/.auth/admin.json' })
+    const page = await ctx.newPage()
+    await page.goto('/dashboard')
+    await page.getByRole('button', { name: 'Sign out' }).click()
+    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 })
+    await ctx.close()
+  })
+})
+
+test.describe('/error page redirects to /login', () => {
+  test('/error without query string redirects to /login', async ({ page }) => {
+    await page.goto('/error')
+    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 })
+  })
+
+  test('/error?error=AccessDenied redirects to /login and preserves error code', async ({ page }) => {
+    await page.goto('/error?error=AccessDenied')
+    await expect(page).toHaveURL(/\/login\?error=AccessDenied/, { timeout: 10_000 })
+  })
+})
+
+test.describe('callbackUrl loop prevention', () => {
+  test('/login?callbackUrl=/login redirects to /dashboard after sign-in', async ({ page }) => {
+    await page.goto('/login?callbackUrl=%2Flogin')
+    await page.getByLabel('Email').fill('alice@govea.dev')
+    await page.getByLabel('Password').fill('dev-password')
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+  })
+
+  test('/login?callbackUrl=/error redirects to /dashboard after sign-in', async ({ page }) => {
+    await page.goto('/login?callbackUrl=%2Ferror')
+    await page.getByLabel('Email').fill('alice@govea.dev')
+    await page.getByLabel('Password').fill('dev-password')
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
   })
 })

--- a/apps/govea/tests/unit/auth-redirect.test.ts
+++ b/apps/govea/tests/unit/auth-redirect.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for auth redirect utilities (#386)
+ *
+ * safeCallbackUrl — prevents callbackUrl values from trapping users in
+ * auth/error route loops after a successful login.
+ *
+ * Capability: iam-sso-authentication, iam-local-authentication
+ */
+
+import { describe, it, expect } from 'vitest'
+import { safeCallbackUrl } from '@/lib/auth-redirect'
+
+describe('safeCallbackUrl', () => {
+  describe('valid destinations — returned as-is', () => {
+    it('accepts a normal app route', () => {
+      expect(safeCallbackUrl('/dashboard')).toBe('/dashboard')
+    })
+
+    it('accepts a deep app route', () => {
+      expect(safeCallbackUrl('/capabilities/abc-123')).toBe('/capabilities/abc-123')
+    })
+
+    it('accepts a route with query string', () => {
+      expect(safeCallbackUrl('/capabilities?status=published')).toBe('/capabilities?status=published')
+    })
+  })
+
+  describe('empty / null input — falls back to /dashboard', () => {
+    it('returns fallback for null', () => {
+      expect(safeCallbackUrl(null)).toBe('/dashboard')
+    })
+
+    it('returns fallback for undefined', () => {
+      expect(safeCallbackUrl(undefined)).toBe('/dashboard')
+    })
+
+    it('returns fallback for empty string', () => {
+      expect(safeCallbackUrl('')).toBe('/dashboard')
+    })
+  })
+
+  describe('auth dead-end routes — redirected to fallback', () => {
+    it('rejects /login', () => {
+      expect(safeCallbackUrl('/login')).toBe('/dashboard')
+    })
+
+    it('rejects /login with query string', () => {
+      expect(safeCallbackUrl('/login?error=AccessDenied')).toBe('/dashboard')
+    })
+
+    it('rejects /error', () => {
+      expect(safeCallbackUrl('/error')).toBe('/dashboard')
+    })
+
+    it('rejects /error with query string', () => {
+      expect(safeCallbackUrl('/error?error=AccessDenied')).toBe('/dashboard')
+    })
+
+    it('rejects /api/auth and sub-paths', () => {
+      expect(safeCallbackUrl('/api/auth/signin')).toBe('/dashboard')
+    })
+
+    it('rejects /api/auth/error', () => {
+      expect(safeCallbackUrl('/api/auth/error')).toBe('/dashboard')
+    })
+  })
+
+  describe('external URLs — rejected', () => {
+    it('rejects https external URL', () => {
+      expect(safeCallbackUrl('https://evil.example.com/phish')).toBe('/dashboard')
+    })
+
+    it('rejects protocol-relative URL', () => {
+      expect(safeCallbackUrl('//evil.example.com')).toBe('/dashboard')
+    })
+  })
+
+  describe('custom fallback', () => {
+    it('uses the supplied fallback when provided', () => {
+      expect(safeCallbackUrl(null, '/home')).toBe('/home')
+    })
+
+    it('uses the supplied fallback for dead-end routes', () => {
+      expect(safeCallbackUrl('/login', '/home')).toBe('/home')
+    })
+  })
+})


### PR DESCRIPTION
Closes #386

## Summary

Three gaps in auth redirect consistency, all closed in this PR:

- **`/error` was a dead-end** — NextAuth sends auth failures (corrupt JWT, SSO not provisioned, `AccessDenied`) to `/error?error=…`. That page had no path back to login. It now immediately redirects to `/login`, preserving the error code so the login page can show a message (already handled by the existing `params.error` branch).

- **`callbackUrl` could loop** — the login page used `params.callbackUrl` directly as `redirectTo`. If NextAuth set `callbackUrl=/login` or `callbackUrl=/error`, the user would bounce straight back after a successful sign-in. New `safeCallbackUrl()` in `lib/auth-redirect.ts` rejects `/login`, `/error`, `/api/auth`, external URLs, and protocol-relative URLs — all fall back to `/dashboard`.

- **Missing tests** — added 16 unit tests for `safeCallbackUrl` (all cases: valid routes, null/undefined, dead-end paths, external/protocol-relative URLs) and e2e tests for sign-out → `/login`, `/error` redirect behaviour, and callbackUrl loop prevention.

## Test plan

- [ ] Sign out from `/dashboard` — lands cleanly on `/login`
- [ ] Visit `/error` — immediately redirected to `/login`
- [ ] Visit `/error?error=AccessDenied` — redirected to `/login?error=AccessDenied`; login page shows "Authentication failed."
- [ ] Visit `/login?callbackUrl=%2Flogin` and sign in — lands on `/dashboard`, not `/login`
- [ ] Visit `/login?callbackUrl=%2Ferror` and sign in — lands on `/dashboard`, not `/error`
- [ ] `pnpm --filter govea test:integration` — 262 tests pass (15 files, +16 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)