### PR TITLE
fix(security): move entity-taxonomy helpers out of 'use server' module (#427)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -5,7 +5,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives, entityTaxonomyValues,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -9,7 +9,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
-import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from './taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from '@/lib/entity-taxonomy-helpers'
 import { getCustomFieldSchema } from './custom-fields'
 
 async function requireContributor() {

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { capabilities, capabilityPersonas, capabilityRelationships, entityTaxonomyValues } from '@/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
-import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -5,7 +5,7 @@ import {
   initiatives, initiativeCapabilities, initiativeObjectives, entityTaxonomyValues,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams, entityTaxonomyValues } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { principles, principleAdrs, principleCapabilities, entityTaxonomyValues } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/actions/taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -11,7 +11,7 @@ import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
-import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from './taxonomy'
+import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from '@/lib/entity-taxonomy-helpers'
 
 async function requireContributor() {
   const session = await auth()

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { taxonomyTerms, principles, entityTaxonomyDefinitions, entityTaxonomyValues } from '@/db/schema'
+import { taxonomyTerms, principles, entityTaxonomyDefinitions } from '@/db/schema'
 import { eq, and, isNull, inArray, count } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -311,63 +311,11 @@ export async function getPersonaTagsFromTaxonomy() {
 
 // ── Entity Taxonomy Definitions ──────────────────────────────────────────────
 
-/**
- * Returns definitions for a given entity type, including the type name and its values.
- * Used by create/edit forms to render dynamic taxonomy inputs.
- */
-export async function getEntityTaxonomyDefinitions(organizationId: string, entityType: string) {
-  const defs = await db.query.entityTaxonomyDefinitions.findMany({
-    where: (d, { eq, and }) =>
-      and(eq(d.organizationId, organizationId), eq(d.entityType, entityType)),
-    orderBy: (d, { asc }) => [asc(d.sortOrder)],
-  })
-
-  if (defs.length === 0) return []
-
-  const typeIds = defs.map(d => d.taxonomyTypeId)
-  const types = await db.query.taxonomyTerms.findMany({
-    where: (t, { inArray }) => inArray(t.id, typeIds),
-  })
-  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
-
-  const values = await db.query.taxonomyTerms.findMany({
-    where: (t, { eq, and, inArray }) =>
-      and(eq(t.organizationId, organizationId), inArray(t.parentId, typeIds)),
-    orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
-  })
-
-  return defs.map(def => ({
-    ...def,
-    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
-    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
-    values: values.filter(v => v.parentId === def.taxonomyTypeId),
-  }))
-}
-
-/**
- * Returns all definitions grouped by entity type, with type names.
- * Used by the taxonomy admin page to show which types are wired to which entity types.
- */
-export async function getAllEntityTaxonomyDefinitions(organizationId: string) {
-  const defs = await db.query.entityTaxonomyDefinitions.findMany({
-    where: (d, { eq }) => eq(d.organizationId, organizationId),
-    orderBy: (d, { asc }) => [asc(d.entityType), asc(d.sortOrder)],
-  })
-
-  if (defs.length === 0) return []
-
-  const typeIds = [...new Set(defs.map(d => d.taxonomyTypeId))]
-  const types = await db.query.taxonomyTerms.findMany({
-    where: (t, { inArray }) => inArray(t.id, typeIds),
-  })
-  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
-
-  return defs.map(def => ({
-    ...def,
-    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
-    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
-  }))
-}
+// Note: getEntityTaxonomyDefinitions, getAllEntityTaxonomyDefinitions,
+// getEntityTaxonomyValues, syncEntityTaxonomyValues, and
+// getEntityTaxonomyValuesForMany previously lived here as exported 'use server'
+// functions with no auth check. They are now in lib/entity-taxonomy-helpers.ts
+// so they cannot be reached as RPC endpoints. See #427.
 
 export async function addEntityTaxonomyDefinition(formData: FormData) {
   const session = await requireAdmin()
@@ -400,77 +348,9 @@ export async function removeEntityTaxonomyDefinition(definitionId: string) {
     ))
 }
 
-// ── Entity Taxonomy Values ────────────────────────────────────────────────────
-
-/** Returns selected taxonomy values for a single entity record, grouped by type. */
-export async function getEntityTaxonomyValues(organizationId: string, entityType: string, entityId: string) {
-  const rows = await db.query.entityTaxonomyValues.findMany({
-    where: (v, { eq, and }) =>
-      and(
-        eq(v.organizationId, organizationId),
-        eq(v.entityType, entityType),
-        eq(v.entityId, entityId),
-      ),
-  })
-  return rows
-}
-
-/**
- * Replaces all taxonomy values for an entity record.
- * Deletes current selections and inserts the new set atomically.
- */
-export async function syncEntityTaxonomyValues(
-  organizationId: string,
-  entityType: string,
-  entityId: string,
-  termIds: string[],
-) {
-  await db.delete(entityTaxonomyValues)
-    .where(and(
-      eq(entityTaxonomyValues.organizationId, organizationId),
-      eq(entityTaxonomyValues.entityType, entityType),
-      eq(entityTaxonomyValues.entityId, entityId),
-    ))
-
-  if (termIds.length > 0) {
-    await db.insert(entityTaxonomyValues).values(
-      termIds.map(termId => ({
-        organizationId,
-        entityType,
-        entityId,
-        taxonomyTermId: termId,
-      }))
-    )
-  }
-}
-
-/**
- * Returns taxonomy values for multiple entity records of the same type.
- * Returns a map of entityId → array of term rows.
- */
-export async function getEntityTaxonomyValuesForMany(
-  organizationId: string,
-  entityType: string,
-  entityIds: string[],
-): Promise<Record<string, typeof entityTaxonomyValues.$inferSelect[]>> {
-  if (entityIds.length === 0) return {}
-
-  const rows = await db.query.entityTaxonomyValues.findMany({
-    where: (v, { eq, and, inArray }) =>
-      and(
-        eq(v.organizationId, organizationId),
-        eq(v.entityType, entityType),
-        inArray(v.entityId, entityIds),
-      ),
-  })
-
-  const result: Record<string, typeof entityTaxonomyValues.$inferSelect[]> = {}
-  for (const row of rows) {
-    if (!result[row.entityId]) result[row.entityId] = []
-    result[row.entityId].push(row)
-  }
-  return result
-}
+// Note: getEntityTaxonomyValues, syncEntityTaxonomyValues, and
+// getEntityTaxonomyValuesForMany are now in lib/entity-taxonomy-helpers.ts.
+// See #427.
 
 /**
  * Ad-hoc: creates a new value under the "Domain" type.

--- a/apps/govea/src/app/(admin)/adrs/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/page.tsx
@@ -5,7 +5,7 @@ import { getCapabilities } from '@/actions/capabilities'
 import { getApplications } from '@/actions/applications'
 import { getInitiatives } from '@/actions/initiatives'
 import { getObjectives } from '@/actions/objectives'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { ADRTable } from './adr-table'
 
 export default async function ADRsPage() {

--- a/apps/govea/src/app/(admin)/applications/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getApplications } from '@/actions/applications'
 import { getCapabilities } from '@/actions/capabilities'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { getCustomFieldSchema } from '@/actions/custom-fields'
 import { ApplicationTable } from './application-table'
 

--- a/apps/govea/src/app/(admin)/capabilities/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/page.tsx
@@ -2,7 +2,8 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getCapabilities } from '@/actions/capabilities'
 import { getPersonas } from '@/actions/personas'
-import { getTaxonomyDomains, getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getTaxonomyDomains } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { CapabilityTable } from './capability-table'
 export default async function CapabilitiesPage() {
   const session = await auth()

--- a/apps/govea/src/app/(admin)/initiatives/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { getInitiatives } from '@/actions/initiatives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getObjectives } from '@/actions/objectives'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { InitiativeTable } from './initiative-table'
 export default async function InitiativesPage() {
   const session = await auth()

--- a/apps/govea/src/app/(admin)/objectives/page.tsx
+++ b/apps/govea/src/app/(admin)/objectives/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getValueStreams } from '@/actions/value-streams'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { ObjectiveTable } from './objective-table'
 export default async function ObjectivesPage() {
   const session = await auth()

--- a/apps/govea/src/app/(admin)/principles/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/page.tsx
@@ -3,7 +3,8 @@ import { redirect } from 'next/navigation'
 import { getPrinciples } from '@/actions/principles'
 import { getADRs } from '@/actions/adrs'
 import { getCapabilities } from '@/actions/capabilities'
-import { getPrincipleTypes, getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getPrincipleTypes } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { PrincipleTable } from './principle-table'
 
 export default async function PrinciplesPage() {

--- a/apps/govea/src/app/(admin)/services/page.tsx
+++ b/apps/govea/src/app/(admin)/services/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getServices } from '@/actions/services'
 import { getPersonas } from '@/actions/personas'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import { ServiceTable } from './service-table'
 
 export default async function ServicesPage() {

--- a/apps/govea/src/app/(admin)/taxonomy/page.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { getTaxonomyTermsWithChildren, getPrincipleTypeValueUsage, getAllEntityTaxonomyDefinitions } from '@/actions/taxonomy'
+import { getTaxonomyTermsWithChildren, getPrincipleTypeValueUsage } from '@/actions/taxonomy'
+import { getAllEntityTaxonomyDefinitions } from '@/lib/entity-taxonomy-helpers'
 import { TaxonomyTable } from './taxonomy-table'
 
 export default async function TaxonomyPage() {

--- a/apps/govea/src/app/api/applications/export/route.ts
+++ b/apps/govea/src/app/api/applications/export/route.ts
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { canEdit } from '@/lib/rbac'
 import { getApplications } from '@/actions/applications'
 import { getCustomFieldSchema } from '@/actions/custom-fields'
-import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/actions/taxonomy'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import type { CustomFieldDefinition } from '@/db/schema'
 import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 

--- a/apps/govea/src/lib/entity-taxonomy-helpers.ts
+++ b/apps/govea/src/lib/entity-taxonomy-helpers.ts
@@ -1,0 +1,160 @@
+import { db } from '@/db/client'
+import { entityTaxonomyValues } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+
+// Internal helpers used by mutations and detail-page reads in actions/capabilities.ts,
+// actions/personas.ts, actions/applications.ts, actions/objectives.ts,
+// actions/initiatives.ts, actions/principles.ts, actions/services.ts, actions/adrs.ts,
+// and a handful of admin pages. They live in lib/ — not actions/ — so they cannot be
+// reached as 'use server' RPC endpoints. Each caller is itself authenticated; these
+// helpers trust that the caller has already validated the session and ownership of
+// the entity in question.
+//
+// History: previously these were exported from actions/taxonomy.ts with no auth check,
+// making them callable by any authenticated user with any organizationId. See #427.
+
+// ── Entity Taxonomy Definitions ──────────────────────────────────────────────
+
+/**
+ * Returns definitions for a given entity type, including the type name and its values.
+ * Used by create/edit forms to render dynamic taxonomy inputs.
+ *
+ * Caller MUST pass an organizationId derived from the actor's session.
+ */
+export async function getEntityTaxonomyDefinitions(organizationId: string, entityType: string) {
+  const defs = await db.query.entityTaxonomyDefinitions.findMany({
+    where: (d, { eq, and }) =>
+      and(eq(d.organizationId, organizationId), eq(d.entityType, entityType)),
+    orderBy: (d, { asc }) => [asc(d.sortOrder)],
+  })
+
+  if (defs.length === 0) return []
+
+  const typeIds = defs.map(d => d.taxonomyTypeId)
+  const types = await db.query.taxonomyTerms.findMany({
+    where: (t, { inArray }) => inArray(t.id, typeIds),
+  })
+  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
+
+  const values = await db.query.taxonomyTerms.findMany({
+    where: (t, { eq, and, inArray }) =>
+      and(eq(t.organizationId, organizationId), inArray(t.parentId, typeIds)),
+    orderBy: (t, { asc }) => [asc(t.sortOrder), asc(t.name)],
+  })
+
+  return defs.map(def => ({
+    ...def,
+    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
+    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
+    values: values.filter(v => v.parentId === def.taxonomyTypeId),
+  }))
+}
+
+/**
+ * Returns all definitions grouped by entity type, with type names.
+ * Used by the taxonomy admin page to show which types are wired to which entity types.
+ *
+ * Caller MUST pass an organizationId derived from the actor's session.
+ */
+export async function getAllEntityTaxonomyDefinitions(organizationId: string) {
+  const defs = await db.query.entityTaxonomyDefinitions.findMany({
+    where: (d, { eq }) => eq(d.organizationId, organizationId),
+    orderBy: (d, { asc }) => [asc(d.entityType), asc(d.sortOrder)],
+  })
+
+  if (defs.length === 0) return []
+
+  const typeIds = [...new Set(defs.map(d => d.taxonomyTypeId))]
+  const types = await db.query.taxonomyTerms.findMany({
+    where: (t, { inArray }) => inArray(t.id, typeIds),
+  })
+  const typeMap = Object.fromEntries(types.map(t => [t.id, t]))
+
+  return defs.map(def => ({
+    ...def,
+    typeName: typeMap[def.taxonomyTypeId]?.name ?? '',
+    typeSlug: typeMap[def.taxonomyTypeId]?.slug ?? '',
+  }))
+}
+
+// ── Entity Taxonomy Values ────────────────────────────────────────────────────
+
+/**
+ * Returns selected taxonomy values for a single entity record, grouped by type.
+ *
+ * Caller MUST pass an organizationId derived from the actor's session, and have
+ * already verified that the entity belongs to that org (or is federated-readable).
+ */
+export async function getEntityTaxonomyValues(organizationId: string, entityType: string, entityId: string) {
+  const rows = await db.query.entityTaxonomyValues.findMany({
+    where: (v, { eq, and }) =>
+      and(
+        eq(v.organizationId, organizationId),
+        eq(v.entityType, entityType),
+        eq(v.entityId, entityId),
+      ),
+  })
+  return rows
+}
+
+/**
+ * Replaces all taxonomy values for an entity record.
+ * Deletes current selections and inserts the new set atomically.
+ *
+ * Caller MUST pass an organizationId derived from the actor's session, and have
+ * already verified write authorization on the entity.
+ */
+export async function syncEntityTaxonomyValues(
+  organizationId: string,
+  entityType: string,
+  entityId: string,
+  termIds: string[],
+) {
+  await db.delete(entityTaxonomyValues)
+    .where(and(
+      eq(entityTaxonomyValues.organizationId, organizationId),
+      eq(entityTaxonomyValues.entityType, entityType),
+      eq(entityTaxonomyValues.entityId, entityId),
+    ))
+
+  if (termIds.length > 0) {
+    await db.insert(entityTaxonomyValues).values(
+      termIds.map(termId => ({
+        organizationId,
+        entityType,
+        entityId,
+        taxonomyTermId: termId,
+      }))
+    )
+  }
+}
+
+/**
+ * Returns taxonomy values for multiple entity records of the same type.
+ * Returns a map of entityId → array of term rows.
+ *
+ * Caller MUST pass an organizationId derived from the actor's session.
+ */
+export async function getEntityTaxonomyValuesForMany(
+  organizationId: string,
+  entityType: string,
+  entityIds: string[],
+): Promise<Record<string, typeof entityTaxonomyValues.$inferSelect[]>> {
+  if (entityIds.length === 0) return {}
+
+  const rows = await db.query.entityTaxonomyValues.findMany({
+    where: (v, { eq, and, inArray }) =>
+      and(
+        eq(v.organizationId, organizationId),
+        eq(v.entityType, entityType),
+        inArray(v.entityId, entityIds),
+      ),
+  })
+
+  const result: Record<string, typeof entityTaxonomyValues.$inferSelect[]> = {}
+  for (const row of rows) {
+    if (!result[row.entityId]) result[row.entityId] = []
+    result[row.entityId].push(row)
+  }
+  return result
+}

--- a/apps/govea/tests/integration/entity-taxonomy-helpers.test.ts
+++ b/apps/govea/tests/integration/entity-taxonomy-helpers.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Lock in the architecture from #427.
+ *
+ * The entity-taxonomy helpers (getEntityTaxonomyDefinitions,
+ * getAllEntityTaxonomyDefinitions, getEntityTaxonomyValues,
+ * syncEntityTaxonomyValues, getEntityTaxonomyValuesForMany) MUST live in
+ * lib/ — not actions/ — so they cannot be reached as 'use server' RPC
+ * endpoints. If a future change re-exports them from actions/, this test
+ * fails.
+ */
+import { vi, describe, it, expect } from 'vitest'
+
+// auth() is mocked because importing actions/taxonomy transitively pulls in
+// next-auth, which has Node-only resolution that breaks in vitest without a
+// mock. We never call auth() in this file.
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('entity-taxonomy-helpers placement (#427)', () => {
+  it('helpers are exported from lib/entity-taxonomy-helpers', async () => {
+    const lib = await import('@/lib/entity-taxonomy-helpers')
+    expect(typeof lib.getEntityTaxonomyDefinitions).toBe('function')
+    expect(typeof lib.getAllEntityTaxonomyDefinitions).toBe('function')
+    expect(typeof lib.getEntityTaxonomyValues).toBe('function')
+    expect(typeof lib.syncEntityTaxonomyValues).toBe('function')
+    expect(typeof lib.getEntityTaxonomyValuesForMany).toBe('function')
+  })
+
+  it('actions/taxonomy no longer exports the entity-taxonomy helpers', async () => {
+    const actions = await import('@/actions/taxonomy')
+    // 'use server' RPC modules must NOT expose internal helpers — those
+    // would otherwise become network-callable endpoints.
+    expect(actions).not.toHaveProperty('getEntityTaxonomyDefinitions')
+    expect(actions).not.toHaveProperty('getAllEntityTaxonomyDefinitions')
+    expect(actions).not.toHaveProperty('getEntityTaxonomyValues')
+    expect(actions).not.toHaveProperty('syncEntityTaxonomyValues')
+    expect(actions).not.toHaveProperty('getEntityTaxonomyValuesForMany')
+  })
+})


### PR DESCRIPTION
Closes #427

## Summary

Closes the same vulnerability pattern as PR #425 (cross-org-link helpers), applied to the five entity-taxonomy helpers in `actions/taxonomy.ts`. They now live in `lib/`, so they can no longer be reached as `'use server'` RPC endpoints.

## What changed

| File | Change |
|---|---|
| `apps/govea/src/lib/entity-taxonomy-helpers.ts` (new) | Houses `getEntityTaxonomyDefinitions`, `getAllEntityTaxonomyDefinitions`, `getEntityTaxonomyValues`, `syncEntityTaxonomyValues`, `getEntityTaxonomyValuesForMany` |
| `apps/govea/src/actions/taxonomy.ts` | Removes the five exports; leaves a comment pointing to the new home; drops the now-unused `entityTaxonomyValues` schema import |
| 7 action files | Import path swap: `@/actions/taxonomy` → `@/lib/entity-taxonomy-helpers` (adrs, applications, capabilities, initiatives, objectives, principles, services) |
| 8 page files | Same path swap; 3 needed the import line split because they pulled in a mix of helpers (moved to lib) and other taxonomy reads (still in actions) |
| 1 API route | Same path swap (`applications/export`) |
| `apps/govea/tests/integration/entity-taxonomy-helpers.test.ts` (new) | Locks in the architecture |

## Why

[#427](https://github.com/roballred/goVEA/issues/427) (severity: High): the five helpers accepted a caller-supplied `organizationId` with no auth check. Any authenticated user could call them with any `organizationId` and read or modify entity-taxonomy state for any tenant.

Same fix shape as PR #425: relocate to `lib/`, where they cannot be reached as RPC endpoints by construction. Each call site is itself a server action that has already authenticated the actor and verified ownership.

## Verification

- All 213 integration tests pass (211 existing + 2 new)
- `tsc --noEmit` clean
- New test asserts:
  - The helpers ARE exported from `lib/entity-taxonomy-helpers`
  - The helpers are NOT exported from `actions/taxonomy`

## Test plan

- [ ] Reviewer confirms `lib/entity-taxonomy-helpers.ts` has no `'use server'` directive
- [ ] Reviewer confirms `actions/taxonomy.ts` no longer exports the five names
- [ ] Reviewer runs `pnpm --filter govea vitest run tests/integration/` and sees 14 files / 213 passed
- [ ] Existing taxonomy admin page (`/taxonomy`) still loads and shows definitions
- [ ] Existing entity detail pages (capabilities, applications, etc.) still show their taxonomy values

🤖 Generated with [Claude Code](https://claude.com/claude-code)