### PR TITLE
fix(security): break-glass dual control + 1h default TTL (#418)

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import { organizations, users, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
-import { eq, and, isNull, gt, like, desc } from 'drizzle-orm'
+import { eq, and, isNull, gt, like, desc, ne } from 'drizzle-orm'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { writeAuditLog } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
@@ -10,6 +10,12 @@ import { MODULE_DEFS, type ModuleKey } from '@/lib/modules'
 import { validatePassword } from '@/lib/password'
 import bcrypt from 'bcryptjs'
 import { themes } from '@/lib/themes'
+import {
+  BREAK_GLASS_APPROVAL_THRESHOLD_MINUTES,
+  BREAK_GLASS_DEFAULT_TTL,
+  isValidBreakGlassTtl,
+} from '@/lib/break-glass'
+import { notifyBreakGlassEvent } from '@/lib/notifications/break-glass'
 
 export async function createOrg(formData: FormData): Promise<{ id: string }> {
   const session = await requireInstanceAdmin()
@@ -57,16 +63,33 @@ export async function createOrg(formData: FormData): Promise<{ id: string }> {
   return { id: orgId }
 }
 
-export async function grantBreakGlass(orgId: string, reason: string) {
+export async function grantBreakGlass(
+  orgId: string,
+  reason: string,
+  ttlMinutes: number = BREAK_GLASS_DEFAULT_TTL,
+) {
   const session = await requireInstanceAdmin()
-  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
 
-  await db.transaction(async (tx) => {
+  const trimmedReason = reason.trim()
+  if (!trimmedReason) throw new Error('Reason is required')
+  if (!isValidBreakGlassTtl(ttlMinutes)) {
+    throw new Error('Invalid TTL — must be one of 60, 240, 480 minutes')
+  }
+
+  const requiresApproval = ttlMinutes > BREAK_GLASS_APPROVAL_THRESHOLD_MINUTES
+  const grantedAt = new Date()
+  // TTL counts from grantedAt, NOT from approvedAt — pre-staging an
+  // approval cannot extend the elevation window beyond what was requested.
+  const expiresAt = new Date(grantedAt.getTime() + ttlMinutes * 60_000)
+
+  const inserted = await db.transaction(async (tx) => {
     const [row] = await tx.insert(breakGlassSessions).values({
       instanceAdminId: session.user.id,
       targetOrgId: orgId,
-      reason,
+      reason: trimmedReason,
+      grantedAt,
       expiresAt,
+      requiresApproval,
     }).returning()
 
     await writeAuditLog(tx, {
@@ -75,36 +98,133 @@ export async function grantBreakGlass(orgId: string, reason: string) {
       entityId: orgId,
       userId: session.user.id,
       organizationId: null,
-      after: { reason, expiresAt, sessionId: row.id },
+      after: {
+        reason: trimmedReason,
+        ttlMinutes,
+        expiresAt,
+        sessionId: row.id,
+        requiresApproval,
+      },
     })
+
+    return row
+  })
+
+  await notifyBreakGlassEvent({
+    event: 'grant',
+    session: inserted,
+    actorUserId: session.user.id,
   })
 
   revalidatePath(`/instance/orgs/${orgId}`)
   revalidatePath('/instance')
 }
 
+export async function approveBreakGlass(sessionId: string) {
+  const session = await requireInstanceAdmin()
+
+  const approved = await db.transaction(async (tx) => {
+    const target = await tx.query.breakGlassSessions.findFirst({
+      where: eq(breakGlassSessions.id, sessionId),
+    })
+    if (!target) throw new Error('Session not found')
+    if (target.instanceAdminId === session.user.id) {
+      throw new Error('Cannot approve your own break-glass session')
+    }
+    if (!target.requiresApproval) {
+      throw new Error('Session does not require approval')
+    }
+    if (target.approvedAt) throw new Error('Session is already approved')
+    if (target.revokedAt) throw new Error('Session is revoked')
+    if (target.expiresAt <= new Date()) throw new Error('Session has expired')
+
+    const approvedAt = new Date()
+    const [row] = await tx.update(breakGlassSessions)
+      .set({ approvedAt, approvedBy: session.user.id })
+      .where(eq(breakGlassSessions.id, sessionId))
+      .returning()
+
+    await writeAuditLog(tx, {
+      action: 'instance.break_glass.approve',
+      entityType: 'break_glass_session',
+      entityId: sessionId,
+      userId: session.user.id,
+      organizationId: null,
+      after: {
+        approvedAt,
+        granterId: target.instanceAdminId,
+        targetOrgId: target.targetOrgId,
+      },
+    })
+
+    return row
+  })
+
+  await notifyBreakGlassEvent({
+    event: 'approval',
+    session: approved,
+    actorUserId: session.user.id,
+  })
+
+  revalidatePath(`/instance/orgs/${approved.targetOrgId}`)
+  revalidatePath('/instance')
+}
+
 export async function revokeBreakGlass(sessionId: string, orgId: string) {
   const session = await requireInstanceAdmin()
 
-  await db.transaction(async (tx) => {
-    await tx.update(breakGlassSessions)
+  const revoked = await db.transaction(async (tx) => {
+    const [row] = await tx.update(breakGlassSessions)
       .set({ revokedAt: new Date(), revokedBy: session.user.id })
       .where(and(
         eq(breakGlassSessions.id, sessionId),
         eq(breakGlassSessions.instanceAdminId, session.user.id),
       ))
+      .returning()
 
-    await writeAuditLog(tx, {
-      action: 'instance.break_glass.revoke',
-      entityType: 'break_glass_session',
-      entityId: sessionId,
-      userId: session.user.id,
-      organizationId: null,
-    })
+    if (row) {
+      await writeAuditLog(tx, {
+        action: 'instance.break_glass.revoke',
+        entityType: 'break_glass_session',
+        entityId: sessionId,
+        userId: session.user.id,
+        organizationId: null,
+      })
+    }
+
+    return row
   })
+
+  if (revoked) {
+    await notifyBreakGlassEvent({
+      event: 'revoke',
+      session: revoked,
+      actorUserId: session.user.id,
+    })
+  }
 
   revalidatePath(`/instance/orgs/${orgId}`)
   revalidatePath('/instance')
+}
+
+/**
+ * Returns pending-approval sessions that the caller can approve — i.e.,
+ * sessions that require approval, are not yet approved, not revoked, not
+ * expired, and were granted by some OTHER instance admin.
+ */
+export async function getPendingBreakGlassApprovals() {
+  const session = await requireInstanceAdmin()
+  const now = new Date()
+  return db.query.breakGlassSessions.findMany({
+    where: and(
+      eq(breakGlassSessions.requiresApproval, true),
+      isNull(breakGlassSessions.approvedAt),
+      isNull(breakGlassSessions.revokedAt),
+      gt(breakGlassSessions.expiresAt, now),
+      ne(breakGlassSessions.instanceAdminId, session.user.id),
+    ),
+    orderBy: (s, { desc }) => [desc(s.grantedAt)],
+  })
 }
 
 export async function suspendOrg(orgId: string, reason: string) {

--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
@@ -2,12 +2,20 @@ import { notFound } from 'next/navigation'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { organizations, users, breakGlassSessions } from '@/db/schema'
-import { eq, and, isNull, gt, desc } from 'drizzle-orm'
+import { eq, and, isNull, gt, ne, desc } from 'drizzle-orm'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { ConfirmWithReason } from '@/components/confirm-with-reason'
-import { suspendOrg, unsuspendOrg, grantBreakGlass, revokeBreakGlass, getOrgGovernanceHistory } from '@/actions/instance'
+import { BreakGlassGrantForm } from '@/components/break-glass-grant-form'
+import {
+  suspendOrg,
+  unsuspendOrg,
+  grantBreakGlass,
+  revokeBreakGlass,
+  approveBreakGlass,
+  getOrgGovernanceHistory,
+} from '@/actions/instance'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
@@ -26,6 +34,7 @@ const ACTION_LABELS: Record<string, string> = {
   'instance.org.unsuspend':           'Unsuspended',
   'instance.org.governance.update':   'Governance updated',
   'instance.break_glass.grant':       'Break-glass granted',
+  'instance.break_glass.approve':     'Break-glass approved',
   'instance.break_glass.revoke':      'Break-glass revoked',
 }
 
@@ -33,7 +42,8 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
   const { id } = await params
   const session = await requireInstanceAdmin()
 
-  const [org, orgUsers, activeBG, bgHistory, govHistory] = await Promise.all([
+  const now = new Date()
+  const [org, orgUsers, myActiveSession, pendingFromOthers, bgHistory, govHistory] = await Promise.all([
     db.query.organizations.findFirst({ where: eq(organizations.id, id) }),
     db.query.users.findMany({
       where: eq(users.organizationId, id),
@@ -44,8 +54,20 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
         eq(breakGlassSessions.instanceAdminId, session.user.id),
         eq(breakGlassSessions.targetOrgId, id),
         isNull(breakGlassSessions.revokedAt),
-        gt(breakGlassSessions.expiresAt, new Date()),
+        gt(breakGlassSessions.expiresAt, now),
       ),
+      orderBy: (s, { desc }) => [desc(s.grantedAt)],
+    }),
+    db.query.breakGlassSessions.findMany({
+      where: and(
+        eq(breakGlassSessions.targetOrgId, id),
+        eq(breakGlassSessions.requiresApproval, true),
+        isNull(breakGlassSessions.approvedAt),
+        isNull(breakGlassSessions.revokedAt),
+        gt(breakGlassSessions.expiresAt, now),
+        ne(breakGlassSessions.instanceAdminId, session.user.id),
+      ),
+      orderBy: (s, { desc }) => [desc(s.grantedAt)],
     }),
     db.query.breakGlassSessions.findMany({
       where: eq(breakGlassSessions.targetOrgId, id),
@@ -54,6 +76,8 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
     }),
     getOrgGovernanceHistory(id),
   ])
+
+  const myActiveIsPending = !!myActiveSession && myActiveSession.requiresApproval && !myActiveSession.approvedAt
 
   if (!org) notFound()
 
@@ -176,36 +200,90 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
           <div>
             <h2 className="text-base font-semibold">Break-Glass Access</h2>
             <p className="text-sm text-muted-foreground mt-0.5">
-              Time-limited read-only access to this organisation&apos;s data for incident investigation. All sessions are audited.
+              Time-limited access to this organisation&apos;s data for incident investigation. Sessions over 1 hour require a second instance admin to approve. All sessions are audited.
             </p>
           </div>
-          {!activeBG && !org.isSystemOrg && (
-            <ConfirmWithReason
+          {!myActiveSession && !org.isSystemOrg && (
+            <BreakGlassGrantForm
               trigger={<Button variant="outline" size="sm">Grant Access</Button>}
-              title="Grant break-glass access"
-              description={`You will have read-only access to "${org.name}" for 24 hours. Enter a reason for the audit log.`}
-              placeholder="e.g. User support request, incident investigation…"
-              confirmLabel="Grant 24h Access"
-              onConfirm={async (reason) => {
+              orgName={org.name}
+              onConfirm={async (reason, ttlMinutes) => {
                 'use server'
-                await grantBreakGlass(id, reason)
+                await grantBreakGlass(id, reason, ttlMinutes)
               }}
             />
           )}
         </div>
 
-        {activeBG ? (
-          <div className="rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 p-4">
+        {/* Pending sessions from OTHER admins — caller can approve them */}
+        {pendingFromOthers.length > 0 && (
+          <div className="mb-4 space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Awaiting your approval
+            </h3>
+            {pendingFromOthers.map(s => (
+              <div
+                key={s.id}
+                className="rounded-md bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 p-4"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div className="text-sm">
+                    <p className="font-medium text-blue-800 dark:text-blue-300">
+                      Pending approval — granted by another admin
+                    </p>
+                    <p className="text-blue-700 dark:text-blue-400 mt-0.5">
+                      Requested {s.grantedAt.toLocaleString()} · expires {s.expiresAt.toLocaleString()} · Reason: {s.reason}
+                    </p>
+                  </div>
+                  <form action={async () => {
+                    'use server'
+                    await approveBreakGlass(s.id)
+                  }}>
+                    <Button type="submit" variant="default" size="sm">Approve</Button>
+                  </form>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {myActiveSession ? (
+          <div
+            className={cn(
+              'rounded-md p-4 border',
+              myActiveIsPending
+                ? 'bg-slate-50 dark:bg-slate-950/40 border-slate-200 dark:border-slate-800'
+                : 'bg-amber-50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800',
+            )}
+          >
             <div className="flex items-center justify-between gap-4">
               <div className="text-sm">
-                <p className="font-medium text-amber-800 dark:text-amber-300">Active session</p>
-                <p className="text-amber-700 dark:text-amber-400 mt-0.5">
-                  Expires {activeBG.expiresAt.toLocaleString()} · Reason: {activeBG.reason}
+                <p
+                  className={cn(
+                    'font-medium',
+                    myActiveIsPending
+                      ? 'text-slate-800 dark:text-slate-300'
+                      : 'text-amber-800 dark:text-amber-300',
+                  )}
+                >
+                  {myActiveIsPending ? 'Pending approval' : 'Active session'}
+                </p>
+                <p
+                  className={cn(
+                    'mt-0.5',
+                    myActiveIsPending
+                      ? 'text-slate-700 dark:text-slate-400'
+                      : 'text-amber-700 dark:text-amber-400',
+                  )}
+                >
+                  {myActiveIsPending
+                    ? `Awaiting approval from another instance admin · expires ${myActiveSession.expiresAt.toLocaleString()} regardless of when approved · Reason: ${myActiveSession.reason}`
+                    : `Expires ${myActiveSession.expiresAt.toLocaleString()} · Reason: ${myActiveSession.reason}`}
                 </p>
               </div>
               <form action={async () => {
                 'use server'
-                await revokeBreakGlass(activeBG.id, id)
+                await revokeBreakGlass(myActiveSession.id, id)
               }}>
                 <Button type="submit" variant="destructive" size="sm">Revoke</Button>
               </form>
@@ -219,22 +297,34 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
           <div className="mt-4">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Session history</h3>
             <div className="divide-y rounded-md border text-sm">
-              {bgHistory.map(s => (
-                <div key={s.id} className="flex items-center gap-3 px-3 py-2">
-                  <span className={cn(
-                    'shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium',
-                    s.revokedAt
-                      ? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
-                      : s.expiresAt < new Date()
-                        ? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
-                        : 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400'
-                  )}>
-                    {s.revokedAt ? 'Revoked' : s.expiresAt < new Date() ? 'Expired' : 'Active'}
-                  </span>
-                  <span className="flex-1 truncate text-muted-foreground">{s.reason}</span>
-                  <span className="shrink-0 text-xs text-muted-foreground">{s.grantedAt.toLocaleString()}</span>
-                </div>
-              ))}
+              {bgHistory.map(s => {
+                const expired = s.expiresAt < new Date()
+                const pending = !s.revokedAt && !expired && s.requiresApproval && !s.approvedAt
+                const status = s.revokedAt
+                  ? 'Revoked'
+                  : expired
+                    ? 'Expired'
+                    : pending
+                      ? 'Pending'
+                      : 'Active'
+                const cls = s.revokedAt || expired
+                  ? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                  : pending
+                    ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400'
+                    : 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400'
+                return (
+                  <div key={s.id} className="flex items-center gap-3 px-3 py-2">
+                    <span className={cn(
+                      'shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium',
+                      cls,
+                    )}>
+                      {status}
+                    </span>
+                    <span className="flex-1 truncate text-muted-foreground">{s.reason}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">{s.grantedAt.toLocaleString()}</span>
+                  </div>
+                )
+              })}
             </div>
           </div>
         )}

--- a/apps/govea/src/app/(instance)/instance/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/page.tsx
@@ -1,25 +1,71 @@
+import Link from 'next/link'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { organizations, users, auditLog, breakGlassSessions } from '@/db/schema'
-import { count, eq, desc, isNull, gt, and, ilike } from 'drizzle-orm'
+import { count, eq, desc, isNull, isNotNull, gt, and, or, ilike } from 'drizzle-orm'
 import { cn } from '@/lib/utils'
 
 export default async function InstanceDashboardPage() {
-  await requireInstanceAdmin()
+  const session = await requireInstanceAdmin()
 
   const now = new Date()
 
-  const [[{ orgCount }], [{ userCount }], [{ bgCount }], recentEvents] = await Promise.all([
+  const [
+    [{ orgCount }],
+    [{ userCount }],
+    [{ activeBgCount }],
+    [{ pendingBgCount }],
+    pendingSessions,
+    recentEvents,
+  ] = await Promise.all([
     db.select({ orgCount: count() }).from(organizations).where(eq(organizations.isSystemOrg, false)),
     db.select({ userCount: count() }).from(users),
-    db.select({ bgCount: count() }).from(breakGlassSessions).where(
-      and(isNull(breakGlassSessions.revokedAt), gt(breakGlassSessions.expiresAt, now))
+    // Active = non-revoked, non-expired, AND (no approval needed OR already approved).
+    // Pending sessions are counted separately below.
+    db.select({ activeBgCount: count() }).from(breakGlassSessions).where(
+      and(
+        isNull(breakGlassSessions.revokedAt),
+        gt(breakGlassSessions.expiresAt, now),
+        or(
+          eq(breakGlassSessions.requiresApproval, false),
+          isNotNull(breakGlassSessions.approvedAt),
+        ),
+      ),
     ),
+    db.select({ pendingBgCount: count() }).from(breakGlassSessions).where(
+      and(
+        eq(breakGlassSessions.requiresApproval, true),
+        isNull(breakGlassSessions.approvedAt),
+        isNull(breakGlassSessions.revokedAt),
+        gt(breakGlassSessions.expiresAt, now),
+      ),
+    ),
+    db.query.breakGlassSessions.findMany({
+      where: and(
+        eq(breakGlassSessions.requiresApproval, true),
+        isNull(breakGlassSessions.approvedAt),
+        isNull(breakGlassSessions.revokedAt),
+        gt(breakGlassSessions.expiresAt, now),
+      ),
+      orderBy: (s, { desc }) => [desc(s.grantedAt)],
+      limit: 10,
+    }),
     db.select().from(auditLog)
       .where(ilike(auditLog.action, 'instance.%'))
       .orderBy(desc(auditLog.createdAt))
       .limit(10),
   ])
+
+  // Resolve org names for pending sessions in a single query.
+  const orgNamesById = new Map<string, string>()
+  if (pendingSessions.length > 0) {
+    const ids = Array.from(new Set(pendingSessions.map(s => s.targetOrgId)))
+    const orgs = await db.query.organizations.findMany({
+      where: (o, { inArray }) => inArray(o.id, ids),
+      columns: { id: true, name: true },
+    })
+    orgs.forEach(o => orgNamesById.set(o.id, o.name))
+  }
 
   return (
     <div className="space-y-6">
@@ -31,8 +77,34 @@ export default async function InstanceDashboardPage() {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <StatCard label="Tenant Organisations" value={orgCount} />
         <StatCard label="Total Users" value={userCount} />
-        <StatCard label="Active Break-Glass Sessions" value={bgCount} warn={bgCount > 0} />
+        <StatCard label="Active Break-Glass Sessions" value={activeBgCount} warn={activeBgCount > 0} />
       </div>
+
+      {pendingBgCount > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold mb-3">
+            Pending Break-Glass Approvals <span className="text-muted-foreground text-base font-normal">({pendingBgCount})</span>
+          </h2>
+          <div className="rounded-lg border divide-y bg-card">
+            {pendingSessions.map(s => {
+              const isOwn = s.instanceAdminId === session.user.id
+              const orgName = orgNamesById.get(s.targetOrgId) ?? s.targetOrgId
+              return (
+                <div key={s.id} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+                  <span className="shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400">
+                    {isOwn ? 'Your request' : 'Awaiting your approval'}
+                  </span>
+                  <Link href={`/instance/orgs/${s.targetOrgId}`} className="flex-1 truncate hover:underline">
+                    <span className="font-medium">{orgName}</span>
+                    <span className="text-muted-foreground"> · {s.reason}</span>
+                  </Link>
+                  <span className="shrink-0 text-xs text-muted-foreground">expires {s.expiresAt.toLocaleString()}</span>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
 
       <div>
         <h2 className="text-lg font-semibold mb-3">Recent Platform Events</h2>

--- a/apps/govea/src/app/(instance)/layout.tsx
+++ b/apps/govea/src/app/(instance)/layout.tsx
@@ -5,7 +5,7 @@ import { isInstanceAdmin } from '@/lib/rbac'
 import { InstanceShell } from '@/components/instance-shell'
 import { db } from '@/db/client'
 import { breakGlassSessions, organizations, platformConfig } from '@/db/schema'
-import { and, eq, isNull, gt } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, gt, or } from 'drizzle-orm'
 
 export default async function InstanceLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
@@ -27,6 +27,12 @@ export default async function InstanceLayout({ children }: { children: React.Rea
           eq(breakGlassSessions.instanceAdminId, session.user.id),
           isNull(breakGlassSessions.revokedAt),
           gt(breakGlassSessions.expiresAt, now),
+          // Pending-approval sessions are not honored; the banner exists to
+          // remind the admin that they currently HAVE elevated access.
+          or(
+            eq(breakGlassSessions.requiresApproval, false),
+            isNotNull(breakGlassSessions.approvedAt),
+          ),
         )
       ),
     db.query.platformConfig.findFirst(),

--- a/apps/govea/src/components/break-glass-grant-form.tsx
+++ b/apps/govea/src/components/break-glass-grant-form.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState, useTransition, type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+
+const TTL_OPTIONS = [
+  { value: 60, label: '1 hour (no approval needed)' },
+  { value: 240, label: '4 hours (requires second-admin approval)' },
+  { value: 480, label: '8 hours (requires second-admin approval)' },
+] as const
+
+interface Props {
+  trigger: ReactNode
+  orgName: string
+  onConfirm: (reason: string, ttlMinutes: number) => Promise<void>
+}
+
+export function BreakGlassGrantForm({ trigger, orgName, onConfirm }: Props) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState('')
+  const [ttl, setTtl] = useState<number>(60)
+  const [error, setError] = useState('')
+  const [isPending, startTransition] = useTransition()
+
+  function handleOpenChange(next: boolean) {
+    if (isPending) return
+    setOpen(next)
+    if (!next) {
+      setReason('')
+      setTtl(60)
+      setError('')
+    }
+  }
+
+  function handleConfirm() {
+    const trimmed = reason.trim()
+    if (!trimmed) {
+      setError('A reason is required.')
+      return
+    }
+    setError('')
+    startTransition(async () => {
+      try {
+        await onConfirm(trimmed, ttl)
+        handleOpenChange(false)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred.')
+      }
+    })
+  }
+
+  const requiresApproval = ttl > 60
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Grant break-glass access</DialogTitle>
+          <DialogDescription>
+            Time-limited access to &quot;{orgName}&quot;. Sessions over 1 hour require a second instance admin to approve before they activate.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="bg-ttl">Duration</Label>
+            <select
+              id="bg-ttl"
+              value={ttl}
+              onChange={e => setTtl(Number(e.target.value))}
+              disabled={isPending}
+              className={cn(
+                'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+            >
+              {TTL_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="bg-reason">Reason</Label>
+            <Textarea
+              id="bg-reason"
+              rows={3}
+              placeholder="e.g. User support request, incident investigation…"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+
+          {requiresApproval && (
+            <div className="rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+              Pending state: this session will be created but inactive until a different instance admin approves it.
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={isPending || !reason.trim()}>
+            {isPending ? 'Working…' : 'Grant access'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/govea/src/db/schema/break-glass-sessions.ts
+++ b/apps/govea/src/db/schema/break-glass-sessions.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { boolean, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { users } from './users'
 import { organizations } from './organizations'
 
@@ -9,6 +9,9 @@ export const breakGlassSessions = pgTable('break_glass_sessions', {
   reason: text('reason').notNull(),
   grantedAt: timestamp('granted_at').notNull().defaultNow(),
   expiresAt: timestamp('expires_at').notNull(),
+  requiresApproval: boolean('requires_approval').notNull().default(false),
+  approvedAt: timestamp('approved_at'),
+  approvedBy: uuid('approved_by').references(() => users.id),
   revokedAt: timestamp('revoked_at'),
   revokedBy: uuid('revoked_by').references(() => users.id),
 })

--- a/apps/govea/src/lib/break-glass.ts
+++ b/apps/govea/src/lib/break-glass.ts
@@ -1,0 +1,43 @@
+import { and, eq, gt, isNotNull, isNull } from 'drizzle-orm'
+import { db } from '@/db/client'
+import { breakGlassSessions, type BreakGlassSession } from '@/db/schema'
+import { or } from 'drizzle-orm'
+
+export const BREAK_GLASS_TTL_PRESETS = [60, 240, 480] as const
+export type BreakGlassTtlMinutes = (typeof BREAK_GLASS_TTL_PRESETS)[number]
+export const BREAK_GLASS_DEFAULT_TTL: BreakGlassTtlMinutes = 60
+export const BREAK_GLASS_APPROVAL_THRESHOLD_MINUTES = 60
+
+export function isValidBreakGlassTtl(value: number): value is BreakGlassTtlMinutes {
+  return (BREAK_GLASS_TTL_PRESETS as readonly number[]).includes(value)
+}
+
+/**
+ * Returns the active, approved, non-expired break-glass session for the given
+ * admin + org, or null if no such session exists. A pending-approval session
+ * does NOT satisfy `requireBreakGlass` — it must be approved first.
+ *
+ * Under Option 2 (see #418 design note), this helper has no caller in the
+ * read path. It will be consulted by the cross-tenant impersonation feature
+ * (#437) once that lands, and by gated cross-tenant reads when #436 promotes
+ * to Option 1.
+ */
+export async function requireBreakGlass(
+  adminId: string,
+  orgId: string,
+): Promise<BreakGlassSession | null> {
+  const now = new Date()
+  const session = await db.query.breakGlassSessions.findFirst({
+    where: and(
+      eq(breakGlassSessions.instanceAdminId, adminId),
+      eq(breakGlassSessions.targetOrgId, orgId),
+      isNull(breakGlassSessions.revokedAt),
+      gt(breakGlassSessions.expiresAt, now),
+      or(
+        eq(breakGlassSessions.requiresApproval, false),
+        isNotNull(breakGlassSessions.approvedAt),
+      ),
+    ),
+  })
+  return session ?? null
+}

--- a/apps/govea/src/lib/notifications/break-glass.ts
+++ b/apps/govea/src/lib/notifications/break-glass.ts
@@ -1,0 +1,56 @@
+import type { BreakGlassSession } from '@/db/schema'
+
+export type BreakGlassEvent = 'grant' | 'approval' | 'revoke'
+
+export interface BreakGlassNotification {
+  event: BreakGlassEvent
+  session: Pick<BreakGlassSession,
+    | 'id'
+    | 'instanceAdminId'
+    | 'targetOrgId'
+    | 'reason'
+    | 'grantedAt'
+    | 'expiresAt'
+    | 'requiresApproval'
+    | 'approvedAt'
+    | 'approvedBy'
+  >
+  actorUserId: string
+}
+
+type Sink = (n: BreakGlassNotification) => void | Promise<void>
+
+let sink: Sink = defaultSink
+
+export function setBreakGlassNotificationSink(next: Sink) {
+  sink = next
+}
+
+export function resetBreakGlassNotificationSink() {
+  sink = defaultSink
+}
+
+export async function notifyBreakGlassEvent(n: BreakGlassNotification): Promise<void> {
+  try {
+    await sink(n)
+  } catch {
+    // Notification failures must not roll back the surrounding transaction.
+    // The audit log is the durable record; the notification is best-effort.
+  }
+}
+
+function defaultSink(n: BreakGlassNotification): void {
+  const banner = '⚠️  BREAK-GLASS'
+  const lines = [
+    `${banner} ${n.event.toUpperCase()}`,
+    `  session=${n.session.id}`,
+    `  actor=${n.actorUserId}`,
+    `  granter=${n.session.instanceAdminId}`,
+    `  targetOrg=${n.session.targetOrgId}`,
+    `  expiresAt=${n.session.expiresAt.toISOString()}`,
+    `  requiresApproval=${n.session.requiresApproval}`,
+    `  approvedAt=${n.session.approvedAt?.toISOString() ?? '-'}`,
+    `  reason=${JSON.stringify(n.session.reason)}`,
+  ]
+  console.warn(lines.join('\n'))
+}

--- a/apps/govea/tests/integration/audit-immutable.test.ts
+++ b/apps/govea/tests/integration/audit-immutable.test.ts
@@ -25,7 +25,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.update-blocked.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -56,7 +56,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.delete-blocked.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -84,7 +84,7 @@ describe('audit_log immutability (#417)', () => {
     const org = await createTestOrg()
     const action = `test.audit.cause-message.${randomUUID()}`
     try {
-      await writeAuditLog({
+      await writeAuditLog(db, {
         action,
         entityType: 'organization',
         entityId: org.id,
@@ -111,7 +111,7 @@ describe('audit_log immutability (#417)', () => {
     const user = await createTestUser(org.id, 'admin')
 
     const action = `test.audit.cascade-safe.${randomUUID()}`
-    await writeAuditLog({
+    await writeAuditLog(db, {
       action,
       entityType: 'user',
       entityId: user.id,

--- a/apps/govea/tests/integration/break-glass-approval.test.ts
+++ b/apps/govea/tests/integration/break-glass-approval.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Integration tests: break-glass approval flow (#418)
+ *
+ * Covers the dual-control + TTL hardening shipped under Option 2:
+ *   - Default TTL is 1 hour; sessions ≤ 1h are immediately active
+ *   - TTL > 1h yields a pending session that requireBreakGlass() refuses
+ *     until a different instance admin approves it
+ *   - Self-approval is rejected
+ *   - Approval after a peer admin has approved is rejected
+ *   - Expired or revoked sessions cannot be approved
+ *   - notifyBreakGlassEvent fires on grant + approval (best-effort, sink-replaceable)
+ *   - Audit-log rows are written under the surrounding transaction
+ *   - Invalid TTL values are rejected
+ *   - Empty / whitespace reasons are rejected
+ *
+ * Capability: iam-instance-administration, iam-role-based-access-control
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import {
+  grantBreakGlass,
+  approveBreakGlass,
+  revokeBreakGlass,
+} from '@/actions/instance'
+import { requireBreakGlass } from '@/lib/break-glass'
+import {
+  resetBreakGlassNotificationSink,
+  setBreakGlassNotificationSink,
+  type BreakGlassNotification,
+} from '@/lib/notifications/break-glass'
+import { db } from '@/db/client'
+import { breakGlassSessions, auditLog } from '@/db/schema'
+import { and, eq, isNull, or, desc } from 'drizzle-orm'
+import {
+  createTestOrg,
+  createTestUser,
+  cleanupOrg,
+  makeSession,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+const mockRevalidate = vi.hoisted(() => vi.fn())
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidate }))
+
+let homeOrgId: string
+let targetOrgId: string
+let adminA: TestUser
+let adminB: TestUser
+
+beforeAll(async () => {
+  const [home, target] = await Promise.all([createTestOrg(), createTestOrg()])
+  homeOrgId = home.id
+  targetOrgId = target.id
+  ;[adminA, adminB] = await Promise.all([
+    createTestUser(homeOrgId, 'admin'),
+    createTestUser(homeOrgId, 'admin'),
+  ])
+})
+
+afterAll(async () => {
+  await db.delete(breakGlassSessions).where(
+    or(
+      eq(breakGlassSessions.targetOrgId, targetOrgId),
+      eq(breakGlassSessions.targetOrgId, homeOrgId),
+    ),
+  )
+  await cleanupOrg(homeOrgId)
+  await cleanupOrg(targetOrgId)
+})
+
+function asAdmin(user: TestUser) {
+  mockAuth.mockResolvedValue(makeSession(user, { instanceRole: 'instance_admin' }))
+}
+
+// Each test starts with a clean slate for break-glass sessions against
+// targetOrgId — multiple concurrent valid sessions are legitimate at runtime
+// (covered by instance-hardening), but they make per-scenario assertions on
+// requireBreakGlass()'s return value harder to reason about.
+beforeEach(async () => {
+  await db.delete(breakGlassSessions).where(eq(breakGlassSessions.targetOrgId, targetOrgId))
+})
+
+async function latestSessionFor(adminId: string) {
+  return db.query.breakGlassSessions.findFirst({
+    where: and(
+      eq(breakGlassSessions.instanceAdminId, adminId),
+      eq(breakGlassSessions.targetOrgId, targetOrgId),
+      isNull(breakGlassSessions.revokedAt),
+    ),
+    orderBy: (s, { desc }) => [desc(s.grantedAt)],
+  })
+}
+
+// ── TTL = 60 (no approval needed) ────────────────────────────────────────────
+
+describe('grantBreakGlass — TTL = 60 (no approval needed)', () => {
+  it('uses 1 hour as the default TTL', async () => {
+    asAdmin(adminA)
+    const before = Date.now()
+    await grantBreakGlass(targetOrgId, 'Default TTL test')
+
+    const session = await latestSessionFor(adminA.id)
+    expect(session).toBeDefined()
+    const ttlMs = session!.expiresAt.getTime() - session!.grantedAt.getTime()
+    expect(ttlMs).toBeGreaterThan(59 * 60_000)
+    expect(ttlMs).toBeLessThan(61 * 60_000)
+    expect(session!.requiresApproval).toBe(false)
+    expect(session!.expiresAt.getTime()).toBeGreaterThan(before)
+  })
+
+  it('requireBreakGlass returns the session immediately', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Immediate access', 60)
+
+    const result = await requireBreakGlass(adminA.id, targetOrgId)
+    expect(result).not.toBeNull()
+    expect(result!.requiresApproval).toBe(false)
+    expect(result!.approvedAt).toBeNull()
+  })
+})
+
+// ── TTL > 60 (pending approval) ──────────────────────────────────────────────
+
+describe('grantBreakGlass — TTL > 60 (pending approval)', () => {
+  it('marks the session as requiring approval and requireBreakGlass refuses until approved', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Long incident', 240)
+
+    const session = await latestSessionFor(adminA.id)
+    expect(session!.requiresApproval).toBe(true)
+    expect(session!.approvedAt).toBeNull()
+
+    // Pre-approval: requireBreakGlass refuses
+    const pre = await requireBreakGlass(adminA.id, targetOrgId)
+    expect(pre).toBeNull()
+  })
+
+  it('a peer admin can approve, after which requireBreakGlass returns the session', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Approve flow', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    asAdmin(adminB)
+    await approveBreakGlass(session!.id)
+
+    const reread = await db.query.breakGlassSessions.findFirst({
+      where: eq(breakGlassSessions.id, session!.id),
+    })
+    expect(reread!.approvedAt).not.toBeNull()
+    expect(reread!.approvedBy).toBe(adminB.id)
+
+    const result = await requireBreakGlass(adminA.id, targetOrgId)
+    expect(result).not.toBeNull()
+    expect(result!.id).toBe(session!.id)
+  })
+
+  it('TTL counts from grantedAt, not from approvedAt', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'TTL anchor test', 240)
+    const session = await latestSessionFor(adminA.id)
+    const expectedExpiry = session!.grantedAt.getTime() + 240 * 60_000
+
+    asAdmin(adminB)
+    await approveBreakGlass(session!.id)
+
+    const reread = await db.query.breakGlassSessions.findFirst({
+      where: eq(breakGlassSessions.id, session!.id),
+    })
+    expect(reread!.expiresAt.getTime()).toBe(expectedExpiry)
+  })
+})
+
+// ── Self-approval / double-approval / revoked / expired ──────────────────────
+
+describe('approveBreakGlass — guards', () => {
+  it('rejects self-approval', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Self approval attempt', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    // Granter is still adminA — try to approve as adminA
+    asAdmin(adminA)
+    await expect(approveBreakGlass(session!.id)).rejects.toThrow(
+      'Cannot approve your own break-glass session',
+    )
+
+    const reread = await db.query.breakGlassSessions.findFirst({
+      where: eq(breakGlassSessions.id, session!.id),
+    })
+    expect(reread!.approvedAt).toBeNull()
+  })
+
+  it('rejects double-approval', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Double approve', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    asAdmin(adminB)
+    await approveBreakGlass(session!.id)
+    await expect(approveBreakGlass(session!.id)).rejects.toThrow('already approved')
+  })
+
+  it('rejects approval of a session that does not require approval', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'No approval needed', 60)
+    const session = await latestSessionFor(adminA.id)
+
+    asAdmin(adminB)
+    await expect(approveBreakGlass(session!.id)).rejects.toThrow(
+      'does not require approval',
+    )
+  })
+
+  it('rejects approval of a revoked session', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Revoke before approve', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    // Granter revokes (revokeBreakGlass scopes to granter)
+    asAdmin(adminA)
+    await revokeBreakGlass(session!.id, targetOrgId)
+
+    asAdmin(adminB)
+    await expect(approveBreakGlass(session!.id)).rejects.toThrow('revoked')
+  })
+
+  it('rejects approval of an expired session', async () => {
+    // Insert a session that expired 1 minute ago, requiring approval
+    const [row] = await db.insert(breakGlassSessions).values({
+      instanceAdminId: adminA.id,
+      targetOrgId,
+      reason: 'Past expiry',
+      grantedAt: new Date(Date.now() - 5 * 60_000),
+      expiresAt: new Date(Date.now() - 60_000),
+      requiresApproval: true,
+    }).returning()
+
+    asAdmin(adminB)
+    await expect(approveBreakGlass(row.id)).rejects.toThrow('expired')
+  })
+
+  it('throws Forbidden for non-instance-admin', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Forbidden test', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    mockAuth.mockResolvedValue(makeSession(adminA))
+    await expect(approveBreakGlass(session!.id)).rejects.toThrow('Forbidden')
+  })
+})
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+describe('grantBreakGlass — validation', () => {
+  it('rejects an invalid TTL', async () => {
+    asAdmin(adminA)
+    await expect(grantBreakGlass(targetOrgId, 'Invalid TTL', 90)).rejects.toThrow('Invalid TTL')
+  })
+
+  it('rejects an empty / whitespace reason', async () => {
+    asAdmin(adminA)
+    await expect(grantBreakGlass(targetOrgId, '   ')).rejects.toThrow('Reason is required')
+  })
+
+  it('caps at 480 minutes (8h)', async () => {
+    asAdmin(adminA)
+    await expect(grantBreakGlass(targetOrgId, 'Too long', 720)).rejects.toThrow('Invalid TTL')
+  })
+})
+
+// ── Notification hook ───────────────────────────────────────────────────────
+
+describe('notifyBreakGlassEvent — fires on grant and approval', () => {
+  let captured: BreakGlassNotification[]
+
+  beforeEach(() => {
+    captured = []
+    setBreakGlassNotificationSink((n) => {
+      captured.push(n)
+    })
+  })
+
+  afterEach(() => {
+    resetBreakGlassNotificationSink()
+  })
+
+  it('fires once on grant and once on approval', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Notify flow', 240)
+    expect(captured.filter(c => c.event === 'grant')).toHaveLength(1)
+
+    const session = await latestSessionFor(adminA.id)
+    asAdmin(adminB)
+    await approveBreakGlass(session!.id)
+    expect(captured.filter(c => c.event === 'approval')).toHaveLength(1)
+    expect(captured.find(c => c.event === 'approval')!.actorUserId).toBe(adminB.id)
+  })
+
+  it('a sink throw does not roll back the audit log', async () => {
+    setBreakGlassNotificationSink(() => {
+      throw new Error('sink down')
+    })
+
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Sink failure', 60)
+    const session = await latestSessionFor(adminA.id)
+    expect(session).toBeDefined()
+
+    const audit = await db.select().from(auditLog)
+      .where(and(eq(auditLog.action, 'instance.break_glass.grant'), eq(auditLog.entityId, targetOrgId)))
+      .orderBy(desc(auditLog.createdAt))
+      .limit(1)
+    expect(audit.length).toBe(1)
+  })
+})
+
+// ── Audit log ───────────────────────────────────────────────────────────────
+
+describe('audit log', () => {
+  it('writes instance.break_glass.approve on approval', async () => {
+    asAdmin(adminA)
+    await grantBreakGlass(targetOrgId, 'Audit approve', 240)
+    const session = await latestSessionFor(adminA.id)
+
+    asAdmin(adminB)
+    await approveBreakGlass(session!.id)
+
+    const entries = await db.select().from(auditLog)
+      .where(and(eq(auditLog.action, 'instance.break_glass.approve'), eq(auditLog.entityId, session!.id)))
+    expect(entries.length).toBeGreaterThan(0)
+    expect(entries[0].userId).toBe(adminB.id)
+  })
+})

--- a/apps/govea/tests/integration/instance-actions.test.ts
+++ b/apps/govea/tests/integration/instance-actions.test.ts
@@ -77,7 +77,7 @@ function asRegularAdmin() {
 // ── Break-glass grant ─────────────────────────────────────────────────────────
 
 describe('grantBreakGlass', () => {
-  it('creates a session row expiring in 24h', async () => {
+  it('creates a session row expiring in 1h by default', async () => {
     asInstanceAdmin()
     const before = Date.now()
     await grantBreakGlass(targetOrgId, 'Integration test reason')
@@ -93,9 +93,10 @@ describe('grantBreakGlass', () => {
 
     expect(session).toBeDefined()
     expect(session!.reason).toBe('Integration test reason')
+    expect(session!.requiresApproval).toBe(false)
     const expiresMs = session!.expiresAt.getTime()
-    expect(expiresMs).toBeGreaterThan(before + 23 * 3600 * 1000)
-    expect(expiresMs).toBeLessThan(before + 25 * 3600 * 1000)
+    expect(expiresMs).toBeGreaterThan(before + 59 * 60_000)
+    expect(expiresMs).toBeLessThan(before + 61 * 60_000)
   })
 
   it('writes an audit log entry', async () => {


### PR DESCRIPTION
Closes #418
Refs #435 (design note), #436 (Option 1 promotion), #437 (impersonation feature), #391 (webhook config)

## Summary

Ships the dual-control + TTL hardening for break-glass under **Option 2** (the design path agreed in #435). Reads remain unrestricted for instance admins; break-glass now gates **mutations / impersonation**, and the new dual-control machinery is ready for those callers.

The `requireBreakGlass(orgId)` helper exists, is tested, and has no caller in the read path under Option 2. The first caller will be the cross-tenant impersonation feature (#437); promotion to Option 1 (gated reads) is tracked in #436.

## What changed

| Layer | Change |
|---|---|
| **Schema** (`break_glass_sessions`) | New columns: `requires_approval` (bool, default false), `approved_at`, `approved_by` (FK→users.id). FK pattern matches the existing `revoked_by`. |
| **Server actions** (`actions/instance.ts`) | `grantBreakGlass(orgId, reason, ttlMinutes=60)` — TTL must be `60` / `240` / `480`, reason required (trimmed), `ttlMinutes > 60` sets `requiresApproval=true`. New `approveBreakGlass(sessionId)` — rejects self-approval, double-approval, sessions that don't require approval, revoked, expired. New `getPendingBreakGlassApprovals()` returns pending sessions a peer admin can approve. |
| **Helper** (NOT in `'use server'`) | New `src/lib/break-glass.ts` exporting `requireBreakGlass(adminId, orgId)` — returns the session iff active + non-revoked + non-expired AND (no approval needed OR already approved). |
| **Notification hook** | New `src/lib/notifications/break-glass.ts` — `notifyBreakGlassEvent` fires on grant / approval / revoke. Default sink is a prominent console banner. Sink is overridable (configurable webhook deferred to #391). Sink failures are swallowed so they never roll back the audit log. |
| **UI — org detail** | New `BreakGlassGrantForm` client component with TTL select (1h / 4h / 8h) and inline notice explaining when approval is required. Pending sessions from OTHER admins render with an Approve button. The granter's own pending session renders distinct from active state. Session history shows a Pending badge. |
| **UI — instance dashboard** | New "Pending Break-Glass Approvals" section with `Awaiting your approval` / `Your request` badge per row. Existing "Active Break-Glass Sessions" stat card now excludes pending sessions. |
| **UI — instance layout banner** | The "Active break-glass session" banner no longer shows for pending sessions (they don't grant access). |
| **Tests** | New `tests/integration/break-glass-approval.test.ts` — 17 tests. Updated `instance-actions.test.ts` for the 1h default. Bundled hotfix below. |

## Two design calls worth flagging

1. **TTL counts from `grantedAt`, not from `approvedAt`** — pre-staging a session and having it approved hours later does NOT extend the elevation window. The granter loses some of the requested time during the approval delay; that's intentional. The alternative would let a granter request 4h, sit on it, and then get a fresh 4h window when an emergency arrives — defeating the time-cap.
2. **Discrete TTL presets (1h / 4h / 8h), not free-form minutes** — cleaner audit trail, harder to misuse, matches the kind of policy you can write down. Validated server-side.

## Bundled hotfix — `audit-immutable.test.ts`

`apps/govea/tests/integration/audit-immutable.test.ts` (added by #433) had 4 calls to `writeAuditLog(...)` using the **old single-arg signature**. The new `writeAuditLog(tx, params)` signature from #434 landed on main inside the #435 squash commit, leaving the test file out of sync with the helper.

Result: **main has been failing the Type check CI job since 2026-05-09T01:47:07Z** (commit `c984e6b`). Build, E2E, and integration jobs were skipped on every commit since because they depend on typecheck.

This PR updates those 4 calls to pass `db` as the first argument, restoring main's CI to green once merged. The fix is bundled here rather than split into a separate hotfix because:
- The 4-line change is unrelated to #418 but blocks ALL PRs from getting green CI
- Splitting it would mean opening a separate PR that also has red CI as the new baseline
- A note in this PR description (above) makes the fix discoverable

## Test plan

- [x] `pnpm --filter govea db:push` (3 new columns added)
- [x] `pnpm --filter govea db:apply-triggers` (no change — triggers already cover audit_log only)
- [x] `pnpm --filter govea exec tsc --noEmit` — clean
- [x] `pnpm --filter govea test:integration` — **362 / 362 passing** (was 345 + 17 new)
- [x] `pnpm --filter govea lint` — 0 errors, 18 pre-existing warnings
- [x] Manual UI verify in dev:
  - [x] Grant 1h session → "Active session" header, global banner shows, expires in 1h
  - [x] Grant 4h session → "Pending approval" header, global banner does NOT show, session history shows blue "Pending" badge
  - [x] Notification banner fires in server logs on grant
  - [x] Revoke works on both active and pending sessions
  - [x] Instance dashboard shows pending session with "Your request" badge; Active count is 0 while pending exists
- [x] Confirm CI's typecheck step turns green again on this PR (was red on main since 2026-05-09)

## Operator note

Default break-glass TTL is now **1 hour** (was 24 hours). 4h and 8h options exist but **require a second instance admin to approve before the session activates**. Self-approval is blocked; the approver pool is "any other instance admin" (no designated subset, by design — see #435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
