### PR TITLE
fix(security): require admin session and strip secrets from getUsers (#411)

### DIFF
--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -17,9 +17,19 @@ async function requireAdmin() {
   return session
 }
 
-export async function getUsers(organizationId: string) {
+export async function getUsers() {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
   return db.query.users.findMany({
-    where: eq(users.organizationId, organizationId),
+    where: eq(users.organizationId, orgId),
+    columns: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      isActive: true,
+    },
     orderBy: (u, { asc }) => [asc(u.name)],
   })
 }

--- a/apps/govea/src/app/(admin)/users/page.tsx
+++ b/apps/govea/src/app/(admin)/users/page.tsx
@@ -9,7 +9,7 @@ export default async function UsersPage() {
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) redirect('/dashboard')
 
-  const userList = await getUsers(session.user.organizationId!)
+  const userList = await getUsers()
 
   return (
     <div className="space-y-4">

--- a/apps/govea/tests/integration/users.test.ts
+++ b/apps/govea/tests/integration/users.test.ts
@@ -8,7 +8,7 @@
  *  - Audit log written with correct before/after for each mutation
  */
 import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { createUser, updateUserRole, deactivateUser, deleteUser, editUser } from '@/actions/users'
+import { createUser, updateUserRole, deactivateUser, deleteUser, editUser, getUsers } from '@/actions/users'
 import { db } from '@/db/client'
 import { users } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
@@ -59,6 +59,73 @@ describe('user management actions', () => {
 
   beforeEach(() => {
     mockAuth.mockResolvedValue(makeSession(admin))
+  })
+
+  // ── getUsers ───────────────────────────────────────────────────────────────
+  // Locks in the security fix from #411: server action requires admin session,
+  // ignores any caller-supplied parameter, and never returns passwordHash.
+
+  describe('getUsers', () => {
+    it('admin in own org receives the org user list', async () => {
+      const list = await getUsers()
+      const ids = list.map(u => u.id)
+      expect(ids).toContain(admin.id)
+      expect(ids).toContain(contributor.id)
+      expect(ids).toContain(viewer.id)
+    })
+
+    it('returned rows never include passwordHash or other secret fields', async () => {
+      const list = await getUsers()
+      expect(list.length).toBeGreaterThan(0)
+      for (const row of list) {
+        expect(row).not.toHaveProperty('passwordHash')
+        expect(row).not.toHaveProperty('emailVerified')
+        expect(row).not.toHaveProperty('image')
+      }
+    })
+
+    it('contributor session → throws Forbidden', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await expect(getUsers()).rejects.toThrow('Forbidden')
+    })
+
+    it('viewer session → throws Forbidden', async () => {
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(getUsers()).rejects.toThrow('Forbidden')
+    })
+
+    it('no session → redirects to /login', async () => {
+      mockAuth.mockResolvedValue(null)
+      await expect(getUsers()).rejects.toThrow('REDIRECT:/login')
+    })
+
+    it('cross-tenant isolation: admin only ever sees their own org users', async () => {
+      // Set up a second org with its own admin and a viewer
+      const otherOrg = await createTestOrg()
+      try {
+        const otherAdmin = await createTestUser(otherOrg.id, 'admin')
+        const otherViewer = await createTestUser(otherOrg.id, 'viewer')
+
+        // Even when authenticated as otherAdmin, getUsers returns only otherOrg
+        mockAuth.mockResolvedValue(makeSession(otherAdmin))
+        const otherList = await getUsers()
+        const otherIds = otherList.map(u => u.id)
+        expect(otherIds).toContain(otherAdmin.id)
+        expect(otherIds).toContain(otherViewer.id)
+        expect(otherIds).not.toContain(admin.id)
+        expect(otherIds).not.toContain(contributor.id)
+        expect(otherIds).not.toContain(viewer.id)
+
+        // And the original admin still sees only their own org
+        mockAuth.mockResolvedValue(makeSession(admin))
+        const ownList = await getUsers()
+        const ownIds = ownList.map(u => u.id)
+        expect(ownIds).not.toContain(otherAdmin.id)
+        expect(ownIds).not.toContain(otherViewer.id)
+      } finally {
+        await cleanupOrg(otherOrg.id)
+      }
+    })
   })
 
   // ── createUser ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #411

## Summary

Closes the cross-tenant data exposure on `getUsers`. The action now requires an admin session, sources `organizationId` from the session, and strips `passwordHash` (and other secret fields) from the response.

## What changed

| File | Change |
|---|---|
| `apps/govea/src/actions/users.ts` | `getUsers()` calls `requireAdmin()`, reads `organizationId` from session, allowlists the returned columns to `id, name, email, role, isActive` |
| `apps/govea/src/app/(admin)/users/page.tsx` | Drops the now-unused argument |
| `apps/govea/tests/integration/users.test.ts` | Adds 6 regression tests for the auth check, the column projection, and cross-tenant isolation |

## Why

[#411](https://github.com/roballred/GovEA/issues/411) (originally Critical, downgraded to High after live verification) — the `'use server'` export had no auth check. Middleware blocks unauthenticated callers, but any authenticated user (Viewer, Contributor, Admin in any org) could call `getUsers(otherOrgUuid)` and receive that org's full user table including bcrypt password hashes.

## Defense-in-depth

The single caller (`(admin)/users/page.tsx`) already performs its own `isAdmin()` gate, so the page-level path was protected. The action-level `requireAdmin()` closes the RPC-replay vector that the page-level check cannot reach.

## Tests

```
✓ admin in own org receives the org user list
✓ returned rows never include passwordHash or other secret fields
✓ contributor session → throws Forbidden
✓ viewer session → throws Forbidden
✓ no session → redirects to /login
✓ cross-tenant isolation: admin only ever sees their own org users
```

All 33 tests in `users.test.ts` pass; `tsc --noEmit` is clean.

## Test plan

- [ ] Reviewer reads the diff in `actions/users.ts` and confirms `requireAdmin()` and the column allowlist
- [ ] Reviewer runs `pnpm --filter govea vitest run tests/integration/users.test.ts` locally and sees 33 passing
- [ ] Reviewer confirms `(admin)/users` page still loads and shows the user list when logged in as an admin
- [ ] Reviewer confirms passwordHash is not present in the response (DevTools → Network → POST `/users` action)

## Out of scope

- The same pattern fix is needed across other read actions (`getCapabilities`, `getOtherOrganizations`, `getConnections`, `taxonomy.ts` reads). Those are tracked in [#412](https://github.com/roballred/GovEA/issues/412), [#413](https://github.com/roballred/GovEA/issues/413), [#414](https://github.com/roballred/GovEA/issues/414).
- Adding `*.tsbuildinfo` to `.gitignore` (a side observation while preparing this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)