### PR TITLE
feat(platform): extend taxonomy foundation to objectives, initiatives, ADRs, and principles

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -2,9 +2,10 @@
 
 import { db } from '@/db/client'
 import {
-  adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
+  adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives, entityTaxonomyValues,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -76,7 +77,12 @@ export async function getADR(id: string) {
   if (!visible) return null
   // Viewer status gate — enforced in the action so all callers inherit the rule (#208)
   if (session.user.role === 'viewer' && adr.status !== VIEWER_ADR_STATUS) return null
-  return adr
+
+  const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    getEntityTaxonomyValues(adr.organizationId, 'adr', id),
+    getEntityTaxonomyDefinitions(adr.organizationId, 'adr'),
+  ])
+  return { ...adr, taxonomyValues, taxonomyDefinitions }
 }
 
 export async function createADR(formData: FormData) {
@@ -112,6 +118,9 @@ export async function createADR(formData: FormData) {
   }).returning()
 
   await insertJunctions(adr.id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
+
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'adr', adr.id, taxonomyTermIds)
 
   await writeAuditLog({
     action: 'adr.create',
@@ -163,6 +172,9 @@ export async function editADR(id: string, formData: FormData) {
   await db.delete(adrObjectives).where(eq(adrObjectives.adrId, id))
   await insertJunctions(id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
 
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'adr', id, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'adr.edit',
     entityType: 'adr',
@@ -180,6 +192,10 @@ export async function deleteADR(id: string) {
 
   const before = await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(eq(entityTaxonomyValues.entityType, 'adr'), eq(entityTaxonomyValues.entityId, id))
+  )
 
   await db.delete(adrs).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
 

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -2,9 +2,10 @@
 
 import { db } from '@/db/client'
 import {
-  initiatives, initiativeCapabilities, initiativeObjectives,
+  initiatives, initiativeCapabilities, initiativeObjectives, entityTaxonomyValues,
 } from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, and } from 'drizzle-orm'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
@@ -69,7 +70,12 @@ export async function getInitiative(id: string) {
   if (!visible) return null
   // Viewer status gate — enforced in the action so all callers inherit the rule (#208)
   if (session.user.role === 'viewer' && !VIEWER_INITIATIVE_STATUSES.includes(initiative.status)) return null
-  return initiative
+
+  const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    getEntityTaxonomyValues(initiative.organizationId, 'initiative', id),
+    getEntityTaxonomyDefinitions(initiative.organizationId, 'initiative'),
+  ])
+  return { ...initiative, taxonomyValues, taxonomyDefinitions }
 }
 
 export async function createInitiative(formData: FormData) {
@@ -101,6 +107,9 @@ export async function createInitiative(formData: FormData) {
       .values(objectiveIds.map(objectiveId => ({ initiativeId: row.id, objectiveId })))
       .onConflictDoNothing()
   }
+
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'initiative', row.id, taxonomyTermIds)
 
   await writeAuditLog({
     action: 'initiative.create',
@@ -151,6 +160,9 @@ export async function editInitiative(id: string, formData: FormData) {
       .onConflictDoNothing()
   }
 
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'initiative', id, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'initiative.edit',
     entityType: 'initiative',
@@ -168,6 +180,10 @@ export async function deleteInitiative(id: string) {
 
   const before = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(eq(entityTaxonomyValues.entityType, 'initiative'), eq(entityTaxonomyValues.entityId, id))
+  )
 
   await db.delete(initiatives).where(eq(initiatives.id, id))
 

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { db } from '@/db/client'
-import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from '@/db/schema'
+import { strategicObjectives, objectiveCapabilities, objectiveValueStreams, entityTaxonomyValues } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -68,7 +69,12 @@ export async function getObjective(id: string) {
   const visible = await canReadFederatedEntity(objective.organizationId, objective.visibility, session.user.organizationId!)
   if (!visible) return null
   if (session.user.role === 'viewer' && objective.status !== 'published') return null
-  return objective
+
+  const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    getEntityTaxonomyValues(objective.organizationId, 'objective', id),
+    getEntityTaxonomyDefinitions(objective.organizationId, 'objective'),
+  ])
+  return { ...objective, taxonomyValues, taxonomyDefinitions }
 }
 
 export async function createObjective(formData: FormData) {
@@ -101,6 +107,9 @@ export async function createObjective(formData: FormData) {
       valueStreamIds.map(vId => ({ objectiveId: obj.id, valueStreamId: vId }))
     )
   }
+
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'objective', obj.id, taxonomyTermIds)
 
   await writeAuditLog({
     action: 'objective.create', entityType: 'objective', entityId: obj.id,
@@ -145,6 +154,9 @@ export async function editObjective(objectiveId: string, formData: FormData) {
     )
   }
 
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'objective', objectiveId, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'objective.edit', entityType: 'objective', entityId: objectiveId,
     userId: session.user.id, organizationId: orgId,
@@ -161,6 +173,10 @@ export async function deleteObjective(objectiveId: string) {
     where: eq(strategicObjectives.id, objectiveId),
   })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(eq(entityTaxonomyValues.entityType, 'objective'), eq(entityTaxonomyValues.entityId, objectiveId))
+  )
 
   await db.delete(strategicObjectives).where(
     and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId))

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { db } from '@/db/client'
-import { principles, principleAdrs, principleCapabilities } from '@/db/schema'
+import { principles, principleAdrs, principleCapabilities, entityTaxonomyValues } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -70,7 +71,12 @@ export async function getPrinciple(id: string) {
   const visible = await canReadFederatedEntity(principle.organizationId, principle.visibility, session.user.organizationId!)
   if (!visible) return null
   if (session.user.role === 'viewer' && principle.status !== 'published') return null
-  return principle
+
+  const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
+    getEntityTaxonomyValues(principle.organizationId, 'principle', id),
+    getEntityTaxonomyDefinitions(principle.organizationId, 'principle'),
+  ])
+  return { ...principle, taxonomyValues, taxonomyDefinitions }
 }
 
 export async function createPrinciple(formData: FormData) {
@@ -96,6 +102,9 @@ export async function createPrinciple(formData: FormData) {
   }).returning()
 
   await insertJunctions(principle.id, adrIds, capabilityIds)
+
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'principle', principle.id, taxonomyTermIds)
 
   await writeAuditLog({
     action: 'principle.create',
@@ -135,6 +144,9 @@ export async function editPrinciple(principleId: string, formData: FormData) {
   await db.delete(principleCapabilities).where(eq(principleCapabilities.principleId, principleId))
   await insertJunctions(principleId, adrIds, capabilityIds)
 
+  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+  await syncEntityTaxonomyValues(orgId, 'principle', principleId, taxonomyTermIds)
+
   await writeAuditLog({
     action: 'principle.edit',
     entityType: 'principle',
@@ -152,6 +164,10 @@ export async function deletePrinciple(principleId: string) {
 
   const before = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
   assertOwnership(before?.organizationId, orgId)
+
+  await db.delete(entityTaxonomyValues).where(
+    and(eq(entityTaxonomyValues.entityType, 'principle'), eq(entityTaxonomyValues.entityId, principleId))
+  )
 
   await db.delete(principles).where(
     and(eq(principles.id, principleId), eq(principles.organizationId, orgId))

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { MarkdownContent } from '@/components/markdown-content'
+import { TaxonomyChips } from '@/components/taxonomy-ui'
 
 const STATUS_STYLES: Record<string, string> = {
   proposed: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -106,6 +107,11 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
             </Link>
           </div>
         )}
+
+        <TaxonomyChips
+          definitions={adr.taxonomyDefinitions}
+          selectedTermIds={adr.taxonomyValues.map(v => v.taxonomyTermId)}
+        />
       </div>
 
       <hr />

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -17,6 +17,8 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import type { EntityTaxonomyValue } from '@/db/schema'
 
 type ADRRow = ADR & {
   organization: { id: string; name: string } | null
@@ -35,6 +37,8 @@ interface Props {
   objectives: Pick<StrategicObjective, 'id' | 'name'>[]
   role: Role
   currentOrgId: string
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -63,10 +67,11 @@ const VISIBILITY_LABELS: Record<string, string> = {
   instance: 'Instance-wide',
 }
 
-export function ADRTable({ adrs, capabilities, applications, initiatives, objectives, role, currentOrgId }: Props) {
+export function ADRTable({ adrs, capabilities, applications, initiatives, objectives, role, currentOrgId, taxonomyDefinitions, taxonomyValueMap }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ADRRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ADRRow | null>(null)
@@ -75,7 +80,15 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
 
-  const filtered = adrs.filter(a => statusFilter === 'all' || a.status === statusFilter)
+  const hasTaxonomyFilter = Object.values(taxonomyFilters).some(v => v !== 'all')
+
+  const filtered = adrs.filter(a => {
+    const matchStatus = statusFilter === 'all' || a.status === statusFilter
+    const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) =>
+      termId === 'all' || (taxonomyValueMap[a.id] ?? []).some(v => v.taxonomyTermId === termId)
+    )
+    return matchStatus && matchTaxonomy
+  })
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
@@ -121,6 +134,11 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
             <option value="superseded">Superseded</option>
           </select>
         )}
+        <TaxonomyFilters
+          defs={taxonomyDefinitions}
+          filters={taxonomyFilters}
+          onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
+        />
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
             + New Architecture Decision Record
@@ -249,6 +267,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
               selectedInitiativeIds={[]}
               selectedObjectiveIds={[]}
             />
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <StatusVisibilitySupersededFields
               adrs={adrs}
               currentId={null}
@@ -289,6 +308,10 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
               selectedApplicationIds={editTarget?.adrApplications.map(aa => aa.application.id) ?? []}
               selectedInitiativeIds={editTarget?.adrInitiatives.map(ai => ai.initiative.id) ?? []}
               selectedObjectiveIds={editTarget?.adrObjectives.map(ao => ao.objective.id) ?? []}
+            />
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
             />
             <StatusVisibilitySupersededFields
               adrs={adrs}

--- a/apps/govea/src/app/(admin)/adrs/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/page.tsx
@@ -5,6 +5,7 @@ import { getCapabilities } from '@/actions/capabilities'
 import { getApplications } from '@/actions/applications'
 import { getInitiatives } from '@/actions/initiatives'
 import { getObjectives } from '@/actions/objectives'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { ADRTable } from './adr-table'
 
 export default async function ADRsPage() {
@@ -14,13 +15,19 @@ export default async function ADRsPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [adrList, capabilityList, applicationList, initiativeList, objectiveList] = await Promise.all([
+  const [adrList, capabilityList, applicationList, initiativeList, objectiveList, taxonomyDefinitions] = await Promise.all([
     getADRs(orgId, role),
     getCapabilities(orgId),
     getApplications(orgId),
     getInitiatives(orgId),
     getObjectives(orgId),
+    getEntityTaxonomyDefinitions(orgId, 'adr'),
   ])
+
+  const adrIds = adrList.map(a => a.id)
+  const taxonomyValueMap = adrIds.length > 0
+    ? await getEntityTaxonomyValuesForMany(orgId, 'adr', adrIds)
+    : {}
 
   return (
     <div className="space-y-6">
@@ -38,6 +45,8 @@ export default async function ADRsPage() {
         objectives={objectiveList}
         role={role}
         currentOrgId={orgId}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
       />
     </div>
   )

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { MarkdownContent } from '@/components/markdown-content'
+import { TaxonomyChips } from '@/components/taxonomy-ui'
 
 const STATUS_STYLES: Record<string, string> = {
   proposed: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -117,6 +118,11 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
         {initiative.description && (
           <MarkdownContent>{initiative.description}</MarkdownContent>
         )}
+
+        <TaxonomyChips
+          definitions={initiative.taxonomyDefinitions}
+          selectedTermIds={initiative.taxonomyValues.map(v => v.taxonomyTermId)}
+        />
 
         {(initiative.startDate || initiative.endDate) && (
           <div className="flex items-center gap-2 text-sm">

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -17,6 +17,8 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import type { EntityTaxonomyValue } from '@/db/schema'
 
 type InitiativeRow = Initiative & {
   organization: { id: string; name: string } | null
@@ -30,6 +32,8 @@ interface Props {
   objectives: StrategicObjective[]
   role: Role
   currentOrgId: string
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -50,11 +54,12 @@ const STATUS_LABELS: Record<string, string> = {
 
 const IMPACT_OPTIONS = ['build', 'improve', 'retire']
 
-export function InitiativeTable({ initiatives, capabilities, objectives, role, currentOrgId }: Props) {
+export function InitiativeTable({ initiatives, capabilities, objectives, role, currentOrgId, taxonomyDefinitions, taxonomyValueMap }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
 
   const orgOptions = Array.from(new Map(
     initiatives.map(i => [i.organizationId, i.organization?.name ?? 'Unknown'])
@@ -69,10 +74,15 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
 
+  const hasTaxonomyFilter = Object.values(taxonomyFilters).some(v => v !== 'all')
+
   const filtered = initiatives.filter(i => {
     const matchStatus = statusFilter === 'all' || i.status === statusFilter
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? i.organizationId === currentOrgId : i.organizationId === orgFilter)
-    return matchStatus && matchOrg
+    const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) =>
+      termId === 'all' || (taxonomyValueMap[i.id] ?? []).some(v => v.taxonomyTermId === termId)
+    )
+    return matchStatus && matchOrg && matchTaxonomy
   })
 
   function openCreate() {
@@ -141,6 +151,11 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
             ))}
           </select>
         )}
+        <TaxonomyFilters
+          defs={taxonomyDefinitions}
+          filters={taxonomyFilters}
+          onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
+        />
         {canEdit && (
           <Button onClick={openCreate} size="sm" className="ml-auto">
             + New Initiative
@@ -273,6 +288,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
                 </div>
               </div>
             )}
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <StatusAndVisibilityFields defaultStatus="proposed" />
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => { setCreateOpen(false); setSelectedCaps([]) }}>Cancel</Button>
@@ -315,6 +331,10 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
                 </div>
               </div>
             )}
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
+            />
             <StatusAndVisibilityFields defaultStatus={editTarget?.status ?? 'proposed'} defaultVisibility={editTarget?.visibility ?? 'org'} />
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => { setEditTarget(null); setSelectedCaps([]) }}>Cancel</Button>

--- a/apps/govea/src/app/(admin)/initiatives/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { getInitiatives } from '@/actions/initiatives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getObjectives } from '@/actions/objectives'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { InitiativeTable } from './initiative-table'
 export default async function InitiativesPage() {
   const session = await auth()
@@ -11,11 +12,17 @@ export default async function InitiativesPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [initiativeList, capabilityList, objectiveList] = await Promise.all([
+  const [initiativeList, capabilityList, objectiveList, taxonomyDefinitions] = await Promise.all([
     getInitiatives(orgId, role),
     getCapabilities(orgId),
     getObjectives(orgId),
+    getEntityTaxonomyDefinitions(orgId, 'initiative'),
   ])
+
+  const initiativeIds = initiativeList.map(i => i.id)
+  const taxonomyValueMap = initiativeIds.length > 0
+    ? await getEntityTaxonomyValuesForMany(orgId, 'initiative', initiativeIds)
+    : {}
 
   return (
     <div className="space-y-6">
@@ -31,6 +38,8 @@ export default async function InitiativesPage() {
         objectives={objectiveList}
         role={role}
         currentOrgId={orgId}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
       />
     </div>
   )

--- a/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/[id]/page.tsx
@@ -16,6 +16,7 @@ import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { dedupeById } from '@/lib/dedup'
 import { MarkdownContent } from '@/components/markdown-content'
+import { TaxonomyChips } from '@/components/taxonomy-ui'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -104,6 +105,11 @@ export default async function ObjectiveDetailPage({ params }: { params: Promise<
         {objective.description && (
           <MarkdownContent>{objective.description}</MarkdownContent>
         )}
+
+        <TaxonomyChips
+          definitions={objective.taxonomyDefinitions}
+          selectedTermIds={objective.taxonomyValues.map(v => v.taxonomyTermId)}
+        />
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
           {objective.successMetric && (

--- a/apps/govea/src/app/(admin)/objectives/objective-table.tsx
+++ b/apps/govea/src/app/(admin)/objectives/objective-table.tsx
@@ -17,6 +17,8 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import type { EntityTaxonomyValue } from '@/db/schema'
 
 type ObjectiveRow = StrategicObjective & {
   organization: { id: string; name: string } | null
@@ -31,6 +33,8 @@ interface Props {
   valueStreams: ValueStream[]
   role: Role
   currentOrgId: string
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -39,11 +43,12 @@ const STATUS_STYLES: Record<string, string> = {
   archived: 'bg-amber-100 text-amber-800 border-amber-200',
 }
 
-export function ObjectiveTable({ objectives, capabilities, valueStreams, role, currentOrgId }: Props) {
+export function ObjectiveTable({ objectives, capabilities, valueStreams, role, currentOrgId, taxonomyDefinitions, taxonomyValueMap }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
 
   const orgOptions = Array.from(new Map(
     objectives.map(o => [o.organizationId, o.organization?.name ?? 'Unknown'])
@@ -56,10 +61,15 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
 
+  const hasTaxonomyFilter = Object.values(taxonomyFilters).some(v => v !== 'all')
+
   const filtered = objectives.filter(o => {
     const matchStatus = statusFilter === 'all' || o.status === statusFilter
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? o.organizationId === currentOrgId : o.organizationId === orgFilter)
-    return matchStatus && matchOrg
+    const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) =>
+      termId === 'all' || (taxonomyValueMap[o.id] ?? []).some(v => v.taxonomyTermId === termId)
+    )
+    return matchStatus && matchOrg && matchTaxonomy
   })
 
   async function handleCreate(formData: FormData) {
@@ -111,6 +121,11 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
             ))}
           </select>
         )}
+        <TaxonomyFilters
+          defs={taxonomyDefinitions}
+          filters={taxonomyFilters}
+          onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
+        />
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
             + New objective
@@ -248,6 +263,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
                 </div>
               </div>
             )}
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <div className="space-y-1.5">
               <Label>Status</Label>
               <select name="status" defaultValue="draft"
@@ -312,6 +328,10 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
                 </div>
               </div>
             )}
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
+            />
             <div className="space-y-1.5">
               <Label>Status</Label>
               <select name="status" defaultValue={editTarget?.status}

--- a/apps/govea/src/app/(admin)/objectives/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { ObjectiveTable } from './objective-table'
 export default async function ObjectivesPage() {
   const session = await auth()
@@ -11,11 +12,17 @@ export default async function ObjectivesPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [objectiveList, capabilityList, valueStreamList] = await Promise.all([
+  const [objectiveList, capabilityList, valueStreamList, taxonomyDefinitions] = await Promise.all([
     getObjectives(orgId, role),
     getCapabilities(orgId, role),
     getValueStreams(orgId, role),
+    getEntityTaxonomyDefinitions(orgId, 'objective'),
   ])
+
+  const objectiveIds = objectiveList.map(o => o.id)
+  const taxonomyValueMap = objectiveIds.length > 0
+    ? await getEntityTaxonomyValuesForMany(orgId, 'objective', objectiveIds)
+    : {}
 
   return (
     <div className="space-y-6">
@@ -31,6 +38,8 @@ export default async function ObjectivesPage() {
         valueStreams={valueStreamList}
         role={role}
         currentOrgId={orgId}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
       />
     </div>
   )

--- a/apps/govea/src/app/(admin)/principles/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/[id]/page.tsx
@@ -16,6 +16,7 @@ import { isModuleEnabled } from '@/lib/modules'
 import { getPrincipleTypes } from '@/actions/taxonomy'
 import { MarkdownContent } from '@/components/markdown-content'
 import { PrincipleEditButton } from '@/components/principle-edit-button'
+import { TaxonomyChips } from '@/components/taxonomy-ui'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -105,6 +106,11 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
             </span>
           </div>
         </div>
+
+        <TaxonomyChips
+          definitions={principle.taxonomyDefinitions}
+          selectedTermIds={principle.taxonomyValues.map(v => v.taxonomyTermId)}
+        />
       </div>
 
       {canMutate && (
@@ -121,6 +127,8 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
             visibility: principle.visibility,
           }}
           principleTypes={principleTypes}
+          taxonomyDefinitions={principle.taxonomyDefinitions}
+          currentTaxonomyValues={principle.taxonomyValues}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/principles/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { getPrinciples } from '@/actions/principles'
 import { getADRs } from '@/actions/adrs'
 import { getCapabilities } from '@/actions/capabilities'
-import { getPrincipleTypes } from '@/actions/taxonomy'
+import { getPrincipleTypes, getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
 import { PrincipleTable } from './principle-table'
 
 export default async function PrinciplesPage() {
@@ -13,12 +13,18 @@ export default async function PrinciplesPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [principleList, adrList, capabilityList, principleTypes] = await Promise.all([
+  const [principleList, adrList, capabilityList, principleTypes, taxonomyDefinitions] = await Promise.all([
     getPrinciples(orgId, role),
     getADRs(orgId, role),
     getCapabilities(orgId, role),
     getPrincipleTypes(orgId),
+    getEntityTaxonomyDefinitions(orgId, 'principle'),
   ])
+
+  const principleIds = principleList.map(p => p.id)
+  const taxonomyValueMap = principleIds.length > 0
+    ? await getEntityTaxonomyValuesForMany(orgId, 'principle', principleIds)
+    : {}
 
   return (
     <div className="space-y-6">
@@ -35,6 +41,8 @@ export default async function PrinciplesPage() {
         principleTypes={principleTypes}
         role={role}
         currentOrgId={orgId}
+        taxonomyDefinitions={taxonomyDefinitions}
+        taxonomyValueMap={taxonomyValueMap}
       />
     </div>
   )

--- a/apps/govea/src/app/(admin)/principles/principle-table.tsx
+++ b/apps/govea/src/app/(admin)/principles/principle-table.tsx
@@ -16,8 +16,9 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
-import type { TaxonomyTerm } from '@/db/schema'
+import type { TaxonomyTerm, EntityTaxonomyValue } from '@/db/schema'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 
 type PrincipleRow = Principle & {
   organization: { id: string; name: string } | null
@@ -32,6 +33,8 @@ interface Props {
   principleTypes: Pick<TaxonomyTerm, 'id' | 'name' | 'slug'>[]
   role: Role
   currentOrgId: string
+  taxonomyDefinitions: EnrichedTaxonomyDefinition[]
+  taxonomyValueMap: Record<string, EntityTaxonomyValue[]>
 }
 
 // Stable colour palette — cycles through when more than 2 types exist
@@ -69,11 +72,12 @@ const VISIBILITY_LABELS: Record<string, string> = {
   instance: 'Instance-wide',
 }
 
-export function PrincipleTable({ principles, adrs, capabilities, principleTypes, role, currentOrgId }: Props) {
+export function PrincipleTable({ principles, adrs, capabilities, principleTypes, role, currentOrgId, taxonomyDefinitions, taxonomyValueMap }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
   const [typeFilter, setTypeFilter] = useState('all')
+  const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<PrincipleRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<PrincipleRow | null>(null)
@@ -82,10 +86,16 @@ export function PrincipleTable({ principles, adrs, capabilities, principleTypes,
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
 
-  const filtered = principles.filter(p =>
-    (statusFilter === 'all' || p.status === statusFilter) &&
-    (typeFilter === 'all' || p.principleType === typeFilter)
-  )
+  const hasTaxonomyFilter = Object.values(taxonomyFilters).some(v => v !== 'all')
+
+  const filtered = principles.filter(p => {
+    const matchStatus = statusFilter === 'all' || p.status === statusFilter
+    const matchType = typeFilter === 'all' || p.principleType === typeFilter
+    const matchTaxonomy = Object.entries(taxonomyFilters).every(([, termId]) =>
+      termId === 'all' || (taxonomyValueMap[p.id] ?? []).some(v => v.taxonomyTermId === termId)
+    )
+    return matchStatus && matchType && matchTaxonomy
+  })
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
@@ -149,6 +159,11 @@ export function PrincipleTable({ principles, adrs, capabilities, principleTypes,
           <option value="published">Published</option>
           <option value="archived">Archived</option>
         </select>
+        <TaxonomyFilters
+          defs={taxonomyDefinitions}
+          filters={taxonomyFilters}
+          onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
+        />
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
             + New Principle
@@ -290,6 +305,7 @@ export function PrincipleTable({ principles, adrs, capabilities, principleTypes,
               selectedAdrIds={[]}
               selectedCapabilityIds={[]}
             />
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <PrincipleTypeField defaultType="architecture" types={principleTypes} />
             <StatusVisibilityFields defaultStatus="draft" defaultVisibility="org" />
             <DialogFooter>
@@ -317,6 +333,10 @@ export function PrincipleTable({ principles, adrs, capabilities, principleTypes,
               capabilities={capabilities}
               selectedAdrIds={editTarget?.principleAdrs.map(pa => pa.adr.id) ?? []}
               selectedCapabilityIds={editTarget?.principleCapabilities.map(pc => pc.capability.id) ?? []}
+            />
+            <TaxonomyInputs
+              defs={taxonomyDefinitions}
+              currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}
             />
             <PrincipleTypeField defaultType={editTarget?.principleType ?? 'architecture'} types={principleTypes} />
             <StatusVisibilityFields

--- a/apps/govea/src/components/principle-edit-button.tsx
+++ b/apps/govea/src/components/principle-edit-button.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import type { EntityTaxonomyValue } from '@/db/schema'
 
 interface PrincipleType {
   id: string
@@ -27,9 +29,11 @@ interface PrincipleEditButtonProps {
     visibility: 'org' | 'connections' | 'instance'
   }
   principleTypes: PrincipleType[]
+  taxonomyDefinitions?: EnrichedTaxonomyDefinition[]
+  currentTaxonomyValues?: EntityTaxonomyValue[]
 }
 
-export function PrincipleEditButton({ principleId, initial, principleTypes }: PrincipleEditButtonProps) {
+export function PrincipleEditButton({ principleId, initial, principleTypes, taxonomyDefinitions = [], currentTaxonomyValues = [] }: PrincipleEditButtonProps) {
   const [editing, setEditing] = useState(false)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
@@ -103,6 +107,12 @@ export function PrincipleEditButton({ principleId, initial, principleTypes }: Pr
                 <option key={t.id} value={t.slug}>{t.name}</option>
               ))}
             </select>
+          </div>
+        )}
+
+        {taxonomyDefinitions.length > 0 && (
+          <div className="sm:col-span-2">
+            <TaxonomyInputs defs={taxonomyDefinitions} currentValues={currentTaxonomyValues} />
           </div>
         )}
 

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -766,6 +766,150 @@ async function seed() {
   }).onConflictDoNothing()
   console.log('  ✓ Capability Priority taxonomy type + entity definition')
 
+  // Objective Category taxonomy + entity definition
+  let objCategoryTermId: string
+  const existingObjCategory = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'objective-category')),
+  })
+  if (existingObjCategory) {
+    objCategoryTermId = existingObjCategory.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Objective Category',
+      slug: 'objective-category',
+      description: 'Classification of strategic objectives by organisational scope.',
+      sortOrder: '70',
+    }).returning()
+    objCategoryTermId = inserted.id
+  }
+  for (const name of ['Strategic', 'Operational', 'Tactical']) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, objCategoryTermId), e(t.slug, slug)),
+    })
+    if (!existing) await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: objCategoryTermId, name, slug })
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'objective',
+    taxonomyTypeId: objCategoryTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Objective Category taxonomy type + entity definition')
+
+  // Initiative Type taxonomy + entity definition
+  let initiativeTypeTermId: string
+  const existingInitiativeType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'initiative-type')),
+  })
+  if (existingInitiativeType) {
+    initiativeTypeTermId = existingInitiativeType.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Initiative Type',
+      slug: 'initiative-type',
+      description: 'Nature of the work being undertaken by the initiative.',
+      sortOrder: '80',
+    }).returning()
+    initiativeTypeTermId = inserted.id
+  }
+  for (const name of ['Transformation', 'Compliance', 'Maintenance', 'Innovation']) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, initiativeTypeTermId), e(t.slug, slug)),
+    })
+    if (!existing) await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: initiativeTypeTermId, name, slug })
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'initiative',
+    taxonomyTypeId: initiativeTypeTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Initiative Type taxonomy type + entity definition')
+
+  // Decision Category taxonomy + entity definition (for ADRs)
+  let decisionCategoryTermId: string
+  const existingDecisionCategory = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'decision-category')),
+  })
+  if (existingDecisionCategory) {
+    decisionCategoryTermId = existingDecisionCategory.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Decision Category',
+      slug: 'decision-category',
+      description: 'Domain of the architecture decision record.',
+      sortOrder: '90',
+    }).returning()
+    decisionCategoryTermId = inserted.id
+  }
+  for (const name of ['Technology', 'Architecture', 'Process', 'Security', 'Data']) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, decisionCategoryTermId), e(t.slug, slug)),
+    })
+    if (!existing) await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: decisionCategoryTermId, name, slug })
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'adr',
+    taxonomyTypeId: decisionCategoryTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Decision Category taxonomy type + entity definition (ADR)')
+
+  // Principle Scope taxonomy + entity definition
+  let principleScopeTermId: string
+  const existingPrincipleScope = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'principle-scope')),
+  })
+  if (existingPrincipleScope) {
+    principleScopeTermId = existingPrincipleScope.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Principle Scope',
+      slug: 'principle-scope',
+      description: 'How broadly this principle applies within the organisation.',
+      sortOrder: '100',
+    }).returning()
+    principleScopeTermId = inserted.id
+  }
+  for (const name of ['Enterprise', 'Domain', 'Team']) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, principleScopeTermId), e(t.slug, slug)),
+    })
+    if (!existing) await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: principleScopeTermId, name, slug })
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'principle',
+    taxonomyTypeId: principleScopeTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 0,
+  }).onConflictDoNothing()
+  console.log('  ✓ Principle Scope taxonomy type + entity definition')
+
   // ── Org 2: Office of Digital Services (state agency) ────────────────────
 
   console.log('\n[Org 2] Office of Digital Services')


### PR DESCRIPTION
Closes #383 (rollout phase — pilots already closed by #393)

## Summary

Completes the taxonomy foundation rollout across all primary EA entity types. With this PR, every entity in the core portfolio layer supports admin-configurable taxonomy classification:

| Entity | Taxonomy type added | Selection |
|---|---|---|
| Objectives | Objective Category (Strategic / Operational / Tactical) | Single |
| Initiatives | Initiative Type (Transformation / Compliance / Maintenance / Innovation) | Single |
| ADRs | Decision Category (Technology / Architecture / Process / Security / Data) | Single |
| Principles | Principle Scope (Enterprise / Domain / Team) | Single |

(Applications, services, and capabilities were wired in earlier PRs.)

## What changed per entity

Each entity received the same consistent wiring:

- **Actions**: `syncEntityTaxonomyValues` on create/edit; `entityTaxonomyValues` cleanup on delete; `taxonomyValues` + `taxonomyDefinitions` fetched in parallel in the detail getter
- **List page**: `getEntityTaxonomyDefinitions` + `getEntityTaxonomyValuesForMany` batch-fetched, forwarded to the table component
- **List table**: `TaxonomyFilters` in toolbar; `TaxonomyInputs` in create and edit dialogs; taxonomy match predicate added to filtered rows
- **Detail page**: `TaxonomyChips` renders selected values next to status badges
- **Principles only**: `PrincipleEditButton` also updated to include `TaxonomyInputs` — kept orthogonal to the existing `principleType` enum field

All seed taxonomy types use `findFirst` guards so re-seeding is idempotent.

## Test plan

- [ ] Open `/objectives` — "All Objective Category" filter appears in toolbar; filter by Strategic/Operational/Tactical narrows the list
- [ ] Create an objective with Category = Strategic — chip appears on its detail page
- [ ] Open `/initiatives` — "All Initiative Type" filter works; set type on create + edit
- [ ] Open `/adrs` — "All Decision Category" filter works; ADR detail shows chip
- [ ] Open `/principles` — "All Principle Scope" filter works; inline edit (pencil button on detail) includes Principle Scope dropdown
- [ ] Re-run seed twice — no duplicate taxonomy terms inserted
- [ ] `pnpm exec vitest run` — 262/262 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)