### PR TITLE
fix(security): transactional audit writes (#416)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -107,32 +107,35 @@ export async function createADR(formData: FormData) {
   const initiativeIds = formData.getAll('initiativeIds') as string[]
   const objectiveIds = formData.getAll('objectiveIds') as string[]
 
-  const [adr] = await db.insert(adrs).values({
-    number,
-    title,
-    context,
-    decision,
-    consequences,
-    status,
-    visibility,
-    supersededBy,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
-
-  await insertJunctions(adr.id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
-
   const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'adr', adr.id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'adr.create',
-    entityType: 'adr',
-    entityId: adr.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { number, title, status, visibility },
+  await db.transaction(async (tx) => {
+    const [adr] = await tx.insert(adrs).values({
+      number,
+      title,
+      context,
+      decision,
+      consequences,
+      status,
+      visibility,
+      supersededBy,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
+
+    await insertJunctions(tx, adr.id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
+
+    await syncEntityTaxonomyValues(tx, orgId, 'adr', adr.id, taxonomyTermIds)
+
+    await writeAuditLog(tx, {
+      action: 'adr.create',
+      entityType: 'adr',
+      entityId: adr.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { number, title, status, visibility },
+    })
   })
 }
 
@@ -157,36 +160,39 @@ export async function editADR(id: string, formData: FormData) {
   const before = await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(adrs).set({
-    number,
-    title,
-    context,
-    decision,
-    consequences,
-    status,
-    visibility,
-    supersededBy,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
-
-  await db.delete(adrCapabilities).where(eq(adrCapabilities.adrId, id))
-  await db.delete(adrApplications).where(eq(adrApplications.adrId, id))
-  await db.delete(adrInitiatives).where(eq(adrInitiatives.adrId, id))
-  await db.delete(adrObjectives).where(eq(adrObjectives.adrId, id))
-  await insertJunctions(id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
-
   const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'adr', id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'adr.edit',
-    entityType: 'adr',
-    entityId: id,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { number: before?.number, title: before?.title, status: before?.status },
-    after: { number, title, status, visibility },
+  await db.transaction(async (tx) => {
+    await tx.update(adrs).set({
+      number,
+      title,
+      context,
+      decision,
+      consequences,
+      status,
+      visibility,
+      supersededBy,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
+
+    await tx.delete(adrCapabilities).where(eq(adrCapabilities.adrId, id))
+    await tx.delete(adrApplications).where(eq(adrApplications.adrId, id))
+    await tx.delete(adrInitiatives).where(eq(adrInitiatives.adrId, id))
+    await tx.delete(adrObjectives).where(eq(adrObjectives.adrId, id))
+    await insertJunctions(tx, id, capabilityIds, applicationIds, initiativeIds, objectiveIds)
+
+    await syncEntityTaxonomyValues(tx, orgId, 'adr', id, taxonomyTermIds)
+
+    await writeAuditLog(tx, {
+      action: 'adr.edit',
+      entityType: 'adr',
+      entityId: id,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { number: before?.number, title: before?.title, status: before?.status },
+      after: { number, title, status, visibility },
+    })
   })
 }
 
@@ -197,23 +203,28 @@ export async function deleteADR(id: string) {
   const before = await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(eq(entityTaxonomyValues.entityType, 'adr'), eq(entityTaxonomyValues.entityId, id))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(eq(entityTaxonomyValues.entityType, 'adr'), eq(entityTaxonomyValues.entityId, id))
+    )
 
-  await db.delete(adrs).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
+    await tx.delete(adrs).where(and(eq(adrs.id, id), eq(adrs.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'adr.delete',
-    entityType: 'adr',
-    entityId: id,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { number: before?.number, title: before?.title },
+    await writeAuditLog(tx, {
+      action: 'adr.delete',
+      entityType: 'adr',
+      entityId: id,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { number: before?.number, title: before?.title },
+    })
   })
 }
 
+type DBOrTx = Pick<typeof db, 'insert'>
+
 async function insertJunctions(
+  tx: DBOrTx,
   adrId: string,
   capabilityIds: string[],
   applicationIds: string[],
@@ -221,11 +232,11 @@ async function insertJunctions(
   objectiveIds: string[],
 ) {
   if (capabilityIds.length > 0)
-    await db.insert(adrCapabilities).values(capabilityIds.map(capabilityId => ({ adrId, capabilityId }))).onConflictDoNothing()
+    await tx.insert(adrCapabilities).values(capabilityIds.map(capabilityId => ({ adrId, capabilityId }))).onConflictDoNothing()
   if (applicationIds.length > 0)
-    await db.insert(adrApplications).values(applicationIds.map(applicationId => ({ adrId, applicationId }))).onConflictDoNothing()
+    await tx.insert(adrApplications).values(applicationIds.map(applicationId => ({ adrId, applicationId }))).onConflictDoNothing()
   if (initiativeIds.length > 0)
-    await db.insert(adrInitiatives).values(initiativeIds.map(initiativeId => ({ adrId, initiativeId }))).onConflictDoNothing()
+    await tx.insert(adrInitiatives).values(initiativeIds.map(initiativeId => ({ adrId, initiativeId }))).onConflictDoNothing()
   if (objectiveIds.length > 0)
-    await db.insert(adrObjectives).values(objectiveIds.map(objectiveId => ({ adrId, objectiveId }))).onConflictDoNothing()
+    await tx.insert(adrObjectives).values(objectiveIds.map(objectiveId => ({ adrId, objectiveId }))).onConflictDoNothing()
 }

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -125,38 +125,40 @@ export async function createApplication(formData: FormData) {
   const fieldDefs = await getCustomFieldSchema(orgId, 'application')
   const customData = extractCustomData(formData, fieldDefs.map(f => f.name))
 
-  const [application] = await db.insert(applications).values({
-    name,
-    description,
-    vendor,
-    version,
-    hostingModel,
-    lifecycleStatus,
-    status,
-    visibility,
-    customData,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [application] = await tx.insert(applications).values({
+      name,
+      description,
+      vendor,
+      version,
+      hostingModel,
+      lifecycleStatus,
+      status,
+      visibility,
+      customData,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (capabilityIds.length > 0) {
-    await db.insert(applicationCapabilities).values(
-      capabilityIds.map(capabilityId => ({ applicationId: application.id, capabilityId }))
-    )
-  }
+    if (capabilityIds.length > 0) {
+      await tx.insert(applicationCapabilities).values(
+        capabilityIds.map(capabilityId => ({ applicationId: application.id, capabilityId }))
+      )
+    }
 
-  if (taxonomyTermIds.length > 0) {
-    await syncEntityTaxonomyValues(orgId, 'application', application.id, taxonomyTermIds)
-  }
+    if (taxonomyTermIds.length > 0) {
+      await syncEntityTaxonomyValues(tx, orgId, 'application', application.id, taxonomyTermIds)
+    }
 
-  await writeAuditLog({
-    action: 'application.create',
-    entityType: 'application',
-    entityId: application.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, vendor, lifecycleStatus, status, visibility, capabilityIds },
+    await writeAuditLog(tx, {
+      action: 'application.create',
+      entityType: 'application',
+      entityId: application.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, vendor, lifecycleStatus, status, visibility, capabilityIds },
+    })
   })
 }
 
@@ -181,37 +183,39 @@ export async function editApplication(applicationId: string, formData: FormData)
   const fieldDefs = await getCustomFieldSchema(orgId, 'application')
   const customData = extractCustomData(formData, fieldDefs.map(f => f.name))
 
-  await db.update(applications).set({
-    name,
-    description,
-    vendor,
-    version,
-    hostingModel,
-    lifecycleStatus,
-    status,
-    visibility,
-    customData,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(applications.id, applicationId), eq(applications.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(applications).set({
+      name,
+      description,
+      vendor,
+      version,
+      hostingModel,
+      lifecycleStatus,
+      status,
+      visibility,
+      customData,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(applications.id, applicationId), eq(applications.organizationId, orgId)))
 
-  await db.delete(applicationCapabilities).where(eq(applicationCapabilities.applicationId, applicationId))
-  if (capabilityIds.length > 0) {
-    await db.insert(applicationCapabilities).values(
-      capabilityIds.map(capabilityId => ({ applicationId, capabilityId }))
-    )
-  }
+    await tx.delete(applicationCapabilities).where(eq(applicationCapabilities.applicationId, applicationId))
+    if (capabilityIds.length > 0) {
+      await tx.insert(applicationCapabilities).values(
+        capabilityIds.map(capabilityId => ({ applicationId, capabilityId }))
+      )
+    }
 
-  await syncEntityTaxonomyValues(orgId, 'application', applicationId, taxonomyTermIds)
+    await syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'application.edit',
-    entityType: 'application',
-    entityId: applicationId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status, visibility: before?.visibility },
-    after: { name, vendor, lifecycleStatus, status, visibility, capabilityIds },
+    await writeAuditLog(tx, {
+      action: 'application.edit',
+      entityType: 'application',
+      entityId: applicationId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status, visibility: before?.visibility },
+      after: { name, vendor, lifecycleStatus, status, visibility, capabilityIds },
+    })
   })
 }
 
@@ -222,25 +226,27 @@ export async function deleteApplication(applicationId: string) {
   const before = await db.query.applications.findFirst({ where: eq(applications.id, applicationId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(
-      eq(entityTaxonomyValues.organizationId, orgId),
-      eq(entityTaxonomyValues.entityType, 'application'),
-      eq(entityTaxonomyValues.entityId, applicationId),
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(
+        eq(entityTaxonomyValues.organizationId, orgId),
+        eq(entityTaxonomyValues.entityType, 'application'),
+        eq(entityTaxonomyValues.entityId, applicationId),
+      )
     )
-  )
 
-  await db.delete(applications).where(
-    and(eq(applications.id, applicationId), eq(applications.organizationId, orgId))
-  )
+    await tx.delete(applications).where(
+      and(eq(applications.id, applicationId), eq(applications.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'application.delete',
-    entityType: 'application',
-    entityId: applicationId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'application.delete',
+      entityType: 'application',
+      entityId: applicationId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name },
+    })
   })
 }
 
@@ -252,18 +258,20 @@ export async function markApplicationReviewed(applicationId: string, _formData: 
   assertOwnership(record?.organizationId, orgId)
 
   const now = new Date()
-  await db.update(applications).set({
-    lastReviewedBy: session.user.id,
-    lastReviewedAt: now,
-  }).where(and(eq(applications.id, applicationId), eq(applications.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(applications).set({
+      lastReviewedBy: session.user.id,
+      lastReviewedAt: now,
+    }).where(and(eq(applications.id, applicationId), eq(applications.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'application.reviewed',
-    entityType: 'application',
-    entityId: applicationId,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { lastReviewedAt: now.toISOString() },
+    await writeAuditLog(tx, {
+      action: 'application.reviewed',
+      entityType: 'application',
+      entityId: applicationId,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { lastReviewedAt: now.toISOString() },
+    })
   })
 
   revalidatePath(`/applications/${applicationId}`)
@@ -338,6 +346,21 @@ export async function importApplications(formData: FormData, dryRun = false): Pr
   let created = 0, updated = 0, skipped = 0
   const errors: string[] = []
 
+  // Validate all rows up front so counters reflect a complete pass before opening a tx.
+  type ValidRow = {
+    name: string
+    description: string | null
+    vendor: string | null
+    version: string | null
+    hostingModel: string | null
+    lifecycleStatus: 'active' | 'sunset' | 'decommissioned' | 'planned'
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    customData: Record<string, string>
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+
   for (const [i, row] of rows.entries()) {
     const rowNum = i + 2 // 1-indexed, accounting for header row
     const name = row['name']?.trim()
@@ -368,50 +391,63 @@ export async function importApplications(formData: FormData, dryRun = false): Pr
     }
 
     const existingId = existingByName.get(name.toLowerCase())
-
-    if (!dryRun) {
-      if (existingId) {
-        await db.update(applications).set({
-          description: row['description'] || null,
-          vendor: row['vendor'] || null,
-          version: row['version'] || null,
-          hostingModel: row['hosting_model'] || null,
-          lifecycleStatus: lifecycleStatus as 'active' | 'sunset' | 'decommissioned' | 'planned',
-          status: status as 'draft' | 'published' | 'archived',
-          visibility: visibility as 'org' | 'connections' | 'instance',
-          customData,
-          updatedBy: session.user.id,
-          updatedAt: new Date(),
-        }).where(and(eq(applications.id, existingId), eq(applications.organizationId, orgId)))
-      } else {
-        await db.insert(applications).values({
-          name,
-          description: row['description'] || null,
-          vendor: row['vendor'] || null,
-          version: row['version'] || null,
-          hostingModel: row['hosting_model'] || null,
-          lifecycleStatus: lifecycleStatus as 'active' | 'sunset' | 'decommissioned' | 'planned',
-          status: status as 'draft' | 'published' | 'archived',
-          visibility: visibility as 'org' | 'connections' | 'instance',
-          customData,
-          organizationId: orgId,
-          createdBy: session.user.id,
-          updatedBy: session.user.id,
-        })
-      }
-    }
-
     if (existingId) updated++; else created++
+    validRows.push({
+      name,
+      description: row['description'] || null,
+      vendor: row['vendor'] || null,
+      version: row['version'] || null,
+      hostingModel: row['hosting_model'] || null,
+      lifecycleStatus: lifecycleStatus as 'active' | 'sunset' | 'decommissioned' | 'planned',
+      status: status as 'draft' | 'published' | 'archived',
+      visibility: visibility as 'org' | 'connections' | 'instance',
+      customData,
+      existingId,
+    })
   }
 
   if (!dryRun && (created > 0 || updated > 0)) {
-    await writeAuditLog({
-      action: 'application.import',
-      entityType: 'application',
-      entityId: orgId,
-      userId: session.user.id,
-      organizationId: orgId,
-      after: { created, updated, skipped, dryRun },
+    await db.transaction(async (tx) => {
+      for (const r of validRows) {
+        if (r.existingId) {
+          await tx.update(applications).set({
+            description: r.description,
+            vendor: r.vendor,
+            version: r.version,
+            hostingModel: r.hostingModel,
+            lifecycleStatus: r.lifecycleStatus,
+            status: r.status,
+            visibility: r.visibility,
+            customData: r.customData,
+            updatedBy: session.user.id,
+            updatedAt: new Date(),
+          }).where(and(eq(applications.id, r.existingId), eq(applications.organizationId, orgId)))
+        } else {
+          await tx.insert(applications).values({
+            name: r.name,
+            description: r.description,
+            vendor: r.vendor,
+            version: r.version,
+            hostingModel: r.hostingModel,
+            lifecycleStatus: r.lifecycleStatus,
+            status: r.status,
+            visibility: r.visibility,
+            customData: r.customData,
+            organizationId: orgId,
+            createdBy: session.user.id,
+            updatedBy: session.user.id,
+          })
+        }
+      }
+
+      await writeAuditLog(tx, {
+        action: 'application.import',
+        entityType: 'application',
+        entityId: orgId,
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, dryRun },
+      })
     })
   }
 

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -163,41 +163,45 @@ export async function createCapability(formData: FormData) {
     await assertEntityInOrg('capability', parentId, orgId)
   }
 
-  const [capability] = await db.insert(capabilities).values({
-    name,
-    description,
-    domain,
-    behaviors,
-    rules,
-    capabilityType,
-    status,
-    visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  // Mutation + audit are wrapped in a single transaction so a DB-layer audit
+  // failure rolls back the capability insert and its junction rows (#416).
+  await db.transaction(async (tx) => {
+    const [capability] = await tx.insert(capabilities).values({
+      name,
+      description,
+      domain,
+      behaviors,
+      rules,
+      capabilityType,
+      status,
+      visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (personaIds.length > 0) {
-    await db.insert(capabilityPersonas).values(
-      personaIds.map(personaId => ({ capabilityId: capability.id, personaId }))
-    )
-  }
+    if (personaIds.length > 0) {
+      await tx.insert(capabilityPersonas).values(
+        personaIds.map(personaId => ({ capabilityId: capability.id, personaId }))
+      )
+    }
 
-  if (parentId) {
-    await db.insert(capabilityRelationships).values({ parentId, childId: capability.id }).onConflictDoNothing()
-  }
+    if (parentId) {
+      await tx.insert(capabilityRelationships).values({ parentId, childId: capability.id }).onConflictDoNothing()
+    }
 
-  if (taxonomyTermIds.length > 0) {
-    await syncEntityTaxonomyValues(orgId, 'capability', capability.id, taxonomyTermIds)
-  }
+    if (taxonomyTermIds.length > 0) {
+      await syncEntityTaxonomyValues(tx, orgId, 'capability', capability.id, taxonomyTermIds)
+    }
 
-  await writeAuditLog({
-    action: 'capability.create',
-    entityType: 'capability',
-    entityId: capability.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, description, domain, capabilityType, status, visibility, personaIds, parentId },
+    await writeAuditLog(tx, {
+      action: 'capability.create',
+      entityType: 'capability',
+      entityId: capability.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, description, domain, capabilityType, status, visibility, personaIds, parentId },
+    })
   })
 }
 
@@ -229,51 +233,55 @@ export async function editCapability(capabilityId: string, formData: FormData) {
     await assertEntityInOrg('capability', parentId, orgId)
   }
 
-  await db.update(capabilities).set({
-    name,
-    description,
-    domain,
-    behaviors,
-    rules,
-    capabilityType,
-    status,
-    visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId)))
+  // Mutation + audit + cross-org-link flag/clear are all in one transaction
+  // so a failure anywhere rolls back the entire edit (#416).
+  await db.transaction(async (tx) => {
+    await tx.update(capabilities).set({
+      name,
+      description,
+      domain,
+      behaviors,
+      rules,
+      capabilityType,
+      status,
+      visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId)))
 
-  // Replace persona links
-  await db.delete(capabilityPersonas).where(eq(capabilityPersonas.capabilityId, capabilityId))
-  if (personaIds.length > 0) {
-    await db.insert(capabilityPersonas).values(
-      personaIds.map(personaId => ({ capabilityId, personaId }))
-    )
-  }
+    // Replace persona links
+    await tx.delete(capabilityPersonas).where(eq(capabilityPersonas.capabilityId, capabilityId))
+    if (personaIds.length > 0) {
+      await tx.insert(capabilityPersonas).values(
+        personaIds.map(personaId => ({ capabilityId, personaId }))
+      )
+    }
 
-  // Replace parent relationship (remove existing, add new if set)
-  await db.delete(capabilityRelationships).where(eq(capabilityRelationships.childId, capabilityId))
-  if (parentId) {
-    await db.insert(capabilityRelationships).values({ parentId, childId: capabilityId }).onConflictDoNothing()
-  }
+    // Replace parent relationship (remove existing, add new if set)
+    await tx.delete(capabilityRelationships).where(eq(capabilityRelationships.childId, capabilityId))
+    if (parentId) {
+      await tx.insert(capabilityRelationships).values({ parentId, childId: capabilityId }).onConflictDoNothing()
+    }
 
-  await syncEntityTaxonomyValues(orgId, 'capability', capabilityId, taxonomyTermIds)
+    await syncEntityTaxonomyValues(tx, orgId, 'capability', capabilityId, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'capability.edit',
-    entityType: 'capability',
-    entityId: capabilityId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status, visibility: before?.visibility },
-    after: { name, description, domain, capabilityType, status, visibility, personaIds, parentId },
+    await writeAuditLog(tx, {
+      action: 'capability.edit',
+      entityType: 'capability',
+      entityId: capabilityId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status, visibility: before?.visibility },
+      after: { name, description, domain, capabilityType, status, visibility, personaIds, parentId },
+    })
+
+    // Flag or clear cross-org links when visibility changes.
+    const prevVis = before?.visibility
+    const visDropped = (prevVis === 'connections' || prevVis === 'instance') && visibility === 'org'
+    const visRaised = prevVis === 'org' && (visibility === 'connections' || visibility === 'instance')
+    if (visDropped) await flagLinksForVisibilityDrop(tx, 'capability', capabilityId, `"${name}" visibility was restricted to org-only — this link may no longer be accessible to the other org`)
+    if (visRaised)  await clearLinksFlag(tx, 'capability', capabilityId)
   })
-
-  // Flag or clear cross-org links when visibility changes.
-  const prevVis = before?.visibility
-  const visDropped = (prevVis === 'connections' || prevVis === 'instance') && visibility === 'org'
-  const visRaised = prevVis === 'org' && (visibility === 'connections' || visibility === 'instance')
-  if (visDropped) await flagLinksForVisibilityDrop('capability', capabilityId, `"${name}" visibility was restricted to org-only — this link may no longer be accessible to the other org`)
-  if (visRaised)  await clearLinksFlag('capability', capabilityId)
 }
 
 export async function deleteCapability(capabilityId: string) {
@@ -283,21 +291,23 @@ export async function deleteCapability(capabilityId: string) {
   const before = await db.query.capabilities.findFirst({ where: eq(capabilities.id, capabilityId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(eq(entityTaxonomyValues.entityType, 'capability'), eq(entityTaxonomyValues.entityId, capabilityId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(eq(entityTaxonomyValues.entityType, 'capability'), eq(entityTaxonomyValues.entityId, capabilityId))
+    )
 
-  await db.delete(capabilities).where(
-    and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId))
-  )
+    await tx.delete(capabilities).where(
+      and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'capability.delete',
-    entityType: 'capability',
-    entityId: capabilityId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'capability.delete',
+      entityType: 'capability',
+      entityId: capabilityId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name },
+    })
   })
 }
 
@@ -309,18 +319,20 @@ export async function markCapabilityReviewed(capabilityId: string, _formData: Fo
   assertOwnership(record?.organizationId, orgId)
 
   const now = new Date()
-  await db.update(capabilities).set({
-    lastReviewedBy: session.user.id,
-    lastReviewedAt: now,
-  }).where(and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(capabilities).set({
+      lastReviewedBy: session.user.id,
+      lastReviewedAt: now,
+    }).where(and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'capability.reviewed',
-    entityType: 'capability',
-    entityId: capabilityId,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { lastReviewedAt: now.toISOString() },
+    await writeAuditLog(tx, {
+      action: 'capability.reviewed',
+      entityType: 'capability',
+      entityId: capabilityId,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { lastReviewedAt: now.toISOString() },
+    })
   })
 
   revalidatePath(`/capabilities/${capabilityId}`)

--- a/apps/govea/src/actions/connections.ts
+++ b/apps/govea/src/actions/connections.ts
@@ -51,20 +51,22 @@ export async function requestConnection(targetOrgId: string) {
   })
   if (existing) throw new Error('Connection already exists or is pending')
 
-  const [connection] = await db.insert(orgConnections).values({
-    fromOrgId: orgId,
-    toOrgId: targetOrgId,
-    status: 'pending',
-    createdBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [connection] = await tx.insert(orgConnections).values({
+      fromOrgId: orgId,
+      toOrgId: targetOrgId,
+      status: 'pending',
+      createdBy: session.user.id,
+    }).returning()
 
-  await writeAuditLog({
-    action: 'connection.request',
-    entityType: 'org_connection',
-    entityId: connection.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { targetOrgId },
+    await writeAuditLog(tx, {
+      action: 'connection.request',
+      entityType: 'org_connection',
+      entityId: connection.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { targetOrgId },
+    })
   })
 }
 
@@ -78,15 +80,17 @@ export async function acceptConnection(connectionId: string) {
   })
   if (!connection) throw new Error('Connection not found or not authorized')
 
-  await db.update(orgConnections).set({ status: 'active', updatedAt: new Date() })
-    .where(eq(orgConnections.id, connectionId))
+  await db.transaction(async (tx) => {
+    await tx.update(orgConnections).set({ status: 'active', updatedAt: new Date() })
+      .where(eq(orgConnections.id, connectionId))
 
-  await writeAuditLog({
-    action: 'connection.accept',
-    entityType: 'org_connection',
-    entityId: connectionId,
-    userId: session.user.id,
-    organizationId: orgId,
+    await writeAuditLog(tx, {
+      action: 'connection.accept',
+      entityType: 'org_connection',
+      entityId: connectionId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
   })
 }
 
@@ -100,15 +104,17 @@ export async function rejectConnection(connectionId: string) {
   })
   if (!connection) throw new Error('Connection not found or not authorized')
 
-  await db.update(orgConnections).set({ status: 'rejected', updatedAt: new Date() })
-    .where(eq(orgConnections.id, connectionId))
+  await db.transaction(async (tx) => {
+    await tx.update(orgConnections).set({ status: 'rejected', updatedAt: new Date() })
+      .where(eq(orgConnections.id, connectionId))
 
-  await writeAuditLog({
-    action: 'connection.reject',
-    entityType: 'org_connection',
-    entityId: connectionId,
-    userId: session.user.id,
-    organizationId: orgId,
+    await writeAuditLog(tx, {
+      action: 'connection.reject',
+      entityType: 'org_connection',
+      entityId: connectionId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
   })
 }
 
@@ -125,14 +131,16 @@ export async function removeConnection(connectionId: string) {
   })
   if (!connection) throw new Error('Connection not found or not authorized')
 
-  await removeLinksForConnection(connection.fromOrgId, connection.toOrgId, session.user.id, orgId)
-  await db.delete(orgConnections).where(eq(orgConnections.id, connectionId))
+  await db.transaction(async (tx) => {
+    await removeLinksForConnection(tx, connection.fromOrgId, connection.toOrgId, session.user.id, orgId)
+    await tx.delete(orgConnections).where(eq(orgConnections.id, connectionId))
 
-  await writeAuditLog({
-    action: 'connection.remove',
-    entityType: 'org_connection',
-    entityId: connectionId,
-    userId: session.user.id,
-    organizationId: orgId,
+    await writeAuditLog(tx, {
+      action: 'connection.remove',
+      entityType: 'org_connection',
+      entityId: connectionId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
   })
 }

--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -284,37 +284,39 @@ export async function requestCrossOrgLink(
     throw new Error('A cross-org link already exists or is awaiting approval')
   }
 
-  let auditLinkId = existing?.id ?? null
+  await db.transaction(async (tx) => {
+    let auditLinkId = existing?.id ?? null
 
-  if (existing?.status === 'rejected') {
-    await db.update(crossOrgLinks).set({
-      linkType,
-      status: 'pending',
-      rejectionReason: null,
-      updatedAt: new Date(),
-    }).where(eq(crossOrgLinks.id, existing.id))
-  } else {
-    const [created] = await db.insert(crossOrgLinks).values({
-      sourceOrgId: source.organizationId,
-      sourceEntityType: type,
-      sourceEntityId,
-      targetOrgId: target.organizationId,
-      targetEntityType: type,
-      targetEntityId,
-      linkType,
-      status: 'pending',
-      createdBy: session.user.id,
-    }).returning()
-    auditLinkId = created.id
-  }
+    if (existing?.status === 'rejected') {
+      await tx.update(crossOrgLinks).set({
+        linkType,
+        status: 'pending',
+        rejectionReason: null,
+        updatedAt: new Date(),
+      }).where(eq(crossOrgLinks.id, existing.id))
+    } else {
+      const [created] = await tx.insert(crossOrgLinks).values({
+        sourceOrgId: source.organizationId,
+        sourceEntityType: type,
+        sourceEntityId,
+        targetOrgId: target.organizationId,
+        targetEntityType: type,
+        targetEntityId,
+        linkType,
+        status: 'pending',
+        createdBy: session.user.id,
+      }).returning()
+      auditLinkId = created.id
+    }
 
-  await writeAuditLog({
-    action: 'cross_org_link.request',
-    entityType: 'cross_org_link',
-    entityId: auditLinkId ?? undefined,
-    userId: session.user.id,
-    organizationId: source.organizationId,
-    after: { sourceEntityId, targetEntityId, linkType, targetOrgId: target.organizationId, type },
+    await writeAuditLog(tx, {
+      action: 'cross_org_link.request',
+      entityType: 'cross_org_link',
+      entityId: auditLinkId ?? undefined,
+      userId: session.user.id,
+      organizationId: source.organizationId,
+      after: { sourceEntityId, targetEntityId, linkType, targetOrgId: target.organizationId, type },
+    })
   })
 
   await revalidateLinkPaths(type, sourceEntityId, targetEntityId)
@@ -328,19 +330,21 @@ export async function approveCrossOrgLink(linkId: string) {
   if (!link) throw new Error('Cross-org link not found or not authorized')
   if (link.status !== 'pending') throw new Error('Only pending links can be approved')
 
-  await db.update(crossOrgLinks).set({
-    status: 'active',
-    rejectionReason: null,
-    updatedAt: new Date(),
-  }).where(eq(crossOrgLinks.id, linkId))
+  await db.transaction(async (tx) => {
+    await tx.update(crossOrgLinks).set({
+      status: 'active',
+      rejectionReason: null,
+      updatedAt: new Date(),
+    }).where(eq(crossOrgLinks.id, linkId))
 
-  await writeAuditLog({
-    action: 'cross_org_link.approve',
-    entityType: 'cross_org_link',
-    entityId: linkId,
-    userId: session.user.id,
-    organizationId: session.user.organizationId!,
-    after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+    await writeAuditLog(tx, {
+      action: 'cross_org_link.approve',
+      entityType: 'cross_org_link',
+      entityId: linkId,
+      userId: session.user.id,
+      organizationId: session.user.organizationId!,
+      after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+    })
   })
 
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
@@ -354,19 +358,21 @@ export async function rejectCrossOrgLink(linkId: string, reason?: string) {
   if (!link) throw new Error('Cross-org link not found or not authorized')
   if (link.status !== 'pending') throw new Error('Only pending links can be rejected')
 
-  await db.update(crossOrgLinks).set({
-    status: 'rejected',
-    rejectionReason: reason?.trim() ? reason.trim() : null,
-    updatedAt: new Date(),
-  }).where(eq(crossOrgLinks.id, linkId))
+  await db.transaction(async (tx) => {
+    await tx.update(crossOrgLinks).set({
+      status: 'rejected',
+      rejectionReason: reason?.trim() ? reason.trim() : null,
+      updatedAt: new Date(),
+    }).where(eq(crossOrgLinks.id, linkId))
 
-  await writeAuditLog({
-    action: 'cross_org_link.reject',
-    entityType: 'cross_org_link',
-    entityId: linkId,
-    userId: session.user.id,
-    organizationId: session.user.organizationId!,
-    after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+    await writeAuditLog(tx, {
+      action: 'cross_org_link.reject',
+      entityType: 'cross_org_link',
+      entityId: linkId,
+      userId: session.user.id,
+      organizationId: session.user.organizationId!,
+      after: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, type: link.sourceEntityType },
+    })
   })
 
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
@@ -379,15 +385,17 @@ export async function withdrawCrossOrgLink(linkId: string) {
   })
   if (!link) throw new Error('Cross-org link not found or not authorized')
 
-  await db.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
+  await db.transaction(async (tx) => {
+    await tx.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
 
-  await writeAuditLog({
-    action: 'cross_org_link.withdraw',
-    entityType: 'cross_org_link',
-    entityId: linkId,
-    userId: session.user.id,
-    organizationId: session.user.organizationId!,
-    before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status },
+    await writeAuditLog(tx, {
+      action: 'cross_org_link.withdraw',
+      entityType: 'cross_org_link',
+      entityId: linkId,
+      userId: session.user.id,
+      organizationId: session.user.organizationId!,
+      before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status },
+    })
   })
 
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)
@@ -401,15 +409,17 @@ export async function revokeCrossOrgLink(linkId: string) {
   if (!link) throw new Error('Cross-org link not found or not authorized')
   if (link.status !== 'active') throw new Error('Only active links can be revoked')
 
-  await db.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
+  await db.transaction(async (tx) => {
+    await tx.delete(crossOrgLinks).where(eq(crossOrgLinks.id, linkId))
 
-  await writeAuditLog({
-    action: 'cross_org_link.revoke',
-    entityType: 'cross_org_link',
-    entityId: linkId,
-    userId: session.user.id,
-    organizationId: session.user.organizationId!,
-    before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status, type: link.sourceEntityType },
+    await writeAuditLog(tx, {
+      action: 'cross_org_link.revoke',
+      entityType: 'cross_org_link',
+      entityId: linkId,
+      userId: session.user.id,
+      organizationId: session.user.organizationId!,
+      before: { sourceEntityId: link.sourceEntityId, targetEntityId: link.targetEntityId, status: link.status, type: link.sourceEntityType },
+    })
   })
 
   await revalidateLinkPaths(link.sourceEntityType as CrossOrgEntityType, link.sourceEntityId, link.targetEntityId)

--- a/apps/govea/src/actions/framework-mappings.ts
+++ b/apps/govea/src/actions/framework-mappings.ts
@@ -69,26 +69,30 @@ export async function addFrameworkMapping(
   if (!targetKind) throw new Error('Invalid entity type')
   await assertEntityInOrg(targetKind, entityId, orgId)
 
-  const [row] = await db
-    .insert(frameworkMappings)
-    .values({
-      organizationId: orgId,
+  const row = await db.transaction(async (tx) => {
+    const [r] = await tx
+      .insert(frameworkMappings)
+      .values({
+        organizationId: orgId,
+        entityType,
+        entityId,
+        framework: 'togaf',
+        conceptLabel,
+        rationale,
+        createdBy: session.user.id,
+      })
+      .returning()
+
+    await writeAuditLog(tx, {
+      action: 'framework_mapping.add',
       entityType,
       entityId,
-      framework: 'togaf',
-      conceptLabel,
-      rationale,
-      createdBy: session.user.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { conceptLabel, rationale },
     })
-    .returning()
 
-  await writeAuditLog({
-    action: 'framework_mapping.add',
-    entityType,
-    entityId,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { conceptLabel, rationale },
+    return r
   })
 
   revalidatePath(`/${entityType === 'capability' ? 'capabilities' : entityType}/${entityId}`)
@@ -103,23 +107,27 @@ export async function removeFrameworkMapping(mappingId: string) {
 
   const orgId = session.user.organizationId!
 
-  const [row] = await db
-    .delete(frameworkMappings)
-    .where(and(
-      eq(frameworkMappings.id, mappingId),
-      eq(frameworkMappings.organizationId, orgId),  // org boundary
-    ))
-    .returning()
+  const row = await db.transaction(async (tx) => {
+    const [r] = await tx
+      .delete(frameworkMappings)
+      .where(and(
+        eq(frameworkMappings.id, mappingId),
+        eq(frameworkMappings.organizationId, orgId),  // org boundary
+      ))
+      .returning()
 
-  if (!row) throw new Error('Not found')
+    if (!r) throw new Error('Not found')
 
-  await writeAuditLog({
-    action: 'framework_mapping.remove',
-    entityType: row.entityType,
-    entityId: row.entityId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { conceptLabel: row.conceptLabel, rationale: row.rationale },
+    await writeAuditLog(tx, {
+      action: 'framework_mapping.remove',
+      entityType: r.entityType,
+      entityId: r.entityId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { conceptLabel: r.conceptLabel, rationale: r.rationale },
+    })
+
+    return r
   })
 
   revalidatePath(`/${row.entityType === 'capability' ? 'capabilities' : row.entityType}/${row.entityId}`)

--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -84,32 +84,36 @@ export async function createGlossaryTerm(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
 
-  const [entry] = await db.insert(glossaryTerms).values({
-    term, definition, definitionSource, definitionSourceUrl,
-    domain, notes, status, visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
-
-  // Insert reference sources if provided — validate each URL before storage
+  // Parse sources outside the transaction so a JSON parse error doesn't
+  // happen inside the tx callback.
   const sourcesJson = formData.get('sources') as string | null
-  if (sourcesJson) {
-    const sources: { name: string; url?: string; definition: string }[] = JSON.parse(sourcesJson)
-    if (sources.length > 0) {
-      await db.insert(glossaryTermSources).values(
-        sources.map(s => ({ termId: entry.id, name: s.name, url: validateWebUrl(s.url ?? null), definition: s.definition }))
+  const parsedSources: { name: string; url?: string; definition: string }[] | null =
+    sourcesJson ? JSON.parse(sourcesJson) : null
+
+  await db.transaction(async (tx) => {
+    const [entry] = await tx.insert(glossaryTerms).values({
+      term, definition, definitionSource, definitionSourceUrl,
+      domain, notes, status, visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
+
+    // Insert reference sources if provided — validate each URL before storage
+    if (parsedSources && parsedSources.length > 0) {
+      await tx.insert(glossaryTermSources).values(
+        parsedSources.map(s => ({ termId: entry.id, name: s.name, url: validateWebUrl(s.url ?? null), definition: s.definition }))
       )
     }
-  }
 
-  await writeAuditLog({
-    action: 'glossary.create',
-    entityType: 'glossary',
-    entityId: entry.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { term, status, visibility },
+    await writeAuditLog(tx, {
+      action: 'glossary.create',
+      entityType: 'glossary',
+      entityId: entry.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { term, status, visibility },
+    })
   })
 }
 
@@ -129,33 +133,37 @@ export async function editGlossaryTerm(termId: string, formData: FormData) {
   const before = await db.query.glossaryTerms.findFirst({ where: eq(glossaryTerms.id, termId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(glossaryTerms).set({
-    term, definition, definitionSource, definitionSourceUrl,
-    domain, notes, status, visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(glossaryTerms.id, termId), eq(glossaryTerms.organizationId, orgId)))
-
-  // Replace reference sources: delete all existing, re-insert — validate each URL
   const sourcesJson = formData.get('sources') as string | null
-  if (sourcesJson !== null) {
-    await db.delete(glossaryTermSources).where(eq(glossaryTermSources.termId, termId))
-    const sources: { name: string; url?: string; definition: string }[] = JSON.parse(sourcesJson)
-    if (sources.length > 0) {
-      await db.insert(glossaryTermSources).values(
-        sources.map(s => ({ termId, name: s.name, url: validateWebUrl(s.url ?? null), definition: s.definition }))
-      )
-    }
-  }
+  const parsedSources: { name: string; url?: string; definition: string }[] | null =
+    sourcesJson !== null ? JSON.parse(sourcesJson) : null
 
-  await writeAuditLog({
-    action: 'glossary.edit',
-    entityType: 'glossary',
-    entityId: termId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { term: before?.term, status: before?.status },
-    after: { term, status, visibility },
+  await db.transaction(async (tx) => {
+    await tx.update(glossaryTerms).set({
+      term, definition, definitionSource, definitionSourceUrl,
+      domain, notes, status, visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(glossaryTerms.id, termId), eq(glossaryTerms.organizationId, orgId)))
+
+    // Replace reference sources: delete all existing, re-insert — validate each URL
+    if (parsedSources !== null) {
+      await tx.delete(glossaryTermSources).where(eq(glossaryTermSources.termId, termId))
+      if (parsedSources.length > 0) {
+        await tx.insert(glossaryTermSources).values(
+          parsedSources.map(s => ({ termId, name: s.name, url: validateWebUrl(s.url ?? null), definition: s.definition }))
+        )
+      }
+    }
+
+    await writeAuditLog(tx, {
+      action: 'glossary.edit',
+      entityType: 'glossary',
+      entityId: termId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { term: before?.term, status: before?.status },
+      after: { term, status, visibility },
+    })
   })
 }
 
@@ -166,16 +174,18 @@ export async function deleteGlossaryTerm(termId: string) {
   const before = await db.query.glossaryTerms.findFirst({ where: eq(glossaryTerms.id, termId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(glossaryTerms).where(
-    and(eq(glossaryTerms.id, termId), eq(glossaryTerms.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(glossaryTerms).where(
+      and(eq(glossaryTerms.id, termId), eq(glossaryTerms.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'glossary.delete',
-    entityType: 'glossary',
-    entityId: termId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { term: before?.term },
+    await writeAuditLog(tx, {
+      action: 'glossary.delete',
+      entityType: 'glossary',
+      entityId: termId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { term: before?.term },
+    })
   })
 }

--- a/apps/govea/src/actions/goals.ts
+++ b/apps/govea/src/actions/goals.ts
@@ -85,22 +85,24 @@ export async function createGoal(formData: FormData) {
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const objectiveIds = formData.getAll('objectiveIds') as string[]
 
-  const [goal] = await db.insert(goals).values({
-    name, description, planningHorizon, owner, status, visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [goal] = await tx.insert(goals).values({
+      name, description, planningHorizon, owner, status, visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (objectiveIds.length > 0) {
-    await db.insert(goalObjectives).values(
-      objectiveIds.map(oId => ({ goalId: goal.id, objectiveId: oId }))
-    )
-  }
+    if (objectiveIds.length > 0) {
+      await tx.insert(goalObjectives).values(
+        objectiveIds.map(oId => ({ goalId: goal.id, objectiveId: oId }))
+      )
+    }
 
-  await writeAuditLog({
-    action: 'goal.create', entityType: 'goal', entityId: goal.id,
-    userId: session.user.id, organizationId: orgId, after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'goal.create', entityType: 'goal', entityId: goal.id,
+      userId: session.user.id, organizationId: orgId, after: { name, status },
+    })
   })
 
   revalidatePath('/goals')
@@ -121,23 +123,25 @@ export async function editGoal(goalId: string, formData: FormData) {
   const before = await db.query.goals.findFirst({ where: eq(goals.id, goalId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(goals).set({
-    name, description, planningHorizon, owner, status, visibility,
-    updatedBy: session.user.id, updatedAt: new Date(),
-  }).where(and(eq(goals.id, goalId), eq(goals.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(goals).set({
+      name, description, planningHorizon, owner, status, visibility,
+      updatedBy: session.user.id, updatedAt: new Date(),
+    }).where(and(eq(goals.id, goalId), eq(goals.organizationId, orgId)))
 
-  await db.delete(goalObjectives).where(eq(goalObjectives.goalId, goalId))
-  if (objectiveIds.length > 0) {
-    await db.insert(goalObjectives).values(
-      objectiveIds.map(oId => ({ goalId, objectiveId: oId }))
-    )
-  }
+    await tx.delete(goalObjectives).where(eq(goalObjectives.goalId, goalId))
+    if (objectiveIds.length > 0) {
+      await tx.insert(goalObjectives).values(
+        objectiveIds.map(oId => ({ goalId, objectiveId: oId }))
+      )
+    }
 
-  await writeAuditLog({
-    action: 'goal.edit', entityType: 'goal', entityId: goalId,
-    userId: session.user.id, organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
-    after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'goal.edit', entityType: 'goal', entityId: goalId,
+      userId: session.user.id, organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+      after: { name, status },
+    })
   })
 
   revalidatePath('/goals')
@@ -151,13 +155,15 @@ export async function deleteGoal(goalId: string) {
   const before = await db.query.goals.findFirst({ where: eq(goals.id, goalId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(goals).where(
-    and(eq(goals.id, goalId), eq(goals.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(goals).where(
+      and(eq(goals.id, goalId), eq(goals.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'goal.delete', entityType: 'goal', entityId: goalId,
-    userId: session.user.id, organizationId: orgId, before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'goal.delete', entityType: 'goal', entityId: goalId,
+      userId: session.user.id, organizationId: orgId, before: { name: before?.name },
+    })
   })
 
   revalidatePath('/goals')

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -88,40 +88,42 @@ export async function createInitiative(formData: FormData) {
   const orgId = session.user.organizationId as string
   const userId = session.user.id
 
-  const [row] = await db.insert(initiatives).values({
-    name: formData.get('name') as string,
-    description: (formData.get('description') as string) || null,
-    status: (formData.get('status') as 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled') || 'proposed',
-    startDate: (formData.get('startDate') as string) || null,
-    endDate: (formData.get('endDate') as string) || null,
-    visibility: (formData.get('visibility') as 'org' | 'connections' | 'instance') || 'org',
-    organizationId: orgId,
-    createdBy: userId,
-    updatedBy: userId,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [row] = await tx.insert(initiatives).values({
+      name: formData.get('name') as string,
+      description: (formData.get('description') as string) || null,
+      status: (formData.get('status') as 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled') || 'proposed',
+      startDate: (formData.get('startDate') as string) || null,
+      endDate: (formData.get('endDate') as string) || null,
+      visibility: (formData.get('visibility') as 'org' | 'connections' | 'instance') || 'org',
+      organizationId: orgId,
+      createdBy: userId,
+      updatedBy: userId,
+    }).returning()
 
-  const capabilityEntries = buildCapabilityEntries(formData, row.id)
-  if (capabilityEntries.length > 0) {
-    await db.insert(initiativeCapabilities).values(capabilityEntries).onConflictDoNothing()
-  }
+    const capabilityEntries = buildCapabilityEntries(formData, row.id)
+    if (capabilityEntries.length > 0) {
+      await tx.insert(initiativeCapabilities).values(capabilityEntries).onConflictDoNothing()
+    }
 
-  const objectiveIds = formData.getAll('objectiveIds') as string[]
-  if (objectiveIds.length > 0) {
-    await db.insert(initiativeObjectives)
-      .values(objectiveIds.map(objectiveId => ({ initiativeId: row.id, objectiveId })))
-      .onConflictDoNothing()
-  }
+    const objectiveIds = formData.getAll('objectiveIds') as string[]
+    if (objectiveIds.length > 0) {
+      await tx.insert(initiativeObjectives)
+        .values(objectiveIds.map(objectiveId => ({ initiativeId: row.id, objectiveId })))
+        .onConflictDoNothing()
+    }
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'initiative', row.id, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'initiative', row.id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'initiative.create',
-    entityType: 'initiative',
-    entityId: row.id,
-    userId,
-    organizationId: orgId,
-    after: { name: row.name, status: row.status, visibility: row.visibility },
+    await writeAuditLog(tx, {
+      action: 'initiative.create',
+      entityType: 'initiative',
+      entityId: row.id,
+      userId,
+      organizationId: orgId,
+      after: { name: row.name, status: row.status, visibility: row.visibility },
+    })
   })
 }
 
@@ -137,44 +139,46 @@ export async function editInitiative(id: string, formData: FormData) {
   const status = (formData.get('status') as 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled') || 'proposed'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') || 'org'
 
-  await db.update(initiatives).set({
-    name,
-    description: (formData.get('description') as string) || null,
-    status,
-    startDate: (formData.get('startDate') as string) || null,
-    endDate: (formData.get('endDate') as string) || null,
-    visibility,
-    updatedBy: userId,
-    updatedAt: new Date(),
-  }).where(eq(initiatives.id, id))
+  await db.transaction(async (tx) => {
+    await tx.update(initiatives).set({
+      name,
+      description: (formData.get('description') as string) || null,
+      status,
+      startDate: (formData.get('startDate') as string) || null,
+      endDate: (formData.get('endDate') as string) || null,
+      visibility,
+      updatedBy: userId,
+      updatedAt: new Date(),
+    }).where(eq(initiatives.id, id))
 
-  // Replace capability junctions
-  await db.delete(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, id))
-  const capabilityEntries = buildCapabilityEntries(formData, id)
-  if (capabilityEntries.length > 0) {
-    await db.insert(initiativeCapabilities).values(capabilityEntries).onConflictDoNothing()
-  }
+    // Replace capability junctions
+    await tx.delete(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, id))
+    const capabilityEntries = buildCapabilityEntries(formData, id)
+    if (capabilityEntries.length > 0) {
+      await tx.insert(initiativeCapabilities).values(capabilityEntries).onConflictDoNothing()
+    }
 
-  // Replace objective junctions
-  await db.delete(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, id))
-  const objectiveIds = formData.getAll('objectiveIds') as string[]
-  if (objectiveIds.length > 0) {
-    await db.insert(initiativeObjectives)
-      .values(objectiveIds.map(objectiveId => ({ initiativeId: id, objectiveId })))
-      .onConflictDoNothing()
-  }
+    // Replace objective junctions
+    await tx.delete(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, id))
+    const objectiveIds = formData.getAll('objectiveIds') as string[]
+    if (objectiveIds.length > 0) {
+      await tx.insert(initiativeObjectives)
+        .values(objectiveIds.map(objectiveId => ({ initiativeId: id, objectiveId })))
+        .onConflictDoNothing()
+    }
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'initiative', id, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'initiative', id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'initiative.edit',
-    entityType: 'initiative',
-    entityId: id,
-    userId,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
-    after: { name, status, visibility },
+    await writeAuditLog(tx, {
+      action: 'initiative.edit',
+      entityType: 'initiative',
+      entityId: id,
+      userId,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+      after: { name, status, visibility },
+    })
   })
 }
 
@@ -185,19 +189,21 @@ export async function deleteInitiative(id: string) {
   const before = await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(eq(entityTaxonomyValues.entityType, 'initiative'), eq(entityTaxonomyValues.entityId, id))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(eq(entityTaxonomyValues.entityType, 'initiative'), eq(entityTaxonomyValues.entityId, id))
+    )
 
-  await db.delete(initiatives).where(eq(initiatives.id, id))
+    await tx.delete(initiatives).where(eq(initiatives.id, id))
 
-  await writeAuditLog({
-    action: 'initiative.delete',
-    entityType: 'initiative',
-    entityId: id,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
+    await writeAuditLog(tx, {
+      action: 'initiative.delete',
+      entityType: 'initiative',
+      entityId: id,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+    })
   })
 }
 

--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -35,42 +35,48 @@ export async function createOrg(formData: FormData): Promise<{ id: string }> {
   const theme = defaults?.defaultTheme ?? 'govea'
   const supportTier = defaults?.defaultSupportTier ?? null
 
-  const [org] = await db
-    .insert(organizations)
-    .values({ name, slug, theme, supportTier })
-    .returning()
+  const orgId = await db.transaction(async (tx) => {
+    const [org] = await tx
+      .insert(organizations)
+      .values({ name, slug, theme, supportTier })
+      .returning()
 
-  await writeAuditLog({
-    action: 'instance.org.create',
-    entityType: 'organization',
-    entityId: org.id,
-    userId: session.user.id,
-    organizationId: null,
-    after: { name, slug, theme, supportTier },
+    await writeAuditLog(tx, {
+      action: 'instance.org.create',
+      entityType: 'organization',
+      entityId: org.id,
+      userId: session.user.id,
+      organizationId: null,
+      after: { name, slug, theme, supportTier },
+    })
+
+    return org.id
   })
 
   revalidatePath('/instance/orgs')
-  return { id: org.id }
+  return { id: orgId }
 }
 
 export async function grantBreakGlass(orgId: string, reason: string) {
   const session = await requireInstanceAdmin()
   const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
 
-  const [row] = await db.insert(breakGlassSessions).values({
-    instanceAdminId: session.user.id,
-    targetOrgId: orgId,
-    reason,
-    expiresAt,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [row] = await tx.insert(breakGlassSessions).values({
+      instanceAdminId: session.user.id,
+      targetOrgId: orgId,
+      reason,
+      expiresAt,
+    }).returning()
 
-  await writeAuditLog({
-    action: 'instance.break_glass.grant',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: null,
-    after: { reason, expiresAt, sessionId: row.id },
+    await writeAuditLog(tx, {
+      action: 'instance.break_glass.grant',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: null,
+      after: { reason, expiresAt, sessionId: row.id },
+    })
   })
 
   revalidatePath(`/instance/orgs/${orgId}`)
@@ -80,19 +86,21 @@ export async function grantBreakGlass(orgId: string, reason: string) {
 export async function revokeBreakGlass(sessionId: string, orgId: string) {
   const session = await requireInstanceAdmin()
 
-  await db.update(breakGlassSessions)
-    .set({ revokedAt: new Date(), revokedBy: session.user.id })
-    .where(and(
-      eq(breakGlassSessions.id, sessionId),
-      eq(breakGlassSessions.instanceAdminId, session.user.id),
-    ))
+  await db.transaction(async (tx) => {
+    await tx.update(breakGlassSessions)
+      .set({ revokedAt: new Date(), revokedBy: session.user.id })
+      .where(and(
+        eq(breakGlassSessions.id, sessionId),
+        eq(breakGlassSessions.instanceAdminId, session.user.id),
+      ))
 
-  await writeAuditLog({
-    action: 'instance.break_glass.revoke',
-    entityType: 'break_glass_session',
-    entityId: sessionId,
-    userId: session.user.id,
-    organizationId: null,
+    await writeAuditLog(tx, {
+      action: 'instance.break_glass.revoke',
+      entityType: 'break_glass_session',
+      entityId: sessionId,
+      userId: session.user.id,
+      organizationId: null,
+    })
   })
 
   revalidatePath(`/instance/orgs/${orgId}`)
@@ -106,18 +114,20 @@ export async function suspendOrg(orgId: string, reason: string) {
   if (!before) throw new Error('Organisation not found')
   if (before.isSystemOrg) throw new Error('Cannot suspend the system org')
 
-  await db.update(organizations)
-    .set({ suspendedAt: new Date(), suspendedReason: reason, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ suspendedAt: new Date(), suspendedReason: reason, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'instance.org.suspend',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: null,
-    before: { suspendedAt: before.suspendedAt },
-    after: { suspendedAt: new Date(), reason },
+    await writeAuditLog(tx, {
+      action: 'instance.org.suspend',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { suspendedAt: before.suspendedAt },
+      after: { suspendedAt: new Date(), reason },
+    })
   })
 
   revalidatePath('/instance/orgs')
@@ -127,16 +137,18 @@ export async function suspendOrg(orgId: string, reason: string) {
 export async function unsuspendOrg(orgId: string) {
   const session = await requireInstanceAdmin()
 
-  await db.update(organizations)
-    .set({ suspendedAt: null, suspendedReason: null, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ suspendedAt: null, suspendedReason: null, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'instance.org.unsuspend',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: null,
+    await writeAuditLog(tx, {
+      action: 'instance.org.unsuspend',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: null,
+    })
   })
 
   revalidatePath('/instance/orgs')
@@ -146,17 +158,19 @@ export async function unsuspendOrg(orgId: string) {
 export async function promoteInstanceAdmin(userId: string, reason?: string) {
   const session = await requireInstanceAdmin()
 
-  await db.update(users)
-    .set({ instanceRole: 'instance_admin', updatedAt: new Date() })
-    .where(eq(users.id, userId))
+  await db.transaction(async (tx) => {
+    await tx.update(users)
+      .set({ instanceRole: 'instance_admin', updatedAt: new Date() })
+      .where(eq(users.id, userId))
 
-  await writeAuditLog({
-    action: 'instance.user.promote',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: null,
-    after: { instanceRole: 'instance_admin', reason: reason?.trim() || null },
+    await writeAuditLog(tx, {
+      action: 'instance.user.promote',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: null,
+      after: { instanceRole: 'instance_admin', reason: reason?.trim() || null },
+    })
   })
 
   revalidatePath('/instance/users')
@@ -166,18 +180,20 @@ export async function demoteInstanceAdmin(userId: string, reason?: string) {
   const session = await requireInstanceAdmin()
   if (userId === session.user.id) throw new Error('Cannot demote yourself')
 
-  await db.update(users)
-    .set({ instanceRole: null, updatedAt: new Date() })
-    .where(eq(users.id, userId))
+  await db.transaction(async (tx) => {
+    await tx.update(users)
+      .set({ instanceRole: null, updatedAt: new Date() })
+      .where(eq(users.id, userId))
 
-  await writeAuditLog({
-    action: 'instance.user.demote',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: null,
-    before: { instanceRole: 'instance_admin' },
-    after: { instanceRole: null, reason: reason?.trim() || null },
+    await writeAuditLog(tx, {
+      action: 'instance.user.demote',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { instanceRole: 'instance_admin' },
+      after: { instanceRole: null, reason: reason?.trim() || null },
+    })
   })
 
   revalidatePath('/instance/users')
@@ -208,48 +224,50 @@ export async function updatePlatformConfig(data: {
 
   const before = await db.query.platformConfig.findFirst()
 
-  await db.insert(platformConfig)
-    .values({
-      id: 'singleton',
-      instanceName: trimmed,
-      defaultTheme: data.defaultTheme,
-      allowLocalAuth: data.allowLocalAuth,
-      defaultSupportTier,
-      updatedAt: new Date(),
-      updatedBy: session.user.id,
-    })
-    .onConflictDoUpdate({
-      target: platformConfig.id,
-      set: {
+  await db.transaction(async (tx) => {
+    await tx.insert(platformConfig)
+      .values({
+        id: 'singleton',
         instanceName: trimmed,
         defaultTheme: data.defaultTheme,
         allowLocalAuth: data.allowLocalAuth,
         defaultSupportTier,
         updatedAt: new Date(),
         updatedBy: session.user.id,
+      })
+      .onConflictDoUpdate({
+        target: platformConfig.id,
+        set: {
+          instanceName: trimmed,
+          defaultTheme: data.defaultTheme,
+          allowLocalAuth: data.allowLocalAuth,
+          defaultSupportTier,
+          updatedAt: new Date(),
+          updatedBy: session.user.id,
+        },
+      })
+
+    await writeAuditLog(tx, {
+      action: 'instance.config.update',
+      entityType: 'platform_config',
+      entityId: 'singleton',
+      userId: session.user.id,
+      organizationId: null,
+      before: before
+        ? {
+            instanceName: before.instanceName,
+            defaultTheme: before.defaultTheme,
+            allowLocalAuth: before.allowLocalAuth,
+            defaultSupportTier: before.defaultSupportTier,
+          }
+        : null,
+      after: {
+        instanceName: trimmed,
+        defaultTheme: data.defaultTheme,
+        allowLocalAuth: data.allowLocalAuth,
+        defaultSupportTier,
       },
     })
-
-  await writeAuditLog({
-    action: 'instance.config.update',
-    entityType: 'platform_config',
-    entityId: 'singleton',
-    userId: session.user.id,
-    organizationId: null,
-    before: before
-      ? {
-          instanceName: before.instanceName,
-          defaultTheme: before.defaultTheme,
-          allowLocalAuth: before.allowLocalAuth,
-          defaultSupportTier: before.defaultSupportTier,
-        }
-      : null,
-    after: {
-      instanceName: trimmed,
-      defaultTheme: data.defaultTheme,
-      allowLocalAuth: data.allowLocalAuth,
-      defaultSupportTier,
-    },
   })
 
   revalidatePath('/instance/config')
@@ -292,30 +310,32 @@ export async function createInstanceUser(formData: FormData) {
   if (!pwValidation.valid) throw new Error(pwValidation.message)
 
   const passwordHash = await bcrypt.hash(password, 12)
-  const [user] = await db.insert(users).values({
-    organizationId,
-    name,
-    email,
-    passwordHash,
-    role,
-    instanceRole: grantPlatformAdmin ? 'instance_admin' : null,
-    isActive: 'true',
-  }).returning()
-
-  await writeAuditLog({
-    action: 'instance.user.create',
-    entityType: 'user',
-    entityId: user.id,
-    userId: session.user.id,
-    organizationId: null,
-    after: {
+  await db.transaction(async (tx) => {
+    const [user] = await tx.insert(users).values({
+      organizationId,
       name,
       email,
+      passwordHash,
       role,
-      organizationId,
-      organizationName: organization.name,
       instanceRole: grantPlatformAdmin ? 'instance_admin' : null,
-    },
+      isActive: 'true',
+    }).returning()
+
+    await writeAuditLog(tx, {
+      action: 'instance.user.create',
+      entityType: 'user',
+      entityId: user.id,
+      userId: session.user.id,
+      organizationId: null,
+      after: {
+        name,
+        email,
+        role,
+        organizationId,
+        organizationName: organization.name,
+        instanceRole: grantPlatformAdmin ? 'instance_admin' : null,
+      },
+    })
   })
 
   revalidatePath('/instance/users')
@@ -333,18 +353,20 @@ export async function updateOrgGovernance(
   const supportTier = data.supportTier?.trim() || null
   const internalNotes = data.internalNotes?.trim() || null
 
-  await db.update(organizations)
-    .set({ supportTier, internalNotes, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ supportTier, internalNotes, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'instance.org.governance.update',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: null,
-    before: { supportTier: before.supportTier, internalNotes: before.internalNotes },
-    after: { supportTier, internalNotes },
+    await writeAuditLog(tx, {
+      action: 'instance.org.governance.update',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { supportTier: before.supportTier, internalNotes: before.internalNotes },
+      after: { supportTier, internalNotes },
+    })
   })
 
   revalidatePath('/instance/orgs')
@@ -379,23 +401,25 @@ export async function setInstanceModuleAvailability(key: ModuleKey, available: b
     afterDisabledModules[key] = true
   }
 
-  const [row] = before
-    ? await db.update(instanceSettings)
-        .set({ disabledModules: afterDisabledModules, updatedAt: new Date() })
-        .where(eq(instanceSettings.id, before.id))
-        .returning()
-    : await db.insert(instanceSettings)
-        .values({ disabledModules: afterDisabledModules })
-        .returning()
+  await db.transaction(async (tx) => {
+    const [row] = before
+      ? await tx.update(instanceSettings)
+          .set({ disabledModules: afterDisabledModules, updatedAt: new Date() })
+          .where(eq(instanceSettings.id, before.id))
+          .returning()
+      : await tx.insert(instanceSettings)
+          .values({ disabledModules: afterDisabledModules })
+          .returning()
 
-  await writeAuditLog({
-    action: 'instance.settings.module_availability',
-    entityType: 'instance_settings',
-    entityId: row.id,
-    userId: session.user.id,
-    organizationId: null,
-    before: { [key]: beforeDisabledModules[key] ? 'disabled' : 'available' },
-    after: { [key]: available ? 'available' : 'disabled' },
+    await writeAuditLog(tx, {
+      action: 'instance.settings.module_availability',
+      entityType: 'instance_settings',
+      entityId: row.id,
+      userId: session.user.id,
+      organizationId: null,
+      before: { [key]: beforeDisabledModules[key] ? 'disabled' : 'available' },
+      after: { [key]: available ? 'available' : 'disabled' },
+    })
   })
 
   revalidatePath('/', 'layout')

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -94,30 +94,32 @@ export async function createObjective(formData: FormData) {
   const capabilityIds = formData.getAll('capabilityIds') as string[]
   const valueStreamIds = formData.getAll('valueStreamIds') as string[]
 
-  const [obj] = await db.insert(strategicObjectives).values({
-    name, description, successMetric, timeHorizon, status, visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [obj] = await tx.insert(strategicObjectives).values({
+      name, description, successMetric, timeHorizon, status, visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (capabilityIds.length > 0) {
-    await db.insert(objectiveCapabilities).values(
-      capabilityIds.map(cId => ({ objectiveId: obj.id, capabilityId: cId }))
-    )
-  }
-  if (valueStreamIds.length > 0) {
-    await db.insert(objectiveValueStreams).values(
-      valueStreamIds.map(vId => ({ objectiveId: obj.id, valueStreamId: vId }))
-    )
-  }
+    if (capabilityIds.length > 0) {
+      await tx.insert(objectiveCapabilities).values(
+        capabilityIds.map(cId => ({ objectiveId: obj.id, capabilityId: cId }))
+      )
+    }
+    if (valueStreamIds.length > 0) {
+      await tx.insert(objectiveValueStreams).values(
+        valueStreamIds.map(vId => ({ objectiveId: obj.id, valueStreamId: vId }))
+      )
+    }
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'objective', obj.id, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'objective', obj.id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'objective.create', entityType: 'objective', entityId: obj.id,
-    userId: session.user.id, organizationId: orgId, after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'objective.create', entityType: 'objective', entityId: obj.id,
+      userId: session.user.id, organizationId: orgId, after: { name, status },
+    })
   })
 }
 
@@ -139,33 +141,35 @@ export async function editObjective(objectiveId: string, formData: FormData) {
   })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(strategicObjectives).set({
-    name, description, successMetric, timeHorizon, status, visibility,
-    updatedBy: session.user.id, updatedAt: new Date(),
-  }).where(and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(strategicObjectives).set({
+      name, description, successMetric, timeHorizon, status, visibility,
+      updatedBy: session.user.id, updatedAt: new Date(),
+    }).where(and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId)))
 
-  await db.delete(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, objectiveId))
-  if (capabilityIds.length > 0) {
-    await db.insert(objectiveCapabilities).values(
-      capabilityIds.map(cId => ({ objectiveId, capabilityId: cId }))
-    )
-  }
+    await tx.delete(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, objectiveId))
+    if (capabilityIds.length > 0) {
+      await tx.insert(objectiveCapabilities).values(
+        capabilityIds.map(cId => ({ objectiveId, capabilityId: cId }))
+      )
+    }
 
-  await db.delete(objectiveValueStreams).where(eq(objectiveValueStreams.objectiveId, objectiveId))
-  if (valueStreamIds.length > 0) {
-    await db.insert(objectiveValueStreams).values(
-      valueStreamIds.map(vId => ({ objectiveId, valueStreamId: vId }))
-    )
-  }
+    await tx.delete(objectiveValueStreams).where(eq(objectiveValueStreams.objectiveId, objectiveId))
+    if (valueStreamIds.length > 0) {
+      await tx.insert(objectiveValueStreams).values(
+        valueStreamIds.map(vId => ({ objectiveId, valueStreamId: vId }))
+      )
+    }
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'objective', objectiveId, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'objective', objectiveId, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'objective.edit', entityType: 'objective', entityId: objectiveId,
-    userId: session.user.id, organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
-    after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'objective.edit', entityType: 'objective', entityId: objectiveId,
+      userId: session.user.id, organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+      after: { name, status },
+    })
   })
 }
 
@@ -178,16 +182,18 @@ export async function deleteObjective(objectiveId: string) {
   })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(eq(entityTaxonomyValues.entityType, 'objective'), eq(entityTaxonomyValues.entityId, objectiveId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(eq(entityTaxonomyValues.entityType, 'objective'), eq(entityTaxonomyValues.entityId, objectiveId))
+    )
 
-  await db.delete(strategicObjectives).where(
-    and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId))
-  )
+    await tx.delete(strategicObjectives).where(
+      and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'objective.delete', entityType: 'objective', entityId: objectiveId,
-    userId: session.user.id, organizationId: orgId, before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'objective.delete', entityType: 'objective', entityId: objectiveId,
+      userId: session.user.id, organizationId: orgId, before: { name: before?.name },
+    })
   })
 }

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -87,30 +87,32 @@ export async function createPersona(formData: FormData) {
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const tagIds = formData.getAll('tagIds') as string[]
 
-  const [persona] = await db.insert(personas).values({
-    name,
-    description,
-    type,
-    status,
-    visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [persona] = await tx.insert(personas).values({
+      name,
+      description,
+      type,
+      status,
+      visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (tagIds.length > 0) {
-    await db.insert(personaTags).values(
-      tagIds.map(tagId => ({ personaId: persona.id, tagId }))
-    )
-  }
+    if (tagIds.length > 0) {
+      await tx.insert(personaTags).values(
+        tagIds.map(tagId => ({ personaId: persona.id, tagId }))
+      )
+    }
 
-  await writeAuditLog({
-    action: 'persona.create',
-    entityType: 'persona',
-    entityId: persona.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, description, type, status, tagIds },
+    await writeAuditLog(tx, {
+      action: 'persona.create',
+      entityType: 'persona',
+      entityId: persona.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, description, type, status, tagIds },
+    })
   })
 }
 
@@ -128,40 +130,42 @@ export async function editPersona(personaId: string, formData: FormData) {
   const before = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(personas).set({
-    name,
-    description,
-    type,
-    status,
-    visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(personas.id, personaId), eq(personas.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(personas).set({
+      name,
+      description,
+      type,
+      status,
+      visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(personas.id, personaId), eq(personas.organizationId, orgId)))
 
-  // Replace junction rows
-  await db.delete(personaTags).where(eq(personaTags.personaId, personaId))
-  if (tagIds.length > 0) {
-    await db.insert(personaTags).values(
-      tagIds.map(tagId => ({ personaId, tagId }))
-    )
-  }
+    // Replace junction rows
+    await tx.delete(personaTags).where(eq(personaTags.personaId, personaId))
+    if (tagIds.length > 0) {
+      await tx.insert(personaTags).values(
+        tagIds.map(tagId => ({ personaId, tagId }))
+      )
+    }
 
-  await writeAuditLog({
-    action: 'persona.edit',
-    entityType: 'persona',
-    entityId: personaId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, description: before?.description, type: before?.type, status: before?.status },
-    after: { name, description, type, status, tagIds },
+    await writeAuditLog(tx, {
+      action: 'persona.edit',
+      entityType: 'persona',
+      entityId: personaId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, description: before?.description, type: before?.type, status: before?.status },
+      after: { name, description, type, status, tagIds },
+    })
+
+    // Flag or clear cross-org links when visibility changes.
+    const prevVis = before?.visibility
+    const visDropped = (prevVis === 'connections' || prevVis === 'instance') && visibility === 'org'
+    const visRaised = prevVis === 'org' && (visibility === 'connections' || visibility === 'instance')
+    if (visDropped) await flagLinksForVisibilityDrop(tx, 'persona', personaId, `"${name}" visibility was restricted to org-only — this link may no longer be accessible to the other org`)
+    if (visRaised)  await clearLinksFlag(tx, 'persona', personaId)
   })
-
-  // Flag or clear cross-org links when visibility changes.
-  const prevVis = before?.visibility
-  const visDropped = (prevVis === 'connections' || prevVis === 'instance') && visibility === 'org'
-  const visRaised = prevVis === 'org' && (visibility === 'connections' || visibility === 'instance')
-  if (visDropped) await flagLinksForVisibilityDrop('persona', personaId, `"${name}" visibility was restricted to org-only — this link may no longer be accessible to the other org`)
-  if (visRaised)  await clearLinksFlag('persona', personaId)
 }
 
 export async function deletePersona(personaId: string) {
@@ -171,17 +175,19 @@ export async function deletePersona(personaId: string) {
   const before = await db.query.personas.findFirst({ where: eq(personas.id, personaId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(personas).where(
-    and(eq(personas.id, personaId), eq(personas.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(personas).where(
+      and(eq(personas.id, personaId), eq(personas.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'persona.delete',
-    entityType: 'persona',
-    entityId: personaId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'persona.delete',
+      entityType: 'persona',
+      entityId: personaId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name },
+    })
   })
 }
 
@@ -193,18 +199,20 @@ export async function markPersonaReviewed(personaId: string, _formData: FormData
   assertOwnership(record?.organizationId, orgId)
 
   const now = new Date()
-  await db.update(personas).set({
-    lastReviewedBy: session.user.id,
-    lastReviewedAt: now,
-  }).where(and(eq(personas.id, personaId), eq(personas.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(personas).set({
+      lastReviewedBy: session.user.id,
+      lastReviewedAt: now,
+    }).where(and(eq(personas.id, personaId), eq(personas.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'persona.reviewed',
-    entityType: 'persona',
-    entityId: personaId,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { lastReviewedAt: now.toISOString() },
+    await writeAuditLog(tx, {
+      action: 'persona.reviewed',
+      entityType: 'persona',
+      entityId: personaId,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { lastReviewedAt: now.toISOString() },
+    })
   })
 
   revalidatePath(`/personas/${personaId}`)

--- a/apps/govea/src/actions/principles.ts
+++ b/apps/govea/src/actions/principles.ts
@@ -24,11 +24,13 @@ async function requireAdmin() {
   return session
 }
 
-async function insertJunctions(principleId: string, adrIds: string[], capabilityIds: string[]) {
+type DBOrTx = Pick<typeof db, 'insert'>
+
+async function insertJunctions(tx: DBOrTx, principleId: string, adrIds: string[], capabilityIds: string[]) {
   if (adrIds.length > 0)
-    await db.insert(principleAdrs).values(adrIds.map(adrId => ({ principleId, adrId }))).onConflictDoNothing()
+    await tx.insert(principleAdrs).values(adrIds.map(adrId => ({ principleId, adrId }))).onConflictDoNothing()
   if (capabilityIds.length > 0)
-    await db.insert(principleCapabilities).values(capabilityIds.map(capabilityId => ({ principleId, capabilityId }))).onConflictDoNothing()
+    await tx.insert(principleCapabilities).values(capabilityIds.map(capabilityId => ({ principleId, capabilityId }))).onConflictDoNothing()
 }
 
 export async function getPrinciples() {
@@ -98,25 +100,27 @@ export async function createPrinciple(formData: FormData) {
   const adrIds = formData.getAll('adrIds') as string[]
   const capabilityIds = formData.getAll('capabilityIds') as string[]
 
-  const [principle] = await db.insert(principles).values({
-    name, description, title, rationale, implications, principleType, status, visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [principle] = await tx.insert(principles).values({
+      name, description, title, rationale, implications, principleType, status, visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  await insertJunctions(principle.id, adrIds, capabilityIds)
+    await insertJunctions(tx, principle.id, adrIds, capabilityIds)
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'principle', principle.id, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'principle', principle.id, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'principle.create',
-    entityType: 'principle',
-    entityId: principle.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, status, visibility },
+    await writeAuditLog(tx, {
+      action: 'principle.create',
+      entityType: 'principle',
+      entityId: principle.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, status, visibility },
+    })
   })
 }
 
@@ -138,27 +142,29 @@ export async function editPrinciple(principleId: string, formData: FormData) {
   const before = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(principles).set({
-    name, description, title, rationale, implications, principleType, status, visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(principles.id, principleId), eq(principles.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(principles).set({
+      name, description, title, rationale, implications, principleType, status, visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(principles.id, principleId), eq(principles.organizationId, orgId)))
 
-  await db.delete(principleAdrs).where(eq(principleAdrs.principleId, principleId))
-  await db.delete(principleCapabilities).where(eq(principleCapabilities.principleId, principleId))
-  await insertJunctions(principleId, adrIds, capabilityIds)
+    await tx.delete(principleAdrs).where(eq(principleAdrs.principleId, principleId))
+    await tx.delete(principleCapabilities).where(eq(principleCapabilities.principleId, principleId))
+    await insertJunctions(tx, principleId, adrIds, capabilityIds)
 
-  const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
-  await syncEntityTaxonomyValues(orgId, 'principle', principleId, taxonomyTermIds)
+    const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+    await syncEntityTaxonomyValues(tx, orgId, 'principle', principleId, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'principle.edit',
-    entityType: 'principle',
-    entityId: principleId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
-    after: { name, status, visibility },
+    await writeAuditLog(tx, {
+      action: 'principle.edit',
+      entityType: 'principle',
+      entityId: principleId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+      after: { name, status, visibility },
+    })
   })
 }
 
@@ -169,20 +175,22 @@ export async function deletePrinciple(principleId: string) {
   const before = await db.query.principles.findFirst({ where: eq(principles.id, principleId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(eq(entityTaxonomyValues.entityType, 'principle'), eq(entityTaxonomyValues.entityId, principleId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(eq(entityTaxonomyValues.entityType, 'principle'), eq(entityTaxonomyValues.entityId, principleId))
+    )
 
-  await db.delete(principles).where(
-    and(eq(principles.id, principleId), eq(principles.organizationId, orgId))
-  )
+    await tx.delete(principles).where(
+      and(eq(principles.id, principleId), eq(principles.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'principle.delete',
-    entityType: 'principle',
-    entityId: principleId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { title: before?.title },
+    await writeAuditLog(tx, {
+      action: 'principle.delete',
+      entityType: 'principle',
+      entityId: principleId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { title: before?.title },
+    })
   })
 }

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -106,35 +106,37 @@ export async function createService(formData: FormData) {
   const personaIds = formData.getAll('personaIds') as string[]
   const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
-  const [service] = await db.insert(services).values({
-    name,
-    description,
-    serviceOwner,
-    channels,
-    status,
-    visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [service] = await tx.insert(services).values({
+      name,
+      description,
+      serviceOwner,
+      channels,
+      status,
+      visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  if (personaIds.length > 0) {
-    await db.insert(servicePersonas).values(
-      personaIds.map(personaId => ({ serviceId: service.id, personaId }))
-    )
-  }
+    if (personaIds.length > 0) {
+      await tx.insert(servicePersonas).values(
+        personaIds.map(personaId => ({ serviceId: service.id, personaId }))
+      )
+    }
 
-  if (taxonomyTermIds.length > 0) {
-    await syncEntityTaxonomyValues(orgId, 'service', service.id, taxonomyTermIds)
-  }
+    if (taxonomyTermIds.length > 0) {
+      await syncEntityTaxonomyValues(tx, orgId, 'service', service.id, taxonomyTermIds)
+    }
 
-  await writeAuditLog({
-    action: 'service.create',
-    entityType: 'service',
-    entityId: service.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, description, serviceOwner, channels, status, visibility, personaIds },
+    await writeAuditLog(tx, {
+      action: 'service.create',
+      entityType: 'service',
+      entityId: service.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, description, serviceOwner, channels, status, visibility, personaIds },
+    })
   })
 }
 
@@ -154,36 +156,38 @@ export async function editService(serviceId: string, formData: FormData) {
   const before = await db.query.services.findFirst({ where: eq(services.id, serviceId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.update(services).set({
-    name,
-    description,
-    serviceOwner,
-    channels,
-    status,
-    visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(services.id, serviceId), eq(services.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(services).set({
+      name,
+      description,
+      serviceOwner,
+      channels,
+      status,
+      visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(services.id, serviceId), eq(services.organizationId, orgId)))
 
-  // Replace persona links
-  await db.delete(servicePersonas).where(eq(servicePersonas.serviceId, serviceId))
-  if (personaIds.length > 0) {
-    await db.insert(servicePersonas).values(
-      personaIds.map(personaId => ({ serviceId, personaId }))
-    )
-  }
+    // Replace persona links
+    await tx.delete(servicePersonas).where(eq(servicePersonas.serviceId, serviceId))
+    if (personaIds.length > 0) {
+      await tx.insert(servicePersonas).values(
+        personaIds.map(personaId => ({ serviceId, personaId }))
+      )
+    }
 
-  // Replace taxonomy values
-  await syncEntityTaxonomyValues(orgId, 'service', serviceId, taxonomyTermIds)
+    // Replace taxonomy values
+    await syncEntityTaxonomyValues(tx, orgId, 'service', serviceId, taxonomyTermIds)
 
-  await writeAuditLog({
-    action: 'service.edit',
-    entityType: 'service',
-    entityId: serviceId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status, visibility: before?.visibility },
-    after: { name, description, serviceOwner, channels, status, visibility, personaIds },
+    await writeAuditLog(tx, {
+      action: 'service.edit',
+      entityType: 'service',
+      entityId: serviceId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status, visibility: before?.visibility },
+      after: { name, description, serviceOwner, channels, status, visibility, personaIds },
+    })
   })
 }
 
@@ -194,24 +198,26 @@ export async function deleteService(serviceId: string) {
   const before = await db.query.services.findFirst({ where: eq(services.id, serviceId) })
   assertOwnership(before?.organizationId, orgId)
 
-  await db.delete(entityTaxonomyValues).where(
-    and(
-      eq(entityTaxonomyValues.organizationId, orgId),
-      eq(entityTaxonomyValues.entityType, 'service'),
-      eq(entityTaxonomyValues.entityId, serviceId),
+  await db.transaction(async (tx) => {
+    await tx.delete(entityTaxonomyValues).where(
+      and(
+        eq(entityTaxonomyValues.organizationId, orgId),
+        eq(entityTaxonomyValues.entityType, 'service'),
+        eq(entityTaxonomyValues.entityId, serviceId),
+      )
     )
-  )
 
-  await db.delete(services).where(
-    and(eq(services.id, serviceId), eq(services.organizationId, orgId))
-  )
+    await tx.delete(services).where(
+      and(eq(services.id, serviceId), eq(services.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'service.delete',
-    entityType: 'service',
-    entityId: serviceId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'service.delete',
+      entityType: 'service',
+      entityId: serviceId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name },
+    })
   })
 }

--- a/apps/govea/src/actions/settings.ts
+++ b/apps/govea/src/actions/settings.ts
@@ -26,18 +26,20 @@ export async function updateOrgTheme(themeId: string) {
     where: eq(organizations.id, orgId),
   })
 
-  await db.update(organizations)
-    .set({ theme: themeId, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ theme: themeId, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'settings.theme_changed',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { theme: before?.theme },
-    after: { theme: themeId },
+    await writeAuditLog(tx, {
+      action: 'settings.theme_changed',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { theme: before?.theme },
+      after: { theme: themeId },
+    })
   })
 
   revalidatePath('/', 'layout')
@@ -64,18 +66,20 @@ export async function setModuleEnabled(key: ModuleKey, enabled: boolean) {
   const before = org?.enabledModules ?? {}
   const after = { ...before, [key]: enabled }
 
-  await db.update(organizations)
-    .set({ enabledModules: after, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ enabledModules: after, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'settings.module_toggled',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { [key]: before[key] ?? true },
-    after: { [key]: enabled },
+    await writeAuditLog(tx, {
+      action: 'settings.module_toggled',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { [key]: before[key] ?? true },
+      after: { [key]: enabled },
+    })
   })
 
   revalidatePath('/', 'layout')
@@ -105,18 +109,20 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
     suppressBelowPercent,
   }
 
-  await db.update(organizations)
-    .set({ confidenceSettings: next, updatedAt: new Date() })
-    .where(eq(organizations.id, orgId))
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ confidenceSettings: next, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
 
-  await writeAuditLog({
-    action: 'settings.confidence_updated',
-    entityType: 'organization',
-    entityId: orgId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { confidenceSettings: before?.confidenceSettings },
-    after: { confidenceSettings: next },
+    await writeAuditLog(tx, {
+      action: 'settings.confidence_updated',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { confidenceSettings: before?.confidenceSettings },
+      after: { confidenceSettings: next },
+    })
   })
 
   revalidatePath('/', 'layout')

--- a/apps/govea/src/actions/setup.ts
+++ b/apps/govea/src/actions/setup.ts
@@ -31,26 +31,28 @@ export async function runSetup(formData: FormData) {
 
   const passwordHash = await bcrypt.hash(password, 12)
 
-  const [org] = await db.insert(organizations).values({
-    name: orgName,
-    slug: orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [org] = await tx.insert(organizations).values({
+      name: orgName,
+      slug: orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
+    }).returning()
 
-  const [user] = await db.insert(users).values({
-    name,
-    email,
-    passwordHash,
-    role: 'admin',
-    organizationId: org.id,
-    isActive: 'true',
-  }).returning()
+    const [user] = await tx.insert(users).values({
+      name,
+      email,
+      passwordHash,
+      role: 'admin',
+      organizationId: org.id,
+      isActive: 'true',
+    }).returning()
 
-  await writeAuditLog({
-    action: 'setup.complete',
-    entityType: 'user',
-    entityId: user.id,
-    organizationId: org.id,
-    after: { name: user.name, email: user.email, role: user.role },
+    await writeAuditLog(tx, {
+      action: 'setup.complete',
+      entityType: 'user',
+      entityId: user.id,
+      organizationId: org.id,
+      after: { name: user.name, email: user.email, role: user.role },
+    })
   })
 
   redirect('/login')

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -135,22 +135,24 @@ export async function createTaxonomyTerm(formData: FormData) {
   const parentId = (formData.get('parentId') as string) || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
 
-  const [entry] = await db.insert(taxonomyTerms).values({
-    organizationId: orgId,
-    name,
-    slug: toSlug(name),
-    description,
-    parentId,
-    sortOrder,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [entry] = await tx.insert(taxonomyTerms).values({
+      organizationId: orgId,
+      name,
+      slug: toSlug(name),
+      description,
+      parentId,
+      sortOrder,
+    }).returning()
 
-  await writeAuditLog({
-    action: 'taxonomy.create',
-    entityType: 'taxonomy_term',
-    entityId: entry.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, parentId },
+    await writeAuditLog(tx, {
+      action: 'taxonomy.create',
+      entityType: 'taxonomy_term',
+      entityId: entry.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, parentId },
+    })
   })
 }
 
@@ -167,18 +169,20 @@ export async function editTaxonomyTerm(termId: string, formData: FormData) {
   const description = (formData.get('description') as string)?.trim() || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
 
-  await db.update(taxonomyTerms)
-    .set({ name, slug: toSlug(name), description, sortOrder, updatedAt: new Date() })
-    .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(taxonomyTerms)
+      .set({ name, slug: toSlug(name), description, sortOrder, updatedAt: new Date() })
+      .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'taxonomy.edit',
-    entityType: 'taxonomy_term',
-    entityId: termId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: existing?.name },
-    after: { name },
+    await writeAuditLog(tx, {
+      action: 'taxonomy.edit',
+      entityType: 'taxonomy_term',
+      entityId: termId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: existing?.name },
+      after: { name },
+    })
   })
 }
 
@@ -235,23 +239,25 @@ export async function deleteTaxonomyTerm(termId: string) {
     }
   }
 
-  // When deleting a type, also delete its values (not promote — orphaned values are useless)
-  // When deleting a value, just delete it
-  if (existing?.parentId === null) {
-    await db.delete(taxonomyTerms)
-      .where(and(eq(taxonomyTerms.parentId, termId), eq(taxonomyTerms.organizationId, orgId)))
-  }
+  await db.transaction(async (tx) => {
+    // When deleting a type, also delete its values (not promote — orphaned values are useless)
+    // When deleting a value, just delete it
+    if (existing?.parentId === null) {
+      await tx.delete(taxonomyTerms)
+        .where(and(eq(taxonomyTerms.parentId, termId), eq(taxonomyTerms.organizationId, orgId)))
+    }
 
-  await db.delete(taxonomyTerms)
-    .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
+    await tx.delete(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'taxonomy.delete',
-    entityType: 'taxonomy_term',
-    entityId: termId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: existing?.name },
+    await writeAuditLog(tx, {
+      action: 'taxonomy.delete',
+      entityType: 'taxonomy_term',
+      entityId: termId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: existing?.name },
+    })
   })
 }
 
@@ -363,48 +369,51 @@ export async function createDomainValue(name: string): Promise<string> {
 
   const trimmed = name.trim()
 
-  // Find or create the "Domain" type
-  let domainType = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq, isNull, and }) =>
-      and(eq(t.organizationId, orgId), isNull(t.parentId), eq(t.slug, 'domain')),
-  })
+  // Find or create the "Domain" type, then add the value, all in one transaction
+  // so the audit row is consistent with the inserted value (#416).
+  return db.transaction(async (tx) => {
+    let domainType = await tx.query.taxonomyTerms.findFirst({
+      where: (t, { eq, isNull, and }) =>
+        and(eq(t.organizationId, orgId), isNull(t.parentId), eq(t.slug, 'domain')),
+    })
 
-  if (!domainType) {
-    const [created] = await db.insert(taxonomyTerms).values({
+    if (!domainType) {
+      const [created] = await tx.insert(taxonomyTerms).values({
+        organizationId: orgId,
+        name: 'Domain',
+        slug: 'domain',
+        parentId: null,
+      }).returning()
+      domainType = created
+    }
+
+    // Avoid duplicates (case-insensitive)
+    const existing = await tx.query.taxonomyTerms.findFirst({
+      where: (t, { eq, and, sql }) =>
+        and(
+          eq(t.organizationId, orgId),
+          eq(t.parentId, domainType!.id),
+          sql`lower(${t.name}) = lower(${trimmed})`
+        ),
+    })
+    if (existing) return existing.name
+
+    const [entry] = await tx.insert(taxonomyTerms).values({
       organizationId: orgId,
-      name: 'Domain',
-      slug: 'domain',
-      parentId: null,
+      name: trimmed,
+      slug: toSlug(trimmed),
+      parentId: domainType.id,
     }).returning()
-    domainType = created
-  }
 
-  // Avoid duplicates (case-insensitive)
-  const existing = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq, and, sql }) =>
-      and(
-        eq(t.organizationId, orgId),
-        eq(t.parentId, domainType!.id),
-        sql`lower(${t.name}) = lower(${trimmed})`
-      ),
+    await writeAuditLog(tx, {
+      action: 'taxonomy.create',
+      entityType: 'taxonomy_term',
+      entityId: entry.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name: trimmed, parentId: domainType.id },
+    })
+
+    return entry.name
   })
-  if (existing) return existing.name
-
-  const [entry] = await db.insert(taxonomyTerms).values({
-    organizationId: orgId,
-    name: trimmed,
-    slug: toSlug(trimmed),
-    parentId: domainType.id,
-  }).returning()
-
-  await writeAuditLog({
-    action: 'taxonomy.create',
-    entityType: 'taxonomy_term',
-    entityId: entry.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name: trimmed, parentId: domainType.id },
-  })
-
-  return entry.name
 }

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -51,19 +51,21 @@ export async function createUser(formData: FormData) {
   if (existing) throw new Error('A user with that email address already exists.')
 
   const passwordHash = await bcrypt.hash(password, 12)
-  const [user] = await db.insert(users).values({
-    name, email, passwordHash, role,
-    organizationId: orgId,
-    isActive: 'true',
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [user] = await tx.insert(users).values({
+      name, email, passwordHash, role,
+      organizationId: orgId,
+      isActive: 'true',
+    }).returning()
 
-  await writeAuditLog({
-    action: 'user.create',
-    entityType: 'user',
-    entityId: user.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, email, role },
+    await writeAuditLog(tx, {
+      action: 'user.create',
+      entityType: 'user',
+      entityId: user.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, email, role },
+    })
   })
 }
 
@@ -72,18 +74,20 @@ export async function updateUserRole(userId: string, role: 'admin' | 'contributo
   const orgId = session.user.organizationId!
 
   const before = await db.query.users.findFirst({ where: eq(users.id, userId) })
-  await db.update(users).set({ role, updatedAt: new Date() }).where(
-    and(eq(users.id, userId), eq(users.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.update(users).set({ role, updatedAt: new Date() }).where(
+      and(eq(users.id, userId), eq(users.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'user.role_changed',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { role: before?.role },
-    after: { role },
+    await writeAuditLog(tx, {
+      action: 'user.role_changed',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { role: before?.role },
+      after: { role },
+    })
   })
 }
 
@@ -99,16 +103,18 @@ export async function deactivateUser(userId: string) {
     throw new Error('Cannot deactivate the last admin')
   }
 
-  await db.update(users).set({ isActive: 'false', updatedAt: new Date() }).where(
-    and(eq(users.id, userId), eq(users.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.update(users).set({ isActive: 'false', updatedAt: new Date() }).where(
+      and(eq(users.id, userId), eq(users.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'user.deactivate',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: orgId,
+    await writeAuditLog(tx, {
+      action: 'user.deactivate',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
   })
 }
 
@@ -124,15 +130,17 @@ export async function deleteUser(userId: string) {
     throw new Error('Cannot delete the last admin')
   }
 
-  await db.delete(users).where(and(eq(users.id, userId), eq(users.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.delete(users).where(and(eq(users.id, userId), eq(users.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'user.delete',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: target?.name, email: target?.email },
+    await writeAuditLog(tx, {
+      action: 'user.delete',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: target?.name, email: target?.email },
+    })
   })
 }
 
@@ -140,16 +148,18 @@ export async function reactivateUser(userId: string) {
   const session = await requireAdmin()
   const orgId = session.user.organizationId!
 
-  await db.update(users).set({ isActive: 'true', updatedAt: new Date() }).where(
-    and(eq(users.id, userId), eq(users.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.update(users).set({ isActive: 'true', updatedAt: new Date() }).where(
+      and(eq(users.id, userId), eq(users.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'user.reactivate',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: orgId,
+    await writeAuditLog(tx, {
+      action: 'user.reactivate',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
   })
 }
 
@@ -191,17 +201,19 @@ export async function editUser(userId: string, formData: FormData) {
     updates.passwordHash = await bcrypt.hash(newPassword, 12)
   }
 
-  await db.update(users).set(updates).where(
-    and(eq(users.id, userId), eq(users.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.update(users).set(updates).where(
+      and(eq(users.id, userId), eq(users.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'user.edit',
-    entityType: 'user',
-    entityId: userId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, email: before?.email, role: before?.role },
-    after: { name, email, role },
+    await writeAuditLog(tx, {
+      action: 'user.edit',
+      entityType: 'user',
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, email: before?.email, role: before?.role },
+      after: { name, email, role },
+    })
   })
 }

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -95,24 +95,26 @@ export async function createValueStream(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
 
-  const [vs] = await db.insert(valueStreams).values({
-    name,
-    description,
-    valueItem,
-    status,
-    visibility,
-    organizationId: orgId,
-    createdBy: session.user.id,
-    updatedBy: session.user.id,
-  }).returning()
+  await db.transaction(async (tx) => {
+    const [vs] = await tx.insert(valueStreams).values({
+      name,
+      description,
+      valueItem,
+      status,
+      visibility,
+      organizationId: orgId,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+    }).returning()
 
-  await writeAuditLog({
-    action: 'value_stream.create',
-    entityType: 'value_stream',
-    entityId: vs.id,
-    userId: session.user.id,
-    organizationId: orgId,
-    after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'value_stream.create',
+      entityType: 'value_stream',
+      entityId: vs.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { name, status },
+    })
   })
 }
 
@@ -128,24 +130,26 @@ export async function editValueStream(valueStreamId: string, formData: FormData)
 
   const before = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
 
-  await db.update(valueStreams).set({
-    name,
-    description,
-    valueItem,
-    status,
-    visibility,
-    updatedBy: session.user.id,
-    updatedAt: new Date(),
-  }).where(and(eq(valueStreams.id, valueStreamId), eq(valueStreams.organizationId, orgId)))
+  await db.transaction(async (tx) => {
+    await tx.update(valueStreams).set({
+      name,
+      description,
+      valueItem,
+      status,
+      visibility,
+      updatedBy: session.user.id,
+      updatedAt: new Date(),
+    }).where(and(eq(valueStreams.id, valueStreamId), eq(valueStreams.organizationId, orgId)))
 
-  await writeAuditLog({
-    action: 'value_stream.edit',
-    entityType: 'value_stream',
-    entityId: valueStreamId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name, status: before?.status },
-    after: { name, status },
+    await writeAuditLog(tx, {
+      action: 'value_stream.edit',
+      entityType: 'value_stream',
+      entityId: valueStreamId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name, status: before?.status },
+      after: { name, status },
+    })
   })
 }
 
@@ -155,17 +159,19 @@ export async function deleteValueStream(valueStreamId: string) {
 
   const before = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
 
-  await db.delete(valueStreams).where(
-    and(eq(valueStreams.id, valueStreamId), eq(valueStreams.organizationId, orgId))
-  )
+  await db.transaction(async (tx) => {
+    await tx.delete(valueStreams).where(
+      and(eq(valueStreams.id, valueStreamId), eq(valueStreams.organizationId, orgId))
+    )
 
-  await writeAuditLog({
-    action: 'value_stream.delete',
-    entityType: 'value_stream',
-    entityId: valueStreamId,
-    userId: session.user.id,
-    organizationId: orgId,
-    before: { name: before?.name },
+    await writeAuditLog(tx, {
+      action: 'value_stream.delete',
+      entityType: 'value_stream',
+      entityId: valueStreamId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before?.name },
+    })
   })
 }
 

--- a/apps/govea/src/lib/audit.ts
+++ b/apps/govea/src/lib/audit.ts
@@ -1,7 +1,36 @@
-import { db } from '@/db/client'
+import type { db } from '@/db/client'
 import { auditLog } from '@/db/schema'
 
-interface AuditParams {
+/**
+ * Audit-log writer (#416).
+ *
+ * Always pass either the top-level `db` client or a Drizzle transaction
+ * handle (`tx`) as the first argument. When called inside a transaction the
+ * audit insert participates in that transaction — if the mutation fails, the
+ * audit row never appears, and if the audit insert fails, the mutation rolls
+ * back. The previous fail-silent `try { … } catch { console.error }` pattern
+ * is removed: audit writes are now first-class data integrity work, not best
+ * effort.
+ *
+ * Typical usage in a server action:
+ *
+ *   await db.transaction(async (tx) => {
+ *     await tx.update(table).set(...).where(...)
+ *     await writeAuditLog(tx, { action: '...', ... })
+ *   })
+ *
+ * For pure-audit events (login success / failure / sign-out) where there is
+ * no companion mutation, pass `db` directly:
+ *
+ *   await writeAuditLog(db, { action: 'auth.login', ... })
+ */
+
+// Structural type that accepts both the top-level db and a Drizzle tx handle.
+// Drizzle's transaction callback receives a typed transaction client whose
+// .insert API is shape-compatible with the top-level db.
+type DBOrTx = Pick<typeof db, 'insert'>
+
+export interface AuditParams {
   action: string
   entityType: string
   entityId?: string
@@ -12,20 +41,15 @@ interface AuditParams {
   metadata?: Record<string, unknown>
 }
 
-export async function writeAuditLog(params: AuditParams) {
-  try {
-    await db.insert(auditLog).values({
-      action: params.action,
-      entityType: params.entityType,
-      entityId: params.entityId ?? null,
-      userId: params.userId ?? null,
-      organizationId: params.organizationId ?? null,
-      before: params.before ?? null,
-      after: params.after ?? null,
-      metadata: params.metadata ?? null,
-    })
-  } catch (err) {
-    // Audit failures should never crash the app
-    console.error('[audit]', err)
-  }
+export async function writeAuditLog(tx: DBOrTx, params: AuditParams): Promise<void> {
+  await tx.insert(auditLog).values({
+    action: params.action,
+    entityType: params.entityType,
+    entityId: params.entityId ?? null,
+    userId: params.userId ?? null,
+    organizationId: params.organizationId ?? null,
+    before: params.before ?? null,
+    after: params.after ?? null,
+    metadata: params.metadata ?? null,
+  })
 }

--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -49,7 +49,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           where: eq(users.email, email),
         })
         if (!user || !user.passwordHash || user.isActive !== 'true') {
-          await writeAuditLog({
+          await writeAuditLog(db, {
             action: 'auth.login_failed',
             entityType: 'user',
             organizationId: user?.organizationId,
@@ -59,7 +59,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         }
         const valid = await bcrypt.compare(credentials.password as string, user.passwordHash)
         if (!valid) {
-          await writeAuditLog({
+          await writeAuditLog(db, {
             action: 'auth.login_failed',
             entityType: 'user',
             organizationId: user.organizationId,
@@ -145,17 +145,19 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         where: eq(users.id, user.id!),
       })
       if (dbUser && !dbUser.organizationId) {
-        await db.update(users).set({ isActive: 'false' }).where(eq(users.id, user.id!))
-        await writeAuditLog({
-          action: 'auth.sso_org_binding_failed',
-          entityType: 'user',
-          entityId: user.id,
-          metadata: { email: user.email, reason: 'no_organization_binding' },
+        await db.transaction(async (tx) => {
+          await tx.update(users).set({ isActive: 'false' }).where(eq(users.id, user.id!))
+          await writeAuditLog(tx, {
+            action: 'auth.sso_org_binding_failed',
+            entityType: 'user',
+            entityId: user.id,
+            metadata: { email: user.email, reason: 'no_organization_binding' },
+          })
         })
       }
     },
     async signIn({ user }) {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action: 'auth.login',
         entityType: 'user',
         entityId: user.id,
@@ -165,7 +167,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
     async signOut(message) {
       const token = 'token' in message ? message.token : null
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action: 'auth.logout',
         entityType: 'user',
         entityId: token?.id as string | undefined,

--- a/apps/govea/src/lib/cross-org-link-helpers.ts
+++ b/apps/govea/src/lib/cross-org-link-helpers.ts
@@ -3,6 +3,12 @@ import { crossOrgLinks } from '@/db/schema'
 import { and, eq, inArray, or } from 'drizzle-orm'
 import { writeAuditLog } from '@/lib/audit'
 
+/**
+ * Structural type accepting either the top-level db client or a Drizzle tx
+ * handle. Mutating helpers participate in the caller's transaction (#416).
+ */
+type DBOrTx = Pick<typeof db, 'delete' | 'insert' | 'update' | 'query'>
+
 export type CrossOrgEntityType = 'capability' | 'persona'
 
 // Internal helpers used by mutations in actions/capabilities.ts, actions/personas.ts,
@@ -20,13 +26,16 @@ export type CrossOrgEntityType = 'capability' | 'persona'
  * a link may no longer be accessible.
  *
  * Caller MUST have already verified that the entity belongs to the actor's org.
+ * Pass the caller's transaction handle as `tx` so this helper participates in
+ * the same transaction as the surrounding mutation and audit write (#416).
  */
 export async function flagLinksForVisibilityDrop(
+  tx: DBOrTx,
   entityType: CrossOrgEntityType,
   entityId: string,
   reason: string,
 ) {
-  await db.update(crossOrgLinks).set({
+  await tx.update(crossOrgLinks).set({
     flaggedForReview: true,
     flagReason: reason,
     updatedAt: new Date(),
@@ -46,12 +55,15 @@ export async function flagLinksForVisibilityDrop(
  * Called when visibility is raised back to 'connections' or 'instance'.
  *
  * Caller MUST have already verified that the entity belongs to the actor's org.
+ * Pass the caller's transaction handle as `tx` so this helper participates in
+ * the same transaction as the surrounding mutation and audit write (#416).
  */
 export async function clearLinksFlag(
+  tx: DBOrTx,
   entityType: CrossOrgEntityType,
   entityId: string,
 ) {
-  await db.update(crossOrgLinks).set({
+  await tx.update(crossOrgLinks).set({
     flaggedForReview: false,
     flagReason: null,
     updatedAt: new Date(),
@@ -72,21 +84,25 @@ export async function clearLinksFlag(
  *
  * `actorUserId` and `actorOrgId` are required so the audit row identifies who
  * performed the removal. Caller MUST be an admin of one of the two orgs.
+ *
+ * Pass the caller's transaction handle as `tx` so the SELECT, the DELETE, and
+ * the audit write all commit atomically (#416).
  */
 export async function removeLinksForConnection(
+  tx: DBOrTx,
   orgAId: string,
   orgBId: string,
   actorUserId: string,
   actorOrgId: string,
 ) {
-  const affectedLinks = await db.query.crossOrgLinks.findMany({
+  const affectedLinks = await tx.query.crossOrgLinks.findMany({
     where: or(
       and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
       and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
     ),
   })
 
-  await db.delete(crossOrgLinks).where(
+  await tx.delete(crossOrgLinks).where(
     or(
       and(eq(crossOrgLinks.sourceOrgId, orgAId), eq(crossOrgLinks.targetOrgId, orgBId)),
       and(eq(crossOrgLinks.sourceOrgId, orgBId), eq(crossOrgLinks.targetOrgId, orgAId)),
@@ -94,7 +110,7 @@ export async function removeLinksForConnection(
   )
 
   if (affectedLinks.length > 0) {
-    await writeAuditLog({
+    await writeAuditLog(tx, {
       action: 'cross_org_link.remove_for_connection',
       entityType: 'org_connection',
       userId: actorUserId,

--- a/apps/govea/src/lib/entity-taxonomy-helpers.ts
+++ b/apps/govea/src/lib/entity-taxonomy-helpers.ts
@@ -2,6 +2,13 @@ import { db } from '@/db/client'
 import { entityTaxonomyValues } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 
+/**
+ * Structural type accepting either the top-level db client or a Drizzle tx
+ * handle. Used by mutating helpers so they can participate in the caller's
+ * transaction (#416).
+ */
+type DBOrTx = Pick<typeof db, 'delete' | 'insert'>
+
 // Internal helpers used by mutations and detail-page reads in actions/capabilities.ts,
 // actions/personas.ts, actions/applications.ts, actions/objectives.ts,
 // actions/initiatives.ts, actions/principles.ts, actions/services.ts, actions/adrs.ts,
@@ -103,14 +110,18 @@ export async function getEntityTaxonomyValues(organizationId: string, entityType
  *
  * Caller MUST pass an organizationId derived from the actor's session, and have
  * already verified write authorization on the entity.
+ *
+ * Pass the caller's transaction handle as `tx` so this helper participates in
+ * the same transaction as the surrounding mutation and audit write (#416).
  */
 export async function syncEntityTaxonomyValues(
+  tx: DBOrTx,
   organizationId: string,
   entityType: string,
   entityId: string,
   termIds: string[],
 ) {
-  await db.delete(entityTaxonomyValues)
+  await tx.delete(entityTaxonomyValues)
     .where(and(
       eq(entityTaxonomyValues.organizationId, organizationId),
       eq(entityTaxonomyValues.entityType, entityType),
@@ -118,7 +129,7 @@ export async function syncEntityTaxonomyValues(
     ))
 
   if (termIds.length > 0) {
-    await db.insert(entityTaxonomyValues).values(
+    await tx.insert(entityTaxonomyValues).values(
       termIds.map(termId => ({
         organizationId,
         entityType,

--- a/apps/govea/tests/integration/audit-immutable.test.ts
+++ b/apps/govea/tests/integration/audit-immutable.test.ts
@@ -25,7 +25,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.update-blocked.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -56,7 +56,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.delete-blocked.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -84,7 +84,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.cause-message.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -111,7 +111,7 @@ describe('audit_log immutability (#417)', () => {
     const user = await createTestUser(org.id, 'admin')
 
     const action = `test.audit.cascade-safe.${randomUUID()}`
-    await writeAuditLog({
+    await writeAuditLog(db, {
       action,
       entityType: 'user',
       entityId: user.id,

--- a/apps/govea/tests/integration/audit-transactional.test.ts
+++ b/apps/govea/tests/integration/audit-transactional.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration tests: transactional audit writes (#416)
+ *
+ * Verifies the central correctness property of the issue: when an audit-log
+ * insert fails inside a transaction, the companion mutation rolls back. There
+ * is no orphaned data — either both the change and its audit row land, or
+ * neither does.
+ *
+ * The previous fail-silent pattern (try { writeAuditLog } catch { console.error })
+ * is gone; this test exists to make sure the new pattern actually delivers the
+ * atomicity it advertises.
+ *
+ * The rollback is forced by inserting an audit row with a NULL `action` value,
+ * which violates the table's NOT NULL constraint. We use raw SQL because the
+ * Drizzle types correctly forbid NULL on a notNull column — the constraint
+ * violation is exactly the simulated "audit-write failure" we need.
+ */
+import { describe, it, expect } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import { organizations, capabilities, auditLog } from '@/db/schema'
+import { writeAuditLog } from '@/lib/audit'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+describe('audit writes are transactional with their mutation (#416)', () => {
+  it('mutation rolls back when the audit insert fails', async () => {
+    const org = await createTestOrg()
+    const capName = `TxRollbackTest-${randomUUID().slice(0, 8)}`
+
+    // Wrap a real mutation + a deliberately-broken audit in a transaction.
+    // The audit insert violates the NOT NULL constraint on `action`, so the
+    // whole transaction must roll back. After it throws, the capability row
+    // should NOT exist.
+    let threw = false
+    try {
+      await db.transaction(async (tx) => {
+        await tx.insert(capabilities).values({
+          name: capName,
+          organizationId: org.id,
+          status: 'draft',
+          visibility: 'org',
+        })
+
+        // Force the audit insert to fail. NULL violates NOT NULL on action.
+        await tx.execute(sql`
+          INSERT INTO audit_log (organization_id, user_id, action, entity_type)
+          VALUES (${org.id}, NULL, NULL, 'capability')
+        `)
+      })
+    } catch {
+      threw = true
+    }
+
+    try {
+      expect(threw).toBe(true)
+
+      // The capability must not exist — rollback worked
+      const survivors = await db.select().from(capabilities)
+        .where(eq(capabilities.name, capName))
+      expect(survivors.length).toBe(0)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+
+  it('audit row never appears when its companion mutation fails', async () => {
+    // Inverse of the first test: prove the audit row is also rolled back when
+    // the mutation fails. This catches the "what if the application caught
+    // the error and still wrote the audit row" anti-pattern.
+    const org = await createTestOrg()
+    const auditAction = `test.audit.tx-rollback.${randomUUID()}`
+
+    let threw = false
+    try {
+      await db.transaction(async (tx) => {
+        // Audit write succeeds...
+        await writeAuditLog(tx, {
+          action: auditAction,
+          entityType: 'capability',
+          organizationId: org.id,
+          after: { test: 'should-not-survive' },
+        })
+
+        // ...but the mutation fails. Insert into a non-existent column
+        // forces a SQL error.
+        await tx.execute(sql`
+          INSERT INTO capabilities (id, name, organization_id, nonexistent_column)
+          VALUES (${randomUUID()}, 'should-fail', ${org.id}, 'oops')
+        `)
+      })
+    } catch {
+      threw = true
+    }
+
+    try {
+      expect(threw).toBe(true)
+
+      // The audit row must not exist — rollback rolled back the audit too
+      const auditRows = await db.select().from(auditLog)
+        .where(eq(auditLog.action, auditAction))
+      expect(auditRows.length).toBe(0)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+
+  it('happy path: mutation and audit both commit together', async () => {
+    // Sanity check that the transactional pattern still allows successful writes.
+    const org = await createTestOrg()
+    const capName = `TxHappyPath-${randomUUID().slice(0, 8)}`
+    const auditAction = `test.audit.tx-happy.${randomUUID()}`
+
+    try {
+      await db.transaction(async (tx) => {
+        await tx.insert(capabilities).values({
+          name: capName,
+          organizationId: org.id,
+          status: 'draft',
+          visibility: 'org',
+        })
+
+        await writeAuditLog(tx, {
+          action: auditAction,
+          entityType: 'capability',
+          organizationId: org.id,
+          after: { name: capName },
+        })
+      })
+
+      const caps = await db.select().from(capabilities)
+        .where(eq(capabilities.name, capName))
+      expect(caps.length).toBe(1)
+
+      const audits = await db.select().from(auditLog)
+        .where(eq(auditLog.action, auditAction))
+      expect(audits.length).toBe(1)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+})
+
+describe('writeAuditLog API surface (#416)', () => {
+  // The new signature requires a tx-or-db handle as the first argument. We
+  // can't directly assert "no caller forgot to pass it" at runtime, but the
+  // refactor relies on TypeScript's compile-time check for that guarantee.
+  // This test just verifies the happy-path top-level usage (writeAuditLog(db, ...))
+  // continues to work for pure-audit events that have no companion mutation.
+
+  it('accepts the top-level db client for pure-audit events', async () => {
+    const org = await createTestOrg()
+    const auditAction = `test.audit.api.${randomUUID()}`
+
+    try {
+      await writeAuditLog(db, {
+        action: auditAction,
+        entityType: 'auth',
+        organizationId: org.id,
+        metadata: { kind: 'login' },
+      })
+
+      const rows = await db.select().from(auditLog)
+        .where(eq(auditLog.action, auditAction))
+      expect(rows.length).toBe(1)
+    } finally {
+      await cleanupOrg(org.id)
+    }
+  })
+})
+
+describe('no swallowed-error pattern remains (#416)', () => {
+  // Defense-in-depth check on the helper itself: if writeAuditLog still had
+  // the old try/catch, this would silently succeed. With the new signature
+  // it surfaces the underlying error, which is what we want.
+  it('writeAuditLog throws when its insert fails', async () => {
+    let caught: unknown
+    try {
+      await writeAuditLog(db, {
+        // Empty action violates NOT NULL via Postgres rejecting empty string?
+        // No — empty string is valid for text. Use a non-existent
+        // organization_id constraint? audit_log no longer has FK on org_id.
+        // Easiest forced failure: pass an entityId that's not a valid UUID.
+        action: 'test',
+        entityType: 'test',
+        entityId: 'not-a-uuid',
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes #416

> **Targets \`fix/audit-immutable-417\` (PR #433)** because the rollback test relies on the immutability trigger being in place. Once #433 merges, retarget this to \`main\`.

## Summary

Audit log entries are now first-class data integrity work, not best effort. The previous fail-silent \`try { writeAuditLog } catch { console.error }\` is gone. Every server action that records a mutation wraps both the mutation and the audit write in a single \`db.transaction(...)\` — neither can succeed without the other.

## API change

\`\`\`diff
- export async function writeAuditLog(params: AuditParams)
+ export async function writeAuditLog(tx: DBOrTx, params: AuditParams): Promise<void>
\`\`\`

The first parameter is **required** with no default. TypeScript caught every missed call site at compile time (83 errors before; 0 after).

## Refactor scope

- **19 caller files refactored** — 18 in \`actions/\`, 1 in \`lib/auth.ts\`
- **4 mutating helpers** updated to accept \`tx\` first: \`syncEntityTaxonomyValues\`, \`flagLinksForVisibilityDrop\`, \`clearLinksFlag\`, \`removeLinksForConnection\`
- **Canonical reference:** \`actions/capabilities.ts\` (4 functions illustrating create / edit-with-helpers / delete / mark-reviewed)

## The pattern

\`\`\`typescript
await db.transaction(async (tx) => {
  await tx.update(table).set(...).where(...)
  await syncEntityTaxonomyValues(tx, orgId, ...)
  await writeAuditLog(tx, { action: '...', ... })
})

// OUTSIDE the transaction: Next.js redirect() throws NEXT_REDIRECT
// which would roll back the tx if it bubbled through.
revalidatePath(...)
redirect(...)
\`\`\`

## Tests added

\`tests/integration/audit-transactional.test.ts\` — 5 new tests, all passing:

- [x] **Mutation rolls back when audit insert fails** — the central #416 acceptance criterion. Forces a NULL-into-NOT-NULL on \`audit_log.action\` inside a transaction; verifies the companion capability insert does not survive.
- [x] **Audit row never appears when its companion mutation fails** — inverse direction; catches "what if the app caught the error and still wrote audit"
- [x] **Happy path** — both commit together
- [x] **\`writeAuditLog(db, ...)\`** still works for pure-audit events with no companion mutation (login / logout)
- [x] **\`writeAuditLog\` throws on insert failure** — defense in depth; proves the swallowed-error pattern is gone

## Acceptance criteria

- [x] \`writeAuditLog\` accepts a tx parameter and uses it when provided — required, no default
- [x] Every mutation that writes an audit row does so inside the same \`db.transaction()\`
- [x] Test: a forced audit-write failure causes the mutation to roll back (no orphaned data)
- [x] No remaining \`try { writeAuditLog }\` swallowed-error patterns — \`grep\` for \`try.*writeAuditLog\` returns zero hits
- [x] All 345 integration tests pass (340 prior + 5 new)
- [x] Zero tsc errors, zero lint errors

## Related

- Builds on **#417 / PR #433** (audit log DB-level immutability). Together these give end-to-end audit integrity: append-only at the schema level, atomic-with-mutation at the application level.
- Severity: high

🤖 Generated with [Claude Code](https://claude.com/claude-code)