### PR TITLE
fix(security): move cross-org-link helpers out of 'use server' module (#412)

### DIFF
--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -10,7 +10,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
-import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/actions/cross-org-links'
+import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
 
 async function requireContributor() {
   const session = await auth()

--- a/apps/govea/src/actions/connections.ts
+++ b/apps/govea/src/actions/connections.ts
@@ -7,7 +7,7 @@ import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
-import { removeLinksForConnection } from './cross-org-links'
+import { removeLinksForConnection } from '@/lib/cross-org-link-helpers'
 
 async function requireAdmin() {
   const session = await auth()
@@ -117,7 +117,7 @@ export async function removeConnection(connectionId: string) {
   })
   if (!connection) throw new Error('Connection not found or not authorized')
 
-  await removeLinksForConnection(connection.fromOrgId, connection.toOrgId)
+  await removeLinksForConnection(connection.fromOrgId, connection.toOrgId, session.user.id, orgId)
   await db.delete(orgConnections).where(eq(orgConnections.id, connectionId))
 
   await writeAuditLog({

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -251,47 +251,9 @@ export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId:
   return { approved, inboundPending, outboundPending, outboundRejected, availableTargets }
 }
 
-// Called by editCapability / editPersona when an entity's visibility drops to 'org'.
-// Flags all active and pending links involving that entity so both orgs are alerted.
-export async function flagLinksForVisibilityDrop(
-  entityType: CrossOrgEntityType,
-  entityId: string,
-  reason: string,
-) {
-  await db.update(crossOrgLinks).set({
-    flaggedForReview: true,
-    flagReason: reason,
-    updatedAt: new Date(),
-  }).where(
-    and(
-      or(
-        and(eq(crossOrgLinks.sourceEntityType, entityType), eq(crossOrgLinks.sourceEntityId, entityId)),
-        and(eq(crossOrgLinks.targetEntityType, entityType), eq(crossOrgLinks.targetEntityId, entityId)),
-      ),
-      inArray(crossOrgLinks.status, ['pending', 'active']),
-    )
-  )
-}
-
-// Called when visibility is raised back to 'connections' or 'instance', clearing stale flags.
-export async function clearLinksFlag(
-  entityType: CrossOrgEntityType,
-  entityId: string,
-) {
-  await db.update(crossOrgLinks).set({
-    flaggedForReview: false,
-    flagReason: null,
-    updatedAt: new Date(),
-  }).where(
-    and(
-      or(
-        and(eq(crossOrgLinks.sourceEntityType, entityType), eq(crossOrgLinks.sourceEntityId, entityId)),
-        and(eq(crossOrgLinks.targetEntityType, entityType), eq(crossOrgLinks.targetEntityId, entityId)),
-      ),
-      eq(crossOrgLinks.flaggedForReview, true),
-    )
-  )
-}
+// Note: flagLinksForVisibilityDrop and clearLinksFlag previously lived here as
+// exported 'use server' functions. They are now internal helpers in
+// lib/cross-org-link-helpers.ts so they cannot be reached as RPC endpoints. See #412.
 
 export async function requestCrossOrgLink(
   type: CrossOrgEntityType,
@@ -453,38 +415,7 @@ export async function revokeCrossOrgLink(linkId: string) {
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
 }
 
-export async function removeLinksForConnection(orgAId: string, orgBId: string) {
-  const affectedLinks = await db.query.crossOrgLinks.findMany({
-    where: or(
-      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
-      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
-    ),
-  })
-
-  await db.delete(crossOrgLinks).where(
-    or(
-      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
-      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
-    )
-  )
-
-  if (affectedLinks.length > 0) {
-    await writeAuditLog({
-      action: 'cross_org_link.remove_for_connection',
-      entityType: 'org_connection',
-      organizationId: orgAId,
-      before: {
-        orgAId,
-        orgBId,
-        removedLinkIds: affectedLinks.map(link => link.id),
-        removedLinks: affectedLinks.map(link => ({
-          id: link.id,
-          sourceEntityId: link.sourceEntityId,
-          targetEntityId: link.targetEntityId,
-          status: link.status,
-          linkType: link.linkType,
-        })),
-      },
-    })
-  }
-}
+// Note: removeLinksForConnection previously lived here as an exported 'use server'
+// function with no auth check. It is now an internal helper in
+// lib/cross-org-link-helpers.ts that requires the caller to pass actor identity
+// (so audit rows are not anonymous). See #412.

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -9,7 +9,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
-import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/actions/cross-org-links'
+import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
 
 async function requireContributor() {
   const session = await auth()

--- a/apps/govea/src/lib/cross-org-link-helpers.ts
+++ b/apps/govea/src/lib/cross-org-link-helpers.ts
@@ -1,0 +1,116 @@
+import { db } from '@/db/client'
+import { crossOrgLinks } from '@/db/schema'
+import { and, eq, inArray, or } from 'drizzle-orm'
+import { writeAuditLog } from '@/lib/audit'
+
+export type CrossOrgEntityType = 'capability' | 'persona'
+
+// Internal helpers used by mutations in actions/capabilities.ts, actions/personas.ts,
+// and actions/connections.ts. They live in lib/ — not actions/ — so they cannot be
+// reached as 'use server' RPC endpoints. Each caller is itself a server action with
+// its own auth check; these helpers trust that the caller has already validated the
+// session and authorization.
+//
+// History: previously these were exported from actions/cross-org-links.ts with no
+// auth check, making them callable by any network client. See #412.
+
+/**
+ * Flag all active and pending cross-org links involving an entity for review.
+ * Called when an entity's visibility drops to 'org' so both orgs are alerted that
+ * a link may no longer be accessible.
+ *
+ * Caller MUST have already verified that the entity belongs to the actor's org.
+ */
+export async function flagLinksForVisibilityDrop(
+  entityType: CrossOrgEntityType,
+  entityId: string,
+  reason: string,
+) {
+  await db.update(crossOrgLinks).set({
+    flaggedForReview: true,
+    flagReason: reason,
+    updatedAt: new Date(),
+  }).where(
+    and(
+      or(
+        and(eq(crossOrgLinks.sourceEntityType, entityType), eq(crossOrgLinks.sourceEntityId, entityId)),
+        and(eq(crossOrgLinks.targetEntityType, entityType), eq(crossOrgLinks.targetEntityId, entityId)),
+      ),
+      inArray(crossOrgLinks.status, ['pending', 'active']),
+    )
+  )
+}
+
+/**
+ * Clear stale review flags on cross-org links for an entity.
+ * Called when visibility is raised back to 'connections' or 'instance'.
+ *
+ * Caller MUST have already verified that the entity belongs to the actor's org.
+ */
+export async function clearLinksFlag(
+  entityType: CrossOrgEntityType,
+  entityId: string,
+) {
+  await db.update(crossOrgLinks).set({
+    flaggedForReview: false,
+    flagReason: null,
+    updatedAt: new Date(),
+  }).where(
+    and(
+      or(
+        and(eq(crossOrgLinks.sourceEntityType, entityType), eq(crossOrgLinks.sourceEntityId, entityId)),
+        and(eq(crossOrgLinks.targetEntityType, entityType), eq(crossOrgLinks.targetEntityId, entityId)),
+      ),
+      eq(crossOrgLinks.flaggedForReview, true),
+    )
+  )
+}
+
+/**
+ * Delete every cross-org link between two organizations. Called when a connection
+ * between orgA and orgB is removed.
+ *
+ * `actorUserId` and `actorOrgId` are required so the audit row identifies who
+ * performed the removal. Caller MUST be an admin of one of the two orgs.
+ */
+export async function removeLinksForConnection(
+  orgAId: string,
+  orgBId: string,
+  actorUserId: string,
+  actorOrgId: string,
+) {
+  const affectedLinks = await db.query.crossOrgLinks.findMany({
+    where: or(
+      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
+      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
+    ),
+  })
+
+  await db.delete(crossOrgLinks).where(
+    or(
+      and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
+      and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
+    )
+  )
+
+  if (affectedLinks.length > 0) {
+    await writeAuditLog({
+      action: 'cross_org_link.remove_for_connection',
+      entityType: 'org_connection',
+      userId: actorUserId,
+      organizationId: actorOrgId,
+      before: {
+        orgAId,
+        orgBId,
+        removedLinkIds: affectedLinks.map(link => link.id),
+        removedLinks: affectedLinks.map(link => ({
+          id: link.id,
+          sourceEntityId: link.sourceEntityId,
+          targetEntityId: link.targetEntityId,
+          status: link.status,
+          linkType: link.linkType,
+        })),
+      },
+    })
+  }
+}

--- a/apps/govea/tests/integration/cross-org-link-helpers.test.ts
+++ b/apps/govea/tests/integration/cross-org-link-helpers.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Lock in the architecture from #412.
+ *
+ * The helpers (flagLinksForVisibilityDrop, clearLinksFlag,
+ * removeLinksForConnection) MUST live in lib/ — not actions/ — so they
+ * cannot be reached as 'use server' RPC endpoints. If a future change
+ * re-exports them from actions/, this test fails.
+ */
+import { vi, describe, it, expect } from 'vitest'
+
+// auth() is mocked because importing actions/cross-org-links transitively
+// pulls in next-auth, which has Node-only resolution that breaks in vitest
+// without a mock. We never call auth() in this file — the mock only exists
+// to keep the import graph happy.
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('cross-org-link-helpers placement (#412)', () => {
+  it('helpers are exported from lib/cross-org-link-helpers', async () => {
+    const lib = await import('@/lib/cross-org-link-helpers')
+    expect(typeof lib.flagLinksForVisibilityDrop).toBe('function')
+    expect(typeof lib.clearLinksFlag).toBe('function')
+    expect(typeof lib.removeLinksForConnection).toBe('function')
+  })
+
+  it('actions/cross-org-links no longer exports the helpers', async () => {
+    const actions = await import('@/actions/cross-org-links')
+    // 'use server' RPC modules must NOT expose internal helpers — the helpers
+    // would otherwise become network-callable endpoints.
+    expect(actions).not.toHaveProperty('flagLinksForVisibilityDrop')
+    expect(actions).not.toHaveProperty('clearLinksFlag')
+    expect(actions).not.toHaveProperty('removeLinksForConnection')
+  })
+})


### PR DESCRIPTION
Closes #412

## Summary

Closes the unauthenticated-mutation surface on three cross-org-link helpers by moving them out of a `'use server'` module. They live in `lib/` now, so they are no longer network-callable RPC endpoints — only the higher-level actions that already authenticate can invoke them.

## What changed

| File | Change |
|---|---|
| `apps/govea/src/lib/cross-org-link-helpers.ts` (new) | Houses `flagLinksForVisibilityDrop`, `clearLinksFlag`, `removeLinksForConnection` |
| `apps/govea/src/actions/cross-org-links.ts` | Removes the three exports; leaves a comment pointing to the new home |
| `apps/govea/src/actions/capabilities.ts` | Import from `@/lib/cross-org-link-helpers` |
| `apps/govea/src/actions/personas.ts` | Same |
| `apps/govea/src/actions/connections.ts` | Same; passes `session.user.id` and `orgId` to `removeLinksForConnection` |
| `apps/govea/tests/integration/cross-org-link-helpers.test.ts` (new) | Locks in the architecture |

## Why

[#412](https://github.com/roballred/GovEA/issues/412) (originally Critical, downgraded to High after live verification): every export from a `'use server'` module is HTTP-callable in Next.js. The three helpers had no auth check, so any logged-in user could:

- Flag/unflag arbitrary cross-org links across the entire instance
- Mass-delete cross-org links between any two orgs by guessing UUIDs
- Inject attacker-controlled `flagReason` text into the DB
- Produce audit rows with no `userId` (because no session was consulted)

The fix relocates them to `lib/`, where they cannot be reached as RPC endpoints by construction. This is the safer of the two options the issue proposed.

## Audit improvement (closes a related gap)

`removeLinksForConnection` now requires `actorUserId` and `actorOrgId` parameters. The audit row written by this helper now identifies the user who performed the removal — closing the "audit row with no userId" gap that the security scan noted alongside this issue.

## Verification

- All 181 integration tests pass (179 existing + 2 new)
- `tsc --noEmit` clean
- New test asserts:
  - The helpers ARE exported from `lib/cross-org-link-helpers`
  - The helpers are NOT exported from `actions/cross-org-links`
  - If anyone re-exports them from the actions module in the future, the test fails

## Test plan

- [ ] Reviewer confirms `lib/cross-org-link-helpers.ts` has no `'use server'` directive
- [ ] Reviewer confirms `actions/cross-org-links.ts` no longer exports the three names
- [ ] Reviewer runs `pnpm --filter govea vitest run tests/integration/` and sees 181 passing
- [ ] Existing legitimate path (admin removing a connection) still works in the UI

## Sequence

This is one of three fixes targeting #411-#414. The next PR will combine #413 + #414 (read actions trusting caller-supplied `organizationId` and `role`) since they're a single audit pass across the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)