### PR TITLE
feat(instance): richer tenant-governance controls (#388)

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -292,9 +292,6 @@ export async function createInstanceUser(formData: FormData) {
   revalidatePath('/instance/users')
 }
 
-export const SUPPORT_TIERS = ['community', 'standard', 'premium', 'enterprise'] as const
-export type SupportTier = typeof SUPPORT_TIERS[number]
-
 export async function updateOrgGovernance(
   orgId: string,
   data: { supportTier: string | null; internalNotes: string | null },

--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -1,8 +1,8 @@
 'use server'
 
 import { db } from '@/db/client'
-import { organizations, users, breakGlassSessions, instanceSettings, platformConfig } from '@/db/schema'
-import { eq, and, isNull, gt } from 'drizzle-orm'
+import { organizations, users, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
+import { eq, and, isNull, gt, like, desc } from 'drizzle-orm'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { writeAuditLog } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
@@ -292,6 +292,48 @@ export async function createInstanceUser(formData: FormData) {
   revalidatePath('/instance/users')
 }
 
+export const SUPPORT_TIERS = ['community', 'standard', 'premium', 'enterprise'] as const
+export type SupportTier = typeof SUPPORT_TIERS[number]
+
+export async function updateOrgGovernance(
+  orgId: string,
+  data: { supportTier: string | null; internalNotes: string | null },
+) {
+  const session = await requireInstanceAdmin()
+
+  const before = await db.query.organizations.findFirst({ where: eq(organizations.id, orgId) })
+  if (!before) throw new Error('Organisation not found')
+
+  const supportTier = data.supportTier?.trim() || null
+  const internalNotes = data.internalNotes?.trim() || null
+
+  await db.update(organizations)
+    .set({ supportTier, internalNotes, updatedAt: new Date() })
+    .where(eq(organizations.id, orgId))
+
+  await writeAuditLog({
+    action: 'instance.org.governance.update',
+    entityType: 'organization',
+    entityId: orgId,
+    userId: session.user.id,
+    organizationId: null,
+    before: { supportTier: before.supportTier, internalNotes: before.internalNotes },
+    after: { supportTier, internalNotes },
+  })
+
+  revalidatePath('/instance/orgs')
+  revalidatePath(`/instance/orgs/${orgId}`)
+}
+
+export async function getOrgGovernanceHistory(orgId: string) {
+  await requireInstanceAdmin()
+
+  return db.select().from(auditLog)
+    .where(and(eq(auditLog.entityId, orgId), like(auditLog.action, 'instance.org.%')))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(10)
+}
+
 /**
  * Controls whether a module is available anywhere on the instance.
  * When unavailable, the module is forced OFF for every organization.
@@ -301,7 +343,9 @@ export async function setInstanceModuleAvailability(key: ModuleKey, available: b
   if (!MODULE_DEFS.find(m => m.key === key)) throw new Error('Unknown module')
 
   const before = await db.query.instanceSettings.findFirst()
-  const beforeDisabledModules = before?.disabledModules ?? {}
+  // When no row exists yet, start from all-disabled (same default as getInstanceDisabledModules).
+  const allDisabled = Object.fromEntries(MODULE_DEFS.map(m => [m.key, true]))
+  const beforeDisabledModules = before?.disabledModules ?? allDisabled
   const afterDisabledModules = { ...beforeDisabledModules }
   if (available) {
     delete afterDisabledModules[key]

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -63,7 +63,6 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       email={session.user.email ?? ''}
       roleBadgeClass={ROLE_BADGE_CLASS[role]}
       themeStyle={themeStyle}
-      isDev={isInstanceAdmin(session.user)}
       isInstanceAdmin={isInstanceAdmin(session.user)}
       enabledModules={enabledModules}
       signOutSlot={signOutSlot}

--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/org-governance-form.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/org-governance-form.tsx
@@ -4,7 +4,8 @@ import { useState, useTransition } from 'react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { updateOrgGovernance, SUPPORT_TIERS } from '@/actions/instance'
+import { updateOrgGovernance } from '@/actions/instance'
+import { SUPPORT_TIERS } from '@/lib/support-tiers'
 
 const TIER_LABELS: Record<string, string> = {
   community: 'Community',

--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/org-governance-form.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/org-governance-form.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { updateOrgGovernance, SUPPORT_TIERS } from '@/actions/instance'
+
+const TIER_LABELS: Record<string, string> = {
+  community: 'Community',
+  standard: 'Standard',
+  premium: 'Premium',
+  enterprise: 'Enterprise',
+}
+
+interface Props {
+  orgId: string
+  initialTier: string | null
+  initialNotes: string | null
+}
+
+export function OrgGovernanceForm({ orgId, initialTier, initialNotes }: Props) {
+  const [tier, setTier] = useState<string>(initialTier ?? '')
+  const [notes, setNotes] = useState(initialNotes ?? '')
+  const [isPending, startTransition] = useTransition()
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSave() {
+    setError(null)
+    setSaved(false)
+    startTransition(async () => {
+      try {
+        await updateOrgGovernance(orgId, {
+          supportTier: tier || null,
+          internalNotes: notes || null,
+        })
+        setSaved(true)
+        setTimeout(() => setSaved(false), 3000)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Something went wrong')
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="support-tier">Support tier</Label>
+        <select
+          id="support-tier"
+          value={tier}
+          onChange={e => setTier(e.target.value)}
+          className="flex h-9 w-52 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <option value="">None</option>
+          {SUPPORT_TIERS.map(t => (
+            <option key={t} value={t}>{TIER_LABELS[t]}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="internal-notes">Internal notes</Label>
+        <Textarea
+          id="internal-notes"
+          value={notes}
+          onChange={e => setNotes(e.target.value)}
+          placeholder="Contract details, escalation contacts, known issues…"
+          rows={4}
+          className="resize-none text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Visible to instance admins only. Not shared with the tenant.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSave} disabled={isPending} size="sm">
+          {isPending ? 'Saving…' : 'Save'}
+        </Button>
+        {saved && <span className="text-sm text-emerald-600 dark:text-emerald-400">Saved</span>}
+      </div>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
@@ -7,16 +7,33 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { ConfirmWithReason } from '@/components/confirm-with-reason'
-import { suspendOrg, unsuspendOrg, grantBreakGlass, revokeBreakGlass } from '@/actions/instance'
+import { suspendOrg, unsuspendOrg, grantBreakGlass, revokeBreakGlass, getOrgGovernanceHistory } from '@/actions/instance'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
+import { OrgGovernanceForm } from './org-governance-form'
+
+const TIER_BADGE: Record<string, { label: string; cls: string }> = {
+  community: { label: 'Community', cls: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' },
+  standard:  { label: 'Standard',  cls: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300' },
+  premium:   { label: 'Premium',   cls: 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300' },
+  enterprise:{ label: 'Enterprise',cls: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300' },
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  'instance.org.create':              'Created',
+  'instance.org.suspend':             'Suspended',
+  'instance.org.unsuspend':           'Unsuspended',
+  'instance.org.governance.update':   'Governance updated',
+  'instance.break_glass.grant':       'Break-glass granted',
+  'instance.break_glass.revoke':      'Break-glass revoked',
+}
 
 export default async function OrgDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const session = await requireInstanceAdmin()
 
-  const [org, orgUsers, activeBG, bgHistory] = await Promise.all([
+  const [org, orgUsers, activeBG, bgHistory, govHistory] = await Promise.all([
     db.query.organizations.findFirst({ where: eq(organizations.id, id) }),
     db.query.users.findMany({
       where: eq(users.organizationId, id),
@@ -35,9 +52,12 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
       orderBy: [desc(breakGlassSessions.grantedAt)],
       limit: 10,
     }),
+    getOrgGovernanceHistory(id),
   ])
 
   if (!org) notFound()
+
+  const tierBadge = org.supportTier ? TIER_BADGE[org.supportTier] : null
 
   return (
     <div className="space-y-8">
@@ -50,7 +70,17 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
             <span>{org.name}</span>
           </div>
           <h1 className="text-2xl font-bold tracking-tight">{org.name}</h1>
-          <p className="text-muted-foreground font-mono text-sm mt-0.5">{org.slug}</p>
+          <div className="flex items-center gap-2 mt-0.5">
+            <p className="text-muted-foreground font-mono text-sm">{org.slug}</p>
+            {tierBadge && (
+              <span className={cn(
+                'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                tierBadge.cls,
+              )}>
+                {tierBadge.label}
+              </span>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <span className={cn(
@@ -104,6 +134,40 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
           <div><dt className="text-muted-foreground">System org</dt><dd className="mt-0.5 font-medium">{org.isSystemOrg ? 'Yes' : 'No'}</dd></div>
           <div><dt className="text-muted-foreground">Users</dt><dd className="mt-0.5 font-medium">{orgUsers.length}</dd></div>
         </dl>
+      </section>
+
+      {/* Governance */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="mb-4">
+          <h2 className="text-base font-semibold">Governance</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Internal-only metadata. Support tier and notes are never shown to the tenant.
+          </p>
+        </div>
+
+        <OrgGovernanceForm
+          orgId={id}
+          initialTier={org.supportTier}
+          initialNotes={org.internalNotes}
+        />
+
+        {govHistory.length > 0 && (
+          <div className="mt-6">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Governance history</h3>
+            <div className="divide-y rounded-md border text-sm">
+              {govHistory.map(entry => (
+                <div key={entry.id} className="flex items-center gap-3 px-3 py-2">
+                  <span className="flex-1 text-muted-foreground">
+                    {ACTION_LABELS[entry.action] ?? entry.action}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {entry.createdAt.toLocaleString()}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </section>
 
       {/* Break-glass */}

--- a/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
@@ -15,6 +15,13 @@ import {
 import { cn } from '@/lib/utils'
 import { createOrg } from '@/actions/instance'
 
+const TIER_BADGE: Record<string, { label: string; cls: string }> = {
+  community: { label: 'Community', cls: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' },
+  standard:  { label: 'Standard',  cls: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300' },
+  premium:   { label: 'Premium',   cls: 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300' },
+  enterprise:{ label: 'Enterprise',cls: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300' },
+}
+
 type OrgRow = {
   id: string
   name: string
@@ -23,6 +30,7 @@ type OrgRow = {
   createdAt: Date
   suspendedAt: Date | null
   isSystemOrg: boolean | null
+  supportTier: string | null
 }
 
 interface Props {
@@ -87,6 +95,7 @@ export function InstanceOrgsTable({ orgs }: Props) {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Slug</TableHead>
+              <TableHead>Tier</TableHead>
               <TableHead>Users</TableHead>
               <TableHead>Created</TableHead>
               <TableHead>Status</TableHead>
@@ -104,6 +113,18 @@ export function InstanceOrgsTable({ orgs }: Props) {
                   )}
                 </TableCell>
                 <TableCell className="font-mono text-sm text-muted-foreground">{org.slug}</TableCell>
+                <TableCell>
+                  {org.supportTier && TIER_BADGE[org.supportTier] ? (
+                    <span className={cn(
+                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                      TIER_BADGE[org.supportTier].cls,
+                    )}>
+                      {TIER_BADGE[org.supportTier].label}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground text-xs">—</span>
+                  )}
+                </TableCell>
                 <TableCell>{org.userCount}</TableCell>
                 <TableCell className="text-muted-foreground whitespace-nowrap">
                   {org.createdAt.toLocaleDateString()}
@@ -122,7 +143,7 @@ export function InstanceOrgsTable({ orgs }: Props) {
             ))}
             {orgs.length === 0 && (
               <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
                   No organisations yet — create one to get started.
                 </TableCell>
               </TableRow>

--- a/apps/govea/src/app/(instance)/instance/orgs/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/page.tsx
@@ -27,6 +27,7 @@ export default async function InstanceOrgsPage() {
         createdAt: org.createdAt,
         suspendedAt: org.suspendedAt,
         isSystemOrg: org.isSystemOrg,
+        supportTier: org.supportTier,
       }))}
     />
   )

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -5,7 +5,6 @@ import { usePathname, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
-import { DevToolbar } from '@/components/dev-toolbar'
 import { DarkModeToggle } from '@/components/dark-mode-toggle'
 import { TourButton } from '@/components/product-tour'
 import { isModuleEnabled, moduleForPath } from '@/lib/modules'
@@ -171,7 +170,6 @@ interface AppShellProps {
   email: string
   roleBadgeClass: string
   themeStyle: string
-  isDev: boolean
   isInstanceAdmin: boolean
   enabledModules: Record<string, boolean>
   signOutSlot: ReactNode
@@ -183,7 +181,6 @@ export function AppShell({
   email,
   roleBadgeClass,
   themeStyle,
-  isDev,
   isInstanceAdmin,
   enabledModules,
   signOutSlot,
@@ -365,12 +362,10 @@ export function AppShell({
         </header>
 
         {/* Page content */}
-        <main className={cn('flex-1 p-4 lg:p-6', isDev && 'pb-16')}>
+        <main className="flex-1 p-4 lg:p-6">
           {children}
         </main>
       </div>
-
-      {isDev && <DevToolbar />}
     </div>
   )
 }

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -19,6 +19,8 @@ export const organizations = pgTable('organizations', {
   parentId: uuid('parent_id').references((): AnyPgColumn => organizations.id, { onDelete: 'set null' }),
   suspendedAt: timestamp('suspended_at'),
   suspendedReason: text('suspended_reason'),
+  supportTier: text('support_tier'),
+  internalNotes: text('internal_notes'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -39,7 +39,9 @@ import {
   taxonomyTerms, entityTaxonomyDefinitions,
   services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
+  instanceSettings,
 } from '../schema'
+import { MODULE_DEFS } from '../../lib/modules'
 import bcrypt from 'bcryptjs'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -1778,6 +1780,20 @@ async function seed() {
     }
   }
   console.log(`  ✓ ${SYSTEM_USERS.length} users (ivan@govea.dev / dev-password, instanceRole=instance_admin)`)
+
+  // ── Instance settings — enable all modules for dev ────────────────────────
+  // Production instances start with every module disabled (opt-in). For dev,
+  // we ensure the singleton row exists with all modules available so the full
+  // app is reachable without manual toggling.
+  const existingInstanceSettings = await db.query.instanceSettings.findFirst()
+  if (existingInstanceSettings) {
+    await db.update(instanceSettings)
+      .set({ disabledModules: {}, updatedAt: new Date() })
+      .where(eq(instanceSettings.id, existingInstanceSettings.id))
+  } else {
+    await db.insert(instanceSettings).values({ disabledModules: {} })
+  }
+  console.log(`  ✓ instanceSettings: all ${MODULE_DEFS.length} modules enabled`)
 
   console.log('\nSeed complete.')
   process.exit(0)

--- a/apps/govea/src/lib/get-enabled-modules.ts
+++ b/apps/govea/src/lib/get-enabled-modules.ts
@@ -2,16 +2,26 @@ import { auth } from '@/lib/auth'
 import { db } from '@/db/client'
 import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
-import { mergeModuleSettings, type ModuleStateMap } from '@/lib/modules'
+import { mergeModuleSettings, MODULE_DEFS, type ModuleStateMap } from '@/lib/modules'
+
+/**
+ * The instance-level default: all modules disabled until an admin opts in.
+ * Used when no instanceSettings row exists yet.
+ */
+const ALL_DISABLED: ModuleStateMap = Object.fromEntries(MODULE_DEFS.map(m => [m.key, true]))
 
 /**
  * Server-only helper: returns the instance-wide disabled module map.
+ *
+ * When no instanceSettings row exists yet (fresh instance), every module is
+ * treated as disabled — the instance admin must explicitly enable each one.
  */
 export async function getInstanceDisabledModules(): Promise<ModuleStateMap> {
   const row = await db.query.instanceSettings.findFirst({
     columns: { disabledModules: true },
   })
-  return row?.disabledModules ?? {}
+  if (!row) return ALL_DISABLED
+  return row.disabledModules ?? {}
 }
 
 /**

--- a/apps/govea/src/lib/support-tiers.ts
+++ b/apps/govea/src/lib/support-tiers.ts
@@ -1,0 +1,2 @@
+export const SUPPORT_TIERS = ['community', 'standard', 'premium', 'enterprise'] as const
+export type SupportTier = typeof SUPPORT_TIERS[number]


### PR DESCRIPTION
Closes #388

## Summary

- **Support tier + internal notes** — two new nullable columns on `organizations` (`support_tier`, `internal_notes`); schema applied via `db:push`
- **Governance section on org detail page** — support tier badge in the header (colour-coded by tier), editable form for tier select + notes textarea, governance event history pulled from the audit log
- **Tier column on org list** — colour-coded badge in the instance orgs table; `—` when unset
- **Dev toolbar removed** — `DevToolbar` stripped from `AppShell`; `isDev` prop removed entirely; the yellow bar no longer appears for instance admins in the org shell
- **Module availability flipped to opt-in** — on a fresh instance (no `instanceSettings` row) every module now defaults to disabled; instance admin must explicitly enable each one on the Features page; `setInstanceModuleAvailability` initialises from all-disabled when creating the first row so the first toggle is correct
- **Dev seed updated** — upserts the `instanceSettings` singleton with `disabledModules: {}` so the dev environment is fully usable after a reseed without manual toggling

## Schema changes

```sql
ALTER TABLE organizations ADD COLUMN support_tier text;
ALTER TABLE organizations ADD COLUMN internal_notes text;
```
Applied via `db:push` (pre-production, no migration file).

## Test plan

- [ ] Instance admin → Organisations list shows Tier column (— for existing orgs, badge after setting)
- [ ] Org detail → Governance section: select a tier, save, reload — value persists and badge appears in header
- [ ] Org detail → Governance section: edit internal notes, save, reload — value persists
- [ ] Governance history panel appears after first save
- [ ] Dev toolbar no longer visible anywhere (including when logged in as instance admin)
- [ ] Fresh instance (truncate `instance_settings`) → Features page shows all modules toggled off
- [ ] Enable one module on Features page → only that module appears in nav; others remain off
- [ ] `pnpm exec tsx --env-file .env.local src/db/seeds/run.ts` → prints `✓ instanceSettings: all 12 modules enabled`; all modules accessible in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)