### PR TITLE
fix(dx): repoint .claude/launch.json at main repo (#451)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "govea-dev",
       "runtimeExecutable": "/opt/homebrew/bin/pnpm",
-      "runtimeArgs": ["-C", "/Users/roballred/Repos/Claude/govea-app/.claude/worktrees/wonderful-chebyshev-9223d0", "--filter", "govea", "dev"],
+      "runtimeArgs": ["-C", "/Users/roballred/Repos/Claude/govea-app", "--filter", "govea", "dev"],
       "port": 3000,
       "autoPort": false
     }


### PR DESCRIPTION
## Summary

The committed \`runtimeArgs\` path \`.claude/worktrees/wonderful-chebyshev-9223d0\` no longer exists, so a fresh \`preview_start\` against the \`govea-dev\` config fails:

\`\`\`
ENOENT: no such file or directory, lstat '/Users/roballred/Repos/Claude/govea-app/.claude/worktrees/wonderful-chebyshev-9223d0'
\`\`\`

Repoints at the main repo path so a clean checkout works out of the box.

## Note for worktree users

The project convention (per the worktree memory note in repo instructions) is that anyone running dev from a worktree should locally edit \`.claude/launch.json\` to point at their worktree. This PR just makes the committed default a path that exists.

## Test plan

- [x] Verified the dev server starts cleanly via \`preview_start govea-dev\` after the change
- [ ] CI green

Closes #451