### PR TITLE
[codex] Refresh planning and taxonomy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Personas -> Capabilities -> Applications
 - **Persona Type** and **Persona Tag** values are managed through **Taxonomy**, not through persona-specific admin tables.
 - **Organization** is the top-level tenant boundary.
 - **Instance Admin** is a separate instance-scoped operating role used for platform administration. It does not automatically make a user the owner or editor of every agency's EA content, and it should not absorb routine org-scoped settings like themes or module choices.
-- Additional core entities include **Architecture Decision Records (ADRs)**, **Strategic Objectives**, **Initiatives**, **Principles**, and the **Glossary**.
+- Additional core entities include **Goals**, **Architecture Decision Records (ADRs)**, **Strategic Objectives**, **Initiatives**, **Principles**, and the **Glossary**.
 - Single-org use is still the default operating mode, but GovEA now also ships a prototype multi-organization model with org-scoped visibility and approval-based cross-org links.
 
 For the implementation-level schema reference, including field metadata, enums, and junction tables, see [`docs/data-model.md`](./docs/data-model.md).
@@ -213,13 +213,15 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Application custom fields with CSV import/export so agencies can extend and load portfolio metadata without schema changes
 - Impact analysis on application and capability detail pages to surface decommission and change consequences from existing relationship data
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
-- Demo-ready planning module: strategic objectives plus initiatives with roadmap grid and executive timeline views
+- Demo-ready planning module: goals, strategic objectives, and initiatives with roadmap grid and executive timeline views
+- Goals layer above strategic objectives, with objective rollup and traceability into initiatives and capabilities
 - Reports hub with generated Architecture Vision, Executive Summary, Heatmap Analysis, and TOGAF Application Landscape outputs from existing repository content
 - Capability relationship map with both focused SVG navigation and Mermaid diagram views
 - Repository-wide search across the core content model
 - Guided product tour with role-aware coach marks for the main application areas
 - Audit trail: immutable before/after log of all changes
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
+- Shared taxonomy foundation now proven across applications and capabilities, including capability-priority classification as the second pilot
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
 - Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, audited break-glass sessions, and instance-level platform configuration
 - Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
@@ -250,7 +252,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Ship repository completeness drill-downs and a stakeholder-facing confidence summary
 - Add architecture debt tracking tied to ADRs, impact analysis, and reporting
 - Start the integration foundation with a REST API plus the first Tier 1 operational sync slice
-- Generalize shared item/taxonomy behavior beyond the current per-entity wiring
+- Extend shared item/taxonomy behavior beyond the current applications-and-capabilities pilots
 - Start lightweight user feedback capture and persona validation for the new analysis surfaces
 
 **Longer-term:**

--- a/business-architecture/capabilities/cms/planning/pl-goals.md
+++ b/business-architecture/capabilities/cms/planning/pl-goals.md
@@ -1,0 +1,32 @@
+# Capability: Goals
+
+## What It Does
+The system must allow organizations to define broad strategic goals above strategic objectives, so GovEA can distinguish long-horizon outcomes from the measurable objectives and initiatives that advance them. In the shipped product, goals are the top layer of the planning hierarchy and roll up linked objectives, initiatives, capabilities, and value streams.
+
+## Personas
+- **Enterprise Architect (Central IT)** — defines enterprise-wide strategic goals and ensures objectives align to them
+- **Agency EA Coordinator** — maintains agency-level goals and keeps linked objectives coherent
+- **Department Director** — views leadership-facing goals and how current objectives and initiatives support them; does not author
+
+## Behaviors
+- Create a goal with name, description, and status
+- Link a goal to one or more strategic objectives
+- View rolled-up initiatives and capabilities through linked objectives
+- View traceability from a goal into supporting objectives, initiatives, and architecture records
+- Filter and search goals in the strategy area
+- Share goals across federation scopes using visibility settings (`org`, `connections`, `instance`)
+
+## Rules
+- A goal must belong to an organization
+- Goals represent broad outcomes and are intentionally fewer and more stable than objectives
+- In the current shipped model, objectives are the measurable targets under a goal; initiatives continue linking to objectives rather than directly to goals
+- Goals follow the standard content workflow: draft -> published -> archived
+- Goal-to-objective linkage is the source of strategy rollup for roadmap, traceability, and related planning surfaces
+
+## Implementation Status
+- **v1:** Implemented. Goals ship as a first-class planning entity with list/detail pages, CRUD, objective linking, rolled-up traceability context, and viewer filtering.
+
+## Links
+- Depends on: Strategic Objectives, Content Workflow, Content Relationships
+- Related: Initiatives, Roadmap, Traceability Views
+- Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Programme Director

--- a/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
+++ b/business-architecture/capabilities/cms/planning/pl-strategic-objectives.md
@@ -1,7 +1,7 @@
 # Capability: Strategic Objectives
 
 ## What It Does
-The system must allow organizations to define strategic business objectives, link them to the capabilities and value streams that deliver on them, and track their status over time. This closes the gap between stated strategy and the architecture that enables it. In the shipped product, objectives are the planning artifact that most closely follows the standard governed-content model.
+The system must allow organizations to define measurable strategic objectives, link them to the capabilities and value streams that deliver on them, and track their status over time. This closes the gap between stated strategy and the architecture that enables it. In the shipped product, objectives sit under Goals in the planning hierarchy and are the planning artifact that most closely follows the standard governed-content model.
 
 ## Personas
 - **Enterprise Architect (Central IT)** — defines enterprise-level objectives and links them to enterprise capabilities
@@ -10,15 +10,18 @@ The system must allow organizations to define strategic business objectives, lin
 
 ## Behaviors
 - Create a strategic objective with name, description, success metric, time horizon, and status
+- Link a strategic objective to a goal
 - Link a strategic objective to one or more capabilities
 - Link a strategic objective to one or more value streams
 - View which capabilities and value streams support a given objective
+- View which goal a given objective advances
 - View which objectives a given capability or value stream contributes to
 - Track objective status through the standard content workflow (`draft`, `published`, `archived`)
 - Share objectives across federation scopes using visibility settings (`org`, `connections`, `instance`)
 
 ## Rules
 - A strategic objective must belong to an organization
+- In the current shipped model, an objective belongs to one goal
 - Strategic objectives follow the standard content workflow: draft → published → archived
 - An objective's success metric is optional but strongly encouraged — objectives without measurable outcomes are flagged as incomplete in the admin dashboard
 - Linking to capabilities and value streams is optional but recommended; unlinked objectives are architecturally orphaned and should surface as a completeness signal
@@ -26,5 +29,5 @@ The system must allow organizations to define strategic business objectives, lin
 
 ## Links
 - Depends on: Content Management — Content Workflow, Content Relationships
-- Related: Capabilities, Value Streams, Initiatives, Roadmap
+- Related: Goals, Capabilities, Value Streams, Initiatives, Roadmap
 - Personas served: Enterprise Architect, Agency EA Coordinator, Department Director, Business Stakeholder, Early-Maturity Practice Lead

--- a/business-architecture/capabilities/cms/planning/planning.md
+++ b/business-architecture/capabilities/cms/planning/planning.md
@@ -11,15 +11,17 @@ The system must allow organizations to document their strategic direction, track
 
 | Capability | File | Description |
 |---|---|---|
-| Strategic Objectives | [pl-strategic-objectives.md](./pl-strategic-objectives.md) | Define and track business goals using the standard content workflow; link to capabilities and value streams |
+| Goals | [pl-goals.md](./pl-goals.md) | Define broad strategic outcomes above objectives and roll up supporting planning context |
+| Strategic Objectives | [pl-strategic-objectives.md](./pl-strategic-objectives.md) | Define measurable objectives under goals using the standard content workflow; link to capabilities and value streams |
 | Initiatives | [pl-initiatives.md](./pl-initiatives.md) | Track change programmes using planning lifecycle states; link to capabilities and objectives with impact |
 | Roadmap | [pl-roadmap.md](./pl-roadmap.md) | Visualize initiatives and objectives in a read-only status-grouped roadmap view |
 
 ## Design Principle
-Planning capabilities are a lens on existing architecture content — they do not exist in isolation. Strategic objectives trace to capabilities and value streams. Initiatives trace to objectives and capabilities. The roadmap visualizes initiative timelines against the architecture they affect. Nothing in this capability group is meaningful unless the underlying capability and persona content is maintained.
+Planning capabilities are a lens on existing architecture content — they do not exist in isolation. Goals roll up strategic intent. Strategic objectives trace to capabilities and value streams. Initiatives trace to objectives and capabilities. The roadmap visualizes initiative timelines against the architecture they affect. Nothing in this capability group is meaningful unless the underlying capability and persona content is maintained.
 
 ## Current Semantic Model
-- Strategic objectives are treated like governed content: they use the standard workflow (`draft`, `published`, `archived`) plus visibility settings.
+- Goals and strategic objectives are treated like governed content: they use the standard workflow (`draft`, `published`, `archived`) plus visibility settings.
+- Goals sit above objectives in the shipped hierarchy: Goal -> Objective -> Initiative.
 - Initiatives are treated like planning records: they use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates.
 - The roadmap is a rendered view over initiative records. It groups initiatives by planning status and shows their linked objectives and capabilities.
-- This is intentionally good enough for demos and early-v1 use, but still evolving. A future iteration may unify planning semantics further, but the current docs should describe the shipped split model accurately.
+- This is still an evolving area, but the biggest early semantic blur has now been corrected by separating goals from objectives in the shipped planning model.

--- a/capabilities.md
+++ b/capabilities.md
@@ -108,13 +108,14 @@ Strategic direction, change initiatives, and timeline visualization.
 
 | Capability | Status | Description |
 |---|---|---|
-| Strategic Objectives | Implemented | Define and track business goals; link to capabilities and value streams |
+| Goals | Implemented | Define broad strategic goals above objectives, with objective rollup and traceability into initiatives and capabilities |
+| Strategic Objectives | Implemented | Define measurable objectives under goals; link to capabilities and value streams |
 | Initiatives | Implemented | Track change programmes with planning lifecycle statuses; link to capabilities and objectives with impact labels (build / improve / retire / migrate) |
 | Roadmap View | Implemented | Visualize initiatives in an executive timeline or planning grid, with linked objectives, date ranges, capability impact labels, and role-aware viewer filtering |
 
-**Design principle:** Planning capabilities are a lens on existing architecture content. Strategic objectives trace to capabilities. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
+**Design principle:** Planning capabilities are a lens on existing architecture content. Goals capture broad strategic intent. Strategic objectives trace to capabilities and value streams as measurable targets under those goals. Initiatives trace to objectives and capabilities. Nothing here is meaningful unless the underlying capability and persona content is maintained.
 
-**Current semantic model:** Strategic objectives follow the standard content workflow (`draft`, `published`, `archived`). Initiatives do not. They use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates. The roadmap is a read-only view over initiative records, shown either as an executive timeline or grouped planning grid.
+**Current semantic model:** Goals and strategic objectives follow the standard content workflow (`draft`, `published`, `archived`). Objectives now sit under goals in the shipped hierarchy. Initiatives do not use the governed-content workflow; they use planning lifecycle states (`proposed`, `active`, `on-hold`, `complete`, `cancelled`) plus optional start/end dates. The roadmap is a read-only view over initiative records, shown either as an executive timeline or grouped planning grid.
 
 This area is strong enough for demos and early v1 use, but the planning model should still be treated as evolving rather than fully settled.
 

--- a/docs/design/base-item-foundation.md
+++ b/docs/design/base-item-foundation.md
@@ -1,7 +1,7 @@
 # Base Item Foundation for Reusable Taxonomy and Shared Content Behavior
 
 **Related issue:** [#349](https://github.com/roballred/GovEA/issues/349)  
-**Status:** Proposed for review
+**Status:** Partially implemented
 
 ---
 
@@ -9,13 +9,20 @@
 
 GovEA currently supports taxonomy-backed fields only where a specific entity has been wired for them in code. That works for today's hardcoded cases, but it does not scale to the broader product direction where administrators can define reusable classification structures and apply them across multiple item types without developer intervention.
 
-This document proposes a **base item foundation** for GovEA. The key idea is:
+This document proposes and now partially validates a **base item foundation** for GovEA. The key idea is:
 
 - treat core content records as a shared family of **items**
 - move reusable concerns such as taxonomy assignment onto that shared layer
 - keep entity-specific tables for entity-specific fields
 
 This is intentionally **foundational**, not a full meta-model rewrite. The near-term goal is to create a shared platform layer that lets applications, capabilities, initiatives, ADRs, and similar records opt into common behaviors without bespoke one-off implementation each time.
+
+Since this note was first drafted, GovEA has shipped the first two real pilots of the shared taxonomy model:
+
+- applications as the initial shared taxonomy-backed extension surface
+- capabilities as the second entity pilot, including `Capability Priority`
+
+The broader multi-entity rollout is still future work, but the direction is no longer only conceptual.
 
 ---
 

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-04
+Last groomed: 2026-05-06
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -13,6 +13,8 @@ Recent merges materially changed the product surface:
 - PR #357 shipped application and capability impact analysis, moving traceability from passive navigation toward real decision support.
 - PR #356 shipped application custom fields plus CSV import/export, reducing one of the biggest practical barriers to getting real portfolio data into the product.
 - PR #376 shipped a Mermaid-based diagram view on the capability map page, broadening how users can understand repository relationships without changing the underlying model.
+- PR #387 shipped a Goals layer above Strategic Objectives, correcting an important planning-model blur before more reporting and roadmap behavior compounds it.
+- PR #393 shipped the capabilities pilot for the shared taxonomy/base-item direction, proving cross-entity reuse beyond the earlier application-only slice.
 - PR #370 and the recent persona documentation passes strengthened the roadmap definition for integration and real government-practice fit, even where product implementation has not started yet.
 
 What this means for prioritization:
@@ -28,7 +30,7 @@ What this means for prioritization:
 | 1 | Ship repository completeness drill-downs and a plain-language confidence summary | Reporting, heatmaps, impact views, and executive summaries now depend on users trusting the underlying repository. GovEA has early coverage signals, but not yet the fuller completeness workflow or stakeholder-facing confidence cues described in the repository-modelling capability docs. | `rm-repository-completeness`, `fd-repository-confidence-summary`, PR #357, PR #316, PR #314 |
 | 2 | Add architecture debt tracking and make ADRs a stronger decision-support surface | Impact analysis now surfaces consequences, but GovEA still lacks a first-class way to record persistent constraints, debt, and tradeoff accumulation. That leaves a gap between "what is affected" and "what should leadership worry about next." | `rm-architecture-debt`, `po-architecture-decisions`, PR #357 |
 | 3 | Start the operational integration foundation: REST API plus the first Tier 1 sync slice | Custom fields and CSV import/export help initial data load, but they do not solve staleness. The integration roadmap is now better defined, and the next meaningful trust move is to reduce manual reconciliation with operational systems. | `int-rest-api`, `integration/`, PR #356, PR #370 |
-| 4 | Generalize the shared item/taxonomy foundation beyond the current application-only extension points | GovEA now has proof that configurable fields are useful, but the current model still requires entity-specific wiring. The base-item/taxonomy direction is the platform move that prevents every future classification or metadata request from becoming bespoke per-entity work. | `docs/design/base-item-foundation.md`, PR #356, PR #350 |
+| 4 | Extend the shared item/taxonomy foundation beyond the current applications-and-capabilities pilots | GovEA now has proof that shared taxonomy assignment works across more than one entity, but the rollout is still too narrow. The next platform move is to keep future classification and metadata work from turning into bespoke per-entity wiring again. | #383, PR #393, `docs/design/base-item-foundation.md` |
 | 5 | Validate assumed personas and start a lightweight product feedback loop for the new analysis surfaces | Repository modelling and integration are still driven by assumed personas in several capability files. With executive reporting, impact analysis, and map views now shipped, the cost of building the wrong next analytic feature has gone up. Validate before compounding. | Persona docs, `docs/research/`, issue #103, PR #314, PR #357, PR #376 |
 
 ## Product Manager Notes
@@ -36,7 +38,7 @@ What this means for prioritization:
 - The old shortlist is materially stale: platform configuration, executive reporting, heatmaps, and impact analysis are already shipped in `main`.
 - The new priority stack is intentionally trust-heavy. GovEA has crossed the point where more views are less valuable than better confidence in what those views are saying.
 - The most pragmatic sequence is: repository confidence -> debt/decision capture -> integration freshness. That is the shortest path from "useful demo" to "credible working repository."
-- Treat the shared item/taxonomy foundation as a platform multiplier, not a side quest. Recent custom-field work proved the demand; the next step is making reuse systematic.
+- Treat the shared item/taxonomy foundation as a platform multiplier, not a side quest. Recent custom-field work and the new capabilities pilot proved the demand; the next step is making reuse systematic across more entities.
 - Keep persona validation attached to these roadmap items, especially for repository-modelling and integration, where several capabilities still explicitly carry assumed-persona risk.
 
 ## Documentation Follow-up


### PR DESCRIPTION
## Summary

This PR updates GovEA documentation to match the current shipped product shape.

- add a dedicated `Goals` planning capability doc and update planning docs to reflect the shipped `Goal -> Objective -> Initiative` model
- refresh top-level product docs so they acknowledge the Goals layer and the shared taxonomy/base-item pilots now shipped
- update the product-priority shortlist so it reflects the post-PR-#387 and post-PR-#393 repo reality

## Why

Recent merged work changed the product surface in ways the repo docs were understating:

- PR #387 shipped the Goals layer above Strategic Objectives
- PR #393 shipped the capabilities pilot for the shared taxonomy/base-item direction

Without these updates, the roadmap and capability summaries still describe older semantics and make the backlog look more stale than it is.

## Impact

- product docs better match what reviewers and contributors will actually find in `main`
- planning capability docs are clearer about the current hierarchy and terminology
- roadmap discussion now treats the taxonomy/base-item work as partially implemented rather than purely proposed

## Validation

- documentation-only changes
- no code changes included in this PR
