### PR TITLE
feat(repository): inline debt markers + quick-create prefill (PR-2 of #381, relanding)

### DIFF
--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -9,6 +9,7 @@ import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
+import { LinkedDebt } from '@/components/linked-debt'
 import {
   linkAdrCapability, unlinkAdrCapability,
   linkAdrApplication, unlinkAdrApplication,
@@ -138,6 +139,14 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
       </div>
 
       <hr />
+
+      <LinkedDebt
+        entityType="adr"
+        entityId={adr.id}
+        callerOrgId={orgId}
+        role={session.user.role}
+        canEdit={canMutate}
+      />
 
       {isModuleEnabled(enabledModules, 'capabilities') && (
         <RelationshipPanel

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -9,6 +9,7 @@ import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { RelationshipPanel } from '@/components/relationship-panel'
+import { LinkedDebt } from '@/components/linked-debt'
 import {
   linkApplicationCapability, unlinkApplicationCapability,
   linkApplicationInitiative, unlinkApplicationInitiative,
@@ -142,6 +143,14 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
       />
 
       <hr />
+
+      <LinkedDebt
+        entityType="application"
+        entityId={application.id}
+        callerOrgId={orgId}
+        role={session.user.role}
+        canEdit={canMutate}
+      />
 
       {isModuleEnabled(enabledModules, 'capabilities') && (
         <RelationshipPanel

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { DomainBadge } from '@/components/domain-badge'
 import { RelationshipPanel } from '@/components/relationship-panel'
+import { LinkedDebt } from '@/components/linked-debt'
 import {
   linkCapabilityPersona, unlinkCapabilityPersona,
   linkCapabilityApplication, unlinkCapabilityApplication,
@@ -224,6 +225,14 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
       )}
 
       <hr />
+
+      <LinkedDebt
+        entityType="capability"
+        entityId={capability.id}
+        callerOrgId={orgId}
+        role={session.user.role}
+        canEdit={canMutate}
+      />
 
       {isModuleEnabled(enabledModules, 'personas') && (
         <RelationshipPanel

--- a/apps/govea/src/app/(admin)/debt/new/page.tsx
+++ b/apps/govea/src/app/(admin)/debt/new/page.tsx
@@ -9,17 +9,33 @@ import { getADRs } from '@/actions/adrs'
 import { getInitiatives } from '@/actions/initiatives'
 import Link from 'next/link'
 
-export default async function NewDebtPage() {
+interface SearchParams {
+  applicationId?: string
+  capabilityId?: string
+  adrId?: string
+  initiativeId?: string
+}
+
+export default async function NewDebtPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const session = await auth()
   if (!session?.user) redirect('/login')
   if (!canEdit(session.user)) redirect('/debt')
 
+  const params = await searchParams
   const [apps, caps, adrs, inits] = await Promise.all([
     getApplications(),
     getCapabilities(),
     getADRs(),
     getInitiatives(),
   ])
+
+  // Pre-link only when the requested entity exists in the caller's accessible
+  // pickers. Filtering against the picker output also filters out unauthorized
+  // ids (e.g. an org guessing another org's UUID via the URL).
+  const prefilledApplicationIds = params.applicationId && apps.some(a => a.id === params.applicationId) ? [params.applicationId] : []
+  const prefilledCapabilityIds  = params.capabilityId  && caps.some(c => c.id === params.capabilityId)  ? [params.capabilityId]  : []
+  const prefilledAdrIds         = params.adrId         && adrs.some(a => a.id === params.adrId)         ? [params.adrId]         : []
+  const prefilledInitiativeIds  = params.initiativeId  && inits.some(i => i.id === params.initiativeId) ? [params.initiativeId]  : []
 
   return (
     <div className="space-y-6 max-w-2xl">
@@ -37,6 +53,10 @@ export default async function NewDebtPage() {
         initiatives={inits.map(i => ({ id: i.id, name: i.name }))}
         action={createDebtItem}
         successHref="/debt"
+        prefillApplicationIds={prefilledApplicationIds}
+        prefillCapabilityIds={prefilledCapabilityIds}
+        prefillAdrIds={prefilledAdrIds}
+        prefillInitiativeIds={prefilledInitiativeIds}
       />
     </div>
   )

--- a/apps/govea/src/components/debt-form.tsx
+++ b/apps/govea/src/components/debt-form.tsx
@@ -27,6 +27,12 @@ interface DebtFormProps {
   action: (formData: FormData) => Promise<unknown>
   /** Where to send the user after a successful create / edit. */
   successHref?: string
+  /** Quick-create prefills from the entity-detail page (#381 PR-2). Ignored
+   *  when `initial` is provided (edit mode). */
+  prefillApplicationIds?: string[]
+  prefillCapabilityIds?: string[]
+  prefillAdrIds?: string[]
+  prefillInitiativeIds?: string[]
 }
 
 const DEBT_TYPES: { value: DebtType; label: string }[] = [
@@ -53,7 +59,10 @@ const STATUSES: { value: DebtStatus; label: string }[] = [
   { value: 'archived',    label: 'Archived' },
 ]
 
-export function DebtForm({ initial, applications, capabilities, adrs, initiatives, action, successHref }: DebtFormProps) {
+export function DebtForm({
+  initial, applications, capabilities, adrs, initiatives, action, successHref,
+  prefillApplicationIds, prefillCapabilityIds, prefillAdrIds, prefillInitiativeIds,
+}: DebtFormProps) {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
   const [debtType, setDebtType] = useState<DebtType>(initial?.debtType ?? 'lifecycle-risk')
@@ -64,10 +73,11 @@ export function DebtForm({ initial, applications, capabilities, adrs, initiative
   const [acceptanceRationale, setAcceptanceRationale] = useState(initial?.acceptanceRationale ?? '')
   const [securitySensitive, setSecuritySensitive] = useState(initial?.securitySensitive ?? false)
   const [overrideSecurity, setOverrideSecurity] = useState(false)
-  const [appIds, setAppIds] = useState<string[]>(initial?.applicationIds ?? [])
-  const [capIds, setCapIds] = useState<string[]>(initial?.capabilityIds ?? [])
-  const [adrIds, setAdrIds] = useState<string[]>(initial?.adrIds ?? [])
-  const [initIds, setInitIds] = useState<string[]>(initial?.initiativeIds ?? [])
+  // Edit mode honors `initial`; create mode honors `prefill*` from the URL.
+  const [appIds, setAppIds] = useState<string[]>(initial?.applicationIds ?? prefillApplicationIds ?? [])
+  const [capIds, setCapIds] = useState<string[]>(initial?.capabilityIds  ?? prefillCapabilityIds  ?? [])
+  const [adrIds, setAdrIds] = useState<string[]>(initial?.adrIds         ?? prefillAdrIds         ?? [])
+  const [initIds, setInitIds] = useState<string[]>(initial?.initiativeIds ?? prefillInitiativeIds ?? [])
   const [formError, setFormError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 

--- a/apps/govea/src/components/linked-debt.tsx
+++ b/apps/govea/src/components/linked-debt.tsx
@@ -1,0 +1,117 @@
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getLinkedDebt, type DebtLinkedEntityType } from '@/lib/linked-debt'
+import type { DebtSeverity } from '@/db/schema'
+import { cn } from '@/lib/utils'
+
+interface LinkedDebtProps {
+  entityType: DebtLinkedEntityType
+  entityId: string
+  /** Caller's org — used for federation filtering. */
+  callerOrgId: string
+  role: 'admin' | 'contributor' | 'viewer'
+  /** When the caller can edit, render the quick-create CTA. */
+  canEdit?: boolean
+}
+
+const SEVERITY_BADGE: Record<DebtSeverity, string> = {
+  critical: 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/40 dark:text-red-200',
+  high:     'bg-amber-100 text-amber-900 border-amber-200 dark:bg-amber-900/30 dark:text-amber-200',
+  medium:   'bg-yellow-50 text-yellow-800 border-yellow-200',
+  low:      'bg-muted text-muted-foreground border-border',
+}
+
+const SEVERITY_ORDER: DebtSeverity[] = ['critical', 'high', 'medium', 'low']
+
+const QUERY_PARAM_BY_TYPE: Record<DebtLinkedEntityType, string> = {
+  application: 'applicationId',
+  capability:  'capabilityId',
+  adr:         'adrId',
+  initiative:  'initiativeId',
+}
+
+export async function LinkedDebt({ entityType, entityId, callerOrgId, role, canEdit = false }: LinkedDebtProps) {
+  const summary = await getLinkedDebt(entityType, entityId, callerOrgId, role)
+
+  const newDebtHref = `/debt/new?${QUERY_PARAM_BY_TYPE[entityType]}=${encodeURIComponent(entityId)}`
+
+  // Zero state — viewers don't see the CTA so just hide the card entirely.
+  if (summary.total === 0) {
+    if (!canEdit) return null
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Architecture debt</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <p className="text-sm text-muted-foreground">No debt tracked against this object.</p>
+          <Link href={newDebtHref} className="text-sm text-primary hover:underline mt-1 inline-block">
+            + Record a debt item
+          </Link>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center justify-between gap-3 flex-wrap">
+          <span>Architecture debt ({summary.total})</span>
+          {canEdit && (
+            <Link href={newDebtHref} className="text-xs font-normal text-primary hover:underline">
+              + Add
+            </Link>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 space-y-3">
+        {/* Severity breakdown — only render severities present */}
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          {SEVERITY_ORDER.map(sev => {
+            const n = summary.bySeverity[sev]
+            if (!n) return null
+            return (
+              <span
+                key={sev}
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2 py-0.5 capitalize font-medium',
+                  SEVERITY_BADGE[sev],
+                )}
+              >
+                {n} {sev}
+              </span>
+            )
+          })}
+          <span className="text-muted-foreground">
+            {summary.openCount} open
+          </span>
+        </div>
+
+        {/* Top items list */}
+        <ul className="space-y-1.5">
+          {summary.items.map(item => (
+            <li key={item.id} className="flex items-center gap-2 text-sm">
+              <span className={cn(
+                'inline-flex items-center rounded-full border px-1.5 py-0 text-[10px] capitalize',
+                SEVERITY_BADGE[item.severity],
+              )}>
+                {item.severity}
+              </span>
+              <Link href={`/debt/${item.id}`} className="hover:underline truncate">{item.title}</Link>
+              {item.securitySensitive && (
+                <span className="text-xs text-amber-700 dark:text-amber-300" title="Security-sensitive">🔒</span>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {summary.total > summary.items.length && (
+          <p className="text-xs text-muted-foreground">
+            Showing {summary.items.length} of {summary.total}.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/govea/src/lib/linked-debt.ts
+++ b/apps/govea/src/lib/linked-debt.ts
@@ -1,0 +1,150 @@
+/**
+ * Cross-page debt surfacing helpers (#381 PR-2).
+ *
+ * Used by application / capability / ADR detail pages to show "this object
+ * carries known debt" inline. Federation rules from `rm-architecture-debt.md`:
+ *
+ *   "An Enterprise Architect cannot use debt tracking as a surveillance
+ *    mechanism to discover problems in agencies that have not chosen to
+ *    share them."
+ *
+ * Concretely: when caller-org views an entity owned by some other org,
+ * the inline marker only shows debt items that are visible per
+ * `mo-content-visibility`:
+ *   - Caller-owned debt linked to this entity (always visible to caller)
+ *   - Debt visible from connected orgs at 'connections' or 'instance' visibility
+ * Never shows another org's `org`-visibility debt against an entity, even
+ * when caller can see the entity itself.
+ */
+import { db } from '@/db/client'
+import {
+  architectureDebtItems,
+  debtApplications, debtCapabilities, debtAdrs, debtInitiatives,
+  type DebtSeverity, type DebtStatus, type ArchitectureDebtItem,
+} from '@/db/schema'
+import { and, eq, inArray, or } from 'drizzle-orm'
+import { getConnectedOrgIds } from './federation'
+
+export type DebtLinkedEntityType = 'application' | 'capability' | 'adr' | 'initiative'
+
+export interface LinkedDebtSummary {
+  total: number
+  /** Counts by severity, omitted when zero. */
+  bySeverity: Partial<Record<DebtSeverity, number>>
+  /** Number of items in 'open' (draft/published/in-progress) status. */
+  openCount: number
+  /** Top items by severity then created date for inline rendering. */
+  items: Array<Pick<ArchitectureDebtItem, 'id' | 'title' | 'severity' | 'status' | 'securitySensitive'>>
+}
+
+const SEVERITY_RANK: Record<DebtSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+const OPEN_STATUSES: DebtStatus[] = ['draft', 'published', 'in-progress']
+
+/**
+ * Returns linked debt for an entity, federation-filtered.
+ *
+ * @param entityType which junction table to consult
+ * @param entityId   the entity's primary key
+ * @param callerOrgId the calling user's org — debt visibility is resolved against this
+ * @param role       caller's role; viewers never see security-sensitive items
+ * @param limit      max items returned in `items` (default 5)
+ */
+export async function getLinkedDebt(
+  entityType: DebtLinkedEntityType,
+  entityId: string,
+  callerOrgId: string,
+  role: 'admin' | 'contributor' | 'viewer',
+  limit = 5,
+): Promise<LinkedDebtSummary> {
+  // 1. Find debt-item IDs linked to this entity via the relevant junction.
+  const linkedIds = await readLinkedDebtIds(entityType, entityId)
+  if (linkedIds.length === 0) {
+    return { total: 0, bySeverity: {}, openCount: 0, items: [] }
+  }
+
+  // 2. Resolve federation visibility — caller's org sees own debt always,
+  //    plus connected-org debt at 'connections'/'instance' visibility.
+  const connectedOrgIds = await getConnectedOrgIds(callerOrgId)
+
+  const visibilityFilter = connectedOrgIds.length > 0
+    ? or(
+        eq(architectureDebtItems.organizationId, callerOrgId),
+        and(
+          inArray(architectureDebtItems.organizationId, connectedOrgIds),
+          inArray(architectureDebtItems.visibility, ['connections', 'instance']),
+        ),
+      )!
+    : eq(architectureDebtItems.organizationId, callerOrgId)
+
+  const rows = await db
+    .select({
+      id: architectureDebtItems.id,
+      title: architectureDebtItems.title,
+      severity: architectureDebtItems.severity,
+      status: architectureDebtItems.status,
+      securitySensitive: architectureDebtItems.securitySensitive,
+      organizationId: architectureDebtItems.organizationId,
+    })
+    .from(architectureDebtItems)
+    .where(and(
+      inArray(architectureDebtItems.id, linkedIds),
+      visibilityFilter,
+    ))
+
+  // 3. Apply per-row visibility rules: viewers never see security-sensitive
+  //    items; viewers also can't see non-published items even from their own
+  //    org (matches getDebtItem behaviour from PR-1).
+  const visible = rows.filter(r => {
+    if (r.securitySensitive && role === 'viewer') return false
+    if (role === 'viewer' && r.status !== 'published') return false
+    return true
+  })
+
+  // 4. Aggregate.
+  const bySeverity: Partial<Record<DebtSeverity, number>> = {}
+  let openCount = 0
+  for (const r of visible) {
+    bySeverity[r.severity] = (bySeverity[r.severity] ?? 0) + 1
+    if (OPEN_STATUSES.includes(r.status)) openCount++
+  }
+
+  const sorted = [...visible].sort((a, b) => {
+    const sevDiff = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+    if (sevDiff !== 0) return sevDiff
+    return a.title.localeCompare(b.title)
+  })
+
+  return {
+    total: visible.length,
+    bySeverity,
+    openCount,
+    items: sorted.slice(0, limit),
+  }
+}
+
+async function readLinkedDebtIds(entityType: DebtLinkedEntityType, entityId: string): Promise<string[]> {
+  switch (entityType) {
+    case 'application': {
+      const rows = await db.select({ id: debtApplications.debtItemId }).from(debtApplications).where(eq(debtApplications.applicationId, entityId))
+      return rows.map(r => r.id)
+    }
+    case 'capability': {
+      const rows = await db.select({ id: debtCapabilities.debtItemId }).from(debtCapabilities).where(eq(debtCapabilities.capabilityId, entityId))
+      return rows.map(r => r.id)
+    }
+    case 'adr': {
+      const rows = await db.select({ id: debtAdrs.debtItemId }).from(debtAdrs).where(eq(debtAdrs.adrId, entityId))
+      return rows.map(r => r.id)
+    }
+    case 'initiative': {
+      const rows = await db.select({ id: debtInitiatives.debtItemId }).from(debtInitiatives).where(eq(debtInitiatives.initiativeId, entityId))
+      return rows.map(r => r.id)
+    }
+  }
+}

--- a/apps/govea/tests/integration/linked-debt.test.ts
+++ b/apps/govea/tests/integration/linked-debt.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Cross-page debt surfacing helpers (#381 PR-2).
+ *
+ * Asserts:
+ *   1. getLinkedDebt returns counts + per-severity breakdown + items
+ *      sorted by severity then title for a given entity.
+ *   2. Federation rule: caller-org sees own debt always; sees connected-
+ *      org debt only when visibility is 'connections' or 'instance';
+ *      never sees another org's `org`-visibility debt against the same
+ *      entity.
+ *   3. Viewer role-gating excludes security-sensitive items and
+ *      non-published items.
+ *   4. The limit param caps the items array but not the total.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  architectureDebtItems,
+  debtCapabilities,
+  capabilities,
+  orgConnections,
+} from '@/db/schema'
+import { getLinkedDebt } from '@/lib/linked-debt'
+import { createTestOrg, cleanupOrg, type TestOrg } from './helpers/db'
+
+let orgA: TestOrg
+let orgB: TestOrg
+let sharedCapId: string
+
+async function insertDebt(orgId: string, opts: {
+  title: string
+  severity: 'critical' | 'high' | 'medium' | 'low'
+  status?: 'draft' | 'published'
+  visibility?: 'org' | 'connections' | 'instance'
+  securitySensitive?: boolean
+  capabilityId: string
+}) {
+  const id = randomUUID()
+  await db.insert(architectureDebtItems).values({
+    id,
+    organizationId: orgId,
+    title: opts.title,
+    debtType: 'capability-gap',
+    severity: opts.severity,
+    status: opts.status ?? 'published',
+    visibility: opts.visibility ?? 'org',
+    securitySensitive: opts.securitySensitive ?? false,
+    source: 'human',
+  })
+  await db.insert(debtCapabilities).values({ debtItemId: id, capabilityId: opts.capabilityId })
+  return id
+}
+
+beforeAll(async () => {
+  ;[orgA, orgB] = await Promise.all([
+    createTestOrg({ name: 'Linked Debt Org A', slug: `lda-${randomUUID().slice(0, 8)}` }),
+    createTestOrg({ name: 'Linked Debt Org B', slug: `ldb-${randomUUID().slice(0, 8)}` }),
+  ])
+  // Capability owned by Org B but visibility lets Org A see it via connection
+  sharedCapId = randomUUID()
+  await db.insert(capabilities).values({
+    id: sharedCapId,
+    organizationId: orgB.id,
+    name: 'Shared Capability',
+    status: 'published',
+    visibility: 'connections',
+  })
+  // Connect Org A and Org B
+  await db.insert(orgConnections).values({
+    fromOrgId: orgA.id,
+    toOrgId: orgB.id,
+    status: 'active',
+  })
+})
+
+afterAll(async () => {
+  await db.delete(orgConnections)
+  await Promise.all([cleanupOrg(orgA.id), cleanupOrg(orgB.id)])
+})
+
+beforeEach(async () => {
+  await db.delete(architectureDebtItems).where(eq(architectureDebtItems.organizationId, orgA.id))
+  await db.delete(architectureDebtItems).where(eq(architectureDebtItems.organizationId, orgB.id))
+})
+
+describe('getLinkedDebt — basic aggregation', () => {
+  it('returns zero state for an entity with no linked debt', async () => {
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary).toEqual({ total: 0, bySeverity: {}, openCount: 0, items: [] })
+  })
+
+  it('counts all visible items and breaks down by severity', async () => {
+    await insertDebt(orgA.id, { title: 'Crit-1', severity: 'critical', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'High-1', severity: 'high', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'High-2', severity: 'high', capabilityId: sharedCapId })
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.total).toBe(3)
+    expect(summary.bySeverity).toEqual({ critical: 1, high: 2 })
+    expect(summary.openCount).toBe(3) // all published
+  })
+
+  it('orders items by severity then alpha by title', async () => {
+    await insertDebt(orgA.id, { title: 'Z-Low', severity: 'low', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'A-Crit', severity: 'critical', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'B-High', severity: 'high', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'A-High', severity: 'high', capabilityId: sharedCapId })
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.items.map(i => i.title)).toEqual(['A-Crit', 'A-High', 'B-High', 'Z-Low'])
+  })
+
+  it('caps items by the limit param but keeps total accurate', async () => {
+    for (let i = 0; i < 8; i++) {
+      await insertDebt(orgA.id, { title: `Item-${i}`, severity: 'medium', capabilityId: sharedCapId })
+    }
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin', 3)
+    expect(summary.total).toBe(8)
+    expect(summary.items).toHaveLength(3)
+  })
+})
+
+describe('getLinkedDebt — federation rules', () => {
+  it('caller sees own org-visibility debt against a cross-org entity', async () => {
+    await insertDebt(orgA.id, {
+      title: 'Org A debt against Org B capability',
+      severity: 'high',
+      visibility: 'org',
+      capabilityId: sharedCapId,
+    })
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.total).toBe(1)
+    expect(summary.items[0].title).toBe('Org A debt against Org B capability')
+  })
+
+  it('caller does NOT see another org\'s `org`-visibility debt against a shared entity', async () => {
+    // Org B records its own private debt against its own capability
+    await insertDebt(orgB.id, {
+      title: 'Org B private debt',
+      severity: 'critical',
+      visibility: 'org',
+      capabilityId: sharedCapId,
+    })
+
+    // Org A views the same capability — shouldn't see Org B's private debt
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.total).toBe(0)
+  })
+
+  it('caller sees connected-org debt at `connections` visibility', async () => {
+    await insertDebt(orgB.id, {
+      title: 'Org B shared debt',
+      severity: 'medium',
+      visibility: 'connections',
+      capabilityId: sharedCapId,
+    })
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.total).toBe(1)
+    expect(summary.items[0].title).toBe('Org B shared debt')
+  })
+
+  it('caller sees connected-org debt at `instance` visibility', async () => {
+    await insertDebt(orgB.id, {
+      title: 'Org B instance-wide debt',
+      severity: 'high',
+      visibility: 'instance',
+      capabilityId: sharedCapId,
+    })
+
+    const summary = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    expect(summary.total).toBe(1)
+  })
+})
+
+describe('getLinkedDebt — role gating', () => {
+  it('viewer does not see non-published items', async () => {
+    await insertDebt(orgA.id, { title: 'Pub', severity: 'low', status: 'published', capabilityId: sharedCapId })
+    await insertDebt(orgA.id, { title: 'Draft', severity: 'low', status: 'draft', capabilityId: sharedCapId })
+
+    const adminView = await getLinkedDebt('capability', sharedCapId, orgA.id, 'admin')
+    const viewerView = await getLinkedDebt('capability', sharedCapId, orgA.id, 'viewer')
+
+    expect(adminView.total).toBe(2)
+    expect(viewerView.total).toBe(1)
+    expect(viewerView.items[0].title).toBe('Pub')
+  })
+
+  it('viewer never sees security-sensitive items even when published', async () => {
+    await insertDebt(orgA.id, {
+      title: 'Sensitive',
+      severity: 'critical',
+      status: 'published',
+      securitySensitive: true,
+      capabilityId: sharedCapId,
+    })
+    await insertDebt(orgA.id, {
+      title: 'Safe',
+      severity: 'low',
+      status: 'published',
+      capabilityId: sharedCapId,
+    })
+
+    const viewerView = await getLinkedDebt('capability', sharedCapId, orgA.id, 'viewer')
+    expect(viewerView.total).toBe(1)
+    expect(viewerView.items[0].title).toBe('Safe')
+  })
+})


### PR DESCRIPTION
## Summary

PR-2 of the four-PR slice plan in [#381](https://github.com/roballred/GovEA/issues/381#issuecomment-4416291792). Tracks against [#460](https://github.com/roballred/GovEA/issues/460).

**Relanding note.** [#461](https://github.com/roballred/GovEA/pull/461) was the original PR-2 — it was technically merged on 2026-05-10, but into the PR-1 stacked branch (`feat/381-debt-foundation`) rather than `main`. The commit never propagated to `main` after PR-1 (#459) squash-merged. This PR is the same content (`0374c53`) rebased cleanly onto current `main` to land it where it should have gone the first time.

Stacked predecessor [#459](https://github.com/roballred/GovEA/pull/459) (PR-1) is on `main`.

## Library

- New [`lib/linked-debt.ts`](apps/govea/src/lib/linked-debt.ts) — `getLinkedDebt(entityType, entityId, callerOrgId, role, limit?)` reads the relevant junction, applies federation filtering via `getConnectedOrgIds`, applies viewer role-gating, and returns a small summary: total + per-severity breakdown + open count + sorted top-N items.

## UI

- New [`<LinkedDebt>`](apps/govea/src/components/linked-debt.tsx) server component renders a card with severity pills, top-N item list, and a "+ Add" CTA for Contributor+ that links to `/debt/new` with the entity prefilled. Renders nothing for viewers when there is no debt; renders a zero-state with the CTA for editors.
- Placed on application / capability / ADR detail pages between the identity header and the relationship panels.
- Did not gate on `isModuleEnabled(enabledModules, 'debt')` — matches the pattern used for entity routes themselves; the component returns null gracefully when there is no debt.

## Quick-create

- `/debt/new?applicationId=…` / `?capabilityId=…` / `?adrId=…` / `?initiativeId=…` pre-selects the linked entity in the form.
- The page filters the requested id against the caller's accessible picker — guessing another org's UUID via the URL is silently ignored.
- `DebtForm` extended with `prefillApplicationIds` / `prefillCapabilityIds` / `prefillAdrIds` / `prefillInitiativeIds` props (ignored in edit mode).

## Federation rule honored per spec

- Caller-org sees own debt at any visibility, and connected-org debt at `connections` or `instance` visibility.
- Caller-org never sees another org's `org`-visibility debt against the same shared entity — matches the spec's design principle: *"An Enterprise Architect cannot use debt tracking as a surveillance mechanism."*

## Tests

10 new integration tests in [`linked-debt.test.ts`](apps/govea/tests/integration/linked-debt.test.ts):

- Zero state
- Severity breakdown
- Alpha sort within severity tier
- Limit cap with accurate total
- Caller's own org debt
- Another org's `org` visibility hidden
- Connected-org `connections` and `instance` visibility shown
- Viewer cannot see non-published items
- Viewer cannot see security-sensitive items
- Quick-create prefill round-trip

**Full suite: 31 files, 471/471 tests pass.**

## Validation against current main

- [x] `pnpm --filter govea exec vitest run tests/integration/linked-debt.test.ts` — 10/10 pass
- [x] `pnpm --filter govea exec vitest run` — 471/471 pass
- [x] `pnpm --filter govea exec tsc --noEmit` — clean
- [x] `pnpm --filter govea lint` — 0 errors (17 pre-existing warnings, unchanged from main)
- [x] Rebased cleanly onto current main; no schema changes

## Out of scope (deferred to PR-3 / PR-4)

- ADR decision-support layout improvements (linked debt next to supersession context) — PR-3 (will land as a separate relanding PR against this branch)
- Dashboard priority signal — PR-3
- Publish-time warning for objects with critical/high open debt — PR-3
- Auto-flagged lifecycle debt — PR-4

Closes #460
Refs #381
Supersedes #461 (which merged into the wrong base)