### PR TITLE
fix(security): audit_log immutable at the DB level (#417)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Push schema to database
         run: pnpm --filter govea db:push --force
 
+      - name: Apply DB triggers (audit_log immutability, etc.)
+        run: pnpm --filter govea db:apply-triggers:container
+
       - name: Run integration tests
         run: pnpm --filter govea test:integration
 
@@ -164,6 +167,9 @@ jobs:
 
       - name: Push schema to database
         run: pnpm --filter govea db:push --force
+
+      - name: Apply DB triggers (audit_log immutability, etc.)
+        run: pnpm --filter govea db:apply-triggers:container
 
       # The db:seed script uses `tsx --env-file .env.local`.  Create an empty
       # placeholder so tsx does not fail on the missing file.  All real env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,20 @@ SSO users default to Viewer. Admins promote as needed.
 
 ## Database Workflow
 
-**Pre-production (current):** Use `db:push` to sync schema changes directly to the dev database. CI also uses `db:push --force` on a fresh database. No migration files needed — run `pnpm --filter govea db:push` after schema edits, then `db:seed` to repopulate.
+**Pre-production (current):** Use `db:push` to sync schema changes directly to the dev database. CI also uses `db:push --force` on a fresh database. No migration files needed — run `pnpm --filter govea db:push` after schema edits, then `db:apply-triggers` to install Postgres triggers, then `db:seed` to repopulate.
 
-**Switch to migrations when:** the first real tenant or persistent data exists that can't be thrown away. At that point: squash the schema into a single `0000_initial_schema.sql`, switch CI from `db:push` to `db:migrate`, and use `db:generate` + `db:migrate` for all schema changes going forward. Update this section when the switch happens.
+**Switch to migrations when:** the first real tenant or persistent data exists that can't be thrown away. At that point: squash the schema into a single `0000_initial_schema.sql`, fold the SQL files in `apps/govea/src/db/sql/` into the migration sequence, switch CI from `db:push` to `db:migrate`, and use `db:generate` + `db:migrate` for all schema changes going forward. Update this section when the switch happens.
 
 Do not commit migration files generated during pre-production development.
+
+### Postgres triggers (DB-level constraints)
+
+Some constraints are enforced by Postgres triggers that drizzle-kit does not manage. Source of truth: `apps/govea/src/db/sql/*.sql`. Idempotent — re-applied after every `db:push` by `pnpm --filter govea db:apply-triggers`.
+
+Currently shipped:
+- `audit-immutable.sql` — blocks UPDATE and DELETE on `audit_log` (#417). Audit rows are append-only at the DB layer; even a compromised admin role cannot rewrite history. Operators: this means the `audit_log` table cannot be retroactively edited, including by you.
+
+When adding a new trigger, drop a new `.sql` file in `src/db/sql/` (idempotent: `CREATE OR REPLACE` for functions, `DROP TRIGGER IF EXISTS` then `CREATE TRIGGER`). The apply-triggers script picks it up automatically.
 
 ---
 

--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -13,6 +13,8 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx --env-file .env.local src/db/seeds/run.ts",
     "db:seed:container": "tsx src/db/seeds/run.ts",
+    "db:apply-triggers": "tsx --env-file .env.local src/db/scripts/apply-triggers.ts",
+    "db:apply-triggers:container": "tsx src/db/scripts/apply-triggers.ts",
     "test:e2e": "playwright test",
     "test:integration": "vitest run --config vitest.config.ts",
     "test:integration:watch": "vitest --config vitest.config.ts"

--- a/apps/govea/src/db/schema/audit.ts
+++ b/apps/govea/src/db/schema/audit.ts
@@ -1,11 +1,17 @@
 import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
-import { organizations } from './organizations'
-import { users } from './users'
 
+/**
+ * Append-only audit log.
+ *
+ * Foreign-key constraints on `organization_id` and `user_id` are intentionally
+ * omitted (#417). Audit rows preserve the UUIDs that were valid at event time;
+ * those UUIDs may legitimately point at later-deleted rows. UPDATE and DELETE
+ * are blocked at the DB level by triggers in `apps/govea/src/db/sql/audit-immutable.sql`.
+ */
 export const auditLog = pgTable('audit_log', {
   id: uuid('id').primaryKey().defaultRandom(),
-  organizationId: uuid('organization_id').references(() => organizations.id, { onDelete: 'set null' }),
-  userId: uuid('user_id').references(() => users.id, { onDelete: 'set null' }),
+  organizationId: uuid('organization_id'), // historical UUID — no FK on purpose
+  userId: uuid('user_id'),                 // historical UUID — no FK on purpose
   action: text('action').notNull(), // e.g. 'create', 'update', 'delete', 'publish', 'login'
   entityType: text('entity_type').notNull(), // e.g. 'persona', 'capability', 'application'
   entityId: uuid('entity_id'),

--- a/apps/govea/src/db/scripts/apply-triggers.ts
+++ b/apps/govea/src/db/scripts/apply-triggers.ts
@@ -1,0 +1,45 @@
+/**
+ * Applies the canonical Postgres triggers from `src/db/sql/*.sql` to the
+ * database referenced by `DATABASE_URL`.
+ *
+ * Run after every `db:push` so the triggers are re-installed on a freshly
+ * pushed schema. Idempotent: each SQL file uses CREATE OR REPLACE / DROP IF
+ * EXISTS so it can run any number of times.
+ *
+ * Local: `pnpm --filter govea db:apply-triggers`
+ * CI:    `pnpm --filter govea db:apply-triggers:container`
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import postgres from 'postgres'
+
+async function main() {
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    console.error('apply-triggers: DATABASE_URL is not set')
+    process.exit(1)
+  }
+
+  const sqlDir = resolve(process.cwd(), 'src/db/sql')
+  const files = readdirSync(sqlDir).filter(f => f.endsWith('.sql')).sort()
+  if (files.length === 0) {
+    console.log('apply-triggers: no SQL files in', sqlDir)
+    return
+  }
+
+  const sql = postgres(url, { onnotice: () => {} })
+  try {
+    for (const f of files) {
+      const text = readFileSync(resolve(sqlDir, f), 'utf8')
+      await sql.unsafe(text)
+      console.log(`apply-triggers: applied ${f}`)
+    }
+  } finally {
+    await sql.end()
+  }
+}
+
+main().catch(err => {
+  console.error('apply-triggers: failed', err)
+  process.exit(1)
+})

--- a/apps/govea/src/db/sql/audit-immutable.sql
+++ b/apps/govea/src/db/sql/audit-immutable.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- audit_log immutability — issue #417
+--
+-- Block UPDATE and DELETE on the audit_log table at the DB level so that even
+-- a caller with full INSERT/SELECT access (the application role, or a
+-- compromised admin) cannot rewrite history.
+--
+-- INSERT remains permitted — that is how new audit rows get written.
+--
+-- This file is idempotent: it can safely be re-run after every `db:push`.
+-- It is applied by `pnpm --filter govea db:apply-triggers` and by CI in the
+-- integration / smoke jobs.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log is append-only — UPDATE and DELETE are not permitted';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS audit_log_no_update ON audit_log;
+CREATE TRIGGER audit_log_no_update
+  BEFORE UPDATE ON audit_log
+  FOR EACH ROW EXECUTE FUNCTION audit_log_immutable();
+
+DROP TRIGGER IF EXISTS audit_log_no_delete ON audit_log;
+CREATE TRIGGER audit_log_no_delete
+  BEFORE DELETE ON audit_log
+  FOR EACH ROW EXECUTE FUNCTION audit_log_immutable();

--- a/apps/govea/tests/integration/audit-immutable.test.ts
+++ b/apps/govea/tests/integration/audit-immutable.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration tests: audit_log append-only enforcement (#417)
+ *
+ * Verifies that:
+ *   - INSERT into audit_log works (the writeAuditLog helper continues to function)
+ *   - UPDATE on audit_log is blocked at the DB level by the immutability trigger
+ *   - DELETE on audit_log is blocked at the DB level by the immutability trigger
+ *   - cleanupOrg still succeeds when there are audit rows referencing the org
+ *     (audit_log no longer has FK constraints back to organizations / users, so
+ *     dropping an org leaves audit rows holding the historical UUIDs)
+ *
+ * If these tests fail, check that `pnpm --filter govea db:apply-triggers` was
+ * run after the most recent `db:push`. CI runs it automatically.
+ */
+import { describe, it, expect } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/db/client'
+import { auditLog } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { writeAuditLog } from '@/lib/audit'
+import { createTestOrg, createTestUser, cleanupOrg } from './helpers/db'
+
+describe('audit_log immutability (#417)', () => {
+  it('rejects UPDATE on audit_log', async () => {
+    const org = await createTestOrg()
+    const action = `test.audit.update-blocked.${randomUUID()}`
+    try {
+      await writeAuditLog({
+        action,
+        entityType: 'organization',
+        entityId: org.id,
+        organizationId: org.id,
+        after: { test: 'before-update' },
+      })
+
+      const [row] = await db.select().from(auditLog).where(eq(auditLog.action, action)).limit(1)
+      expect(row).toBeDefined()
+
+      // Drizzle wraps the trigger's RAISE EXCEPTION as "Failed query: …";
+      // the canonical append-only text lives on err.cause. Cheapest robust
+      // assertion: the call throws AND the row is unchanged after.
+      await expect(
+        db.update(auditLog)
+          .set({ action: `${action}.tampered` })
+          .where(eq(auditLog.id, row.id))
+      ).rejects.toThrow()
+
+      const [after] = await db.select().from(auditLog).where(eq(auditLog.id, row.id)).limit(1)
+      expect(after.action).toBe(action)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+
+  it('rejects DELETE on audit_log', async () => {
+    const org = await createTestOrg()
+    const action = `test.audit.delete-blocked.${randomUUID()}`
+    try {
+      await writeAuditLog({
+        action,
+        entityType: 'organization',
+        entityId: org.id,
+        organizationId: org.id,
+        after: { test: 'before-delete' },
+      })
+
+      const [row] = await db.select().from(auditLog).where(eq(auditLog.action, action)).limit(1)
+      expect(row).toBeDefined()
+
+      await expect(
+        db.delete(auditLog).where(eq(auditLog.id, row.id))
+      ).rejects.toThrow()
+
+      const survivors = await db.select().from(auditLog).where(eq(auditLog.id, row.id))
+      expect(survivors.length).toBe(1)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+
+  it('surfaces the append-only message on the underlying postgres error', async () => {
+    // Defense in depth: confirm the trigger's message is reachable for diagnostics
+    // even though Drizzle wraps the top-level error.
+    const org = await createTestOrg()
+    const action = `test.audit.cause-message.${randomUUID()}`
+    try {
+      await writeAuditLog({
+        action,
+        entityType: 'organization',
+        entityId: org.id,
+        organizationId: org.id,
+      })
+
+      const [row] = await db.select().from(auditLog).where(eq(auditLog.action, action)).limit(1)
+      let caught: { message?: string; cause?: { message?: string } } | undefined
+      try {
+        await db.delete(auditLog).where(eq(auditLog.id, row.id))
+      } catch (e) {
+        caught = e as { message?: string; cause?: { message?: string } }
+      }
+      expect(caught).toBeDefined()
+      const combined = `${caught?.message ?? ''}|${caught?.cause?.message ?? ''}`
+      expect(combined).toMatch(/append-only/i)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+
+  it('cleanupOrg succeeds when audit rows reference the deleted org', async () => {
+    const org = await createTestOrg()
+    const user = await createTestUser(org.id, 'admin')
+
+    const action = `test.audit.cascade-safe.${randomUUID()}`
+    await writeAuditLog({
+      action,
+      entityType: 'user',
+      entityId: user.id,
+      userId: user.id,
+      organizationId: org.id,
+    })
+
+    // Org delete should succeed — audit_log has no FK back, so the org row
+    // can be dropped without Postgres needing to UPDATE audit_log to NULL it.
+    await expect(cleanupOrg(org.id)).resolves.toBeUndefined()
+
+    // The audit row still exists with its original UUID values intact
+    const [row] = await db.select().from(auditLog).where(eq(auditLog.action, action)).limit(1)
+    expect(row).toBeDefined()
+    expect(row!.organizationId).toBe(org.id)
+    expect(row!.userId).toBe(user.id)
+  })
+})


### PR DESCRIPTION
Closes #417

## Summary

Adds Postgres triggers that block \`UPDATE\` and \`DELETE\` on \`audit_log\` so audit history cannot be rewritten — even by a caller with full DB write access. \`INSERT\` remains permitted; that's how audit rows get written.

## What changed

| Layer | Change |
|---|---|
| **Schema** | Dropped FK constraints on \`audit_log.organization_id\` and \`audit_log.user_id\`. Audit rows now preserve the UUIDs valid at event time, even after the referenced row is deleted. Without this, the immutability trigger would block Postgres's \`onDelete:'set null'\` cascade and \`cleanupOrg\` in every test would fail. |
| **SQL** | New \`apps/govea/src/db/sql/audit-immutable.sql\` — idempotent (\`CREATE OR REPLACE FUNCTION\` + \`DROP TRIGGER IF EXISTS\` / \`CREATE TRIGGER\`). |
| **Apply script** | New \`apps/govea/src/db/scripts/apply-triggers.ts\` — iterates every \`.sql\` file in \`src/db/sql/\` and runs it through the existing \`postgres-js\` client. |
| **Package scripts** | \`db:apply-triggers\` and \`db:apply-triggers:container\`, modeled on the existing \`db:seed\` pattern. |
| **CI** | Integration and smoke jobs now run \`db:apply-triggers:container\` after \`db:push --force\`. |
| **Docs** | \`CLAUDE.md\` — new "Postgres triggers" section under the database workflow. Notes that operators cannot retroactively edit \`audit_log\`. |

## Tests added

\`tests/integration/audit-immutable.test.ts\` — 4 tests, all passing locally:

- [x] \`UPDATE\` on \`audit_log\` throws and the row is unchanged
- [x] \`DELETE\` on \`audit_log\` throws and the row survives
- [x] The append-only message is reachable on \`err.cause\` for diagnostics (defense in depth)
- [x] \`cleanupOrg\` still succeeds when audit rows reference the deleted org

Full suite: 340/340 passing.

## Test plan

- [ ] Local: \`pnpm --filter govea db:push --force && pnpm --filter govea db:apply-triggers && pnpm --filter govea test:integration tests/integration/audit-immutable.test.ts\`
- [ ] Confirm CI's integration job runs \`Apply DB triggers\` step after \`Push schema to database\`
- [ ] Confirm smoke job does the same
- [ ] Manual: \`psql\` into the dev DB, try \`UPDATE audit_log SET action='hi'\` — expect \`ERROR: audit_log is append-only\`

## Operator note

\`audit_log\` cannot be retroactively edited even by operators with DB-level access. If you legitimately need to clean up test/dev rows, drop the trigger temporarily, do the cleanup, and re-apply via \`db:apply-triggers\`. This is intentional friction.

## Related

- Companion to #416 (transactional audit writes — coming next)
- Severity: high

🤖 Generated with [Claude Code](https://claude.com/claude-code)