### PR TITLE
docs(data-architecture): create capability group + persona docs (#473)

### DIFF
--- a/business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md
+++ b/business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md
@@ -1,0 +1,53 @@
+# Capability: Chen Notation Visualization
+
+## What It Does
+
+Renders the Data Architecture metamodel — entities, attributes, links, business keys, and the three cross-object semantic relationship kinds — as a Chen Notation graph that a Data Architect or Modeler can read at a glance. Reading the model object-by-object through detail pages is sufficient for editing; it is not sufficient for explaining the model to a stakeholder, for spotting an entity that has too few characterizing attributes, or for confirming that two entities are related the way the modeler intended. The visualization closes that gap without becoming a second editing surface.
+
+Chen Notation is the SME's preferred conceptual / logical-layer convention. Using it here for the physical layer is a deliberate choice — it gives the architect a familiar shape language for explaining what they have built, even when the underlying tables are Data Vault hubs / sats / links.
+
+## Personas
+
+- **Enterprise Data Architect** — needs a single view they can present to non-technical stakeholders and to use as the basis for the model scorecard conversation
+- **Data Modeler** — needs a quick visual check that the model they have built has the connections, characterizing attributes, and business keys they intended; sees the diagram as a sanity check on their work
+
+> ⚠️ Enterprise Data Architect and Data Modeler are **Assumed** personas. Behaviors below describe the design intent; validation with additional practitioners may surface differences in expected notation, filter behavior, or layout strategy.
+
+## Behaviors
+
+- Render the org's metamodel as a single Chen Notation graph at `/data/diagram`:
+  - **Entities** rendered as rectangles
+  - **Cross-object relationships** rendered as diamonds with the kind labelled ("is related," "characterized by," "shares," "instantiates")
+  - **Attributes** rendered as ovals
+  - **Business keys** rendered with a distinct glyph (e.g. underlined attribute, double-bordered oval — convention to be chosen during implementation)
+- Surface filter controls to reduce the graph to a tractable subset:
+  - by owner persona
+  - by physical attribute type
+  - by physical relationship type
+  - by free-text name match
+- Honor federation visibility on every node — an Org A user cannot see an Org B object that lacks `connections` or `instance` visibility
+- Honor workflow status — Viewer-role users see only published nodes; Admin / Contributor see drafts as well, visually distinguished
+- Render is read-only in v1. Editing happens on the existing detail / edit / relationships pages; the diagram links each node back to its detail page
+- Support a deep-linked "focus" mode that filters the graph to a single entity plus its 1-hop neighborhood, opened from the entity detail page
+
+## Rules
+
+- The diagram never reveals an object the caller could not already read through `/data/{resource}/[id]` directly — the same federation and role-gating rules apply
+- The diagram is computed server-side from the published-or-better state of the metamodel; the client receives data already filtered for visibility
+- Layout is deterministic per render so a user revisiting the page sees the same shape unless the underlying model changed
+- The diagram must not introduce a write path. All edit links navigate away to the existing detail pages
+
+## Implementation Status
+
+**Planned — not yet implemented.** Tracked at [#470](https://github.com/roballred/GovEA/issues/470). Working assumption is React Flow for the layout / interaction library; the implementation PR should confirm tree-shakeability or fall back to a hand-rolled SVG renderer if not.
+
+## Out of Scope (v1)
+
+- Edit-from-diagram (creating or deleting objects from the canvas) — would re-open the question of where the authoritative editing surface lives. Deferred to a separate issue
+- Export to PNG / SVG — useful but not required for the read-only viewing use case
+- Automatic layout improvements beyond what the chosen library provides — fine to ship with the library's default plus minimal manual hints
+
+## Links
+
+- Depends on: `da-physical-metamodel`
+- Related: `po-capability-map` (precedent for a read-only diagram surface inside GovEA)

--- a/business-architecture/capabilities/ea/data-architecture/da-physical-metamodel.md
+++ b/business-architecture/capabilities/ea/data-architecture/da-physical-metamodel.md
@@ -1,0 +1,56 @@
+# Capability: Physical Metamodel
+
+## What It Does
+
+Captures the organization's physical data model as a first-class set of objects inside GovEA: the entities (Hubs in Data Vault terms) that represent subject things, the attributes (Satellites) that characterize them, the links between entities (Data Vault Links), and the business keys that identify each entity. Each object carries the physical-layer metadata a database administrator needs to generate the corresponding physical table — physical table name, server, database, schema, plus type tags appropriate to its role. Cross-object semantic relationships ("is related," "instantiates," "characterized by," "shares") are tracked separately from the structural metadata so the same model can be queried as a graph for downstream analysis.
+
+The objective is not to replace a dedicated data modelling tool. The objective is to make the model an addressable part of the broader architecture repository, so a Data Architect can answer "what is this entity, who owns it, what physical table is it stored in, and what does it relate to" without leaving GovEA.
+
+## Personas
+
+- **Enterprise Data Architect** — needs an authoritative store of the metamodel that survives turnover in the Data Modeler / DBA team; needs to defend the model's scorecard, not necessarily draw every diagram
+- **Data Modeler** — needs the metadata captured at modelling time to survive into the physical layer, so the hand-off to a DBA does not lose definitions, naming, or owner attribution
+
+> ⚠️ Enterprise Data Architect and Data Modeler are **Assumed** personas. The behaviors below reflect one SME's stated practice; validation through direct user research with additional practitioners is required before treating the design as settled.
+
+## Behaviors
+
+- Create, edit, and delete **Entities** with: name, description, owners (multi-persona), workflow status (draft / published / archived), federation visibility (org / connections / instance), and physical Hub table name plus server / database / schema
+- Create, edit, and delete **Attributes** with the same base metadata plus physical Satellite table name and a physical attribute type tag (Effectivity, Multi-Active, Record Tracking, Status Tracking)
+- Create, edit, and delete **Links** (Data Vault Link tables) with the same base metadata plus physical Link table name and a physical relationship type tag (Same-As, Hierarchical)
+- Create, edit, and delete **Business Keys** with name, description, owners, data type, and a non-nullable reference to the owning entity (the Hub the business key instantiates)
+- Manage cross-object semantic relationships in three kinds:
+  - entity ↔ entity — "is related" (undirected; canonical-ordered pair)
+  - entity ↔ attribute — "is characterized by" / "characterizes"
+  - attribute ↔ attribute — "shares" (undirected; canonical-ordered pair)
+- View the fourth kind — entity ↔ business key "instantiates / is instantiated by" — surfaced via the existing structural FK (each business key has a non-null owning entity)
+- View linked items as inline panels on the detail page of each object (Entity detail shows related entities, characterizing attributes, and instantiating business keys; Attribute detail shows shares-with attributes; Business Key detail shows owning entity)
+- Edit cross-object relationships on a dedicated `relationships` sub-page per object so the basic-fields edit form is not bloated with multi-pickers
+
+## Rules
+
+- All metamodel objects belong to an organization and follow the standard content workflow: draft → published → archived
+- Viewer-role users see only published objects; the federation read filter is applied via the standard `canReadFederatedEntity` helper
+- A business key cannot exist without an owning entity; the database enforces this with a non-nullable foreign key. Deleting an entity cascades to its business keys — this is intentional model integrity, not data loss
+- The owning entity of a business key must belong to the same organization as the business key itself; a guessed cross-org entity ID is rejected server-side
+- All cross-object relationship kinds enforce src/tgt type validity server-side. Invalid (sourceType, targetType, kind) combinations are rejected, not just hidden in the UI
+- Symmetric relationship kinds (entity ↔ entity "is related"; attribute ↔ attribute "shares") are stored as undirected canonical pairs (smaller UUID stored first). The database constraint prevents two rows for the same undirected pair
+- Self-relationships are silently filtered out at the server-action layer (an entity cannot be related to itself; an attribute cannot share with itself)
+- Cross-object relationship operations replace the relationship set atomically — the form sends the desired final state, the server computes the diff
+- Only Contributors and Admins can mutate objects or their relationships; only Admins can delete
+- Audit log entries are written for every create / update / delete and for every relationship-set replacement
+
+## Implementation Status
+
+**Shipped (v1):** Schema, CRUD server actions, owner-junction tables, and the full set of UI pages (hub at `/data`, per-resource index / new / detail / edit / relationships) landed in GovEA via:
+
+- [#471](https://github.com/roballred/GovEA/pull/471) — schema + CRUD foundation. Four tables + four owner junctions + two enum types
+- [#472](https://github.com/roballred/GovEA/pull/472) — cross-object semantic relationships. Three relationship tables + server actions + relationship-edit sub-pages
+
+Persona seeds for Enterprise Data Architect and Data Modeler ship as dev fixtures from #471.
+
+## Links
+
+- Depends on: `cms/iam`, `iam-user-management` (owners are personas, which require persona management)
+- Enables: `da-chen-visualization`
+- Related: `rm-end-to-end-traceability`, `rm-architecture-debt`

--- a/business-architecture/capabilities/ea/data-architecture/data-architecture.md
+++ b/business-architecture/capabilities/ea/data-architecture/data-architecture.md
@@ -1,0 +1,62 @@
+# Capability Group: Data Architecture
+
+The system must support the practice of Data Architecture as defined by the DAMA Knowledge Areas — capturing the data assets that exist in an organization, the structural model that relates them, and the layered representations (conceptual / logical / physical) that let architects, modelers, and database administrators each work at the level their role expects. The objective is to support a Data Architect and their team in a Data & Analytics organization end to end, not to ship a replacement for any dedicated modelling tool.
+
+> ⚠️ This group is implemented from one SME conversation (Nichole) treated as the subject-matter expert. The Enterprise Data Architect and Data Modeler personas are both **Assumed**. Capabilities here carry elevated implementation risk until those personas are validated through direct user research with additional practitioners.
+
+## Personas
+
+- **Enterprise Data Architect** — owns the metamodel, governs methodology choice per layer, and reviews completed models against a scorecard; cannot personally produce every model
+- **Data Modeler** — produces conceptual, logical, and physical models; cares about scorecard-grade structural soundness and metadata fidelity across layers
+
+## Sub-Capabilities
+
+| Capability | File | Status | Description |
+|---|---|---|---|
+| Physical Metamodel | [da-physical-metamodel.md](./da-physical-metamodel.md) | Shipped (v1) | Data Vault-aligned physical-layer metamodel: entities (Hubs), attributes (Satellites), links, and business keys, with four cross-object semantic relationship kinds |
+| Chen Notation Visualization | [da-chen-visualization.md](./da-chen-visualization.md) | Planned — not yet implemented | Read-only Chen Notation graph rendering of the metamodel so architects can see the full picture rather than navigating object by object |
+
+## Success Criteria
+
+- A Data Architect can describe an organization's physical data model in GovEA — entities, characterizing attributes, links between entities, and business keys that identify each entity — without leaving the product
+- The metamodel preserves the metadata a DBA needs to hand off into Data Vault physical generation: physical table name, server, database, schema, physical attribute type, physical link type, data type for business keys
+- Cross-object semantic relationships (is related / instantiates / characterized by / shares) survive round-trips between objects and are queryable from either side
+- A new modelling layer (conceptual, logical) can be added later without restructuring the physical-layer tables
+- Stakeholders who are not Data Architects (e.g. Department Director, City Council Member) can view the model when published without seeing draft-only or sensitive structural detail
+
+## Rules
+
+- Data Architecture objects belong to an organization and follow the standard content workflow: draft → published → archived
+- Cross-object semantic relationships must be enforced at the model level: invalid (sourceType, targetType, kind) combinations are rejected server-side, not just at the UI
+- Symmetric relationship kinds (entity ↔ entity "is related"; attribute ↔ attribute "shares") are stored as undirected pairs — there is exactly one row per pair regardless of which side initiated it
+- The cross-object semantic relationships never exceed organization scope without an explicit federation visibility setting on the participating objects
+- A business key cannot exist without an owning entity; cascading delete from entity to its business keys is intentional
+
+## Reference Sources
+
+- **DAMA-DMBOK** — the canonical reference for the Knowledge Areas that scope this group. The SME's framing of v1 was Data Architecture + Data Modeling & Design, deferring the other nine DAMA areas
+- **Data Vault 2.0** (Linstedt / Olschimke) — the physical-layer modelling methodology v1 is aligned with. Entities map to Hubs; Attributes map to Satellites; Links map to Links; Business Keys are the natural identifiers of Hubs
+- **Chen Notation** — the conceptual / logical notation v1's visualization slice targets. Rectangles for entities, diamonds for relationships, ovals for attributes
+- **TOGAF** treatment of DAMA Knowledge Areas as Capabilities — the SME's framing that informed how this work fits inside GovEA's existing capability model
+
+## Out of Scope (v1)
+
+- Conceptual and logical modelling layers as separate first-class object types. v1 is **physical-only**. Conceptual / logical can be added later; the physical-layer tables are designed not to require restructuring when they arrive
+- Semantic modelling (IDEF1X) and UML
+- Data Vault automation hooks that generate physical DDL from the metamodel. The fields collected in v1 are the necessary precondition for this future work but the generation itself is not in scope
+- The Data Model Scorecard® as a tracked artifact inside GovEA. Useful concept; not in v1
+- DAMA Knowledge Areas as first-class Capability seeds. Per the SME these are recognized as Level-1 capabilities in TOGAF treatment but seeding them is parked
+- Data products (curated datasets / reports / feeds) as a distinct object. Per the SME, reports are out of scope for data management governance in this product
+
+## Implementation Status
+
+**Shipped (v1):**
+- `da-physical-metamodel` via PRs [#471](https://github.com/roballred/EasyEA/pull/471) (schema + CRUD, schema actually merged at roballred/GovEA#471) and [#472](https://github.com/roballred/GovEA/pull/472) (cross-object semantic relationships). Four CRUD-able object types with the Data Vault metadata fields the SME specified; three cross-object semantic relationship junctions (entity ↔ entity, entity ↔ attribute, attribute ↔ attribute) plus the structural FK for entity ↔ business-key "instantiates"
+
+**Planned:**
+- `da-chen-visualization` — tracked at [#470](https://github.com/roballred/GovEA/issues/470)
+
+## Links
+
+- Depends on: `cms/iam`, `cms/admin-configuration`
+- Related: `rm-end-to-end-traceability`, `rm-architecture-debt`, `cms/content-management`

--- a/business-architecture/personas/data-modeler.md
+++ b/business-architecture/personas/data-modeler.md
@@ -1,0 +1,30 @@
+# Persona: Data Modeler
+
+**Validation Status: Assumed** — drafted from the same design conversation that produced `enterprise-data-architect.md`. The role boundary between Data Modeler, Business Analyst, and Database Administrator is described from the SME's practice but not yet corroborated against other organizations. Moves to Validated when at least one interview or direct observation with a working data modeler in a state or local government context confirms the goals, pain points, and the conceptual ↔ logical ↔ physical boundary described below.
+
+## Role Type
+Internal — Data & Analytics organization, individual contributor
+
+## Who They Are
+The Data Modeler produces conceptual, logical, and physical data models — though "physical" in this persona's scope means the third-normal-form relational model or the dimensional/tabular model for serving. They typically do not produce the intermediary Data Vault layer (DBAs own that) and they typically do not own the conceptual model's authoritative form (Business Analysts share that responsibility). They work day-to-day in modelling tools and care about the structural soundness of what they produce — primary keys, normalization, naming, readability, definitions — measured against a model scorecard.
+
+## Goals
+- Produce data models that score well against the Steve Hoberman Data Model Scorecard® — capture requirements, structurally sound, well-named, well-defined, consistent with the enterprise
+- Move efficiently between modelling notations as the layer requires (Chen Notation for conceptual / logical, normalized or dimensional for physical serving layers)
+- Hand off a model to a Database Administrator with enough metadata that the physical implementation (Data Vault hubs / sats / links, or 3NF tables, or dimensional facts / dims) can be generated rather than re-translated
+- Keep entities, attributes, and relationships traceable across layers so a downstream change request can be assessed for impact before it lands
+
+## Pain Points
+- Most tools force a single notation; switching between Chen and normalized form means re-drawing or losing definitions
+- Naming standards drift when there is no enforced linter or scorecard hook in the tool
+- Definitions captured at the conceptual stage tend to get lost by the physical stage; metadata loss is the silent killer of model quality
+- Generic structures (abstracting Customer Location to a more reusable Location) are hard to advocate for inside tools optimized for diagram aesthetics rather than reuse
+- A model that scores well technically but doesn't match the actual data stored in the resulting tables is worthless — the modeler has no easy way to keep model and data in sync without DBA participation
+
+## Critical Insight
+A Data Modeler succeeds when the model they hand off survives contact with the data. Tools that make the diagram pretty without preserving definitions, naming standards, and traceability across layers reward the wrong work. The product should treat the model's metadata — owner, definitions, naming, source-to-target lineage — as a first-class deliverable equal in weight to the diagram itself.
+
+## Relevant Capabilities
+- `da-physical-metamodel` — captures the physical-layer model (Data Vault hub / sat / link) with the metadata fields needed to hand off to a DBA
+- `da-chen-visualization` — supports the modeler's preferred notation for conceptual / logical work and for explaining the physical model back to stakeholders
+- `ea/data-architecture` (group) — the broader Data Architecture capability set

--- a/business-architecture/personas/enterprise-data-architect.md
+++ b/business-architecture/personas/enterprise-data-architect.md
@@ -1,0 +1,33 @@
+# Persona: Enterprise Data Architect
+
+**Validation Status: Assumed** — drafted from an extended design conversation with one SME (Nichole) over multiple weeks. Reflects the SME's stated practice and DAMA framing, but has not been confirmed against other practitioners. Moves to Validated when at least one additional interview or direct observation with a real enterprise data architect in a state or local government context corroborates the goals, pain points, and critical insight below.
+
+## Role Type
+Internal — Central IT / Data & Analytics organization
+
+## Who They Are
+The Enterprise Data Architect owns the data architecture strategy and modelling standards across the organization. They are accountable for the integrity of the metamodel — what data assets exist, how they relate to each other, and what conceptual / logical / physical layers govern their representation. They do not necessarily produce every data model themselves; they oversee Data Modelers and Database Administrators, recommend modelling methodologies (Chen, Crow's Foot, Data Vault, Dimensional), and govern that the methodologies chosen for a given storage layer are appropriate to that layer's purpose. They are typically also the bridge between business analysts framing conceptual entities and DBAs designing physical tables.
+
+## Goals
+- Maintain an authoritative metamodel of entities, attributes, relationships, and business keys that the rest of the data team can build against
+- Govern the choice of modelling methodology per layer (conceptual, logical, physical) so each model fits its purpose
+- Trace conceptual subject areas through logical entities to physical tables — without that traceability, downstream lineage and impact analysis are unreliable
+- Review and score completed data models against an explicit scorecard (e.g. Steve Hoberman's Data Model Scorecard®) so quality is measurable
+- Surface and govern technical debt in the physical model (space utilization, query performance, schema drift) before it compounds
+- Stay aligned with DAMA Knowledge Areas as the canonical scope of "what a data management organization does"
+
+## Pain Points
+- Most enterprise data modelling tools optimize for one notation or one methodology; switching layers means switching tools, and traceability across them is manual at best
+- Business Intelligence and report development frequently bypass governance — reports get built on data sets whose conceptual ↔ logical ↔ physical lineage is incomplete
+- Conceptual entities and glossary terms get conflated, which causes the glossary to drift into doing metamodel work it shouldn't own
+- Data Modelers and Database Administrators sometimes disagree on where the boundary between logical model and physical table lives; without an explicit convention this disagreement re-litigates per project
+- "Master Data Management" terminology carries connotations that make modern teams uncomfortable; framing matters when surfacing data domains
+
+## Critical Insight
+The Enterprise Data Architect rarely needs to be the one drawing the diagram, but they always need to be the one who can defend its scorecard. The product must support modelling activities they do not perform directly — and must let them explain the resulting model in plain language to non-technical stakeholders. If the tool optimizes only for the modeler's screen and forgets the architect's review conversation, the architect stops using it.
+
+## Relevant Capabilities
+- `da-physical-metamodel` — authoritative store of entities, attributes, links, and business keys at the physical layer
+- `da-chen-visualization` — read-only graph rendering of the metamodel in a Data Architect-familiar notation
+- `ea/data-architecture` (group) — the broader Data Architecture capability set this persona depends on
+- `rm-architecture-debt` — applies the same severity-tier vocabulary to data-layer debt as to the broader architecture


### PR DESCRIPTION
## Summary

Closes the Standards.md traceability gap in the #363 data architecture stream. The implementation work landed via [#471](https://github.com/roballred/GovEA/pull/471) and [#472](https://github.com/roballred/GovEA/pull/472) without the authoritative capability documents and persona files that [Standards.md](../blob/main/Standards.md) requires. This PR fills that gap so subsequent work — starting with PR-3 ([#470](https://github.com/roballred/GovEA/issues/470)) — has proper capability IDs to reference.

**No code changes.** Documentation only.

Capability: ea/data-architecture, da-physical-metamodel, da-chen-visualization
Persona: Enterprise Data Architect, Data Modeler

Closes #473
Refs #363, #470, #471, #472

## Files added

| File | Purpose |
|---|---|
| `business-architecture/capabilities/ea/data-architecture/data-architecture.md` | Group parent. DAMA / Data Vault framing, success criteria, rules, out-of-scope, references, implementation status |
| `business-architecture/capabilities/ea/data-architecture/da-physical-metamodel.md` | Sub-capability documenting what #471 + #472 shipped. **Implementation Status: Shipped (v1)** with PR links |
| `business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md` | Sub-capability for the planned visualization slice. **Implementation Status: Planned — not yet implemented**; tracks against #470 |
| `business-architecture/personas/enterprise-data-architect.md` | **Validation Status: Assumed** — Nichole acts as SME proxy; what would move it to Validated is documented |
| `business-architecture/personas/data-modeler.md` | **Validation Status: Assumed** — same rationale |

## Why this is a documentation-only PR

- Per maintainer direction, the merged #471 / #472 commits are not amended. The new capability docs reference those PRs as evidence of "shipped" status instead.
- Persona files explicitly flag elevated implementation risk per [Standards.md §"Persona Validation Status"](../blob/main/Standards.md#persona-validation-status) until additional practitioner research is done.
- [STYLE.md](../blob/main/business-architecture/STYLE.md) compliance: required sections present, canonical headings, canonical Link vocabulary, no empty placeholders.

## Impact on #470

#470's issue body has been updated to add the `Capability: da-chen-visualization` and `Persona:` traceability lines. PR-3 of #363 should not open until this PR merges so those capability IDs point at real files.

## Review focus

- **Persona accuracy:** the Enterprise Data Architect and Data Modeler descriptions are drafted from one SME conversation. The risk is over-fitting to one practitioner's framing. Flag anything that overgeneralizes from Nichole's specific practice.
- **Capability framing:** the SME's "DAMA Knowledge Areas treated as Level-1 capabilities" framing is referenced but not adopted as a structural change here. Out-of-scope notes call this out explicitly.
- **Out-of-scope list:** confirm the deferred items (conceptual / logical layers, semantic modelling, DDL generation, scorecard tracking, data products) match the maintainer's mental model.

## Test plan

- [x] All files follow [STYLE.md](../blob/main/business-architecture/STYLE.md) required structure
- [x] Capability IDs match the file-stem convention from [Standards.md §"Capability IDs"](../blob/main/Standards.md#capability-ids)
- [x] Both persona files declare explicit `Validation Status: Assumed`
- [x] Group parent's `Implementation Status` section uses the canonical heading
- [x] No empty sections / placeholders