### PR TITLE
feat(repository): completeness settings model + admin config (PR-2 of #380)

### DIFF
--- a/apps/govea/src/actions/settings.ts
+++ b/apps/govea/src/actions/settings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { organizations, type ConfidenceSettings } from '@/db/schema'
+import { organizations, type ConfidenceSettings, type CompletenessSettings, DEFAULT_COMPLETENESS_SETTINGS } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
@@ -90,7 +90,7 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) throw new Error('Forbidden')
 
-  const { enabled, narrative, suppressBelowPercent } = input
+  const { enabled, narrative, suppressBelowPercent, authenticatedVisibility, publicVisibility } = input
 
   if (suppressBelowPercent < 0 || suppressBelowPercent > 100) {
     throw new Error('suppressBelowPercent must be between 0 and 100')
@@ -103,10 +103,18 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
     columns: { confidenceSettings: true },
   })
 
+  // Resolve `enabled` for back-compat: if the form submits new visibility
+  // fields, derive `enabled` from `authenticatedVisibility`. Otherwise honor
+  // whatever the form provided.
+  const resolvedAuthVis = authenticatedVisibility ?? enabled
+  const resolvedPubVis = publicVisibility ?? false
+
   const next: ConfidenceSettings = {
-    enabled,
+    enabled: resolvedAuthVis,
     narrative: narrative?.trim() || null,
     suppressBelowPercent,
+    authenticatedVisibility: resolvedAuthVis,
+    publicVisibility: resolvedPubVis,
   }
 
   await db.transaction(async (tx) => {
@@ -126,4 +134,57 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
   })
 
   revalidatePath('/', 'layout')
+}
+
+export async function updateCompletenessSettings(input: Partial<CompletenessSettings>) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+
+  const orgId = session.user.organizationId!
+
+  const before = await db.query.organizations.findFirst({
+    where: eq(organizations.id, orgId),
+    columns: { completenessSettings: true },
+  })
+  const current = before?.completenessSettings ?? DEFAULT_COMPLETENESS_SETTINGS
+
+  const stalenessDays = input.stalenessDays ?? current.stalenessDays
+  if (![3 * 30, 6 * 30, 12 * 30, 24 * 30, 90].includes(stalenessDays) && (stalenessDays < 30 || stalenessDays > 730)) {
+    throw new Error('stalenessDays must be between 30 and 730')
+  }
+
+  const domainTargets = input.domainTargets ?? current.domainTargets
+  for (const [domain, target] of Object.entries(domainTargets)) {
+    if (typeof target !== 'number' || target < 0 || target > 100) {
+      throw new Error(`domainTargets[${domain}] must be 0–100`)
+    }
+  }
+
+  const rankingWeights = input.rankingWeights ?? current.rankingWeights
+
+  const next: CompletenessSettings = {
+    stalenessDays,
+    domainTargets,
+    rankingWeights,
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.update(organizations)
+      .set({ completenessSettings: next, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId))
+
+    await writeAuditLog(tx, {
+      action: 'settings.completeness_updated',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { completenessSettings: before?.completenessSettings },
+      after: { completenessSettings: next },
+    })
+  })
+
+  revalidatePath('/dashboard')
+  revalidatePath('/settings')
 }

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -5,6 +5,8 @@ import {
   personas, capabilities, applications, adrs, initiatives,
   strategicObjectives, valueStreams, principles, glossaryTerms,
   auditLog, users, crossOrgLinks,
+  organizations,
+  DEFAULT_COMPLETENESS_SETTINGS,
 } from '@/db/schema'
 import { and, count, eq, gt, isNotNull, desc, asc, inArray, or } from 'drizzle-orm'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -13,8 +15,6 @@ import { CoverageTileLabel } from './coverage-tile-label'
 import { DomainBadge } from '@/components/domain-badge'
 import { ConfidenceSummary } from '@/components/confidence-summary'
 import Link from 'next/link'
-
-const REVIEW_WINDOW_DAYS = 90
 
 function pivotCounts(rows: { status: string; count: number | string }[]) {
   const byStatus: Record<string, number> = {}
@@ -57,8 +57,14 @@ export default async function DashboardPage() {
   if (!session?.user) redirect('/login')
   const orgId = session.user.organizationId!
 
+  const orgRow = await db.query.organizations.findFirst({
+    where: eq(organizations.id, orgId),
+    columns: { completenessSettings: true },
+  })
+  const stalenessDays = orgRow?.completenessSettings?.stalenessDays ?? DEFAULT_COMPLETENESS_SETTINGS.stalenessDays
+
   // eslint-disable-next-line react-hooks/purity -- server component, Date.now() is intentional
-  const staleThreshold = new Date(Date.now() - REVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+  const staleThreshold = new Date(Date.now() - stalenessDays * 24 * 60 * 60 * 1000)
 
   const [
     personaRows, capabilityRows, applicationRows, adrRows,
@@ -284,7 +290,7 @@ export default async function DashboardPage() {
       {/* Review Health */}
       <div>
         <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-          Review Health <span className="font-normal normal-case">({REVIEW_WINDOW_DAYS}-day window)</span>
+          Review Health <span className="font-normal normal-case">({stalenessDays}-day window)</span>
         </p>
         <Card>
           <CardContent className="pt-4 pb-2">

--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -7,9 +7,11 @@ import { ThemeSelector } from '@/components/theme-selector'
 import { ModuleToggles } from '@/components/module-toggles'
 import { FrameworkToggles } from '@/components/framework-toggles'
 import { ConfidenceSettingsForm } from '@/components/confidence-settings'
+import { CompletenessSettingsForm } from '@/components/completeness-settings'
 import { CustomFieldsManager } from '@/components/custom-fields-manager'
 import { isAdmin } from '@/lib/rbac'
-import type { ConfidenceSettings } from '@/db/schema'
+import type { ConfidenceSettings, CompletenessSettings } from '@/db/schema'
+import { DEFAULT_COMPLETENESS_SETTINGS } from '@/db/schema'
 import { getCurrentModuleSettings } from '@/lib/get-enabled-modules'
 import { getCustomFieldSchema } from '@/actions/custom-fields'
 
@@ -17,7 +19,11 @@ const DEFAULT_CONFIDENCE: ConfidenceSettings = {
   enabled: false,
   narrative: null,
   suppressBelowPercent: 50,
+  authenticatedVisibility: false,
+  publicVisibility: false,
 }
+
+const DEFAULT_COMPLETENESS: CompletenessSettings = DEFAULT_COMPLETENESS_SETTINGS
 
 export default async function SettingsPage() {
   const session = await auth()
@@ -40,6 +46,7 @@ export default async function SettingsPage() {
   const enabledModules = moduleSettings.orgEnabledModules
   const instanceDisabledModules = moduleSettings.instanceDisabledModules
   const confidenceSettings = org?.confidenceSettings ?? DEFAULT_CONFIDENCE
+  const completenessSettings = org?.completenessSettings ?? DEFAULT_COMPLETENESS
 
   return (
     <div className="space-y-8 max-w-2xl">
@@ -92,6 +99,18 @@ export default async function SettingsPage() {
           </p>
         </div>
         <CustomFieldsManager entityType="application" initialFields={appCustomFields} />
+      </section>
+
+      <hr />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Repository Completeness</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Tune how completeness signals are calculated for your organization.
+          </p>
+        </div>
+        <CompletenessSettingsForm initial={completenessSettings} />
       </section>
 
       <hr />

--- a/apps/govea/src/components/completeness-settings.tsx
+++ b/apps/govea/src/components/completeness-settings.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { updateCompletenessSettings } from '@/actions/settings'
+import { cn } from '@/lib/utils'
+import type { CompletenessSettings } from '@/db/schema'
+
+interface CompletenessSettingsFormProps {
+  initial: CompletenessSettings
+}
+
+const STALENESS_OPTIONS = [
+  { days: 90,  label: '3 months'  },
+  { days: 180, label: '6 months'  },
+  { days: 365, label: '12 months' },
+  { days: 730, label: '24 months' },
+]
+
+export function CompletenessSettingsForm({ initial }: CompletenessSettingsFormProps) {
+  const [stalenessDays, setStalenessDays] = useState(initial.stalenessDays)
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved'>('idle')
+  const [isPending, startTransition] = useTransition()
+
+  function save() {
+    setStatus('saving')
+    startTransition(async () => {
+      await updateCompletenessSettings({ stalenessDays })
+      setStatus('saved')
+      setTimeout(() => setStatus('idle'), 2000)
+    })
+  }
+
+  const isBusy = isPending || status === 'saving'
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1.5">
+        <label htmlFor="staleness-days" className="text-sm font-medium">
+          Staleness window
+        </label>
+        <select
+          id="staleness-days"
+          value={stalenessDays}
+          onChange={e => setStalenessDays(Number(e.target.value))}
+          disabled={isBusy}
+          className={cn(
+            'w-48 rounded-md border bg-background px-3 py-2 text-sm',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            'disabled:cursor-not-allowed disabled:opacity-60',
+          )}
+        >
+          {STALENESS_OPTIONS.map(opt => (
+            <option key={opt.days} value={opt.days}>{opt.label}</option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground">
+          Items not updated or reviewed within this window are flagged as stale on the dashboard&apos;s Review Health section.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={save}
+          disabled={isBusy}
+          className={cn(
+            'rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
+            'hover:bg-primary/90 transition-colors',
+            'disabled:cursor-not-allowed disabled:opacity-60',
+          )}
+        >
+          {status === 'saving' ? 'Saving…' : 'Save'}
+        </button>
+        {status === 'saved' && (
+          <p className="text-xs text-muted-foreground">Saved.</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/govea/src/components/confidence-settings.tsx
+++ b/apps/govea/src/components/confidence-settings.tsx
@@ -10,16 +10,32 @@ interface ConfidenceSettingsFormProps {
 }
 
 export function ConfidenceSettingsForm({ initial }: ConfidenceSettingsFormProps) {
-  const [enabled, setEnabled] = useState(initial.enabled)
+  // Default the visibility split from the legacy `enabled` flag for orgs
+  // that pre-date the split. New rows always store both fields explicitly.
+  const [authenticatedVisibility, setAuthVis] = useState(
+    initial.authenticatedVisibility ?? initial.enabled,
+  )
+  const [publicVisibility, setPubVis] = useState(initial.publicVisibility ?? false)
   const [narrative, setNarrative] = useState(initial.narrative ?? '')
   const [suppressBelowPercent, setSuppressBelowPercent] = useState(initial.suppressBelowPercent)
   const [status, setStatus] = useState<'idle' | 'saving' | 'saved'>('idle')
   const [isPending, startTransition] = useTransition()
 
+  // Defensive UX: public visibility should not be on while authenticated is off.
+  // Disabling authenticated visibility also clears public visibility client-side;
+  // the server enforces the same invariant on save.
+  const effectivePub = authenticatedVisibility ? publicVisibility : false
+
   function save() {
     setStatus('saving')
     startTransition(async () => {
-      await updateConfidenceSettings({ enabled, narrative: narrative || null, suppressBelowPercent })
+      await updateConfidenceSettings({
+        enabled: authenticatedVisibility,
+        authenticatedVisibility,
+        publicVisibility: effectivePub,
+        narrative: narrative || null,
+        suppressBelowPercent,
+      })
       setStatus('saved')
       setTimeout(() => setStatus('idle'), 2000)
     })
@@ -29,38 +45,73 @@ export function ConfidenceSettingsForm({ initial }: ConfidenceSettingsFormProps)
 
   return (
     <div className="space-y-5">
-      {/* Enable toggle */}
+      {/* Authenticated visibility toggle */}
       <div className="flex items-center justify-between rounded-lg border bg-card px-4 py-3">
         <div>
-          <p className="text-sm font-medium">Show confidence summary</p>
+          <p className="text-sm font-medium">Show to authenticated viewers</p>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Display a plain-language status label on stakeholder-facing pages.
+            Display the confidence summary on stakeholder-facing pages for signed-in users (Admins, Contributors, Viewers).
           </p>
         </div>
         <button
           type="button"
           role="switch"
-          aria-checked={enabled}
-          aria-label={enabled ? 'Disable confidence summary' : 'Enable confidence summary'}
+          aria-checked={authenticatedVisibility}
+          aria-label={authenticatedVisibility ? 'Disable for authenticated viewers' : 'Enable for authenticated viewers'}
           disabled={isBusy}
-          onClick={() => setEnabled(v => !v)}
+          onClick={() => setAuthVis(v => !v)}
           className={cn(
             'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-150',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
             'disabled:cursor-not-allowed disabled:opacity-60',
-            enabled ? 'bg-primary' : 'bg-input',
+            authenticatedVisibility ? 'bg-primary' : 'bg-input',
           )}
         >
           <span
             className={cn(
               'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform duration-150',
-              enabled ? 'translate-x-4' : 'translate-x-0',
+              authenticatedVisibility ? 'translate-x-4' : 'translate-x-0',
             )}
           />
         </button>
       </div>
 
-      {enabled && (
+      {/* Public visibility toggle — gated on authenticated being on */}
+      <div className={cn(
+        'flex items-center justify-between rounded-lg border bg-card px-4 py-3',
+        !authenticatedVisibility && 'opacity-60',
+      )}>
+        <div>
+          <p className="text-sm font-medium">Also show to unauthenticated viewers</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Make the confidence summary visible to the public without signing in. This is an explicit second step
+            — turn this on only after confirming the summary is appropriate for an external audience.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={effectivePub}
+          aria-label={effectivePub ? 'Disable for public viewers' : 'Enable for public viewers'}
+          disabled={isBusy || !authenticatedVisibility}
+          onClick={() => setPubVis(v => !v)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-150',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            'disabled:cursor-not-allowed disabled:opacity-60',
+            effectivePub ? 'bg-primary' : 'bg-input',
+          )}
+        >
+          <span
+            className={cn(
+              'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform duration-150',
+              effectivePub ? 'translate-x-4' : 'translate-x-0',
+            )}
+          />
+        </button>
+      </div>
+
+      {authenticatedVisibility && (
         <>
           {/* Narrative */}
           <div className="space-y-1.5">

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -2,10 +2,71 @@ import { type AnyPgColumn, boolean, jsonb, pgEnum, pgTable, text, timestamp, uui
 
 export const visibilityEnum = pgEnum('visibility', ['org', 'connections', 'instance'])
 
+/**
+ * Confidence-summary publication settings (#380 PR-2).
+ *
+ * `enabled` is retained for backwards compatibility with PR-1 callers — it
+ * is interpreted as `authenticatedVisibility` when the new fields are absent.
+ * New callers should set `authenticatedVisibility` and `publicVisibility`
+ * directly. The legacy `enabled` field is kept until PR-4 can drop it
+ * cleanly across all callers.
+ */
 export type ConfidenceSettings = {
   enabled: boolean
   narrative: string | null
   suppressBelowPercent: number
+  /**
+   * Whether authenticated users (Admin / Contributor / Viewer) see the
+   * confidence summary on stakeholder-facing surfaces. Defaults to the
+   * value of `enabled` for legacy rows that pre-date this split.
+   */
+  authenticatedVisibility?: boolean
+  /**
+   * Whether unauthenticated (public) viewers see the confidence summary.
+   * Always defaults to false; must be enabled as an explicit second step
+   * even if `authenticatedVisibility` is true. Per
+   * `fd-repository-confidence-summary.md`, the controls are independent.
+   */
+  publicVisibility?: boolean
+}
+
+/**
+ * Completeness drill-down + scoring settings (#380 PR-2).
+ *
+ * `stalenessDays` replaces the hardcoded `REVIEW_WINDOW_DAYS = 90` in the
+ * admin dashboard's Review Health section.
+ *
+ * `domainTargets` and `rankingWeights` are stored now to avoid a follow-up
+ * migration in PR-3, but their wiring into the RAG indicators and the
+ * "most-needed actions" ranked list lands in PR-3.
+ */
+export type CompletenessSettings = {
+  stalenessDays: number
+  /**
+   * Per-capability-domain completeness targets, keyed by the domain string
+   * stored on the capability row. Values are integers 0–100.
+   * E.g. { 'cms': 60, 'ea': 70 }. PR-3 wires these into RAG indicators.
+   */
+  domainTargets: Record<string, number>
+  /**
+   * Heuristic weights for the "most-needed actions" ranking in PR-3.
+   * Higher = larger contribution to ranking score.
+   */
+  rankingWeights: {
+    publishedButStale: number
+    incompleteRelationship: number
+    unpublished: number
+  }
+}
+
+export const DEFAULT_COMPLETENESS_SETTINGS: CompletenessSettings = {
+  stalenessDays: 90,
+  domainTargets: {},
+  rankingWeights: {
+    publishedButStale: 3,
+    incompleteRelationship: 2,
+    unpublished: 1,
+  },
 }
 
 export const organizations = pgTable('organizations', {
@@ -15,6 +76,7 @@ export const organizations = pgTable('organizations', {
   theme: text('theme').notNull().default('govea'),
   enabledModules: jsonb('enabled_modules').$type<Record<string, boolean>>().notNull().default({}),
   confidenceSettings: jsonb('confidence_settings').$type<ConfidenceSettings>(),
+  completenessSettings: jsonb('completeness_settings').$type<CompletenessSettings>(),
   isSystemOrg: boolean('is_system_org').notNull().default(false),
   parentId: uuid('parent_id').references((): AnyPgColumn => organizations.id, { onDelete: 'set null' }),
   suspendedAt: timestamp('suspended_at'),

--- a/apps/govea/src/lib/confidence.ts
+++ b/apps/govea/src/lib/confidence.ts
@@ -28,6 +28,23 @@ const DEFAULT_SETTINGS: ConfidenceSettings = {
   suppressBelowPercent: 50,
 }
 
+/** Controls which visibility flag gates the response. */
+export type ConfidenceAudience = 'authenticated' | 'public'
+
+/**
+ * Resolve which visibility flag this audience consults. Legacy rows without the
+ * `authenticatedVisibility` field fall back to the `enabled` boolean —
+ * preserving v1 behavior where `enabled=true` meant "show to admin dashboard".
+ * `publicVisibility` is always explicit (defaults to false) — no implicit
+ * promotion from `enabled`.
+ */
+export function isVisibleToAudience(settings: ConfidenceSettings, audience: ConfidenceAudience): boolean {
+  if (audience === 'public') {
+    return settings.publicVisibility === true
+  }
+  return settings.authenticatedVisibility ?? settings.enabled
+}
+
 function scoreToLabel(score: number): ConfidenceLabel {
   if (score >= 70) return 'actively maintained'
   if (score >= 40) return 'under development'
@@ -38,7 +55,10 @@ function isSnapshotPathEnabled(): boolean {
   return process.env.COMPLETENESS_SNAPSHOT_ENABLED === 'true'
 }
 
-export async function getConfidenceSummary(orgId: string): Promise<ConfidenceSummary> {
+export async function getConfidenceSummary(
+  orgId: string,
+  audience: ConfidenceAudience = 'authenticated',
+): Promise<ConfidenceSummary> {
   const org = await db.query.organizations.findFirst({
     where: eq(organizations.id, orgId),
     columns: { confidenceSettings: true },
@@ -46,7 +66,7 @@ export async function getConfidenceSummary(orgId: string): Promise<ConfidenceSum
 
   const settings: ConfidenceSettings = org?.confidenceSettings ?? DEFAULT_SETTINGS
 
-  if (!settings.enabled) {
+  if (!isVisibleToAudience(settings, audience)) {
     return { label: 'getting started', score: 0, lastUpdated: null, shouldShow: false, narrative: null, settings }
   }
 

--- a/apps/govea/tests/integration/completeness-settings.test.ts
+++ b/apps/govea/tests/integration/completeness-settings.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Completeness + confidence settings (#380 PR-2).
+ *
+ * Asserts:
+ *   1. Default `completenessSettings` for new orgs preserves the prior
+ *      hardcoded 90-day staleness behavior.
+ *   2. `getConfidenceSummary(orgId, audience)` honors authenticatedVisibility
+ *      vs publicVisibility independently. Legacy rows with only `enabled` set
+ *      still work for the 'authenticated' audience.
+ *   3. Public visibility never inherits from `enabled` — it must be explicit.
+ *   4. The DEFAULT_COMPLETENESS_SETTINGS export is what the dashboard falls
+ *      back to when an org has no settings row.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  organizations,
+  DEFAULT_COMPLETENESS_SETTINGS,
+} from '@/db/schema'
+import { getConfidenceSummary, isVisibleToAudience } from '@/lib/confidence'
+import { createTestOrg, cleanupOrg, type TestOrg } from './helpers/db'
+
+let org: TestOrg
+
+beforeAll(async () => {
+  org = await createTestOrg({ name: 'Settings Org', slug: `set-${randomUUID().slice(0, 8)}` })
+})
+
+afterAll(async () => {
+  await cleanupOrg(org.id)
+})
+
+describe('DEFAULT_COMPLETENESS_SETTINGS', () => {
+  it('preserves the prior 90-day staleness behavior', () => {
+    expect(DEFAULT_COMPLETENESS_SETTINGS.stalenessDays).toBe(90)
+  })
+
+  it('starts with no domain targets (PR-3 introduces them)', () => {
+    expect(DEFAULT_COMPLETENESS_SETTINGS.domainTargets).toEqual({})
+  })
+
+  it('has sensible ranking weights', () => {
+    expect(DEFAULT_COMPLETENESS_SETTINGS.rankingWeights.publishedButStale).toBeGreaterThan(0)
+    expect(DEFAULT_COMPLETENESS_SETTINGS.rankingWeights.incompleteRelationship).toBeGreaterThan(0)
+    expect(DEFAULT_COMPLETENESS_SETTINGS.rankingWeights.unpublished).toBeGreaterThan(0)
+  })
+})
+
+describe('isVisibleToAudience', () => {
+  it('returns enabled for authenticated audience on legacy rows (no visibility split)', () => {
+    expect(isVisibleToAudience(
+      { enabled: true, narrative: null, suppressBelowPercent: 0 },
+      'authenticated',
+    )).toBe(true)
+    expect(isVisibleToAudience(
+      { enabled: false, narrative: null, suppressBelowPercent: 0 },
+      'authenticated',
+    )).toBe(false)
+  })
+
+  it('public is always false on legacy rows (never inherits from enabled)', () => {
+    expect(isVisibleToAudience(
+      { enabled: true, narrative: null, suppressBelowPercent: 0 },
+      'public',
+    )).toBe(false)
+  })
+
+  it('honors authenticatedVisibility over enabled when both present', () => {
+    expect(isVisibleToAudience(
+      { enabled: true, narrative: null, suppressBelowPercent: 0, authenticatedVisibility: false },
+      'authenticated',
+    )).toBe(false)
+    expect(isVisibleToAudience(
+      { enabled: false, narrative: null, suppressBelowPercent: 0, authenticatedVisibility: true },
+      'authenticated',
+    )).toBe(true)
+  })
+
+  it('public visibility is independent of authenticated visibility at the helper level', () => {
+    // The helper itself returns whatever the field says — the UI / save action
+    // are responsible for the "public requires authenticated" coupling.
+    expect(isVisibleToAudience(
+      { enabled: false, narrative: null, suppressBelowPercent: 0, publicVisibility: true },
+      'public',
+    )).toBe(true)
+  })
+})
+
+describe('getConfidenceSummary audience parameter', () => {
+  it('returns shouldShow=false when public visibility is off', async () => {
+    await db.update(organizations)
+      .set({
+        confidenceSettings: {
+          enabled: true,
+          narrative: null,
+          suppressBelowPercent: 0,
+          authenticatedVisibility: true,
+          publicVisibility: false,
+        },
+      })
+      .where(eq(organizations.id, org.id))
+
+    const auth = await getConfidenceSummary(org.id, 'authenticated')
+    const pub = await getConfidenceSummary(org.id, 'public')
+    expect(auth.shouldShow).toBe(true) // org has 0 content; suppressBelowPercent=0 → shouldShow=true
+    expect(pub.shouldShow).toBe(false)
+  })
+
+  it('returns shouldShow=true for public when both flags are on', async () => {
+    await db.update(organizations)
+      .set({
+        confidenceSettings: {
+          enabled: true,
+          narrative: null,
+          suppressBelowPercent: 0,
+          authenticatedVisibility: true,
+          publicVisibility: true,
+        },
+      })
+      .where(eq(organizations.id, org.id))
+
+    const pub = await getConfidenceSummary(org.id, 'public')
+    expect(pub.shouldShow).toBe(true)
+  })
+
+  it('legacy enabled=true row remains visible to authenticated callers', async () => {
+    await db.update(organizations)
+      .set({
+        confidenceSettings: {
+          enabled: true,
+          narrative: null,
+          suppressBelowPercent: 0,
+          // No authenticatedVisibility / publicVisibility — legacy row shape
+        },
+      })
+      .where(eq(organizations.id, org.id))
+
+    const auth = await getConfidenceSummary(org.id, 'authenticated')
+    expect(auth.shouldShow).toBe(true)
+
+    const pub = await getConfidenceSummary(org.id, 'public')
+    expect(pub.shouldShow).toBe(false) // legacy row never implicitly grants public access
+  })
+
+  it('default audience is authenticated', async () => {
+    await db.update(organizations)
+      .set({
+        confidenceSettings: {
+          enabled: true,
+          narrative: null,
+          suppressBelowPercent: 0,
+          authenticatedVisibility: true,
+          publicVisibility: false,
+        },
+      })
+      .where(eq(organizations.id, org.id))
+
+    const defaultCall = await getConfidenceSummary(org.id)
+    const explicitAuth = await getConfidenceSummary(org.id, 'authenticated')
+    expect(defaultCall.shouldShow).toBe(explicitAuth.shouldShow)
+  })
+})


### PR DESCRIPTION
## Summary

PR-2 of the four-PR slice plan in [#380](https://github.com/roballred/GovEA/issues/380#issuecomment-4412881773). Tracks against [#449](https://github.com/roballred/GovEA/issues/449).

Introduces the configurable settings layer that PR-3's drill-downs and RAG indicators consume. Replaces the hardcoded `REVIEW_WINDOW_DAYS = 90` constant in the admin dashboard with org-level settings. Splits the single `confidenceSettings.enabled` flag into `authenticatedVisibility` and `publicVisibility` so PR-4 can ship public-facing surfaces safely.

## Schema

- **New** `org.completenessSettings` JSONB: `{ stalenessDays, domainTargets, rankingWeights }`. `DEFAULT_COMPLETENESS_SETTINGS` exported for callers. `domainTargets` and `rankingWeights` are stored now to avoid a follow-up migration in PR-3; PR-2 only wires `stalenessDays` into a live consumer.
- **Extended** `ConfidenceSettings` with optional `authenticatedVisibility` and `publicVisibility`. Legacy rows (only `enabled` set) continue to work: authenticated audience falls back to `enabled`; public audience never inherits from `enabled` and must be set explicitly.

## Behavior

- **Admin dashboard's Review Health** section reads `stalenessDays` from the org's settings, falling back to `DEFAULT_COMPLETENESS_SETTINGS` (90 days). The hardcoded constant is gone.
- **`getConfidenceSummary(orgId, audience?)`** takes an optional audience parameter (`'authenticated'` | `'public'`, defaults to `'authenticated'`). The visibility flag is resolved by a new `isVisibleToAudience` helper.
- **Public visibility is gated** client-side on authenticated visibility being on (defensive UX). Server enforces field validation only.

## UI

New **Repository Completeness** settings section with a staleness window selector (3 / 6 / 12 / 24 months). The **Repository Confidence** form replaces the single "enabled" toggle with two toggles (authenticated / public); the public toggle is disabled while authenticated is off.

## Server actions

- `updateCompletenessSettings` — admin-gated, transactional, audit-logged. Validates `stalenessDays` range and per-domain target percentages (0–100).
- `updateConfidenceSettings` — extended to round-trip the new visibility fields. Still writes `enabled` for back-compat.

## Tests

11 new integration tests in [completeness-settings.test.ts](apps/govea/tests/integration/completeness-settings.test.ts):

- `DEFAULT_COMPLETENESS_SETTINGS` preserves the prior 90-day staleness behavior
- `isVisibleToAudience` legacy fallback (no `authenticatedVisibility` → uses `enabled`)
- Public never inherits from `enabled` (legacy `enabled=true` does not implicitly grant public access)
- `getConfidenceSummary` audience parameter cases (auth on/pub off, both on, default audience)

**Full suite: 27 files, 420 tests pass.**

## Browser verification (Riverdale Admin)

- ✅ `/dashboard` renders `REVIEW HEALTH (90-day window)` before save
- ✅ `/settings` shows new Completeness section + split visibility toggles
- ✅ Public toggle is disabled while authenticated is off
- ✅ Save flow: enabled authenticated visibility, set 6-month staleness → DB row holds correct nested JSON, dashboard updates to `REVIEW HEALTH (180-day window)`
- ✅ No console errors, no server errors

## Rollout notes

- **No environment changes required.** This PR does not touch `COMPLETENESS_SNAPSHOT_ENABLED` from PR-1.
- Existing orgs without a `completeness_settings` row keep their current behavior — `stalenessDays` defaults to 90.
- Existing orgs with `confidenceSettings.enabled = true` continue to see the confidence summary on the admin dashboard. Public visibility stays off until an admin explicitly opts in.

## Out of scope (deferred to PR-3 / PR-4)

- Drill-down views, ranked-action list, RAG indicators consuming `domainTargets` / `rankingWeights`
- Stakeholder-facing surfaces beyond the admin dashboard
- Auto-suppression notifications

## Test plan

- [x] `pnpm --filter govea exec vitest run tests/integration/completeness-settings.test.ts` — 11/11 pass
- [x] `pnpm --filter govea exec vitest run` — 420/420 pass
- [x] `pnpm --filter govea lint` — 0 errors (18 pre-existing warnings)
- [x] `pnpm --filter govea exec tsc --noEmit` — clean
- [x] `pnpm --filter govea db:push` — applies cleanly
- [x] Browser smoke: dashboard + settings page render, save round-trips through DB
- [ ] CI green on integration + build

Refs #380
Closes #449