### PR TITLE
docs(ba): add STYLE.md format standard for persona and capability docs (#70)

### DIFF
--- a/Standards.md
+++ b/Standards.md
@@ -34,6 +34,10 @@ Capabilities are organized hierarchically:
 
 Capability groups should be organized by module or product area under `business-architecture/capabilities/`.
 
+### Documentation Format
+
+The structural format for persona and capability files — required sections, optional sections, link vocabulary, and naming conventions — is defined in [`business-architecture/STYLE.md`](business-architecture/STYLE.md). All persona and capability documentation must follow that format.
+
 ### Reference Sources vs. Capability Definitions
 
 Reference sources (external frameworks, existing products, prior art used as inputs to capability design) must be clearly distinguished from capability definitions (the authoritative outputs of EasyEA work).

--- a/business-architecture/STYLE.md
+++ b/business-architecture/STYLE.md
@@ -1,0 +1,204 @@
+# Business Architecture Documentation Style
+
+This file defines the format standard for persona and capability documentation under `business-architecture/`. It is a companion to [Standards.md](../Standards.md), which establishes the underlying EasyEA principles. If they conflict, Standards.md governs the principle and this file governs the format.
+
+The standard exists so newer files do not drift from older ones, AI-assisted work has a single template to follow, and reviewers have an objective compliance check.
+
+---
+
+## Persona Files
+
+Persona files live in `business-architecture/personas/` — one file per persona. Filename uses kebab-case (e.g. `agency-ea-coordinator.md`).
+
+### Required structure
+
+```markdown
+# Persona: <Persona Name>
+
+**Validation Status: Assumed|Validated** — <one-sentence rationale: how the persona was drafted, and what would move it to Validated>
+
+## Role Type
+<short phrase: Internal | External | both, plus broad role family>
+
+## Who They Are
+<one or two paragraphs describing the persona in plain language>
+
+## Goals
+- <bullet list of what this persona is trying to accomplish>
+
+## Pain Points
+- <bullet list of what currently frustrates them>
+
+## Critical Insight
+<one short paragraph capturing the single non-obvious truth that would change a designer's mind about how to serve this persona>
+
+## Relevant Capabilities
+- <bullet list of capabilities (or capability groups) this persona depends on>
+```
+
+### Optional sections (use when applicable)
+
+- `## Government Equivalent` — what an equivalent role looks like in state/local government (recommended for technical roles where the title varies between private and public sector)
+- `## Distinction from <Other Persona>` — small comparison table to disambiguate when two personas could be confused
+- `## Data Stored About This Persona` — for personas that map to system users (RBAC roles); describes what data the product stores about them
+
+### Validation Status rules
+
+Per Standards.md every persona must declare a status. Two values are allowed:
+
+- **Assumed** — drafted without direct user research. May drive capability design but must not drive implementation
+- **Validated** — confirmed through at least one interview or direct observation with a real user of that type
+
+The rationale sentence after the status is required and should describe how the persona was drafted and what evidence would move it to Validated.
+
+### What not to include
+
+- A `## Most Valuable Capabilities` section. The canonical heading is `## Relevant Capabilities`. Two terms for the same content cause drift.
+- RBAC role definitions. Personas describe people; roles describe access. Document roles in `business-architecture/capabilities/cms/iam/`.
+
+---
+
+## Capability Group Files
+
+Capability group files are the parent file at the root of each group folder. Filename matches the folder name (e.g. `business-architecture/capabilities/cms/iam/iam.md`).
+
+### Required structure
+
+```markdown
+# Capability: <Group Name>
+
+## What It Does
+<one or two paragraphs explaining what this capability group enables in plain language>
+
+## Personas
+- **<Persona Name>** — <one-line description of this persona's relationship to the group>
+
+## Sub-Capabilities
+
+| Capability | File | Description |
+|---|---|---|
+| <Sub-cap name> | [<prefix>-<slug>.md](./<prefix>-<slug>.md) | <one-line description> |
+
+## Success Criteria
+- <bullet list of 3–5 outcome statements: "indicates this group is working well after deployment">
+
+## Rules
+- <bullet list of group-wide invariants — what must always be true>
+
+## Implementation Status
+<short paragraph or bulleted list distinguishing what is shipped today, partial, or not yet implemented>
+
+## Links
+- Depends on: <other capability group(s)>
+- Enables: <other capability group(s)>
+- Related: <other capability group(s)>
+```
+
+### Optional sections (use when applicable)
+
+- `## Out of Scope` — capabilities that look adjacent but are intentionally excluded
+- `## Deferred to v2` (or later) — capabilities planned but not in v1
+- `## Design Principle` — short statement explaining the philosophy behind the group
+- `## Reference Sources` — external frameworks the group draws on (TOGAF, DAMA, etc.)
+- `## Upgrade & Migration` — operator-facing guidance for groups with persistent state
+- `## Capabilities Covered Elsewhere` — when work that would naturally land here is intentionally housed in another group
+
+### Status section naming
+
+The canonical heading for current state is `## Implementation Status`. Do not use `Current Scope`, `Current State`, `Current Maturity`, or other variants. Single name keeps lint and search reliable.
+
+---
+
+## Sub-Capability Files
+
+Sub-capability files live alongside the group file in the same folder. Filename uses the group prefix followed by a slug (e.g. `iam-user-management.md`, `cm-content-authoring.md`, `rm-end-to-end-traceability.md`).
+
+### Required structure
+
+```markdown
+# Capability: <Sub-capability Name>
+
+## What It Does
+<short paragraph explaining what this sub-capability enables>
+
+## Personas
+- **<Persona Name>** — <one-line description>
+
+## Behaviors
+- <bullet list of what the system does to deliver this sub-capability>
+
+## Rules
+- <bullet list of invariants for this sub-capability>
+
+## Implementation Status
+<short paragraph or bulleted list. Required even when status is "Planned — not yet implemented">
+
+## Links
+- Depends on: <other sub-capability or group>
+- Enables: <other sub-capability or group>
+- Related: <other sub-capability or group>
+```
+
+### Optional sections (use when content earns its keep)
+
+Examples seen in the repo and accepted as optional:
+
+- Domain-specific tables — `State Definitions`, `Retention Policy`, `Data Classification Field`, `Seeded Domain Values`, `Federation Behavior`, `Security Classification Guidance`
+- Reference material — `Default Government Domain Taxonomy`, `Core Relationship Rules (GovEA)`
+
+These are allowed when the sub-capability genuinely needs them. Do not add empty placeholders.
+
+---
+
+## Capability ID Convention
+
+Per Standards.md, capability IDs are file stems (filename without `.md`):
+
+- Sub-capability ID: `iam-user-management`, `cm-content-authoring`, `rm-end-to-end-traceability`
+- Capability group ID: directory path, e.g. `cms/iam`, `ea/repository-modelling`
+
+Use these IDs verbatim in:
+
+- Issue bodies: `Capability: iam-user-management`
+- PR descriptions: `Capability: iam-user-management`
+- Commit message footers: `Capability: iam-user-management`
+
+---
+
+## Link Vocabulary
+
+The `## Links` section uses three labels, no others:
+
+- **Depends on:** — this capability cannot work without the linked capability
+- **Enables:** — this capability is required for the linked capability to work
+- **Related:** — this capability shares concepts or context with the linked capability but neither depends on the other
+
+Do not invent new labels (`Pairs with`, `See also`, `Sometimes uses`, etc.). The vocabulary is intentionally narrow.
+
+Link targets may be either capability group IDs (e.g. `IAM`, `Content Management`) or sub-capability IDs (e.g. `iam-user-management`). Free-form text is allowed when the target is not yet a capability file.
+
+---
+
+## What This Standard Does Not Cover
+
+This file standardizes format, not content quality. It does not enforce:
+
+- Whether a capability is well-scoped (that is an EasyEA validation question — see Standards.md)
+- Whether `What It Does` is genuinely user-facing rather than implementation-leaking
+- Whether `Implementation Status` is honest about what is shipped vs. planned
+
+Those are review judgments. The standard makes drift visible; reviewers still own substance.
+
+---
+
+## Compliance and Enforcement
+
+Compliance is currently checked manually during PR review. A CI lint check is a deferred follow-up — see the linked issue.
+
+When adding or editing a persona or capability file:
+
+1. Read the existing file before editing — patch in place, do not rewrite from scratch
+2. Confirm the file matches the structure above
+3. Use the canonical heading names
+4. Use the canonical Link vocabulary
+5. Do not add empty sections — omit optional sections when there is nothing real to say


### PR DESCRIPTION
Closes #70

## Summary

- Adds `business-architecture/STYLE.md` — a single format standard for persona files, capability group files, and sub-capability files
- Updates `Standards.md` to reference `STYLE.md` as the structural authority
- Establishes canonical link vocabulary: `Depends on:`, `Enables:`, `Related:`
- Establishes canonical status heading: `Implementation Status` (replaces `Current Scope`, `Current State`, `Current Maturity`)
- Drops `Most Valuable Capabilities` as a persona section — `Relevant Capabilities` is the single canonical name

## Why

Per ARB finding #70: persona and capability documentation has a recognizable structure but the format is not explicitly standardized. Newer files were stronger than older ones, and contributors lacked a single template to follow. Memory note in `CLAUDE.md` already flagged that several persona files were added in prior PRs but their issues remained open because something was missing — having an explicit standard prevents that going forward.

## What is **not** in this PR

This PR defines the standard. It does not retrofit existing files. Retrofit work is tracked in:

- #405 — persona retrofits per STYLE.md (v0.9)
- #406 — capability group retrofits per STYLE.md (v0.9)
- #407 — sub-capability retrofits + duplicate-heading bug fixes per STYLE.md (v0.9)
- #408 — CI lint check for STYLE.md compliance (backlog)
- #409 — consider modeling Success Criteria as first-class product data (backlog)

Each retrofit is a separate, mechanical PR after this one merges.

## Test plan

- [ ] `business-architecture/STYLE.md` renders correctly on GitHub
- [ ] `Standards.md` link to `STYLE.md` resolves
- [ ] STYLE.md is consistent with itself (link vocabulary used internally; no contradictions with Standards.md principles)
- [ ] Approve / request changes — no code changes, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)