### PR TITLE
feat(repository): completeness drill-downs + ranked actions + RAG (PR-3 of #380)

### DIFF
--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -14,7 +14,21 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { CoverageTileLabel } from './coverage-tile-label'
 import { DomainBadge } from '@/components/domain-badge'
 import { ConfidenceSummary } from '@/components/confidence-summary'
+import { canEdit } from '@/lib/rbac'
+import {
+  getCategorizedSignals,
+  getMostNeededActions,
+  getDomainRagBuckets,
+  type RagBucket,
+} from '@/lib/completeness-signals'
 import Link from 'next/link'
+
+const RAG_TEXT_CLASS: Record<RagBucket, string> = {
+  green:   'text-green-700 dark:text-green-400',
+  amber:   'text-amber-600 dark:text-amber-400',
+  red:     'text-red-600 dark:text-red-400',
+  neutral: 'text-foreground',
+}
 
 function pivotCounts(rows: { status: string; count: number | string }[]) {
   const byStatus: Record<string, number> = {}
@@ -148,9 +162,23 @@ export default async function DashboardPage() {
     { label: 'Personas',     href: '/personas',     total: Number(personaTotal[0].count), modified: Number(personaModified[0].count), reviewed: Number(personaReviewed[0].count) },
   ]
 
-  const needsAttention = COVERAGE_ENTITIES
-    .map(e => ({ ...e, draftCount: stats[e.key].byStatus[e.draftKey] ?? 0 }))
-    .filter(e => e.draftCount > 0)
+  // PR-3: completeness drill-down counts, top-5 ranked actions, per-domain RAG.
+  // Most-Needed Actions is gated to Admin/Contributor per `rm-repository-completeness`.
+  const showRanked = canEdit(session.user)
+  const [signals, mostNeeded, domainRag] = await Promise.all([
+    getCategorizedSignals(orgId),
+    showRanked ? getMostNeededActions(orgId) : Promise.resolve([]),
+    getDomainRagBuckets(orgId),
+  ])
+  const ragByDomain = new Map<string, RagBucket>(
+    domainRag.map(r => [r.domain || '__uncategorized__', r.bucket]),
+  )
+  const targetByDomain = new Map<string, number | null>(
+    domainRag.map(r => [r.domain || '__uncategorized__', r.target]),
+  )
+  const publishedPctByDomain = new Map<string, number>(
+    domainRag.map(r => [r.domain || '__uncategorized__', r.publishedPct]),
+  )
 
   // Resolve target entity names for inbound pending links
   const fedCapIds = fedInboundLinks.filter(l => l.targetEntityType === 'capability').map(l => l.targetEntityId)
@@ -324,26 +352,38 @@ export default async function DashboardPage() {
         </Card>
       </div>
 
-      {/* Capabilities by Domain */}
+      {/* Capabilities by Domain — RAG-colored vs domainTargets */}
       {capsByDomain.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">Capabilities by Domain</p>
           <Card>
             <CardContent className="pt-4 pb-4">
               <div className="flex flex-wrap gap-3">
-                {capsByDomain.map(row => (
-                  <Link
-                    key={row.domain ?? '__none__'}
-                    href={`/capabilities${row.domain ? `?domain=${encodeURIComponent(row.domain)}` : ''}`}
-                    className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2 hover:bg-muted/50 transition-colors"
-                  >
-                    {row.domain
-                      ? <DomainBadge domain={row.domain} />
-                      : <span className="text-xs text-muted-foreground">Uncategorized</span>
-                    }
-                    <span className="text-sm font-semibold">{Number(row.count)}</span>
-                  </Link>
-                ))}
+                {capsByDomain.map(row => {
+                  const key = row.domain ?? '__uncategorized__'
+                  const bucket = ragByDomain.get(key) ?? 'neutral'
+                  const target = targetByDomain.get(key) ?? null
+                  const publishedPct = publishedPctByDomain.get(key) ?? 0
+                  return (
+                    <Link
+                      key={row.domain ?? '__none__'}
+                      href={`/capabilities${row.domain ? `?domain=${encodeURIComponent(row.domain)}` : ''}`}
+                      className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2 hover:bg-muted/50 transition-colors"
+                      title={target != null ? `${publishedPct}% published vs ${target}% target` : undefined}
+                    >
+                      {row.domain
+                        ? <DomainBadge domain={row.domain} />
+                        : <span className="text-xs text-muted-foreground">Uncategorized</span>
+                      }
+                      <span className={`text-sm font-semibold ${RAG_TEXT_CLASS[bucket]}`}>{Number(row.count)}</span>
+                      {target != null && (
+                        <span className={`text-xs ${RAG_TEXT_CLASS[bucket]}`}>
+                          {publishedPct}/{target}%
+                        </span>
+                      )}
+                    </Link>
+                  )
+                })}
               </div>
             </CardContent>
           </Card>
@@ -351,26 +391,65 @@ export default async function DashboardPage() {
       )}
 
       <div className="grid gap-6 md:grid-cols-2">
-        {/* Needs Attention */}
+        {/* Needs Attention — categorized drill-down */}
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-base">Needs Attention</CardTitle>
           </CardHeader>
           <CardContent>
-            {needsAttention.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No drafts — all content is published.</p>
+            {(signals.stale + signals.unpublished + signals.incompleteRelationships) === 0 ? (
+              <p className="text-sm text-muted-foreground">Repository is current — nothing to flag.</p>
             ) : (
               <ul className="space-y-2">
-                {needsAttention.map(e => (
-                  <li key={e.key} className="flex items-center justify-between text-sm">
-                    <Link href={e.href} className="hover:underline">{e.label}</Link>
-                    <span className="font-medium text-amber-600">{e.draftCount} draft</span>
-                  </li>
-                ))}
+                <li className="flex items-center justify-between text-sm">
+                  <span>
+                    Stale <span className="text-xs text-muted-foreground">(past staleness window)</span>
+                  </span>
+                  <span className={`font-medium ${signals.stale > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                    {signals.stale}
+                  </span>
+                </li>
+                <li className="flex items-center justify-between text-sm">
+                  <span>Unpublished <span className="text-xs text-muted-foreground">(drafts)</span></span>
+                  <span className={`font-medium ${signals.unpublished > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                    {signals.unpublished}
+                  </span>
+                </li>
+                <li className="flex items-center justify-between text-sm">
+                  <span>
+                    Incomplete relationships <span className="text-xs text-muted-foreground">(capability ↔ application / persona)</span>
+                  </span>
+                  <span className={`font-medium ${signals.incompleteRelationships > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                    {signals.incompleteRelationships}
+                  </span>
+                </li>
               </ul>
             )}
           </CardContent>
         </Card>
+
+        {/* Most-Needed Actions — top 5 ranked items, Admin/Contributor only */}
+        {showRanked && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Most-Needed Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {mostNeeded.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Nothing pressing — everything is current.</p>
+              ) : (
+                <ol className="space-y-2">
+                  {mostNeeded.map(action => (
+                    <li key={action.key} className="text-sm">
+                      <Link href={action.href} className="font-medium hover:underline">{action.name}</Link>
+                      <p className="text-xs text-muted-foreground mt-0.5">{action.detail}</p>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         {/* Initiative breakdown */}
         <Card>

--- a/apps/govea/src/lib/completeness-signals.ts
+++ b/apps/govea/src/lib/completeness-signals.ts
@@ -1,0 +1,335 @@
+/**
+ * Completeness signals for the admin dashboard (#380 PR-3).
+ *
+ * Three independent surfaces:
+ *   - getCategorizedSignals(orgId) → counts for the Stale / Unpublished /
+ *     Incomplete-relationship drill-down tile
+ *   - getMostNeededActions(orgId) → top-5 specific items ranked by a
+ *     weighted heuristic (publishedButStale > incompleteRelationship >
+ *     unpublished). Deterministic tie-break by entity-type alpha then
+ *     by name.
+ *   - getDomainRagBuckets(orgId) → for each capability domain, the
+ *     published-rate vs the org-configured target, bucketed
+ *     green/amber/red/neutral.
+ *
+ * All three respect PR-2's `org.completenessSettings`. Per ADR
+ * `rm-query-performance-decision.md`, these are bounded queries (not
+ * unbounded joins) and degrade gracefully when settings are absent.
+ */
+import { db } from '@/db/client'
+import {
+  capabilities, applications, personas, valueStreams,
+  strategicObjectives, principles, glossaryTerms, initiatives, adrs,
+  applicationCapabilities, capabilityPersonas,
+  organizations,
+  DEFAULT_COMPLETENESS_SETTINGS,
+  type CompletenessSettings,
+} from '@/db/schema'
+import { and, count, eq, lt, notInArray, sql } from 'drizzle-orm'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface CategorizedSignals {
+  stale: number
+  unpublished: number
+  incompleteRelationships: number
+}
+
+export type MostNeededReason = 'publishedButStale' | 'incompleteRelationship' | 'unpublished'
+
+export interface MostNeededAction {
+  /** Stable key used for React list rendering. */
+  key: string
+  entityType: 'capability' | 'application' | 'persona'
+  entityId: string
+  name: string
+  reason: MostNeededReason
+  /** Reason expressed as one short, plain-language sentence. */
+  detail: string
+  /** Rank score — higher = more impactful. Public for tests. */
+  score: number
+  href: string
+}
+
+export type RagBucket = 'green' | 'amber' | 'red' | 'neutral'
+
+export interface DomainRag {
+  domain: string
+  publishedPct: number
+  target: number | null
+  bucket: RagBucket
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function loadSettings(orgId: string): Promise<CompletenessSettings> {
+  const row = await db.query.organizations.findFirst({
+    where: eq(organizations.id, orgId),
+    columns: { completenessSettings: true },
+  })
+  return row?.completenessSettings ?? DEFAULT_COMPLETENESS_SETTINGS
+}
+
+function staleCutoff(settings: CompletenessSettings): Date {
+  return new Date(Date.now() - settings.stalenessDays * 24 * 60 * 60 * 1000)
+}
+
+// ── Categorized drill-down counts ────────────────────────────────────────────
+
+/**
+ * Counts for the dashboard's three-category drill-down tile.
+ *
+ * - Stale: published items whose `updated_at` is older than the staleness window
+ * - Unpublished: items in `draft` (or `proposed` for ADRs/initiatives)
+ * - Incomplete relationships: capabilities with no application link OR no persona link
+ *   (the most consequential case; broader coverage in a follow-up)
+ */
+export async function getCategorizedSignals(orgId: string): Promise<CategorizedSignals> {
+  const settings = await loadSettings(orgId)
+  const cutoff = staleCutoff(settings)
+
+  // Stale: published items past the window across the nine content types.
+  // Each query is org-scoped and uses the indexes added in PR-1.
+  const stalePublished = (table: typeof capabilities | typeof applications | typeof personas | typeof valueStreams | typeof strategicObjectives | typeof principles | typeof glossaryTerms) =>
+    db.select({ c: count() }).from(table).where(and(
+      eq(table.organizationId, orgId),
+      eq(table.status, 'published'),
+      lt(table.updatedAt, cutoff),
+    ))
+
+  const [
+    capStale, appStale, persStale, vsStale, objStale, prinStale, glossStale,
+    capDraft, appDraft, persDraft, vsDraft, objDraft, prinDraft, glossDraft,
+    initProposed, adrProposed,
+    initStale, adrStale,
+    capNoApp, capNoPersona,
+  ] = await Promise.all([
+    stalePublished(capabilities),
+    stalePublished(applications),
+    stalePublished(personas),
+    stalePublished(valueStreams),
+    stalePublished(strategicObjectives),
+    stalePublished(principles),
+    stalePublished(glossaryTerms),
+    db.select({ c: count() }).from(capabilities).where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'draft'))),
+    db.select({ c: count() }).from(applications).where(and(eq(applications.organizationId, orgId), eq(applications.status, 'draft'))),
+    db.select({ c: count() }).from(personas).where(and(eq(personas.organizationId, orgId), eq(personas.status, 'draft'))),
+    db.select({ c: count() }).from(valueStreams).where(and(eq(valueStreams.organizationId, orgId), eq(valueStreams.status, 'draft'))),
+    db.select({ c: count() }).from(strategicObjectives).where(and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.status, 'draft'))),
+    db.select({ c: count() }).from(principles).where(and(eq(principles.organizationId, orgId), eq(principles.status, 'draft'))),
+    db.select({ c: count() }).from(glossaryTerms).where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.status, 'draft'))),
+    db.select({ c: count() }).from(initiatives).where(and(eq(initiatives.organizationId, orgId), eq(initiatives.status, 'proposed'))),
+    db.select({ c: count() }).from(adrs).where(and(eq(adrs.organizationId, orgId), eq(adrs.status, 'proposed'))),
+    db.select({ c: count() }).from(initiatives).where(and(eq(initiatives.organizationId, orgId), eq(initiatives.status, 'active'), lt(initiatives.updatedAt, cutoff))),
+    db.select({ c: count() }).from(adrs).where(and(eq(adrs.organizationId, orgId), eq(adrs.status, 'accepted'), lt(adrs.updatedAt, cutoff))),
+    // Capabilities with no application link
+    db.select({ c: count() }).from(capabilities)
+      .where(and(
+        eq(capabilities.organizationId, orgId),
+        eq(capabilities.status, 'published'),
+        notInArray(
+          capabilities.id,
+          db.select({ id: applicationCapabilities.capabilityId }).from(applicationCapabilities),
+        ),
+      )),
+    // Capabilities with no persona link
+    db.select({ c: count() }).from(capabilities)
+      .where(and(
+        eq(capabilities.organizationId, orgId),
+        eq(capabilities.status, 'published'),
+        notInArray(
+          capabilities.id,
+          db.select({ id: capabilityPersonas.capabilityId }).from(capabilityPersonas),
+        ),
+      )),
+  ])
+
+  const stale = Number(capStale[0].c) + Number(appStale[0].c) + Number(persStale[0].c)
+    + Number(vsStale[0].c) + Number(objStale[0].c) + Number(prinStale[0].c)
+    + Number(glossStale[0].c) + Number(initStale[0].c) + Number(adrStale[0].c)
+
+  const unpublished = Number(capDraft[0].c) + Number(appDraft[0].c) + Number(persDraft[0].c)
+    + Number(vsDraft[0].c) + Number(objDraft[0].c) + Number(prinDraft[0].c)
+    + Number(glossDraft[0].c) + Number(initProposed[0].c) + Number(adrProposed[0].c)
+
+  // A single capability missing both links contributes twice; this overcounts by
+  // intent — operationally it's still one "incomplete cap" that needs two fixes.
+  // Underlying drill-down list (out of scope here) shows distinct items.
+  const incompleteRelationships = Number(capNoApp[0].c) + Number(capNoPersona[0].c)
+
+  return { stale, unpublished, incompleteRelationships }
+}
+
+// ── Most-Needed Actions (top 5 ranked) ───────────────────────────────────────
+
+interface CandidateRow {
+  entityType: MostNeededAction['entityType']
+  entityId: string
+  name: string
+  reason: MostNeededReason
+}
+
+/**
+ * Top-5 specific items ranked by weighted contribution. Per
+ * `rm-repository-completeness.md`, this list is shown only to Contributors
+ * and Admins — caller is responsible for that gate.
+ *
+ * Heuristic:
+ *   - publishedButStale: weight × 1 per item
+ *   - incompleteRelationship: weight × 1 per item
+ *   - unpublished: weight × 1 per item
+ *
+ * Tie-break: alpha by entityType, then alpha by name. Deterministic for tests.
+ */
+export async function getMostNeededActions(orgId: string): Promise<MostNeededAction[]> {
+  const settings = await loadSettings(orgId)
+  const cutoff = staleCutoff(settings)
+  const w = settings.rankingWeights
+
+  // We scope to capabilities, applications, personas. These three drive most
+  // of the EA value and also have href patterns the dashboard already links.
+  const [
+    capsStale, appsStale, personasStale,
+    capsDraft, appsDraft, personasDraft,
+    capsNoApp, capsNoPersona,
+  ] = await Promise.all([
+    db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities)
+      .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'published'), lt(capabilities.updatedAt, cutoff))),
+    db.select({ id: applications.id, name: applications.name }).from(applications)
+      .where(and(eq(applications.organizationId, orgId), eq(applications.status, 'published'), lt(applications.updatedAt, cutoff))),
+    db.select({ id: personas.id, name: personas.name }).from(personas)
+      .where(and(eq(personas.organizationId, orgId), eq(personas.status, 'published'), lt(personas.updatedAt, cutoff))),
+    db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities)
+      .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'draft'))),
+    db.select({ id: applications.id, name: applications.name }).from(applications)
+      .where(and(eq(applications.organizationId, orgId), eq(applications.status, 'draft'))),
+    db.select({ id: personas.id, name: personas.name }).from(personas)
+      .where(and(eq(personas.organizationId, orgId), eq(personas.status, 'draft'))),
+    db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities)
+      .where(and(
+        eq(capabilities.organizationId, orgId),
+        eq(capabilities.status, 'published'),
+        notInArray(capabilities.id, db.select({ id: applicationCapabilities.capabilityId }).from(applicationCapabilities)),
+      )),
+    db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities)
+      .where(and(
+        eq(capabilities.organizationId, orgId),
+        eq(capabilities.status, 'published'),
+        notInArray(capabilities.id, db.select({ id: capabilityPersonas.capabilityId }).from(capabilityPersonas)),
+      )),
+  ])
+
+  const tag = (
+    rows: { id: string; name: string }[],
+    entityType: MostNeededAction['entityType'],
+    reason: MostNeededReason,
+  ): CandidateRow[] => rows.map(r => ({ entityType, entityId: r.id, name: r.name, reason }))
+
+  const candidates: CandidateRow[] = [
+    ...tag(capsStale,      'capability',  'publishedButStale'),
+    ...tag(appsStale,      'application', 'publishedButStale'),
+    ...tag(personasStale,  'persona',     'publishedButStale'),
+    ...tag(capsNoApp,      'capability',  'incompleteRelationship'),
+    ...tag(capsNoPersona,  'capability',  'incompleteRelationship'),
+    ...tag(capsDraft,      'capability',  'unpublished'),
+    ...tag(appsDraft,      'application', 'unpublished'),
+    ...tag(personasDraft,  'persona',     'unpublished'),
+  ]
+
+  // Score + dedupe (a capability can appear in multiple buckets; keep the
+  // highest-weight reason for that item)
+  const byEntity = new Map<string, MostNeededAction>()
+  for (const c of candidates) {
+    const score = scoreFor(c.reason, w)
+    const key = `${c.entityType}:${c.entityId}`
+    const existing = byEntity.get(key)
+    if (!existing || score > existing.score) {
+      byEntity.set(key, {
+        key,
+        entityType: c.entityType,
+        entityId: c.entityId,
+        name: c.name,
+        reason: c.reason,
+        detail: detailFor(c.reason, settings),
+        score,
+        href: hrefFor(c.entityType, c.entityId),
+      })
+    }
+  }
+
+  // Sort: score desc, then entityType alpha, then name alpha (deterministic)
+  const sorted = [...byEntity.values()].sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score
+    if (a.entityType !== b.entityType) return a.entityType.localeCompare(b.entityType)
+    return a.name.localeCompare(b.name)
+  })
+
+  return sorted.slice(0, 5)
+}
+
+function scoreFor(reason: MostNeededReason, w: CompletenessSettings['rankingWeights']): number {
+  switch (reason) {
+    case 'publishedButStale':       return w.publishedButStale
+    case 'incompleteRelationship':  return w.incompleteRelationship
+    case 'unpublished':             return w.unpublished
+  }
+}
+
+function detailFor(reason: MostNeededReason, settings: CompletenessSettings): string {
+  switch (reason) {
+    case 'publishedButStale':       return `Published but not updated in ${settings.stalenessDays} days`
+    case 'incompleteRelationship':  return 'Published but missing required relationship'
+    case 'unpublished':             return 'Still in draft'
+  }
+}
+
+function hrefFor(entityType: MostNeededAction['entityType'], id: string): string {
+  switch (entityType) {
+    case 'capability':  return `/capabilities/${id}`
+    case 'application': return `/applications/${id}`
+    case 'persona':     return `/personas/${id}`
+  }
+}
+
+// ── RAG buckets per capability domain ────────────────────────────────────────
+
+/**
+ * Per-domain published-rate bucketed against `domainTargets` from settings.
+ * Returns one row per existing domain (including null/uncategorized).
+ *
+ * Bucketing per `rm-repository-completeness.md`:
+ *   green  ≥ target
+ *   amber  within 15 points below target
+ *   red    >15 below target
+ *   neutral if no target is set for the domain
+ */
+export async function getDomainRagBuckets(orgId: string): Promise<DomainRag[]> {
+  const settings = await loadSettings(orgId)
+
+  const rows = await db.select({
+    domain: capabilities.domain,
+    total: count(),
+    published: sql<number>`count(*) filter (where ${capabilities.status} = 'published')`,
+  })
+    .from(capabilities)
+    .where(eq(capabilities.organizationId, orgId))
+    .groupBy(capabilities.domain)
+
+  return rows.map(r => {
+    const total = Number(r.total)
+    const published = Number(r.published)
+    const publishedPct = total === 0 ? 0 : Math.round((published / total) * 100)
+    const domainKey = r.domain ?? '__uncategorized__'
+    const target = settings.domainTargets[domainKey] ?? null
+
+    let bucket: RagBucket = 'neutral'
+    if (target != null) {
+      if (publishedPct >= target) bucket = 'green'
+      else if (target - publishedPct <= 15) bucket = 'amber'
+      else bucket = 'red'
+    }
+
+    return { domain: r.domain ?? '', publishedPct, target, bucket }
+  })
+}
+

--- a/apps/govea/tests/integration/completeness-signals.test.ts
+++ b/apps/govea/tests/integration/completeness-signals.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Completeness signals (#380 PR-3).
+ *
+ * Asserts:
+ *   - getCategorizedSignals returns counts that match what we seeded for
+ *     stale / unpublished / incomplete-relationship cases.
+ *   - getMostNeededActions:
+ *       - returns at most 5 items
+ *       - is deterministic given identical inputs
+ *       - applies the publishedButStale > incompleteRelationship > unpublished
+ *         priority via rankingWeights from settings
+ *       - dedupes a single entity that hits multiple buckets to its highest
+ *         scoring reason
+ *   - getDomainRagBuckets buckets per `domainTargets` correctly
+ *     (green ≥ target, amber within 15 below, red >15 below, neutral if no
+ *     target).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  capabilities, applications, personas,
+  applicationCapabilities, capabilityPersonas,
+  organizations,
+  DEFAULT_COMPLETENESS_SETTINGS,
+} from '@/db/schema'
+import {
+  getCategorizedSignals,
+  getMostNeededActions,
+  getDomainRagBuckets,
+} from '@/lib/completeness-signals'
+import { createTestOrg, cleanupOrg, type TestOrg } from './helpers/db'
+
+const STALE_DAYS = 90
+const PAST_STALE = new Date(Date.now() - (STALE_DAYS + 5) * 24 * 60 * 60 * 1000)
+
+let org: TestOrg
+
+beforeAll(async () => {
+  org = await createTestOrg({ name: 'Signals Org', slug: `sig-${randomUUID().slice(0, 8)}` })
+  await db.update(organizations)
+    .set({ completenessSettings: DEFAULT_COMPLETENESS_SETTINGS })
+    .where(eq(organizations.id, org.id))
+})
+
+afterAll(async () => {
+  await cleanupOrg(org.id)
+})
+
+beforeEach(async () => {
+  // Clean slate inside the org between tests
+  await db.delete(applicationCapabilities)
+  await db.delete(capabilityPersonas)
+  await db.delete(capabilities).where(eq(capabilities.organizationId, org.id))
+  await db.delete(applications).where(eq(applications.organizationId, org.id))
+  await db.delete(personas).where(eq(personas.organizationId, org.id))
+})
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function insertCap(name: string, opts: {
+  status?: 'draft' | 'published' | 'archived'
+  domain?: string
+  updatedAt?: Date
+} = {}) {
+  const id = randomUUID()
+  await db.insert(capabilities).values({
+    id,
+    organizationId: org.id,
+    name,
+    domain: opts.domain ?? null,
+    status: opts.status ?? 'published',
+    visibility: 'org',
+    updatedAt: opts.updatedAt ?? new Date(),
+  })
+  return id
+}
+
+async function insertApp(name: string, opts: { status?: 'draft' | 'published'; updatedAt?: Date } = {}) {
+  const id = randomUUID()
+  await db.insert(applications).values({
+    id,
+    organizationId: org.id,
+    name,
+    status: opts.status ?? 'published',
+    visibility: 'org',
+    updatedAt: opts.updatedAt ?? new Date(),
+  })
+  return id
+}
+
+async function insertPersona(name: string, opts: { status?: 'draft' | 'published'; updatedAt?: Date } = {}) {
+  const id = randomUUID()
+  await db.insert(personas).values({
+    id,
+    organizationId: org.id,
+    name,
+    status: opts.status ?? 'published',
+    visibility: 'org',
+    updatedAt: opts.updatedAt ?? new Date(),
+  })
+  return id
+}
+
+// ── getCategorizedSignals ────────────────────────────────────────────────────
+
+describe('getCategorizedSignals', () => {
+  it('counts stale published items past the staleness window', async () => {
+    await insertCap('Fresh', { updatedAt: new Date() })
+    await insertCap('Stale-1', { updatedAt: PAST_STALE })
+    await insertCap('Stale-2', { updatedAt: PAST_STALE })
+    await insertApp('Stale-App', { updatedAt: PAST_STALE })
+
+    const signals = await getCategorizedSignals(org.id)
+    expect(signals.stale).toBe(3)
+  })
+
+  it('counts unpublished drafts', async () => {
+    await insertCap('Draft-Cap', { status: 'draft' })
+    await insertCap('Published-Cap', { status: 'published' })
+    await insertApp('Draft-App', { status: 'draft' })
+    await insertPersona('Draft-Persona', { status: 'draft' })
+
+    const signals = await getCategorizedSignals(org.id)
+    expect(signals.unpublished).toBe(3)
+  })
+
+  it('counts capabilities with missing application or persona links', async () => {
+    const cap1 = await insertCap('Cap-Linked')
+    const cap2 = await insertCap('Cap-NoApp')      // missing app link
+    const cap3 = await insertCap('Cap-NoPersona')  // missing persona link
+    const _cap4 = await insertCap('Cap-NeitherLink') // missing both
+    const app = await insertApp('App-1')
+    const persona = await insertPersona('Persona-1')
+
+    // Cap1: linked to both
+    await db.insert(applicationCapabilities).values({ applicationId: app, capabilityId: cap1 })
+    await db.insert(capabilityPersonas).values({ capabilityId: cap1, personaId: persona })
+    // Cap2: only persona
+    await db.insert(capabilityPersonas).values({ capabilityId: cap2, personaId: persona })
+    // Cap3: only app
+    await db.insert(applicationCapabilities).values({ applicationId: app, capabilityId: cap3 })
+    // Cap4: no links
+
+    const signals = await getCategorizedSignals(org.id)
+    // Cap2 contributes via the no-app side; Cap3 via the no-persona side;
+    // Cap4 contributes to both. Total = 1 (no-app: Cap2 + Cap4 = 2) + (no-persona: Cap3 + Cap4 = 2) = 4
+    expect(signals.incompleteRelationships).toBe(4)
+  })
+
+  it('returns zeros for an empty org', async () => {
+    const signals = await getCategorizedSignals(org.id)
+    expect(signals).toEqual({ stale: 0, unpublished: 0, incompleteRelationships: 0 })
+  })
+})
+
+// ── getMostNeededActions ─────────────────────────────────────────────────────
+
+describe('getMostNeededActions', () => {
+  it('returns at most 5 items', async () => {
+    for (let i = 0; i < 10; i++) {
+      await insertCap(`Stale-${i}`, { updatedAt: PAST_STALE })
+    }
+    const actions = await getMostNeededActions(org.id)
+    expect(actions.length).toBe(5)
+  })
+
+  it('is deterministic for identical inputs', async () => {
+    await insertCap('A', { status: 'draft' })
+    await insertCap('B', { status: 'draft' })
+    await insertCap('C', { updatedAt: PAST_STALE })
+
+    const a = await getMostNeededActions(org.id)
+    const b = await getMostNeededActions(org.id)
+    expect(a.map(x => x.key)).toEqual(b.map(x => x.key))
+  })
+
+  it('ranks publishedButStale (weight 3) above unpublished (weight 1)', async () => {
+    await insertCap('Z-Stale', { updatedAt: PAST_STALE })
+    await insertCap('A-Draft', { status: 'draft' })
+
+    const actions = await getMostNeededActions(org.id)
+    expect(actions[0].name).toBe('Z-Stale')
+    expect(actions[0].reason).toBe('publishedButStale')
+    expect(actions[1].name).toBe('A-Draft')
+    expect(actions[1].reason).toBe('unpublished')
+  })
+
+  it('ranks incompleteRelationship (weight 2) above unpublished (weight 1)', async () => {
+    const cap = await insertCap('Z-NoLinks') // published but no links → incomplete
+    await insertCap('A-Draft', { status: 'draft' })
+
+    const actions = await getMostNeededActions(org.id)
+    // Z-NoLinks has the higher score
+    expect(actions[0].entityId).toBe(cap)
+    expect(actions[0].reason).toBe('incompleteRelationship')
+  })
+
+  it('dedupes one item to its highest-scoring reason', async () => {
+    // A capability that is BOTH published-but-stale AND missing relationships
+    // — should only appear once, with the higher-scoring reason
+    await insertCap('Multi', { updatedAt: PAST_STALE }) // published, no links
+    const actions = await getMostNeededActions(org.id)
+    const multiActions = actions.filter(a => a.name === 'Multi')
+    expect(multiActions).toHaveLength(1)
+    expect(multiActions[0].reason).toBe('publishedButStale') // weight 3 > weight 2
+  })
+
+  it('sorts ties alphabetically by entityType then name', async () => {
+    // Two stale items with the same score, different entityTypes
+    await insertCap('Z-Cap', { updatedAt: PAST_STALE })
+    await insertApp('A-App', { updatedAt: PAST_STALE })
+
+    const actions = await getMostNeededActions(org.id)
+    // application < capability alphabetically, so A-App ranks first on tie
+    expect(actions[0].entityType).toBe('application')
+    expect(actions[1].entityType).toBe('capability')
+  })
+})
+
+// ── getDomainRagBuckets ──────────────────────────────────────────────────────
+
+describe('getDomainRagBuckets', () => {
+  beforeEach(async () => {
+    // Set domain targets: 'cms' = 60, 'ea' = 80, 'finance' has no target
+    await db.update(organizations)
+      .set({
+        completenessSettings: {
+          ...DEFAULT_COMPLETENESS_SETTINGS,
+          domainTargets: { cms: 60, ea: 80 },
+        },
+      })
+      .where(eq(organizations.id, org.id))
+  })
+
+  it('green when published-rate ≥ target', async () => {
+    await insertCap('A', { domain: 'cms', status: 'published' })
+    await insertCap('B', { domain: 'cms', status: 'published' })
+    await insertCap('C', { domain: 'cms', status: 'draft' })
+    // 2/3 ≈ 67% ≥ 60 → green
+
+    const buckets = await getDomainRagBuckets(org.id)
+    const cms = buckets.find(b => b.domain === 'cms')
+    expect(cms?.bucket).toBe('green')
+    expect(cms?.publishedPct).toBe(67)
+  })
+
+  it('amber when within 15 points below target', async () => {
+    await insertCap('A', { domain: 'ea', status: 'published' })
+    await insertCap('B', { domain: 'ea', status: 'published' })
+    await insertCap('C', { domain: 'ea', status: 'draft' })
+    // 2/3 ≈ 67%; target 80 → 13 below → amber
+
+    const buckets = await getDomainRagBuckets(org.id)
+    expect(buckets.find(b => b.domain === 'ea')?.bucket).toBe('amber')
+  })
+
+  it('red when more than 15 points below target', async () => {
+    await insertCap('A', { domain: 'ea', status: 'draft' })
+    await insertCap('B', { domain: 'ea', status: 'draft' })
+    await insertCap('C', { domain: 'ea', status: 'draft' })
+    // 0/3 = 0%; target 80 → 80 below → red
+
+    const buckets = await getDomainRagBuckets(org.id)
+    expect(buckets.find(b => b.domain === 'ea')?.bucket).toBe('red')
+  })
+
+  it('neutral when no target is set for the domain', async () => {
+    await insertCap('A', { domain: 'finance', status: 'published' })
+    const buckets = await getDomainRagBuckets(org.id)
+    expect(buckets.find(b => b.domain === 'finance')?.bucket).toBe('neutral')
+  })
+})


### PR DESCRIPTION
## Summary

PR-3 of the four-PR slice plan in [#380](https://github.com/roballred/GovEA/issues/380#issuecomment-4412881773). Tracks against [#453](https://github.com/roballred/GovEA/issues/453).

The headline UX move — makes the dashboard's existing signals **categorized and actionable**. Three independent surfaces, all wired through one new library ([\`lib/completeness-signals.ts\`](apps/govea/src/lib/completeness-signals.ts)).

## Three new surfaces

### 1. Categorized "Needs Attention" tile

Replaces the existing draft-only list with three labeled categories:
- **Stale** — published items past the org's \`stalenessDays\` window (PR-2 settings)
- **Unpublished** — drafts (any of the nine EA content types)
- **Incomplete relationships** — capabilities with no application or no persona link (the most consequential case)

Counts only — drill-through filtered list pages are deferred.

### 2. Most-Needed Actions tile

Top-5 specific items ranked by a deterministic heuristic using PR-2's \`rankingWeights\`:

\`\`\`
publishedButStale (3) > incompleteRelationship (2) > unpublished (1)
\`\`\`

One item appears once even if it hits multiple buckets — kept at its highest-scoring reason. Deterministic tie-break: score desc, then entityType alpha, then name alpha.

Per [\`rm-repository-completeness.md\`](business-architecture/capabilities/ea/repository-modelling/rm-repository-completeness.md), gated to **Admin / Contributor** (Viewer-role users don't see this tile).

### 3. Capabilities by Domain RAG indicators

Each domain badge is colored vs the org's \`domainTargets\`:
- **green** ≥ target
- **amber** within 15 below target
- **red** >15 below target
- **neutral** if no target is set for the domain

Hover tooltip shows "X% published vs Y% target". Existing per-domain link behavior is unchanged.

## Tests

14 new integration tests in [completeness-signals.test.ts](apps/govea/tests/integration/completeness-signals.test.ts):

- Drill-down count correctness for each bucket (stale, unpublished, incomplete)
- Ranked actions: 5-item cap; determinism; weight ordering; per-entity dedupe to highest-scoring reason; alpha tie-break
- RAG bucketing across all four colors

**Full suite: 28 files, 434 tests pass.**

## Browser verification (Riverdale Admin, dev seed)

| Check | Result |
|---|---|
| \`/dashboard\` renders three drill-down rows in Needs Attention | ✅ (Stale 0, Unpublished 11, Incomplete relationships 22) |
| Most-Needed Actions tile shows 5 ranked items with reason labels | ✅ |
| Capabilities by Domain — green when over target | ✅ (Community Development 100/60%) |
| Capabilities by Domain — amber within 15 below | ✅ (Information Technology 86/95%) |
| Capabilities by Domain — neutral when no target | ✅ |
| Console errors / server errors | ✅ none |

Screenshot of the live dashboard with Riverdale data and a few injected domain targets is in the commit message context.

## Out of scope (deferred)

- **Filtered list pages** (\`?filter=stale\` etc) — would touch every entity list page; defer until usage data shows it's worth it
- **Wire ranked-action signals into the unified priority signal summary** referenced in \`rm-repository-completeness.md\` — the architecture-debt capability that owns that signal is not yet built (#381)
- **Stakeholder-facing surfaces beyond admin dashboard** — PR-4
- **Trend-line, auto-suppression notifications** — PR-4

## Rollout notes

- **No environment changes.** Doesn't touch \`COMPLETENESS_SNAPSHOT_ENABLED\` from PR-1.
- Orgs with no \`completeness_settings\` row keep working — \`stalenessDays\` defaults to 90, all domains render neutral (no targets configured).
- The \`canEdit\` (Admin / Contributor) gate on Most-Needed Actions means Viewer-role users keep their current dashboard shape; no need to re-design that view separately.

## Test plan

- [x] \`pnpm --filter govea exec vitest run tests/integration/completeness-signals.test.ts\` — 14/14 pass
- [x] \`pnpm --filter govea exec vitest run\` — 434/434 pass
- [x] \`pnpm --filter govea lint\` — 0 errors (18 pre-existing warnings, unchanged)
- [x] \`pnpm --filter govea exec tsc --noEmit\` — clean
- [x] Browser smoke: dashboard renders + RAG colors update with live target changes
- [ ] CI green on integration + build

Refs #380
Closes #453