### PR TITLE
docs: refresh product priorities — security wave fully closed (2026-05-09)

### DIFF
--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,51 +1,51 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-08 (PM cadence refresh — afternoon)
+Last groomed: 2026-05-09 (security wave fully closed; regression coverage in flight; feature roadmap unblocked)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
 ## Current Signal
 
-A security scan on 2026-05-07 surfaced nine high-severity findings. Six are now fixed (PRs #424–#426, #428, #429); three remain open (#416, #417, #418). The fixed cluster covered the entire server-action multi-tenant authority surface — auth gating, session-sourced `organizationId`/`role`, RPC exposure of internal helpers, and target-entity org checks on junction writes. The three open findings are a different category: they are about the integrity of what the platform records *after* a mutation succeeds (#416 transactional audit, #417 append-only audit table) and how break-glass access is governed (#418).
+The 2026-05-07 security scan that surfaced nine high-severity findings is now fully closed. The last three open from yesterday — #416 (transactional audit), #417 (append-only `audit_log`), #418 (break-glass TTL + dual control) — all merged today (PRs #433, #438). The hardening wave is done; the live tenant-data attack surface, the post-mutation integrity surface, and the exception-access surface are all addressed.
 
-Significant merges since the last grooming pass (earlier today, PR #430):
+Two follow-up issues opened off #418 — both are explicit deferrals of scope, not new findings:
 
-- PR #428 closed #427 — entity-taxonomy helpers moved out of `'use server'`, removing an RPC-reachable surface.
-- PR #429 closed #415 — junction-table inserts now verify the target entity belongs to the caller's org.
+- [#436](https://github.com/roballred/GovEA/issues/436) — promote break-glass to gate cross-tenant **reads** (Option 1 promotion of #418's Option 2)
+- [#437](https://github.com/roballred/GovEA/issues/437) — wire cross-tenant **impersonation** through the break-glass gate
 
-Earlier in this hardening wave (still relevant for context):
+A triage pass posted on both today flagged that the `requireBreakGlass(orgId)` enforcement helper they assume *does not yet exist* — only `getActiveBreakGlass(adminId, orgId)` (returns row or undefined). Whichever issue lands first must add the enforcement helper as PR-A. Recommended sequence: helper → #437 (mutation caller, makes #418 a functional control) → operational soak → #436 (read-gating). My read is #436 is post-v1; happy to be overruled.
 
-- PRs #424–#426 fixed unauthenticated `getUsers`, cross-org-link helpers reachable as RPC, and read actions trusting caller-supplied `organizationId`/`role`.
-- PRs #397–#401 shipped richer tenant-governance controls and instance-level platform defaults (theme, module defaults, org provisioning stamps), fully closing the instance-config surface defined in #308.
-- PR #410 and PR #423 landed the business-architecture STYLE.md standard and retrofitted all personas to match it.
+Regression test coverage for the hardening wave is in flight:
+
+- [#440](https://github.com/roballred/GovEA/pull/440) — middleware unauth-POST regression test (#421) — re-PR'd against `main` after the original PR landed on a feature branch instead.
+- [#441](https://github.com/roballred/GovEA/pull/441) — read-action tenant-isolation regression test (#422) — locks in the #411–#414 contract that read actions source `organizationId`/`role` from the session, never from caller input. Covers `getUsers`, `getCapabilities`, `getOtherOrganizations`, `getConnections`, `getTaxonomyTerms`.
 
 What this means for prioritization:
 
-- The "live" attack surface on tenant data through server actions is now closed. The remaining security work is about *post-mutation* trust (audit log) and *exceptional* access (break-glass) — important but no longer blocking normal feature work in the same way.
-- Regression tests (#421, #422) become the priority cost-of-not-doing item: without them, a future widening of the middleware matcher or a reintroduced `organizationId` parameter will silently regress what was just fixed.
-- The feature roadmap below the security work is unchanged: repository trust, debt tracking, integration freshness, and persona validation are still the right next moves.
-- The instance admin surface is now solid enough to plan the deferred platform defaults (#402) as the next platform-management task.
+- Security work is no longer the lead item. The two regression-test PRs (#440, #441) are the last items closing the wave; everything after is feature roadmap.
+- The deferred break-glass extensions (#436, #437) are real but should not block v1. They become important once Option 2 has operational mileage.
+- The feature roadmap below is now genuinely unblocked: repository trust → debt/decision capture → persona validation. None of these have been started in implementation.
+- [#402](https://github.com/roballred/GovEA/issues/402) (configurable platform defaults, deferred from #390) remains the smallest concrete platform-admin task and is a good "one-PR win" candidate between security and the next feature slice.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Close the three remaining high-severity audit / break-glass findings | All server-action multi-tenant findings are fixed (PRs #428, #429 merged today, joining #424–#426). What remains is post-mutation integrity and exception access: #416 (non-transactional audit writes), #417 (mutable `audit_log`), and #418 (break-glass TTL 24h, no dual control). #416 and #417 can ship as a paired migration. For #418, ship the TTL cap (1h default) immediately as a one-line config change; plan dual control as a separate design issue linked to #391. | #416, #417, #418 |
-| 2 | Add security regression tests for the hardened server actions | Issues #421 and #422 lock in the invariants fixed this week — six high-severity issues' worth. Without them, a developer who widens the middleware matcher or reintroduces a caller-supplied `organizationId`/`role` param will be uncaught in CI. With the live surface now closed (item 1 is no longer blocking), regression coverage is the highest-leverage way to keep it closed. Straightforward integration tests against existing auth machinery. | #421, #422 |
-| 3 | Ship repository completeness drill-downs and a plain-language confidence summary | Reporting, heatmaps, impact views, and executive summaries now depend on users trusting the underlying repository. GovEA has early coverage signals but not yet the fuller completeness workflow or stakeholder-facing confidence cues. | `rm-repository-completeness`, `fd-repository-confidence-summary`, #380 |
-| 4 | Add architecture debt tracking and make ADRs a stronger decision-support surface | Impact analysis surfaces consequences, but GovEA still lacks a first-class way to record persistent constraints and tradeoff accumulation. That is the gap between "what is affected" and "what should leadership worry about next." | `rm-architecture-debt`, `po-architecture-decisions`, #381 |
-| 5 | Validate assumed personas and start a lightweight product feedback loop | Repository modelling and integration are still driven by assumed personas. With multi-tenant hardening done and executive-facing surfaces shipped, the cost of building the wrong next analytic feature has gone up. | Persona docs, `docs/research/`, #103, #384 |
+| 1 | Land #440 and #441 — regression coverage for the hardening wave | All nine high-severity findings are fixed in production code; without these tests, a future change that widens the middleware matcher or reintroduces a caller-supplied `organizationId`/`role` parameter will regress silently. Both PRs are open against `main`, tests passing locally (29/29 for #440, 12/12 for #441). | #421, #422 |
+| 2 | Ship repository completeness drill-downs and a plain-language confidence summary | Reporting, heatmaps, impact analysis, and executive summaries now depend on users trusting the underlying repository. v0 (live-query coverage signals + admin-only `ConfidenceSummary` component) is in code; the issue scope adds snapshots, drill-downs, configurable targets, ranked-action list, and stakeholder-facing surfaces. Sliced into 4 PRs in the [issue plan](https://github.com/roballred/GovEA/issues/380#issuecomment-4412881773): snapshot foundation → settings model → drill-downs + ranked actions → trend line + stakeholder surfaces. | `rm-repository-completeness`, `fd-repository-confidence-summary`, [#380](https://github.com/roballred/GovEA/issues/380) |
+| 3 | Add architecture debt tracking and make ADRs a stronger decision-support surface | Impact analysis surfaces consequences, but GovEA still lacks a first-class way to record persistent constraints and tradeoff accumulation. That is the gap between "what is affected" and "what should leadership worry about next." Pairs naturally with #380 PR-3 (the unified priority signal summary referenced in `rm-architecture-debt`). | `rm-architecture-debt`, `po-architecture-decisions`, [#381](https://github.com/roballred/GovEA/issues/381) |
+| 4 | Validate assumed personas and start a lightweight product feedback loop | Repository modelling and integration are still driven by assumed personas. With multi-tenant hardening done and executive-facing surfaces shipped, the cost of building the wrong next analytic feature has gone up. | Persona docs, `docs/research/`, [#103](https://github.com/roballred/GovEA/issues/103), [#384](https://github.com/roballred/GovEA/issues/384) |
+| 5 | Ship #402 — configurable platform operation defaults | Small, well-defined, deferred from #390. Good one-PR win to slot between feature slices when context-switching. Schema impact is minimal. | [#402](https://github.com/roballred/GovEA/issues/402) |
 
 ## Product Manager Notes
 
-- The two open-PR rows from this morning's note are now merged. The remaining three high-severity findings (#416, #417, #418) are still real, but they are no longer blocking feature PRs from merging — the live tenant-data surface is closed. Regression tests (#421, #422) deserve to move up in tempo.
-- For #418 (break-glass): ship the TTL cap (1h default) immediately as a one-line config change; plan dual-control approval as a follow-on design issue linked to #391 (platform endpoint config). Do not block the TTL fix waiting for the full design.
-- #402 (configurable platform defaults — deferred from #390) is the next concrete platform-admin task after security. Schema impact is small and well-defined in the issue.
-- The feature roadmap (items 3–5) is unchanged from the 2026-05-06 grooming: repository trust → debt/decision capture → persona validation. Security did not make these wrong; it just moved ahead of them.
-- Issue #363 (Data Architecture Metamodel) is now in active triage — the maintainer has replied with concrete design questions about how to model the conceptual / logical / physical layers, and the contributor has added a follow-up about capturing data domain (Master / Multi-Use Data Management). It still has no labels and no v1-vs-future scope decision; that decision is the next move on the issue, not another general reply.
-- The ARB/research issues (90s, 130s, 300s) remain important but are capability-definition work. None are blocking the items above.
+- The hardening wave is fully closed. The remaining "security" backlog (#436, #437) is feature work gated on operational experience with #418, not blockers.
+- The break-glass machinery currently has no production caller for mutations — #418 is decorative until #437 (or a smaller "wire requireBreakGlass into one mutation surface" issue) lands. This is fine for v1 *only if* an operator never actually relies on break-glass to control an incident. For real cross-tenant ops, #437 should land before public launch.
+- #380 is the next big feature slice and is genuinely sized — 4 PRs, sub-300 LoC each in product code, with the performance ADR (`rm-query-performance-decision.md`) already accepted. The first PR (snapshot foundation + indexes) has no UI changes and is risk-free to land.
+- [#363](https://github.com/roballred/GovEA/issues/363) (Data Architecture Metamodel) remains in active triage — maintainer questions outstanding. Next move there is a v1-vs-future scope decision, not engineering. Worth a 15-minute pass.
+- The ARB/research issues (90s, 130s, 300s) remain capability-definition work. None blocking the items above.
 
-## Security Remediation Status (as of 2026-05-08)
+## Security Remediation Status (as of 2026-05-09)
 
 | Issue | Severity | Status |
 |---|---|---|
@@ -55,8 +55,10 @@ What this means for prioritization:
 | #414 — read actions trust caller `role` | High | ✅ Fixed (PR #426) |
 | #427 — entity-taxonomy helpers reachable as RPC | High | ✅ Fixed (PR #428) |
 | #415 — junction writes skip target-entity org check | High | ✅ Fixed (PR #429) |
-| #416 — audit writes not transactional with mutation | High | Open |
-| #417 — `audit_log` has no DB-level append-only constraint | High | Open |
-| #418 — break-glass TTL 24h; no dual control | High | Open |
-| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | Open |
-| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | Open |
+| #416 — audit writes not transactional with mutation | High | ✅ Fixed |
+| #417 — `audit_log` has no DB-level append-only constraint | High | ✅ Fixed (PR #433) |
+| #418 — break-glass TTL 24h; no dual control | High | ✅ Fixed (PR #438) |
+| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | 🟡 PR #440 open against main |
+| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | 🟡 PR #441 open against main |
+| #436 — promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 per triage) |
+| #437 — wire cross-tenant impersonation through break-glass | Medium | Open (pre-v1 per triage) |


### PR DESCRIPTION
## Summary

Refreshes \`docs/product-priorities.md\` to reflect the actual state of the repo as of today:

- **All 9 high-severity security findings are now closed** — #416, #417, #418 merged today via PRs #433 and #438. The previous doc revision still listed them as open.
- **Regression coverage is in flight** — #440 (middleware unauth-POST) and #441 (read-action tenant isolation) are open against \`main\`. They're now the rank-1 priority since they're the last items closing the wave.
- **#436 and #437 added to the security table** as Medium-severity follow-ups, with the sequencing recommendation posted on those issues today.
- **#380 plan link** — the 4-PR slice plan posted on #380 today is referenced from the rank-2 row.
- **#402 surfaced as rank-5** — a one-PR win between feature slices.

No rank-order changes for items 2–4. The feature roadmap (repository trust → debt/decision capture → persona validation) is unchanged from prior groomings.

## Test plan

- [x] Reads cleanly as a standalone document
- [ ] Maintainer accepts the rank-order and the post-v1 framing on #436