### PR TITLE
fix(ci): bump Postgres max_connections to 200 to unblock integration suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Bump max_connections from the postgres:16-alpine default of 100 to 200
+      # so the integration suite has headroom while the underlying connection
+      # leak in server actions is investigated. See #475 for the diagnostic
+      # and follow-ups. max_connections is a restart-required setting, so
+      # ALTER SYSTEM is paired with `docker restart` of the service container.
+      - name: Bump Postgres max_connections
+        run: |
+          docker exec ${{ job.services.postgres.id }} psql -U postgres -d govea -c "ALTER SYSTEM SET max_connections = 200;"
+          docker restart ${{ job.services.postgres.id }}
+          for i in {1..20}; do
+            if docker exec ${{ job.services.postgres.id }} pg_isready -U postgres >/dev/null 2>&1; then
+              echo "Postgres ready after restart"
+              break
+            fi
+            sleep 1
+          done
+
       - name: Push schema to database
         run: pnpm --filter govea db:push --force
 


### PR DESCRIPTION
## Summary

Unblocks the integration test job, which started failing intermittently with `PostgresError: sorry, too many clients already` (code 53300) after the #363 stream landed on main. The failure reproduces on documentation-only PRs ([#474](https://github.com/roballred/GovEA/pull/474) — zero code changes — failed twice), which confirms it's CI infrastructure, not a regression in any one PR's contents.

Closes #475

## What this changes

One step added to the **Integration tests** job in `.github/workflows/ci.yml`:

```yaml
- name: Bump Postgres max_connections
  run: |
    docker exec ${{ job.services.postgres.id }} psql ... \
      -c "ALTER SYSTEM SET max_connections = 200;"
    docker restart ${{ job.services.postgres.id }}
    # wait for ready
```

That's the entire diff. No code changes, no test changes, no schema changes.

## Why this approach

- **Default `postgres:16-alpine` ships with `max_connections=100`.** The integration suite (34 files, growing) hits the limit because of a connection leak in server actions added during the #363 stream (#471 + #472).
- **GitHub Actions service definitions don't support a `command:` field** the way docker-compose does, so passing `-c max_connections=200` to the Postgres entrypoint requires a workaround.
- **`ALTER SYSTEM SET` + `docker restart` is the documented, low-risk pattern** for tuning a service container's Postgres config in GHA. The setting persists in `postgresql.auto.conf` and is picked up on the restart.
- **Stopgap, not a fix.** The underlying connection leak is still present. [#475](https://github.com/roballred/GovEA/issues/475) tracks the follow-up work: audit lifecycle in `data-architecture.ts` and `data-architecture-relationships.ts` server actions, add a tear-down hook in `tests/integration/setup.ts`, consider lowering the pool max in `db/client.ts` so the leak surfaces locally.

## Trade-offs considered

| Approach | Why not |
|---|---|
| Lower `postgres-js` pool `max` to 5 in `db/client.ts` | Surfaces the leak earlier locally but does not address the CI failure today. Worth doing in a follow-up. |
| Add `command:` field to service definition | Not supported by GHA service syntax. |
| Use a custom Postgres image with config baked in | Heavier; rebuilds on every workflow run unless cached. Overkill for a one-line stopgap. |

## Why no test changes

The fix is purely a CI-runtime setting. The application's behavior is unchanged. Existing tests should pass with the new ceiling.

## Test plan

- [ ] CI green on this PR — integration job completes 481/481 tests without `53300 FATAL`
- [ ] After merge, the next #474-style docs-only PR also passes CI cleanly (i.e. the flake is gone)

## Traceability

This is CI infrastructure work — no capability mapping applies. Per Standards.md §3 the traceability convention is for capability-implementing changes; infra/process work is documented in the issue body instead.