### PR TITLE
docs(personas): drop Most Valuable Capabilities sections per STYLE.md (#405)

### DIFF
--- a/business-architecture/personas/junior-ea-analyst.md
+++ b/business-architecture/personas/junior-ea-analyst.md
@@ -31,18 +31,10 @@ In government, this role is common in medium-to-large agencies and central IT sh
 ## Critical Insight
 The Junior EA Analyst is the fastest-growing segment of EA tool users as practices mature and repository maintenance scales beyond what a single senior architect can manage alone. They are also the group most likely to degrade repository quality if the tool does not provide guidance, validation, and soft guardrails. Designing for this persona is not about simplification — it is about making correct contribution the path of least resistance.
 
-## Most Valuable Capabilities
-
-| Capability | What it solves |
-|---|---|
-| Guided templates and starter patterns | Reduces first-contribution errors by showing what a complete record looks like before the analyst has internalised the methodology |
-| Impact visualisation before committing changes | Allows the analyst to see downstream effects of a relationship or status change before they propagate — replaces the senior architect review as the first line of quality control |
-| Automated data validation | Catches misclassified records, broken relationship chains, and missing required fields at save time, not at the next stakeholder review |
-| Role-based access with guardrails | Limits the blast radius of mistakes without blocking contribution — Contributor role limits delete access; workflow gates require publish confirmation |
-
 ## Relevant Capabilities
-- Content authoring and editing with relationship validation
+- Guided templates and starter patterns — reduces first-contribution errors before the analyst has internalised the methodology
+- Content authoring and editing with relationship validation — catches misclassified records, broken chains, and missing required fields at save time, not at the next stakeholder review
 - Content workflow (draft → review → publish) as a quality gate
-- Repository completeness signals (to know what is missing before being asked)
-- Relationship navigation (to understand downstream impact before making changes)
-- Role-based access control (limits blast radius without blocking contribution)
+- Repository completeness signals — to know what is missing before being asked
+- Relationship navigation and impact visualisation — see downstream effects before changes propagate; replaces the senior architect review as the first line of quality control
+- Role-based access with guardrails — limits blast radius without blocking contribution; Contributor role limits delete access, workflow gates require publish confirmation

--- a/business-architecture/personas/programme-director.md
+++ b/business-architecture/personas/programme-director.md
@@ -32,16 +32,6 @@ Unlike the Department Director, who asks strategic investment questions over a 3
 ## Critical Insight
 The Programme Director will engage with GovEA only if dependency lookups and impact analysis are self-service, filtered to their scope, and written in plain language. If the EA team is still required as an interpreter between the architecture repository and delivery decision-making, this persona will default to asking colleagues or making assumptions. The value of EA to programme delivery is unlocked exactly at the point where the Programme Director can answer their own questions.
 
-## Most Valuable Capabilities
-
-| Capability | What it solves |
-|---|---|
-| Self-service dependency lookup | Replaces ad-hoc EA team queries with direct repository access |
-| Programme-scoped impact view | Filters the portfolio to applications and capabilities relevant to their programme |
-| Plain-language architecture summaries | Translates EA content into delivery-relevant language without requiring EA training |
-| Technology lifecycle visibility | Surfaces decommission timelines and lifecycle states before they become programme risks |
-| Change notification | Alerts the Programme Director when a platform their programme depends on changes state |
-
 ## Distinction from Department Director
 
 | | Department Director | Programme Director |


### PR DESCRIPTION
Closes #405

## Summary

Brings the 14 persona files in `business-architecture/personas/` into compliance with the format standard added in [`business-architecture/STYLE.md`](business-architecture/STYLE.md) (#70 / PR #410).

The standard names `Relevant Capabilities` as the single canonical section for the capabilities a persona depends on. Two persona files (`junior-ea-analyst.md`, `programme-director.md`) carried a duplicate `Most Valuable Capabilities` section with overlapping content. Two terms for the same content cause drift — STYLE.md drops it.

## Changes

| File | What changed |
|---|---|
| `business-architecture/personas/junior-ea-analyst.md` | Removed `Most Valuable Capabilities` table; merged the "what it solves" context into the existing `Relevant Capabilities` bullets so no insight is lost |
| `business-architecture/personas/programme-director.md` | Removed `Most Valuable Capabilities` table — its content was already covered by the `Relevant Capabilities` bullets below |

The other 12 persona files were spot-checked and already comply (all 14 have `Validation Status` and the 6 required H2 sections per STYLE.md).

## Verification

```
$ for f in business-architecture/personas/*.md; do
    grep -q "^## Most Valuable Capabilities" "$f" && echo "FAIL: $f"
  done
# (no output — none remain)

$ # all 14 have required H2s + validation status
$ # (compliance script verified locally)
```

## Test plan

- [ ] Two affected files render correctly on GitHub
- [ ] No content from the dropped tables is lost (junior-ea-analyst merged into bullets; programme-director already had equivalent content)
- [ ] Other 12 persona files unchanged
- [ ] Branch is from `origin/main` (not the worktree's long-history branch per `CLAUDE.md`)

## Sequence

This is PR-B in the #70 retrofit sequence:
- PR-A (#410) — STYLE.md spec ← merge this first
- **PR-B (this)** — persona retrofits per #405
- PR-C — capability group retrofits per #406 (next session)
- PR-D — sub-capability retrofits + duplicate-heading fixes per #407 (next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)