### PR TITLE
docs(process): add risk register for backlog grooming

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Application custom fields with CSV import/export so agencies can extend and load portfolio metadata without schema changes
 - Impact analysis on application and capability detail pages to surface decommission and change consequences from existing relationship data
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
+- Repository completeness workflow foundations: daily snapshot model, configurable staleness windows, ranked cleanup actions, and domain-target RAG indicators on the admin dashboard
 - Demo-ready planning module: goals, strategic objectives, and initiatives with roadmap grid and executive timeline views
 - Goals layer above strategic objectives, with objective rollup and traceability into initiatives and capabilities
 - Reports hub with generated Architecture Vision, Executive Summary, Heatmap Analysis, and TOGAF Application Landscape outputs from existing repository content
@@ -241,19 +242,19 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
 
 **Active work:**
-- Closing open high-severity security findings from the 2026-05-07 static scan (audit trail integrity, break-glass TTL controls, junction cross-tenant writes — see SECURITY.md and the security remediation table in `docs/product-priorities.md`)
-- Adding regression tests to lock in the server-action auth invariants hardened this week
-- Turning early repository signals into fuller completeness and confidence workflows
+- Completing the repository-confidence slice with trend history, stakeholder-facing confidence surfaces, and auto-suppression behavior
 - Maturing ADRs and decision support into stronger architecture-debt and tradeoff visibility
+- Validating assumed stakeholder personas and starting a lightweight feedback loop for analysis surfaces
+- Wiring break-glass to a real cross-tenant operational caller before relying on it in support scenarios
 - Expanding automated test coverage
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Close remaining high-severity security findings (#416, #417, #418) and merge open security PRs (#428, #429)
-- Ship repository completeness drill-downs and a stakeholder-facing confidence summary
+- Merge PR #457 to finish the repository-confidence rollout across `/dashboard`, `/roadmap`, and `/executive`
 - Add architecture debt tracking tied to ADRs, impact analysis, and reporting
-- Start the integration foundation with a REST API plus the first Tier 1 operational sync slice
 - Start lightweight user feedback capture and persona validation for the analysis surfaces
+- Decide v1-vs-future scope for the Data Architecture Metamodel contribution thread
+- Start the integration foundation with a REST API plus the first Tier 1 operational sync slice
 
 **Longer-term:**
 - End-to-end traceability and architecture debt tracking

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,51 +1,55 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-09 (security wave fully closed; regression coverage in flight; feature roadmap unblocked)
+Last groomed: 2026-05-10 (security regression coverage merged; repository-completeness slice 1-3 merged; PR-4 open)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
+Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog item depends on unresolved product-fit, scope, operational, or documentation risks.
+
 ## Current Signal
 
-The 2026-05-07 security scan that surfaced nine high-severity findings is now fully closed. The last three open from yesterday — #416 (transactional audit), #417 (append-only `audit_log`), #418 (break-glass TTL + dual control) — all merged today (PRs #433, #438). The hardening wave is done; the live tenant-data attack surface, the post-mutation integrity surface, and the exception-access surface are all addressed.
+The 2026-05-07 security hardening wave is closed end-to-end. The production fixes merged via PRs #424, #425, #426, #428, #429, #433, and #438, and the two regression-test follow-ups are also merged:
 
-Two follow-up issues opened off #418 — both are explicit deferrals of scope, not new findings:
+- [#421](https://github.com/roballred/GovEA/issues/421) — closed by PR #440
+- [#422](https://github.com/roballred/GovEA/issues/422) — closed by PR #441
 
-- [#436](https://github.com/roballred/GovEA/issues/436) — promote break-glass to gate cross-tenant **reads** (Option 1 promotion of #418's Option 2)
-- [#437](https://github.com/roballred/GovEA/issues/437) — wire cross-tenant **impersonation** through the break-glass gate
+That means security is no longer the immediate planning bottleneck. The bottleneck has shifted back to repository trust and product fit.
 
-A triage pass posted on both today flagged that the `requireBreakGlass(orgId)` enforcement helper they assume *does not yet exist* — only `getActiveBreakGlass(adminId, orgId)` (returns row or undefined). Whichever issue lands first must add the enforcement helper as PR-A. Recommended sequence: helper → #437 (mutation caller, makes #418 a functional control) → operational soak → #436 (read-gating). My read is #436 is post-v1; happy to be overruled.
+The repository-completeness slice in [#380](https://github.com/roballred/GovEA/issues/380) is also no longer merely "planned":
 
-Regression test coverage for the hardening wave is in flight:
+- PR-1 merged: [#448](https://github.com/roballred/GovEA/pull/448) — snapshot foundation + indexes
+- PR-2 merged: [#450](https://github.com/roballred/GovEA/pull/450) — settings model + admin config
+- PR-3 merged: [#454](https://github.com/roballred/GovEA/pull/454) — drill-downs + ranked actions + RAG indicators
+- PR-4 open: [#457](https://github.com/roballred/GovEA/pull/457) — trend line + stakeholder surfaces + auto-suppression, tracking [#455](https://github.com/roballred/GovEA/issues/455)
 
-- [#440](https://github.com/roballred/GovEA/pull/440) — middleware unauth-POST regression test (#421) — re-PR'd against `main` after the original PR landed on a feature branch instead.
-- [#441](https://github.com/roballred/GovEA/pull/441) — read-action tenant-isolation regression test (#422) — locks in the #411–#414 contract that read actions source `organizationId`/`role` from the session, never from caller input. Covers `getUsers`, `getCapabilities`, `getOtherOrganizations`, `getConnections`, `getTaxonomyTerms`.
+Only one PR is currently open in the repo: **#457**. So the highest-leverage next move is to finish that slice cleanly, close #455, and then either close #380 or reduce it to whatever remains after PR-4 merges.
 
-What this means for prioritization:
+Two break-glass follow-up issues remain open from #418:
 
-- Security work is no longer the lead item. The two regression-test PRs (#440, #441) are the last items closing the wave; everything after is feature roadmap.
-- The deferred break-glass extensions (#436, #437) are real but should not block v1. They become important once Option 2 has operational mileage.
-- The feature roadmap below is now genuinely unblocked: repository trust → debt/decision capture → persona validation. None of these have been started in implementation.
-- [#402](https://github.com/roballred/GovEA/issues/402) (configurable platform defaults, deferred from #390) remains the smallest concrete platform-admin task and is a good "one-PR win" candidate between security and the next feature slice.
+- [#437](https://github.com/roballred/GovEA/issues/437) — wire a real cross-tenant mutation/impersonation caller through `requireBreakGlass`
+- [#436](https://github.com/roballred/GovEA/issues/436) — later Option 1 promotion to gate cross-tenant reads
+
+These are not new vulnerabilities, but they do matter for operational credibility. #437 is the earlier one because it gives the new break-glass control an actual caller; #436 is stricter follow-on hardening and reads as post-v1 unless operator experience says otherwise.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Land #440 and #441 — regression coverage for the hardening wave | All nine high-severity findings are fixed in production code; without these tests, a future change that widens the middleware matcher or reintroduces a caller-supplied `organizationId`/`role` parameter will regress silently. Both PRs are open against `main`, tests passing locally (29/29 for #440, 12/12 for #441). | #421, #422 |
-| 2 | Ship repository completeness drill-downs and a plain-language confidence summary | Reporting, heatmaps, impact analysis, and executive summaries now depend on users trusting the underlying repository. v0 (live-query coverage signals + admin-only `ConfidenceSummary` component) is in code; the issue scope adds snapshots, drill-downs, configurable targets, ranked-action list, and stakeholder-facing surfaces. Sliced into 4 PRs in the [issue plan](https://github.com/roballred/GovEA/issues/380#issuecomment-4412881773): snapshot foundation → settings model → drill-downs + ranked actions → trend line + stakeholder surfaces. | `rm-repository-completeness`, `fd-repository-confidence-summary`, [#380](https://github.com/roballred/GovEA/issues/380) |
-| 3 | Add architecture debt tracking and make ADRs a stronger decision-support surface | Impact analysis surfaces consequences, but GovEA still lacks a first-class way to record persistent constraints and tradeoff accumulation. That is the gap between "what is affected" and "what should leadership worry about next." Pairs naturally with #380 PR-3 (the unified priority signal summary referenced in `rm-architecture-debt`). | `rm-architecture-debt`, `po-architecture-decisions`, [#381](https://github.com/roballred/GovEA/issues/381) |
-| 4 | Validate assumed personas and start a lightweight product feedback loop | Repository modelling and integration are still driven by assumed personas. With multi-tenant hardening done and executive-facing surfaces shipped, the cost of building the wrong next analytic feature has gone up. | Persona docs, `docs/research/`, [#103](https://github.com/roballred/GovEA/issues/103), [#384](https://github.com/roballred/GovEA/issues/384) |
-| 5 | Ship #402 — configurable platform operation defaults | Small, well-defined, deferred from #390. Good one-PR win to slot between feature slices when context-switching. Schema impact is minimal. | [#402](https://github.com/roballred/GovEA/issues/402) |
+| 1 | Merge PR #457 and close out the repository-confidence slice | PRs #448, #450, and #454 already landed, so #457 is the last open step in the highest-value current feature stream. It puts the confidence summary onto `/roadmap` and `/executive`, adds the trend line, and finishes the suppression loop. That closes #455 and likely most or all of #380. | [#457](https://github.com/roballred/GovEA/pull/457), [#455](https://github.com/roballred/GovEA/issues/455), [#380](https://github.com/roballred/GovEA/issues/380) |
+| 2 | Start architecture debt tracking and ADR decision support | The product can now show impact and repository quality, but it still cannot record durable constraints, debt severity, or remediation paths. This is the clean next step in the repository-modelling roadmap, and PR-3 already laid groundwork for a future unified priority queue. | `rm-architecture-debt`, `po-architecture-decisions`, [#381](https://github.com/roballred/GovEA/issues/381) |
+| 3 | Run the persona-validation and feedback-capture slice | The riskiest product assumption is now fit, not infrastructure. The research materials already exist in `docs/research/`, and #103's manual feedback log is still unstarted. Before building more stakeholder-facing analytics, validate who actually uses these views and what they trust. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
+| 4 | Give break-glass a real production caller via #437 | #418 shipped the control machinery, but today it is still mostly governance scaffolding. If GovEA expects instance admins to rely on break-glass in real support/debugging scenarios, #437 is the issue that turns it into a functional control. | [#437](https://github.com/roballred/GovEA/issues/437) |
+| 5 | Make the v1-vs-future scope decision on the Data Architecture Metamodel | #363 is active, externally visible, and now has enough discussion to require a product call. The next move is not engineering; it is deciding whether GovEA should absorb conceptual/logical/physical data-model concerns in v1 scope or explicitly defer them. | [#363](https://github.com/roballred/GovEA/issues/363) |
 
 ## Product Manager Notes
 
-- The hardening wave is fully closed. The remaining "security" backlog (#436, #437) is feature work gated on operational experience with #418, not blockers.
-- The break-glass machinery currently has no production caller for mutations — #418 is decorative until #437 (or a smaller "wire requireBreakGlass into one mutation surface" issue) lands. This is fine for v1 *only if* an operator never actually relies on break-glass to control an incident. For real cross-tenant ops, #437 should land before public launch.
-- #380 is the next big feature slice and is genuinely sized — 4 PRs, sub-300 LoC each in product code, with the performance ADR (`rm-query-performance-decision.md`) already accepted. The first PR (snapshot foundation + indexes) has no UI changes and is risk-free to land.
-- [#363](https://github.com/roballred/GovEA/issues/363) (Data Architecture Metamodel) remains in active triage — maintainer questions outstanding. Next move there is a v1-vs-future scope decision, not engineering. Worth a 15-minute pass.
-- The ARB/research issues (90s, 130s, 300s) remain capability-definition work. None blocking the items above.
+- The hardening wave is fully closed, including regression coverage. The remaining security-labeled backlog is productized control work, not emergency remediation.
+- #457 is now the natural "finish what is already 75% shipped" priority. It has the best effort-to-value ratio in the repo because it completes an existing four-PR sequence instead of starting a new stream.
+- #381 is the next major implementation stream after #457. It is the cleanest continuation of the trust story: repository confidence tells users whether to trust the repository; architecture debt tells them what to worry about inside it.
+- #384 and #103 should run as a product-management workstream, not wait until after more analytics are built. The interview guide and assumption register are already good enough to execute.
+- [#402](https://github.com/roballred/GovEA/issues/402) is still a good opportunistic one-PR win, but it no longer belongs in the top five ahead of #437 or #363.
 
-## Security Remediation Status (as of 2026-05-09)
+## Security Remediation Status (as of 2026-05-10)
 
 | Issue | Severity | Status |
 |---|---|---|
@@ -58,7 +62,7 @@ What this means for prioritization:
 | #416 — audit writes not transactional with mutation | High | ✅ Fixed |
 | #417 — `audit_log` has no DB-level append-only constraint | High | ✅ Fixed (PR #433) |
 | #418 — break-glass TTL 24h; no dual control | High | ✅ Fixed (PR #438) |
-| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | 🟡 PR #440 open against main |
-| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | 🟡 PR #441 open against main |
+| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | ✅ Fixed (PR #440) |
+| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | ✅ Fixed (PR #441) |
 | #436 — promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 per triage) |
-| #437 — wire cross-tenant impersonation through break-glass | Medium | Open (pre-v1 per triage) |
+| #437 — wire cross-tenant impersonation through break-glass | Medium | Open (recommended before relying on break-glass operationally) |

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -1,0 +1,118 @@
+# GovEA Risk Register
+
+**Purpose:** Track active product, delivery, operational, and process risks that could materially change what GovEA should build next, how quickly it can ship, or how confidently the team can rely on the current product direction.
+
+This register is intentionally lightweight:
+
+- It captures **active, decision-relevant** risks, not every issue in the backlog.
+- It complements [`docs/product-priorities.md`](./product-priorities.md), which ranks work; this file explains what could go wrong if key assumptions or dependencies do not hold.
+- It complements [`docs/research/stakeholder-assumption-register.md`](./research/stakeholder-assumption-register.md), which is narrower and focused specifically on stakeholder-facing feature assumptions.
+
+## How To Use
+
+- Review during backlog grooming and before starting a major feature slice.
+- Update `Status`, `Mitigation`, and `Last reviewed` when a risk meaningfully changes.
+- Use the optional `Details` section only when the summary row is not enough.
+
+## Scale
+
+- **Impact:** `High`, `Medium`, `Low`
+- **Likelihood:** `High`, `Medium`, `Low`
+- **Status:** `Open`, `Watching`, `Mitigated`, `Closed`
+
+## Summary Table
+
+| ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
+|---|---|---|---|---|---|---|---|---|
+| R-001 | Repository confidence rollout is only partially finished until PR #457 lands | Delivery / Product | High | Medium | Merge PR #457, verify stakeholder surfaces, then close #455 and revisit #380 scope | Product / Engineering | Open | 2026-05-10 |
+| R-002 | GovEA can show impact and quality signals but still cannot track architecture debt as a first-class object | Product | High | High | Start #381 after #457 and keep the first slice tightly scoped to debt model + ADR linkage | Product | Open | 2026-05-10 |
+| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-10 |
+| R-004 | Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice | Operational / Security | High | Medium | Ship #437 before treating break-glass as an operationally credible control | Product / Engineering | Open | 2026-05-10 |
+| R-005 | The Data Architecture Metamodel request could pull v1 scope into a broad adjacent domain without a product boundary decision | Scope | Medium | Medium | Make an explicit v1-vs-future decision on #363 before design or implementation expands | Product | Open | 2026-05-10 |
+| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-10 |
+
+## Risk Details
+
+### R-001 — Repository confidence rollout is only partially finished until PR #457 lands
+
+- **Category:** Delivery / Product
+- **Impact:** High
+- **Likelihood:** Medium
+- **Owner:** Product / Engineering
+- **Status:** Open
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Merge PR #457, verify `/dashboard`, `/roadmap`, and `/executive`, then close #455 and reduce or close #380 based on what remains.
+
+#### Details
+
+PRs #448, #450, and #454 are already merged, which means most of the repository-confidence slice is shipped. The remaining risk is not "whether to start" but "whether the final stakeholder-facing rollout lands cleanly." Until PR #457 merges, the confidence story is still incomplete across the roadmap and executive surfaces, and the suppression/trend behavior is not fully in place.
+
+### R-002 — GovEA can show impact and quality signals but still cannot track architecture debt as a first-class object
+
+- **Category:** Product
+- **Impact:** High
+- **Likelihood:** High
+- **Owner:** Product
+- **Status:** Open
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Start #381 after #457. Keep the first slice small: debt item model, status/severity rules, ADR linkage, and dashboard hooks.
+
+#### Details
+
+This is now the largest product gap in the repository-modelling story. GovEA can surface affected applications and incomplete repository areas, but it still cannot represent durable constraints, known shortcuts, decision drift, or remediation intent. That limits how well the product supports actual prioritization and governance conversations.
+
+### R-003 — Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
+
+- **Category:** Product Fit
+- **Impact:** High
+- **Likelihood:** High
+- **Owner:** Product
+- **Status:** Open
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Execute #384 and start #103 Phase 1 with a manual feedback log tied to recently shipped stakeholder-facing surfaces.
+
+#### Details
+
+The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, and guided-answer surfaces, what formats they trust, and whether they act on freshness/confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
+
+### R-004 — Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice
+
+- **Category:** Operational / Security
+- **Impact:** High
+- **Likelihood:** Medium
+- **Owner:** Product / Engineering
+- **Status:** Open
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Ship #437 before treating break-glass as operationally credible. Defer #436 unless operator experience shows read-gating is immediately required.
+
+#### Details
+
+The hardening work for #418 shipped TTL reduction, dual control, approval flow, and the `requireBreakGlass` helper. The remaining risk is practical rather than theoretical: until GovEA uses that control in a real support/debugging flow, the control is only partially proven. That matters if the platform team expects to rely on break-glass under incident conditions.
+
+### R-005 — The Data Architecture Metamodel request could pull v1 scope into a broad adjacent domain without a product boundary decision
+
+- **Category:** Scope
+- **Impact:** Medium
+- **Likelihood:** Medium
+- **Owner:** Product
+- **Status:** Open
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Decide on #363 whether this is a v1 concern, a post-v1 expansion area, or a separate capability stream with explicit constraints.
+
+#### Details
+
+The request is valid and externally visible, but it reaches beyond the current GovEA center of gravity. Without a firm scope call, the team risks sliding from enterprise architecture repository work into a much larger data-architecture and data-modelling product surface without deliberate sequencing.
+
+### R-006 — Documentation can drift behind shipped repo state during fast-moving backlog turns
+
+- **Category:** Process
+- **Impact:** Medium
+- **Likelihood:** Medium
+- **Owner:** Product
+- **Status:** Watching
+- **Last reviewed:** 2026-05-10
+- **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
+
+#### Details
+
+This risk showed up directly on 2026-05-10: the checked-in priority note still described the completeness work as largely unstarted even though PRs #448, #450, and #454 had already merged and only PR #457 remained open. The consequence is not just cosmetic; stale docs distort prioritization.


### PR DESCRIPTION
Closes #463

## Summary

- add `docs/risk-register.md` as a lightweight active-risk register for backlog grooming
- seed the register with the current active product, delivery, operational, scope, and process risks
- link `docs/product-priorities.md` to the risk register so the two are reviewed together
- refresh `README.md` active/near-term language to reflect the current repo state and the new risk-register workflow

## Why

GovEA had issue tracking and a stakeholder assumption register, but not one place to capture broader active risks that can change sequencing or prioritization. This adds a lightweight register with a compact table plus per-risk detail sections, including optional `Details` subsections where nuance matters.

## Files

- `docs/risk-register.md`
- `docs/product-priorities.md`
- `README.md`

## Test plan

- [x] Read-through review of the new docs for internal consistency
- [ ] Automated tests not run; docs/process change only
