### PR TITLE
feat(repository): debt dashboard signal + publish-time gate (PR-3 of #381)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -10,6 +10,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { redirect } from 'next/navigation'
 
 async function requireContributor() {
@@ -162,6 +163,16 @@ export async function editADR(id: string, formData: FormData) {
 
   const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
 
+  // Publish-time debt gate (#381 PR-3). For ADRs, "publish" = accepted.
+  const transitioningToAccepted = before?.status !== 'accepted' && status === 'accepted'
+  const acknowledgeOpenDebt = formData.get('acknowledgeOpenDebt') === 'on'
+  const debtAck = await ensurePublishOpenDebtAck({
+    entityType: 'adr',
+    entityId: id,
+    transitioningToPublished: transitioningToAccepted,
+    acknowledged: acknowledgeOpenDebt,
+  })
+
   await db.transaction(async (tx) => {
     await tx.update(adrs).set({
       number,
@@ -193,6 +204,21 @@ export async function editADR(id: string, formData: FormData) {
       before: { number: before?.number, title: before?.title, status: before?.status },
       after: { number, title, status, visibility },
     })
+
+    if (debtAck.acknowledged) {
+      await writeAuditLog(tx, {
+        action: 'publish.acknowledged_open_debt',
+        entityType: 'adr',
+        entityId: id,
+        userId: session.user.id,
+        organizationId: orgId,
+        metadata: {
+          criticalCount: debtAck.criticalCount,
+          highCount: debtAck.highCount,
+          publishedAt: new Date().toISOString(),
+        },
+      })
+    }
   })
 }
 

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -7,6 +7,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from '@/lib/entity-taxonomy-helpers'
@@ -183,6 +184,16 @@ export async function editApplication(applicationId: string, formData: FormData)
   const fieldDefs = await getCustomFieldSchema(orgId, 'application')
   const customData = extractCustomData(formData, fieldDefs.map(f => f.name))
 
+  // Publish-time debt gate (#381 PR-3)
+  const transitioningToPublished = before?.status !== 'published' && status === 'published'
+  const acknowledgeOpenDebt = formData.get('acknowledgeOpenDebt') === 'on'
+  const debtAck = await ensurePublishOpenDebtAck({
+    entityType: 'application',
+    entityId: applicationId,
+    transitioningToPublished,
+    acknowledged: acknowledgeOpenDebt,
+  })
+
   await db.transaction(async (tx) => {
     await tx.update(applications).set({
       name,
@@ -216,6 +227,21 @@ export async function editApplication(applicationId: string, formData: FormData)
       before: { name: before?.name, status: before?.status, visibility: before?.visibility },
       after: { name, vendor, lifecycleStatus, status, visibility, capabilityIds },
     })
+
+    if (debtAck.acknowledged) {
+      await writeAuditLog(tx, {
+        action: 'publish.acknowledged_open_debt',
+        entityType: 'application',
+        entityId: applicationId,
+        userId: session.user.id,
+        organizationId: orgId,
+        metadata: {
+          criticalCount: debtAck.criticalCount,
+          highCount: debtAck.highCount,
+          publishedAt: new Date().toISOString(),
+        },
+      })
+    }
   })
 }
 

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -8,6 +8,7 @@ import { assertEntityInOrg, assertOwnership, canReadFederatedEntity, getConnecte
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
@@ -233,6 +234,17 @@ export async function editCapability(capabilityId: string, formData: FormData) {
     await assertEntityInOrg('capability', parentId, orgId)
   }
 
+  // Publish-time debt gate (#381 PR-3): when transitioning to 'published'
+  // with linked critical/high open debt, require explicit ack from the form.
+  const transitioningToPublished = before?.status !== 'published' && status === 'published'
+  const acknowledgeOpenDebt = formData.get('acknowledgeOpenDebt') === 'on'
+  const debtAck = await ensurePublishOpenDebtAck({
+    entityType: 'capability',
+    entityId: capabilityId,
+    transitioningToPublished,
+    acknowledged: acknowledgeOpenDebt,
+  })
+
   // Mutation + audit + cross-org-link flag/clear are all in one transaction
   // so a failure anywhere rolls back the entire edit (#416).
   await db.transaction(async (tx) => {
@@ -274,6 +286,22 @@ export async function editCapability(capabilityId: string, formData: FormData) {
       before: { name: before?.name, status: before?.status, visibility: before?.visibility },
       after: { name, description, domain, capabilityType, status, visibility, personaIds, parentId },
     })
+
+    // #381 PR-3: when the publish-debt gate was acknowledged, log it.
+    if (debtAck.acknowledged) {
+      await writeAuditLog(tx, {
+        action: 'publish.acknowledged_open_debt',
+        entityType: 'capability',
+        entityId: capabilityId,
+        userId: session.user.id,
+        organizationId: orgId,
+        metadata: {
+          criticalCount: debtAck.criticalCount,
+          highCount: debtAck.highCount,
+          publishedAt: new Date().toISOString(),
+        },
+      })
+    }
 
     // Flag or clear cross-org links when visibility changes.
     const prevVis = before?.visibility

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -101,9 +101,24 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
   async function handleEdit(formData: FormData) {
     if (!editTarget) return
     startTransition(async () => {
-      await editADR(editTarget.id, formData)
-      setEditTarget(null)
-      refresh()
+      try {
+        await editADR(editTarget.id, formData)
+        setEditTarget(null)
+        refresh()
+      } catch (err) {
+        // #381 PR-3 publish-time debt gate: confirm + re-submit with ack.
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('Publishing requires acknowledgment')) {
+          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nAccept anyway? Your acknowledgment will be logged in the audit trail.')) {
+            formData.set('acknowledgeOpenDebt', 'on')
+            await editADR(editTarget.id, formData)
+            setEditTarget(null)
+            refresh()
+            return
+          }
+        }
+        throw err
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -323,9 +323,24 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
   async function handleEdit(formData: FormData) {
     if (!editTarget) return
     startTransition(async () => {
-      await editApplication(editTarget.id, formData)
-      setEditTarget(null)
-      refresh()
+      try {
+        await editApplication(editTarget.id, formData)
+        setEditTarget(null)
+        refresh()
+      } catch (err) {
+        // #381 PR-3 publish-time debt gate: confirm + re-submit with ack.
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('Publishing requires acknowledgment')) {
+          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
+            formData.set('acknowledgeOpenDebt', 'on')
+            await editApplication(editTarget.id, formData)
+            setEditTarget(null)
+            refresh()
+            return
+          }
+        }
+        throw err
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -136,9 +136,26 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
   async function handleEdit(formData: FormData) {
     if (!editTarget) return
     startTransition(async () => {
-      await editCapability(editTarget.id, formData)
-      setEditTarget(null)
-      refresh()
+      try {
+        await editCapability(editTarget.id, formData)
+        setEditTarget(null)
+        refresh()
+      } catch (err) {
+        // #381 PR-3 publish-time debt gate: explicit confirmation flow.
+        // Server throws when transitioning to published with linked critical/high
+        // open debt and no ack. We prompt the user, then re-submit with the ack.
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('Publishing requires acknowledgment')) {
+          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
+            formData.set('acknowledgeOpenDebt', 'on')
+            await editCapability(editTarget.id, formData)
+            setEditTarget(null)
+            refresh()
+            return
+          }
+        }
+        throw err
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -397,7 +397,7 @@ export default async function DashboardPage() {
             <CardTitle className="text-base">Needs Attention</CardTitle>
           </CardHeader>
           <CardContent>
-            {(signals.stale + signals.unpublished + signals.incompleteRelationships) === 0 ? (
+            {(signals.stale + signals.unpublished + signals.incompleteRelationships + signals.openDebt) === 0 ? (
               <p className="text-sm text-muted-foreground">Repository is current — nothing to flag.</p>
             ) : (
               <ul className="space-y-2">
@@ -421,6 +421,14 @@ export default async function DashboardPage() {
                   </span>
                   <span className={`font-medium ${signals.incompleteRelationships > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
                     {signals.incompleteRelationships}
+                  </span>
+                </li>
+                <li className="flex items-center justify-between text-sm">
+                  <Link href="/debt" className="hover:underline">
+                    Open debt <span className="text-xs text-muted-foreground">(draft / published / in-progress)</span>
+                  </Link>
+                  <span className={`font-medium ${signals.openDebt > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                    {signals.openDebt}
                   </span>
                 </li>
               </ul>

--- a/apps/govea/src/lib/completeness-signals.ts
+++ b/apps/govea/src/lib/completeness-signals.ts
@@ -22,10 +22,11 @@ import {
   strategicObjectives, principles, glossaryTerms, initiatives, adrs,
   applicationCapabilities, capabilityPersonas,
   organizations,
+  architectureDebtItems,
   DEFAULT_COMPLETENESS_SETTINGS,
   type CompletenessSettings,
 } from '@/db/schema'
-import { and, count, eq, lt, notInArray, sql } from 'drizzle-orm'
+import { and, count, eq, inArray, lt, notInArray, sql } from 'drizzle-orm'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -33,14 +34,16 @@ export interface CategorizedSignals {
   stale: number
   unpublished: number
   incompleteRelationships: number
+  /** Open debt items (status in draft/published/in-progress). Added in #381 PR-3. */
+  openDebt: number
 }
 
-export type MostNeededReason = 'publishedButStale' | 'incompleteRelationship' | 'unpublished'
+export type MostNeededReason = 'publishedButStale' | 'incompleteRelationship' | 'unpublished' | 'openCriticalDebt' | 'openHighDebt'
 
 export interface MostNeededAction {
   /** Stable key used for React list rendering. */
   key: string
-  entityType: 'capability' | 'application' | 'persona'
+  entityType: 'capability' | 'application' | 'persona' | 'architecture_debt_item'
   entityId: string
   name: string
   reason: MostNeededReason
@@ -144,6 +147,13 @@ export async function getCategorizedSignals(orgId: string): Promise<CategorizedS
       )),
   ])
 
+  // Open debt — counted separately because it joins a different schema family.
+  // "Open" matches the spec's working definition: draft / published / in-progress.
+  const openDebtRows = await db.select({ c: count() }).from(architectureDebtItems).where(and(
+    eq(architectureDebtItems.organizationId, orgId),
+    inArray(architectureDebtItems.status, ['draft', 'published', 'in-progress']),
+  ))
+
   const stale = Number(capStale[0].c) + Number(appStale[0].c) + Number(persStale[0].c)
     + Number(vsStale[0].c) + Number(objStale[0].c) + Number(prinStale[0].c)
     + Number(glossStale[0].c) + Number(initStale[0].c) + Number(adrStale[0].c)
@@ -157,7 +167,9 @@ export async function getCategorizedSignals(orgId: string): Promise<CategorizedS
   // Underlying drill-down list (out of scope here) shows distinct items.
   const incompleteRelationships = Number(capNoApp[0].c) + Number(capNoPersona[0].c)
 
-  return { stale, unpublished, incompleteRelationships }
+  const openDebt = Number(openDebtRows[0].c)
+
+  return { stale, unpublished, incompleteRelationships, openDebt }
 }
 
 // ── Most-Needed Actions (top 5 ranked) ───────────────────────────────────────
@@ -188,10 +200,14 @@ export async function getMostNeededActions(orgId: string): Promise<MostNeededAct
 
   // We scope to capabilities, applications, personas. These three drive most
   // of the EA value and also have href patterns the dashboard already links.
+  // Open debt is added alongside in #381 PR-3 — critical and high debt items
+  // outrank everything else by design (immediate operational/security risk
+  // per `rm-architecture-debt.md`).
   const [
     capsStale, appsStale, personasStale,
     capsDraft, appsDraft, personasDraft,
     capsNoApp, capsNoPersona,
+    criticalDebt, highDebt,
   ] = await Promise.all([
     db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities)
       .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.status, 'published'), lt(capabilities.updatedAt, cutoff))),
@@ -217,6 +233,21 @@ export async function getMostNeededActions(orgId: string): Promise<MostNeededAct
         eq(capabilities.status, 'published'),
         notInArray(capabilities.id, db.select({ id: capabilityPersonas.capabilityId }).from(capabilityPersonas)),
       )),
+    // Open critical and high debt — surfaced as ranked actions in their own right.
+    // Excludes security-sensitive items at the read layer so the Most-Needed Actions
+    // tile is safe for Contributor+ (caller is responsible for the role gate).
+    db.select({ id: architectureDebtItems.id, name: architectureDebtItems.title }).from(architectureDebtItems)
+      .where(and(
+        eq(architectureDebtItems.organizationId, orgId),
+        eq(architectureDebtItems.severity, 'critical'),
+        inArray(architectureDebtItems.status, ['draft', 'published', 'in-progress']),
+      )),
+    db.select({ id: architectureDebtItems.id, name: architectureDebtItems.title }).from(architectureDebtItems)
+      .where(and(
+        eq(architectureDebtItems.organizationId, orgId),
+        eq(architectureDebtItems.severity, 'high'),
+        inArray(architectureDebtItems.status, ['draft', 'published', 'in-progress']),
+      )),
   ])
 
   const tag = (
@@ -226,6 +257,8 @@ export async function getMostNeededActions(orgId: string): Promise<MostNeededAct
   ): CandidateRow[] => rows.map(r => ({ entityType, entityId: r.id, name: r.name, reason }))
 
   const candidates: CandidateRow[] = [
+    ...tag(criticalDebt,   'architecture_debt_item', 'openCriticalDebt'),
+    ...tag(highDebt,       'architecture_debt_item', 'openHighDebt'),
     ...tag(capsStale,      'capability',  'publishedButStale'),
     ...tag(appsStale,      'application', 'publishedButStale'),
     ...tag(personasStale,  'persona',     'publishedButStale'),
@@ -267,8 +300,15 @@ export async function getMostNeededActions(orgId: string): Promise<MostNeededAct
   return sorted.slice(0, 5)
 }
 
+// Debt items outrank the original three buckets by design. Critical = immediate
+// operational/security risk per `rm-architecture-debt.md` severity tiers.
+const DEBT_CRITICAL_WEIGHT = 5
+const DEBT_HIGH_WEIGHT = 4
+
 function scoreFor(reason: MostNeededReason, w: CompletenessSettings['rankingWeights']): number {
   switch (reason) {
+    case 'openCriticalDebt':        return DEBT_CRITICAL_WEIGHT
+    case 'openHighDebt':            return DEBT_HIGH_WEIGHT
     case 'publishedButStale':       return w.publishedButStale
     case 'incompleteRelationship':  return w.incompleteRelationship
     case 'unpublished':             return w.unpublished
@@ -277,6 +317,8 @@ function scoreFor(reason: MostNeededReason, w: CompletenessSettings['rankingWeig
 
 function detailFor(reason: MostNeededReason, settings: CompletenessSettings): string {
   switch (reason) {
+    case 'openCriticalDebt':        return 'Open critical-severity debt'
+    case 'openHighDebt':            return 'Open high-severity debt'
     case 'publishedButStale':       return `Published but not updated in ${settings.stalenessDays} days`
     case 'incompleteRelationship':  return 'Published but missing required relationship'
     case 'unpublished':             return 'Still in draft'
@@ -285,9 +327,10 @@ function detailFor(reason: MostNeededReason, settings: CompletenessSettings): st
 
 function hrefFor(entityType: MostNeededAction['entityType'], id: string): string {
   switch (entityType) {
-    case 'capability':  return `/capabilities/${id}`
-    case 'application': return `/applications/${id}`
-    case 'persona':     return `/personas/${id}`
+    case 'capability':              return `/capabilities/${id}`
+    case 'application':             return `/applications/${id}`
+    case 'persona':                 return `/personas/${id}`
+    case 'architecture_debt_item':  return `/debt/${id}`
   }
 }
 

--- a/apps/govea/src/lib/debt-publish-gate.ts
+++ b/apps/govea/src/lib/debt-publish-gate.ts
@@ -1,0 +1,125 @@
+/**
+ * Publish-time debt gate (#381 PR-3).
+ *
+ * Per `rm-architecture-debt.md` §Rules:
+ *   "When a user attempts to publish an architecture object that has one or
+ *    more linked `critical` or `high` severity debt items in `open` status,
+ *    the system must display a warning and require explicit acknowledgment
+ *    before publishing proceeds — the publish action is not blocked, but
+ *    the acknowledgment is mandatory and logged in the audit trail."
+ *
+ * Used by capability, application, and ADR edit actions. The form submits
+ * `acknowledgeOpenDebt` when the user has explicitly confirmed the warning.
+ * If the gate fires and the ack is missing, the action throws a specific
+ * error class that the form catches and uses to prompt the user.
+ */
+import { db } from '@/db/client'
+import {
+  architectureDebtItems,
+  debtApplications, debtCapabilities, debtAdrs,
+  type DebtSeverity,
+} from '@/db/schema'
+import { and, eq, inArray } from 'drizzle-orm'
+
+export type GatedEntityType = 'application' | 'capability' | 'adr'
+
+const OPEN_STATUSES = ['draft', 'published', 'in-progress'] as const
+const GATING_SEVERITIES: DebtSeverity[] = ['critical', 'high']
+
+/**
+ * Error thrown when a publish attempt needs explicit acknowledgment of
+ * linked critical/high open debt. Callers (server actions) should let this
+ * propagate; the client form catches it, shows the ack dialog, and resubmits
+ * with `acknowledgeOpenDebt=on`.
+ */
+export class OpenDebtAcknowledgmentRequiredError extends Error {
+  readonly code = 'OPEN_DEBT_ACK_REQUIRED'
+  readonly criticalCount: number
+  readonly highCount: number
+
+  constructor(criticalCount: number, highCount: number) {
+    super(
+      `Publishing requires acknowledgment of ${criticalCount} critical and ${highCount} high-severity open debt items linked to this object.`,
+    )
+    this.criticalCount = criticalCount
+    this.highCount = highCount
+  }
+}
+
+/**
+ * Returns counts of open critical/high debt linked to a given entity.
+ * Used by the publish gate and by audit-log payloads.
+ */
+export async function countGatingDebt(
+  entityType: GatedEntityType,
+  entityId: string,
+): Promise<{ criticalCount: number; highCount: number }> {
+  const linkedDebtIds = await readLinkedDebtIds(entityType, entityId)
+  if (linkedDebtIds.length === 0) return { criticalCount: 0, highCount: 0 }
+
+  const rows = await db
+    .select({ severity: architectureDebtItems.severity })
+    .from(architectureDebtItems)
+    .where(and(
+      inArray(architectureDebtItems.id, linkedDebtIds),
+      inArray(architectureDebtItems.severity, GATING_SEVERITIES),
+      inArray(architectureDebtItems.status, [...OPEN_STATUSES]),
+    ))
+
+  let criticalCount = 0
+  let highCount = 0
+  for (const r of rows) {
+    if (r.severity === 'critical') criticalCount++
+    else if (r.severity === 'high') highCount++
+  }
+  return { criticalCount, highCount }
+}
+
+/**
+ * The gate itself. Call from a publish-changing server action with:
+ *   - `transitioningToPublished`: true when the edit moves the entity from a
+ *     non-published state into a published one. Re-publishes (already-published
+ *     edits) do not trigger the gate.
+ *   - `acknowledged`: true when the form sent `acknowledgeOpenDebt=on`.
+ *
+ * Throws `OpenDebtAcknowledgmentRequiredError` when the gate fires and the
+ * ack is missing. When ack IS present, returns the counts so the caller can
+ * write a `publish.acknowledged_open_debt` audit row.
+ */
+export async function ensurePublishOpenDebtAck({
+  entityType, entityId, transitioningToPublished, acknowledged,
+}: {
+  entityType: GatedEntityType
+  entityId: string
+  transitioningToPublished: boolean
+  acknowledged: boolean
+}): Promise<{ acknowledged: boolean; criticalCount: number; highCount: number }> {
+  if (!transitioningToPublished) {
+    return { acknowledged: false, criticalCount: 0, highCount: 0 }
+  }
+  const { criticalCount, highCount } = await countGatingDebt(entityType, entityId)
+  if (criticalCount === 0 && highCount === 0) {
+    return { acknowledged: false, criticalCount: 0, highCount: 0 }
+  }
+  if (!acknowledged) {
+    throw new OpenDebtAcknowledgmentRequiredError(criticalCount, highCount)
+  }
+  return { acknowledged: true, criticalCount, highCount }
+}
+
+async function readLinkedDebtIds(entityType: GatedEntityType, entityId: string): Promise<string[]> {
+  switch (entityType) {
+    case 'application': {
+      const rows = await db.select({ id: debtApplications.debtItemId }).from(debtApplications).where(eq(debtApplications.applicationId, entityId))
+      return rows.map(r => r.id)
+    }
+    case 'capability': {
+      const rows = await db.select({ id: debtCapabilities.debtItemId }).from(debtCapabilities).where(eq(debtCapabilities.capabilityId, entityId))
+      return rows.map(r => r.id)
+    }
+    case 'adr': {
+      const rows = await db.select({ id: debtAdrs.debtItemId }).from(debtAdrs).where(eq(debtAdrs.adrId, entityId))
+      return rows.map(r => r.id)
+    }
+  }
+}

--- a/apps/govea/tests/integration/completeness-signals.test.ts
+++ b/apps/govea/tests/integration/completeness-signals.test.ts
@@ -151,7 +151,7 @@ describe('getCategorizedSignals', () => {
 
   it('returns zeros for an empty org', async () => {
     const signals = await getCategorizedSignals(org.id)
-    expect(signals).toEqual({ stale: 0, unpublished: 0, incompleteRelationships: 0 })
+    expect(signals).toEqual({ stale: 0, unpublished: 0, incompleteRelationships: 0, openDebt: 0 })
   })
 })
 

--- a/apps/govea/tests/integration/debt-dashboard-signal.test.ts
+++ b/apps/govea/tests/integration/debt-dashboard-signal.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Dashboard debt signal + publish-time gate (#381 PR-3).
+ *
+ * Asserts:
+ *   1. CategorizedSignals.openDebt counts items in draft/published/in-progress
+ *      states, not resolved/accepted/archived.
+ *   2. getMostNeededActions surfaces critical/high open debt items above the
+ *      existing publishedButStale / incompleteRelationship / unpublished
+ *      buckets — and respects deterministic tie-break across categories.
+ *   3. ensurePublishOpenDebtAck:
+ *      - returns early when not transitioning into published
+ *      - returns early when no critical/high open debt is linked
+ *      - throws OpenDebtAcknowledgmentRequiredError when ack is missing
+ *      - returns success counts when ack is present
+ *      - low/medium debt does NOT trigger the gate
+ *      - already-published edits (no transition) do NOT trigger the gate
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  architectureDebtItems, debtCapabilities, debtApplications,
+  capabilities, applications, organizations,
+} from '@/db/schema'
+import { getCategorizedSignals, getMostNeededActions } from '@/lib/completeness-signals'
+import {
+  ensurePublishOpenDebtAck,
+  countGatingDebt,
+  OpenDebtAcknowledgmentRequiredError,
+} from '@/lib/debt-publish-gate'
+import { createTestOrg, createTestUser, cleanupOrg, makeSession, type TestOrg, type TestUser } from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+let orgA: TestOrg
+let adminA: TestUser
+let capId: string
+let appId: string
+
+beforeAll(async () => {
+  orgA = await createTestOrg({ name: 'Debt Dashboard Org', slug: `dd-${randomUUID().slice(0, 8)}` })
+  adminA = await createTestUser(orgA.id, 'admin', { name: 'DD Admin' })
+  capId = randomUUID()
+  appId = randomUUID()
+  await Promise.all([
+    db.insert(capabilities).values({ id: capId, organizationId: orgA.id, name: 'Cap-A', status: 'published', visibility: 'org' }),
+    db.insert(applications).values({ id: appId, organizationId: orgA.id, name: 'App-A', status: 'published', visibility: 'org' }),
+  ])
+})
+
+afterAll(async () => {
+  await cleanupOrg(orgA.id)
+})
+
+beforeEach(async () => {
+  await db.delete(architectureDebtItems).where(eq(architectureDebtItems.organizationId, orgA.id))
+  mockAuth.mockResolvedValue(makeSession(adminA))
+})
+
+async function insertDebt(opts: {
+  title: string
+  severity: 'critical' | 'high' | 'medium' | 'low'
+  status?: 'draft' | 'published' | 'in-progress' | 'resolved' | 'accepted' | 'archived'
+  capabilityId?: string
+  applicationId?: string
+}) {
+  const id = randomUUID()
+  await db.insert(architectureDebtItems).values({
+    id,
+    organizationId: orgA.id,
+    title: opts.title,
+    debtType: 'lifecycle-risk',
+    severity: opts.severity,
+    status: opts.status ?? 'published',
+    visibility: 'org',
+    securitySensitive: false,
+    source: 'human',
+  })
+  if (opts.capabilityId) {
+    await db.insert(debtCapabilities).values({ debtItemId: id, capabilityId: opts.capabilityId })
+  }
+  if (opts.applicationId) {
+    await db.insert(debtApplications).values({ debtItemId: id, applicationId: opts.applicationId })
+  }
+  return id
+}
+
+// ── 1. CategorizedSignals.openDebt ──────────────────────────────────────────
+
+describe('getCategorizedSignals.openDebt', () => {
+  it('counts draft / published / in-progress', async () => {
+    await insertDebt({ title: 'D', severity: 'high', status: 'draft', capabilityId: capId })
+    await insertDebt({ title: 'P', severity: 'high', status: 'published', capabilityId: capId })
+    await insertDebt({ title: 'I', severity: 'medium', status: 'in-progress', capabilityId: capId })
+
+    const signals = await getCategorizedSignals(orgA.id)
+    expect(signals.openDebt).toBe(3)
+  })
+
+  it('excludes resolved / accepted / archived', async () => {
+    await insertDebt({ title: 'R', severity: 'high', status: 'resolved', capabilityId: capId })
+    await insertDebt({ title: 'A', severity: 'medium', status: 'accepted', capabilityId: capId })
+    await insertDebt({ title: 'X', severity: 'low', status: 'archived', capabilityId: capId })
+    await insertDebt({ title: 'OPEN', severity: 'high', status: 'published', capabilityId: capId })
+
+    const signals = await getCategorizedSignals(orgA.id)
+    expect(signals.openDebt).toBe(1)
+  })
+})
+
+// ── 2. getMostNeededActions surfaces critical/high debt above other buckets ─
+
+describe('getMostNeededActions — debt ranking', () => {
+  it('critical debt ranks ABOVE publishedButStale', async () => {
+    // A capability that's stale (3 weight) AND a critical debt (5 weight)
+    const PAST_STALE = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000)
+    await db.update(capabilities).set({ updatedAt: PAST_STALE }).where(eq(capabilities.id, capId))
+    await insertDebt({ title: 'Critical-A', severity: 'critical', status: 'published', capabilityId: capId })
+
+    const actions = await getMostNeededActions(orgA.id)
+    expect(actions[0].reason).toBe('openCriticalDebt')
+    expect(actions[0].name).toBe('Critical-A')
+  })
+
+  it('high debt ranks ABOVE publishedButStale', async () => {
+    const PAST_STALE = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000)
+    await db.update(capabilities).set({ updatedAt: PAST_STALE }).where(eq(capabilities.id, capId))
+    await insertDebt({ title: 'High-A', severity: 'high', status: 'published', capabilityId: capId })
+
+    const actions = await getMostNeededActions(orgA.id)
+    expect(actions[0].reason).toBe('openHighDebt')
+  })
+
+  it('only OPEN debt is ranked — resolved is ignored', async () => {
+    await insertDebt({ title: 'Closed-Crit', severity: 'critical', status: 'resolved', capabilityId: capId })
+
+    const actions = await getMostNeededActions(orgA.id)
+    expect(actions.filter(a => a.entityType === 'architecture_debt_item')).toHaveLength(0)
+  })
+
+  it('href routes to /debt/{id} for ranked debt items', async () => {
+    const id = await insertDebt({ title: 'Crit', severity: 'critical', status: 'published', capabilityId: capId })
+
+    const actions = await getMostNeededActions(orgA.id)
+    expect(actions[0].href).toBe(`/debt/${id}`)
+  })
+
+  it('medium / low debt does NOT promote ahead of other buckets', async () => {
+    // Set up: one publishedButStale capability (weight 3), one medium debt (no rank)
+    const PAST_STALE = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000)
+    await db.update(capabilities).set({ updatedAt: PAST_STALE }).where(eq(capabilities.id, capId))
+    await insertDebt({ title: 'Medium-Debt', severity: 'medium', status: 'published', capabilityId: capId })
+
+    const actions = await getMostNeededActions(orgA.id)
+    // First action should be the capability publishedButStale, not the medium debt
+    expect(actions[0].entityType).not.toBe('architecture_debt_item')
+  })
+})
+
+// ── 3. countGatingDebt + ensurePublishOpenDebtAck ──────────────────────────
+
+describe('countGatingDebt', () => {
+  it('counts critical + high linked open debt, ignoring medium/low and closed', async () => {
+    await insertDebt({ title: 'Crit', severity: 'critical', status: 'published', capabilityId: capId })
+    await insertDebt({ title: 'High', severity: 'high', status: 'draft', capabilityId: capId })
+    await insertDebt({ title: 'Med', severity: 'medium', status: 'published', capabilityId: capId })
+    await insertDebt({ title: 'ResolvedCrit', severity: 'critical', status: 'resolved', capabilityId: capId })
+
+    const { criticalCount, highCount } = await countGatingDebt('capability', capId)
+    expect(criticalCount).toBe(1)
+    expect(highCount).toBe(1)
+  })
+
+  it('returns zero when no open critical/high debt is linked', async () => {
+    const { criticalCount, highCount } = await countGatingDebt('capability', capId)
+    expect(criticalCount).toBe(0)
+    expect(highCount).toBe(0)
+  })
+})
+
+describe('ensurePublishOpenDebtAck', () => {
+  beforeEach(async () => {
+    await insertDebt({ title: 'Crit', severity: 'critical', status: 'published', capabilityId: capId })
+  })
+
+  it('passes through when not transitioning to published', async () => {
+    const result = await ensurePublishOpenDebtAck({
+      entityType: 'capability',
+      entityId: capId,
+      transitioningToPublished: false,
+      acknowledged: false,
+    })
+    expect(result.acknowledged).toBe(false)
+    expect(result.criticalCount).toBe(0)
+    expect(result.highCount).toBe(0)
+  })
+
+  it('passes through when no gating debt is linked', async () => {
+    // Different capability with no debt
+    const otherCap = randomUUID()
+    await db.insert(capabilities).values({ id: otherCap, organizationId: orgA.id, name: 'Other', status: 'published', visibility: 'org' })
+    const result = await ensurePublishOpenDebtAck({
+      entityType: 'capability',
+      entityId: otherCap,
+      transitioningToPublished: true,
+      acknowledged: false,
+    })
+    expect(result.acknowledged).toBe(false)
+    expect(result.criticalCount).toBe(0)
+    expect(result.highCount).toBe(0)
+  })
+
+  it('throws when transitioning to published with gating debt and no ack', async () => {
+    await expect(ensurePublishOpenDebtAck({
+      entityType: 'capability',
+      entityId: capId,
+      transitioningToPublished: true,
+      acknowledged: false,
+    })).rejects.toThrow(OpenDebtAcknowledgmentRequiredError)
+  })
+
+  it('returns success counts when ack is provided', async () => {
+    const result = await ensurePublishOpenDebtAck({
+      entityType: 'capability',
+      entityId: capId,
+      transitioningToPublished: true,
+      acknowledged: true,
+    })
+    expect(result.acknowledged).toBe(true)
+    expect(result.criticalCount).toBe(1)
+    expect(result.highCount).toBe(0)
+  })
+
+  it('the thrown error includes counts so the form can render them', async () => {
+    await insertDebt({ title: 'High-B', severity: 'high', status: 'published', capabilityId: capId })
+    try {
+      await ensurePublishOpenDebtAck({
+        entityType: 'capability',
+        entityId: capId,
+        transitioningToPublished: true,
+        acknowledged: false,
+      })
+      // unreachable
+      expect.fail('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(OpenDebtAcknowledgmentRequiredError)
+      const err = e as OpenDebtAcknowledgmentRequiredError
+      expect(err.criticalCount).toBe(1)
+      expect(err.highCount).toBe(1)
+    }
+  })
+})
+
+// Suppress unused-import lint
+void organizations


### PR DESCRIPTION
## Summary

PR-3 of the four-PR slice plan in [#381](https://github.com/roballred/GovEA/issues/381#issuecomment-4416291792). Tracks against [#462](https://github.com/roballred/GovEA/issues/462).

**Stacked on PR-2 ([#461](https://github.com/roballred/GovEA/pull/461)).** Base is \`feat/381-debt-inline-markers\`. Once PR-1 + PR-2 merge, this PR rebases onto main.

Wires architecture debt into the **dashboard signal** AND gates **publication** of objects with linked critical/high open debt.

## Dashboard signal

- \`CategorizedSignals\` extends with \`openDebt\` count (draft / published / in-progress; excludes resolved/accepted/archived). Renders as a new row in **Needs Attention** alongside Stale / Unpublished / Incomplete relationships, linking to \`/debt\`.
- \`getMostNeededActions\` now surfaces critical and high open debt items above the existing buckets:

| Reason | Weight |
|---|---|
| **openCriticalDebt** | **5** |
| **openHighDebt** | **4** |
| publishedButStale | 3 |
| incompleteRelationship | 2 |
| unpublished | 1 |

Items route to \`/debt/[id]\`. Medium/low debt does NOT promote — they're surfaced via the count + \`/debt\` directly.

## Publish-time gate

Per [\`rm-architecture-debt.md\`](business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md) §Rules:

> "When a user attempts to publish an architecture object that has one or more linked critical or high severity debt items in open status, the system must display a warning and require explicit acknowledgment before publishing proceeds — the publish action is not blocked, but the acknowledgment is mandatory and logged in the audit trail."

Implementation:

- New [\`lib/debt-publish-gate.ts\`](apps/govea/src/lib/debt-publish-gate.ts) with \`countGatingDebt\`, \`ensurePublishOpenDebtAck\`, and \`OpenDebtAcknowledgmentRequiredError\`.
- Wired into \`editCapability\`, \`editApplication\`, \`editADR\`. Gate fires when transitioning into the published state (\`accepted\` for ADRs) with one or more linked critical or high open debt items.
- When the form does not send \`acknowledgeOpenDebt=on\`, the action throws the error class with counts. Form catches the error, prompts the user with \`window.confirm\` showing the count message, and re-submits with the ack on confirmation.
- When the ack is applied, a \`publish.acknowledged_open_debt\` audit row is written alongside the entity's edit audit — preserves accountability per spec.
- **Already-published edits do NOT trigger the gate.** Only the transition triggers.
- **Medium / low debt does NOT trigger.** Only critical and high.

## Tests

14 new integration tests in [\`debt-dashboard-signal.test.ts\`](apps/govea/tests/integration/debt-dashboard-signal.test.ts):

- \`openDebt\` counts draft / published / in-progress, excludes resolved / accepted / archived
- Critical / high debt outranks publishedButStale
- Medium / low does not promote
- Resolved debt is ignored
- Href routes to \`/debt/{id}\`
- \`countGatingDebt\` filters correctly
- Gate passes through on non-transition / no gating debt
- Throws with no ack
- Succeeds with ack
- Thrown error carries counts so the form can render them

Plus a one-line update to the existing zero-state test in \`completeness-signals.test.ts\` for the new field.

**Full suite: 31 files, 473 tests pass.**

## Browser verification

- ✅ Needs Attention tile renders the new "Open debt (draft / published / in-progress) 1" row in amber
- ✅ Most-Needed Actions shows the critical debt item at top with reason "Open critical-severity debt", routing to \`/debt/[id]\`
- ✅ No console or server errors

## Rollout notes

- **No environment changes.** Builds on PR-1's debt schema + PR-2's federation helper.
- The publish gate is purely additive — existing publish flows that don't have linked critical/high debt continue to work unchanged.
- The \`window.confirm\` prompt is a pragmatic v1; a future PR could replace it with a modal dialog if review feedback prefers that.

## Out of scope (PR-4)

- Auto-flagged lifecycle debt (system-detected queue)
- Unified priority signal merging traceability broken-chain — the traceability capability isn't built yet; this PR's dashboard aggregation is the v1

## Test plan

- [x] \`pnpm --filter govea exec vitest run tests/integration/debt-dashboard-signal.test.ts\` — 14/14 pass
- [x] \`pnpm --filter govea exec vitest run\` — 473/473 pass
- [x] \`pnpm --filter govea lint\` — 0 errors (18 pre-existing warnings, unchanged)
- [x] \`pnpm --filter govea exec tsc --noEmit\` — clean
- [x] Browser smoke: Needs Attention + Most-Needed Actions render with seeded critical debt
- [ ] CI green on integration + build
- [ ] **Rebase onto main after PR #459 and #461 merge**

Closes #462
Refs #381