### PR TITLE
test(security): regression test that middleware blocks unauth POSTs (#421)

### DIFF
--- a/apps/govea/tests/integration/middleware-auth.test.ts
+++ b/apps/govea/tests/integration/middleware-auth.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression test: middleware.ts blocks unauthenticated requests (#421).
+ *
+ * The middleware in `apps/govea/src/middleware.ts` is the primary defense for
+ * unauthenticated server-action exploitation. If a developer ever broadens
+ * `PUBLIC_PATHS`, removes the matcher, or weakens the redirect logic, every
+ * server action in the listed protected route groups becomes potentially
+ * callable without a session.
+ *
+ * This file locks in the following invariants:
+ *
+ *   1. Anonymous request to a representative protected path in EACH route
+ *      group ((admin), (instance), /api/* mutation routes, root) returns a
+ *      redirect to /login.
+ *   2. Anonymous request to each documented PUBLIC_PATH passes through.
+ *   3. /_next/static and /favicon.ico pass through (the static-asset escape
+ *      hatch).
+ *   4. /instance/* requires the `instance_admin` role even with a session.
+ *
+ * If you add a new public path, also add it to the PASSTHROUGH_PATHS list
+ * here. If you intentionally make a previously-protected route public,
+ * remove it from PROTECTED_PATHS — the test will then no longer enforce
+ * its protection. Don't silently delete a case to make a red test pass.
+ *
+ * Note: this is a pure unit test of the middleware's branching logic.
+ * It does not exercise next-auth's session resolution; that is mocked so we
+ * can drive `req.auth` directly. End-to-end coverage of the cookie → session
+ * pipeline lives in the e2e suite.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock next-auth so `NextAuth(authConfig).auth(handler)` returns the handler
+// itself. This lets us call the middleware's inner logic directly with a
+// constructed request.
+vi.mock('next-auth', () => ({
+  default: () => ({
+    auth: (handler: (req: unknown) => unknown) => handler,
+  }),
+}))
+
+// authConfig pulls in db/server-only modules; we don't need its real value
+// since the mock above never invokes it.
+vi.mock('@/lib/auth.config', () => ({ authConfig: {} }))
+
+type MockReq = {
+  nextUrl: URL
+  url: string
+  auth: { user?: { role?: string; instanceRole?: string | null } } | null
+}
+
+// next-auth's middleware type requires (req, event); we don't use event in
+// the handler under test, but we cast to satisfy the compiler.
+type SingleArg = (req: MockReq) => Promise<Response>
+
+async function loadMiddleware(): Promise<SingleArg> {
+  const mod = await import('@/middleware')
+  return mod.default as unknown as SingleArg
+}
+
+function makeRequest(pathname: string, auth: MockReq['auth'] = null): MockReq {
+  const url = new URL(`https://example.test${pathname}`)
+  return { nextUrl: url, url: url.toString(), auth }
+}
+
+function asRegularUser(): MockReq['auth'] {
+  return { user: { role: 'admin', instanceRole: null } }
+}
+
+function asInstanceAdmin(): MockReq['auth'] {
+  return { user: { role: 'admin', instanceRole: 'instance_admin' } }
+}
+
+// Representative protected paths — at least one per route group. Adding a
+// path to PUBLIC_PATHS in middleware.ts that matches any of these will fail
+// the test below.
+const PROTECTED_PATHS = [
+  // Root / dashboard
+  '/',
+  '/dashboard',
+  // (admin) route group
+  '/settings',
+  '/capabilities',
+  '/goals',
+  '/users',
+  '/value-streams',
+  '/audit',
+  // (instance) route group
+  '/instance',
+  '/instance/orgs',
+  '/instance/users',
+  '/instance/audit',
+  // /api/* non-auth routes (mutation / data exports)
+  '/api/applications/export',
+] as const
+
+const PASSTHROUGH_PATHS = [
+  '/login',
+  '/login/sso/callback',
+  '/setup',
+  '/setup/wizard',
+  '/error',
+  '/api/auth/signin',
+  '/api/auth/callback/credentials',
+  '/maintenance',
+] as const
+
+const STATIC_PATHS = [
+  '/_next/static/foo.js',
+  '/_next/data/route.json',
+  '/favicon.ico',
+] as const
+
+beforeEach(() => {
+  // Reset MAINTENANCE_MODE — middleware reads the env at module load via the
+  // top-level `MAINTENANCE_MODE` constant, but a few tests below override it.
+  process.env.MAINTENANCE_MODE = 'false'
+  vi.resetModules()
+})
+
+describe('middleware — anonymous requests to protected paths redirect to /login', () => {
+  it.each(PROTECTED_PATHS)('blocks anonymous %s', async (pathname) => {
+    const m = await loadMiddleware()
+    const req = makeRequest(pathname, null)
+    const res = await m(req)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(`https://example.test/login`)
+  })
+})
+
+describe('middleware — public paths pass through without a session', () => {
+  it.each(PASSTHROUGH_PATHS)('lets anonymous reach %s', async (pathname) => {
+    const m = await loadMiddleware()
+    const req = makeRequest(pathname, null)
+    const res = await m(req)
+    // NextResponse.next() is a 200 with the special `x-middleware-next` header.
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+
+  it.each(STATIC_PATHS)('lets static asset %s through', async (pathname) => {
+    const m = await loadMiddleware()
+    const req = makeRequest(pathname, null)
+    const res = await m(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})
+
+describe('middleware — /instance/* requires instance_admin even with a session', () => {
+  it('redirects a regular admin away from /instance', async () => {
+    const m = await loadMiddleware()
+    const req = makeRequest('/instance/orgs', asRegularUser())
+    const res = await m(req)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(`https://example.test/`)
+  })
+
+  it('lets an instance_admin through to /instance', async () => {
+    const m = await loadMiddleware()
+    const req = makeRequest('/instance/orgs', asInstanceAdmin())
+    const res = await m(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})
+
+describe('middleware — maintenance mode redirects non-admins', () => {
+  it('redirects a non-admin to /maintenance when MAINTENANCE_MODE is on', async () => {
+    process.env.MAINTENANCE_MODE = 'true'
+    vi.resetModules()
+    const m = await loadMiddleware()
+    const req = makeRequest('/dashboard', { user: { role: 'viewer', instanceRole: null } })
+    const res = await m(req)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(`https://example.test/maintenance`)
+  })
+
+  it('lets an admin through during maintenance', async () => {
+    process.env.MAINTENANCE_MODE = 'true'
+    vi.resetModules()
+    const m = await loadMiddleware()
+    const req = makeRequest('/dashboard', { user: { role: 'admin', instanceRole: null } })
+    const res = await m(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})
+
+describe('middleware — sanity: protected and passthrough sets do not overlap', () => {
+  it('PROTECTED_PATHS and PASSTHROUGH_PATHS are disjoint', () => {
+    const protectedSet = new Set<string>(PROTECTED_PATHS)
+    for (const p of PASSTHROUGH_PATHS) {
+      // A path that startsWith one of PUBLIC_PATHS is public; the protected
+      // list must not contain anything that the middleware would treat as
+      // public. This catches accidental drift between this file and
+      // middleware.ts's PUBLIC_PATHS.
+      expect(protectedSet.has(p)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Re-targeting [#439](https://github.com/roballred/GovEA/pull/439) at `main`. The original PR was merged into base `fix/break-glass-hardening-418` instead of `main`, so the test never actually reached the production branch and #421 stayed open.

This branch is the same 200-line test file, rebased onto current `main`. 29/29 tests pass locally:

```
✓ tests/integration/middleware-auth.test.ts (29 tests) 48ms
Test Files  1 passed (1)
     Tests  29 passed (29)
```

## What it locks in

Regression coverage for the invariants enforced by `apps/govea/src/middleware.ts`. A future change that broadens `PUBLIC_PATHS`, removes the matcher, or weakens the redirect logic will fail CI:

- Anonymous request to a representative protected path in EACH route group (`(admin)`, `(instance)`, `/api/*` mutation routes, root) returns a 307 redirect to `/login`.
- Anonymous request to each documented `PUBLIC_PATH` passes through (`NextResponse.next`, `x-middleware-next: 1`).
- `/_next/static` and `/favicon.ico` pass through (the static-asset escape hatch).
- `/instance/*` requires the `instance_admin` role even with a session (regular admin gets redirected to `/`, instance admin gets through).
- `MAINTENANCE_MODE` redirects non-admins to `/maintenance` and lets admins through.

Pure unit test of the middleware's branching logic — mocks next-auth's HOF wrapper so the inner handler is called directly with a constructed request. End-to-end coverage of the cookie → session pipeline lives in the e2e suite.

## Test plan

- [x] `pnpm --filter govea test:integration tests/integration/middleware-auth.test.ts` — 29/29 pass
- [ ] CI green on the integration job
- [ ] Verify after merge that #421 auto-closes via `Closes #421`

Closes #421