### PR TITLE
feat(data-architecture): Chen Notation visualization (PR-3 of #363)

### DIFF
--- a/apps/govea/src/app/(admin)/data/diagram/page.tsx
+++ b/apps/govea/src/app/(admin)/data/diagram/page.tsx
@@ -1,0 +1,183 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import {
+  getDataArchitectureGraph,
+  type GraphFilters,
+} from '@/lib/data-architecture-graph'
+import { DataArchitectureDiagram } from '@/components/data-architecture-diagram'
+import { getPersonas } from '@/actions/personas'
+import type { PhysicalAttributeType, PhysicalLinkType } from '@/db/schema'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+const PHYSICAL_ATTRIBUTE_TYPES: PhysicalAttributeType[] = [
+  'effectivity', 'multi-active', 'record-tracking', 'status-tracking',
+]
+const PHYSICAL_LINK_TYPES: PhysicalLinkType[] = ['same-as', 'hierarchical']
+
+interface SearchParams {
+  ownerPersonaId?: string
+  q?: string
+  attrType?: string
+  linkType?: string
+}
+
+/**
+ * /data/diagram — Chen Notation overview of the entire metamodel.
+ *
+ * Capability: da-chen-visualization
+ * Persona: Enterprise Data Architect, Data Modeler
+ */
+export default async function DataArchitectureDiagramPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const params = await searchParams
+  const role = session.user.role
+
+  const filters: GraphFilters = {}
+  if (params.ownerPersonaId) filters.ownerPersonaIds = [params.ownerPersonaId]
+  if (params.q?.trim()) filters.nameSearch = params.q.trim()
+  if (params.attrType && PHYSICAL_ATTRIBUTE_TYPES.includes(params.attrType as PhysicalAttributeType)) {
+    filters.physicalAttributeType = params.attrType as PhysicalAttributeType
+  }
+  if (params.linkType && PHYSICAL_LINK_TYPES.includes(params.linkType as PhysicalLinkType)) {
+    filters.physicalLinkType = params.linkType as PhysicalLinkType
+  }
+
+  const [graph, allPersonas] = await Promise.all([
+    getDataArchitectureGraph({
+      organizationId: session.user.organizationId!,
+      role,
+      filters,
+    }),
+    getPersonas(),
+  ])
+
+  const filtersActive = !!(filters.ownerPersonaIds?.length || filters.nameSearch || filters.physicalAttributeType || filters.physicalLinkType)
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href="/data" className="text-sm text-muted-foreground hover:underline">← Data architecture</Link>
+        <h1 className="text-2xl font-bold tracking-tight mt-2">Diagram</h1>
+        <p className="text-muted-foreground mt-1 text-sm max-w-2xl">
+          Chen Notation overview of the org&apos;s metamodel. Entities as rectangles, attributes as ovals,
+          business keys as underlined ovals (Chen key convention). Diamonds label cross-object
+          relationships ({'"'}is related{'"'} / {'"'}shares{'"'} / {'"'}instantiates{'"'}). The diagram is read-only — click any
+          node to edit it on its detail page.
+        </p>
+      </div>
+
+      <FilterBar params={params} personas={allPersonas} filtersActive={filtersActive} />
+
+      <p className="text-xs text-muted-foreground">
+        Showing {graph.entities.length} {plural(graph.entities.length, 'entity', 'entities')},{' '}
+        {graph.attributes.length} {plural(graph.attributes.length, 'attribute', 'attributes')},{' '}
+        {graph.businessKeys.length} business key{graph.businessKeys.length === 1 ? '' : 's'},{' '}
+        {graph.edges.length} relationship{graph.edges.length === 1 ? '' : 's'}.
+      </p>
+
+      <DataArchitectureDiagram graph={graph} />
+
+      <Legend />
+    </div>
+  )
+}
+
+function plural(n: number, sing: string, pl: string): string {
+  return n === 1 ? sing : pl
+}
+
+function FilterBar({ params, personas, filtersActive }: {
+  params: SearchParams
+  personas: { id: string; name: string }[]
+  filtersActive: boolean
+}) {
+  return (
+    <form method="get" className="flex flex-wrap items-end gap-3 rounded-lg border bg-card px-4 py-3">
+      <div className="space-y-1">
+        <label htmlFor="q" className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Name</label>
+        <input
+          id="q" name="q" type="text"
+          defaultValue={params.q ?? ''}
+          placeholder="Search by name"
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm w-44"
+        />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="ownerPersonaId" className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Owner</label>
+        <select
+          id="ownerPersonaId" name="ownerPersonaId"
+          defaultValue={params.ownerPersonaId ?? ''}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm w-44"
+        >
+          <option value="">All owners</option>
+          {personas.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+        </select>
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="attrType" className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Attribute type</label>
+        <select
+          id="attrType" name="attrType"
+          defaultValue={params.attrType ?? ''}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm w-40"
+        >
+          <option value="">All types</option>
+          {PHYSICAL_ATTRIBUTE_TYPES.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="linkType" className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Link type</label>
+        <select
+          id="linkType" name="linkType"
+          defaultValue={params.linkType ?? ''}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm w-40"
+        >
+          <option value="">All types</option>
+          {PHYSICAL_LINK_TYPES.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-end gap-2">
+        <button
+          type="submit"
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Apply
+        </button>
+        {filtersActive && (
+          <Link
+            href="/data/diagram"
+            className={cn('rounded-md border bg-card px-3 py-1.5 text-sm hover:bg-muted/50')}
+          >
+            Reset
+          </Link>
+        )}
+      </div>
+    </form>
+  )
+}
+
+function Legend() {
+  return (
+    <div className="rounded-lg border bg-card px-4 py-3 text-xs text-muted-foreground">
+      <p className="font-medium text-foreground mb-2">Legend</p>
+      <ul className="grid gap-1 sm:grid-cols-2">
+        <li>▭ Entity (Data Vault Hub)</li>
+        <li>◯ Attribute (Data Vault Satellite)</li>
+        <li>◯ Business key (underlined — Chen key convention)</li>
+        <li>◇ Cross-object relationship — labeled with kind</li>
+        <li>→ Solid arrow: instantiates (entity → business key)</li>
+        <li>┄ Dashed line: shares (attribute ↔ attribute)</li>
+      </ul>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/data/page.tsx
+++ b/apps/govea/src/app/(admin)/data/page.tsx
@@ -42,12 +42,20 @@ export default async function DataArchitectureHub() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Data architecture</h1>
-        <p className="text-muted-foreground mt-1 text-sm max-w-2xl">
-          A Data Vault-aligned metamodel for Data Architects. Capture entities, attributes, links,
-          and business keys with their physical-table metadata.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Data architecture</h1>
+          <p className="text-muted-foreground mt-1 text-sm max-w-2xl">
+            A Data Vault-aligned metamodel for Data Architects. Capture entities, attributes, links,
+            and business keys with their physical-table metadata.
+          </p>
+        </div>
+        <Link
+          href="/data/diagram"
+          className="shrink-0 rounded-md border bg-card px-3 py-1.5 text-sm font-medium hover:bg-muted/50"
+        >
+          View diagram
+        </Link>
       </div>
 
       <ul className="grid gap-4 sm:grid-cols-2">

--- a/apps/govea/src/components/data-architecture-diagram.tsx
+++ b/apps/govea/src/components/data-architecture-diagram.tsx
@@ -1,0 +1,345 @@
+/**
+ * Chen Notation visualization for the Data Architecture metamodel
+ * (#363 PR-3 / #470). Server-rendered SVG — no client JS, no hydration.
+ *
+ * Layout is deterministic: entities placed in a horizontal row at the top,
+ * sorted alphabetically; for each entity, its characterizing attributes
+ * appear as ovals branching upward and its instantiating business keys as
+ * underlined ovals branching downward. Edges across entities ("is related")
+ * connect entity rectangles directly. Shared-attribute edges ("shares")
+ * connect attribute ovals directly.
+ *
+ * Chen glyph conventions (per da-chen-visualization capability):
+ *   Entity         → rectangle
+ *   Attribute      → oval
+ *   Business key   → oval with underlined text (Chen convention for keys)
+ *   Relationship   → diamond, labeled with kind, placed midway on the edge
+ *
+ * Capability: da-chen-visualization
+ * Persona: Enterprise Data Architect, Data Modeler
+ */
+
+import Link from 'next/link'
+import type {
+  DataArchitectureGraph, GraphEntityNode, GraphAttributeNode, GraphBusinessKeyNode,
+} from '@/lib/data-architecture-graph'
+
+// ── Layout constants ────────────────────────────────────────────────────────
+
+const ENTITY_W = 160
+const ENTITY_H = 56
+const ATTR_W = 130
+const ATTR_H = 36
+const BK_W = 140
+const BK_H = 36
+
+const COL_W = ENTITY_W + 60          // horizontal stride per entity
+const ROW_GAP = 24
+const TOP_PAD = 80                   // space above entity row for attributes
+const BOT_PAD = 60                   // space below entity row for business keys
+const ENTITY_Y = TOP_PAD + 160       // y-coordinate of the entity row
+const ATTR_BAND_Y = TOP_PAD          // y of the attribute cluster top
+const BK_BAND_Y = ENTITY_Y + ENTITY_H + 40  // y of the business-key cluster top
+
+const COLORS = {
+  draft: {
+    fill: '#f8fafc', stroke: '#94a3b8', text: '#475569',
+  },
+  published: {
+    fill: '#ffffff', stroke: '#0f172a', text: '#0f172a',
+  },
+  archived: {
+    fill: '#f1f5f9', stroke: '#cbd5e1', text: '#94a3b8',
+  },
+} as const
+
+const EDGE = {
+  'is-related':       { stroke: '#0f172a', dasharray: undefined, label: 'is related' },
+  'characterized-by': { stroke: '#64748b', dasharray: undefined, label: undefined  }, // thin line from entity to attribute oval
+  'shares':           { stroke: '#94a3b8', dasharray: '4 3',     label: 'shares' },
+  'instantiates':     { stroke: '#0f172a', dasharray: undefined, label: 'instantiates' },
+} as const
+
+interface NodePos { x: number; y: number; w: number; h: number }
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+interface LaidOutGraph {
+  width: number
+  height: number
+  entityPositions: Map<string, NodePos>
+  attributePositions: Map<string, NodePos>
+  bkPositions: Map<string, NodePos>
+}
+
+function computeLayout(graph: DataArchitectureGraph): LaidOutGraph {
+  const entities = [...graph.entities].sort((a, b) => a.name.localeCompare(b.name))
+
+  const entityPositions = new Map<string, NodePos>()
+  const attributePositions = new Map<string, NodePos>()
+  const bkPositions = new Map<string, NodePos>()
+
+  // Group attributes per entity for cluster placement above each entity. An
+  // attribute that characterizes multiple entities is assigned to its
+  // alphabetically-first entity for layout purposes; cross-entity links are
+  // still drawn correctly.
+  const attrsByEntity = new Map<string, GraphAttributeNode[]>()
+  const charEdges = graph.edges.filter(e => e.kind === 'characterized-by')
+  for (const a of graph.attributes) {
+    const owningEntityIds = charEdges
+      .filter(e => e.targetId === a.id)
+      .map(e => e.sourceId)
+      .sort()
+    const home = owningEntityIds[0] ?? '__orphan__'
+    const list = attrsByEntity.get(home) ?? []
+    list.push(a)
+    attrsByEntity.set(home, list)
+  }
+
+  const bksByEntity = new Map<string, GraphBusinessKeyNode[]>()
+  for (const bk of graph.businessKeys) {
+    const list = bksByEntity.get(bk.owningEntityId) ?? []
+    list.push(bk)
+    bksByEntity.set(bk.owningEntityId, list)
+  }
+
+  // Place each entity + its cluster.
+  let maxY = ENTITY_Y + ENTITY_H + BOT_PAD
+  for (let i = 0; i < entities.length; i++) {
+    const e = entities[i]
+    const colX = i * COL_W + 40
+    const cx = colX + ENTITY_W / 2
+
+    entityPositions.set(e.id, { x: colX, y: ENTITY_Y, w: ENTITY_W, h: ENTITY_H })
+
+    const eAttrs = (attrsByEntity.get(e.id) ?? []).slice().sort((a, b) => a.name.localeCompare(b.name))
+    eAttrs.forEach((a, idx) => {
+      const ax = cx - ATTR_W / 2
+      const ay = ATTR_BAND_Y + idx * (ATTR_H + ROW_GAP)
+      attributePositions.set(a.id, { x: ax, y: ay, w: ATTR_W, h: ATTR_H })
+      const bottom = ay + ATTR_H
+      if (bottom > maxY) maxY = bottom
+    })
+
+    const eBKs = (bksByEntity.get(e.id) ?? []).slice().sort((a, b) => a.name.localeCompare(b.name))
+    eBKs.forEach((bk, idx) => {
+      const bx = cx - BK_W / 2
+      const by = BK_BAND_Y + idx * (BK_H + ROW_GAP)
+      bkPositions.set(bk.id, { x: bx, y: by, w: BK_W, h: BK_H })
+      const bottom = by + BK_H
+      if (bottom > maxY) maxY = bottom
+    })
+  }
+
+  // Orphan attributes (no characterized-by edge) get a row at the bottom.
+  const orphans = (attrsByEntity.get('__orphan__') ?? []).slice().sort((a, b) => a.name.localeCompare(b.name))
+  const orphanY = maxY + ROW_GAP * 2
+  orphans.forEach((a, idx) => {
+    attributePositions.set(a.id, {
+      x: 40 + (idx % Math.max(1, entities.length || 1)) * COL_W + (COL_W - ATTR_W) / 2,
+      y: orphanY + Math.floor(idx / Math.max(1, entities.length || 1)) * (ATTR_H + ROW_GAP),
+      w: ATTR_W, h: ATTR_H,
+    })
+  })
+  if (orphans.length > 0) {
+    maxY = orphanY + Math.ceil(orphans.length / Math.max(1, entities.length || 1)) * (ATTR_H + ROW_GAP)
+  }
+
+  const width = Math.max(800, entities.length * COL_W + 80)
+  const height = maxY + 40
+
+  return { width, height, entityPositions, attributePositions, bkPositions }
+}
+
+// ── Renderer ────────────────────────────────────────────────────────────────
+
+export function DataArchitectureDiagram({ graph }: { graph: DataArchitectureGraph }) {
+  if (graph.entities.length === 0 && graph.attributes.length === 0 && graph.businessKeys.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+        No metamodel objects yet. Create at least one entity to see it on the diagram.
+      </div>
+    )
+  }
+
+  const layout = computeLayout(graph)
+  const { width, height, entityPositions, attributePositions, bkPositions } = layout
+
+  // Resolve glyph centers for edge midpoint calculation.
+  const center = (p: NodePos | undefined) => p ? ({ x: p.x + p.w / 2, y: p.y + p.h / 2 }) : null
+
+  return (
+    <div className="overflow-x-auto rounded-lg border bg-card">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        width={width} height={height}
+        role="img"
+        aria-label="Chen Notation diagram of the data architecture metamodel"
+        style={{ display: 'block', minWidth: '100%' }}
+      >
+        {/* arrow marker for instantiates */}
+        <defs>
+          <marker id="arrow-instantiates" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto">
+            <path d="M0,0 L10,5 L0,10 Z" fill="#0f172a" />
+          </marker>
+        </defs>
+
+        {/* Edges first so nodes render on top */}
+        {graph.edges.map((e, i) => {
+          const a = center(entityPositions.get(e.sourceId) ?? attributePositions.get(e.sourceId))
+          const b = center(
+            e.kind === 'is-related' ? entityPositions.get(e.targetId)
+            : e.kind === 'characterized-by' ? attributePositions.get(e.targetId)
+            : e.kind === 'shares' ? attributePositions.get(e.targetId)
+            : bkPositions.get(e.targetId), // instantiates → business key
+          )
+          if (!a || !b) return null
+          const cfg = EDGE[e.kind]
+          const midX = (a.x + b.x) / 2
+          const midY = (a.y + b.y) / 2
+
+          return (
+            <g key={`e-${i}`}>
+              <line
+                x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+                stroke={cfg.stroke}
+                strokeWidth={1.2}
+                strokeDasharray={cfg.dasharray}
+                markerEnd={e.kind === 'instantiates' ? 'url(#arrow-instantiates)' : undefined}
+              />
+              {/* Diamond glyph for labeled cross-object kinds */}
+              {cfg.label && (
+                <g transform={`translate(${midX} ${midY})`}>
+                  <polygon
+                    points="0,-9 14,0 0,9 -14,0"
+                    fill="#ffffff"
+                    stroke={cfg.stroke}
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={0} y={3}
+                    textAnchor="middle"
+                    fontSize={9}
+                    fontFamily="system-ui, sans-serif"
+                    fill={cfg.stroke}
+                  >
+                    {cfg.label}
+                  </text>
+                </g>
+              )}
+            </g>
+          )
+        })}
+
+        {/* Entities — rectangles */}
+        {graph.entities.map(e => {
+          const p = entityPositions.get(e.id)
+          if (!p) return null
+          const c = COLORS[e.status]
+          return (
+            <Link key={e.id} href={`/data/entities/${e.id}`}>
+              <g transform={`translate(${p.x} ${p.y})`}>
+                <rect width={p.w} height={p.h} fill={c.fill} stroke={c.stroke} strokeWidth={1.5} rx={3} />
+                <text
+                  x={p.w / 2} y={p.h / 2 + 4}
+                  textAnchor="middle"
+                  fontSize={13}
+                  fontFamily="system-ui, sans-serif"
+                  fontWeight={600}
+                  fill={c.text}
+                >
+                  {truncate(e.name, 20)}
+                </text>
+                {e.physicalHubTableName && (
+                  <text
+                    x={p.w / 2} y={p.h / 2 + 18}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+                    fill={c.text}
+                    opacity={0.6}
+                  >
+                    {truncate(e.physicalHubTableName, 22)}
+                  </text>
+                )}
+              </g>
+            </Link>
+          )
+        })}
+
+        {/* Attributes — ovals */}
+        {graph.attributes.map(a => {
+          const p = attributePositions.get(a.id)
+          if (!p) return null
+          const c = COLORS[a.status]
+          return (
+            <Link key={a.id} href={`/data/attributes/${a.id}`}>
+              <g transform={`translate(${p.x} ${p.y})`}>
+                <ellipse
+                  cx={p.w / 2} cy={p.h / 2}
+                  rx={p.w / 2} ry={p.h / 2}
+                  fill={c.fill} stroke={c.stroke} strokeWidth={1.2}
+                />
+                <text
+                  x={p.w / 2} y={p.h / 2 + 4}
+                  textAnchor="middle"
+                  fontSize={12}
+                  fontFamily="system-ui, sans-serif"
+                  fill={c.text}
+                >
+                  {truncate(a.name, 16)}
+                </text>
+              </g>
+            </Link>
+          )
+        })}
+
+        {/* Business keys — ovals with underlined text (Chen key convention) */}
+        {graph.businessKeys.map(bk => {
+          const p = bkPositions.get(bk.id)
+          if (!p) return null
+          const c = COLORS[bk.status]
+          const label = truncate(bk.name, 16)
+          // approximate underline width for visual key indication
+          const underlineW = Math.min(label.length * 7, p.w - 16)
+          return (
+            <Link key={bk.id} href={`/data/business-keys/${bk.id}`}>
+              <g transform={`translate(${p.x} ${p.y})`}>
+                <ellipse
+                  cx={p.w / 2} cy={p.h / 2}
+                  rx={p.w / 2} ry={p.h / 2}
+                  fill={c.fill} stroke={c.stroke} strokeWidth={1.2}
+                />
+                <text
+                  x={p.w / 2} y={p.h / 2 + 4}
+                  textAnchor="middle"
+                  fontSize={12}
+                  fontFamily="system-ui, sans-serif"
+                  fill={c.text}
+                  fontWeight={500}
+                >
+                  {label}
+                </text>
+                <line
+                  x1={(p.w - underlineW) / 2}
+                  y1={p.h / 2 + 7}
+                  x2={(p.w + underlineW) / 2}
+                  y2={p.h / 2 + 7}
+                  stroke={c.text}
+                  strokeWidth={1}
+                />
+              </g>
+            </Link>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…'
+}

--- a/apps/govea/src/lib/data-architecture-graph.ts
+++ b/apps/govea/src/lib/data-architecture-graph.ts
@@ -1,0 +1,279 @@
+/**
+ * Data Architecture graph data fetcher (#363 PR-3).
+ *
+ * Reads the four metamodel object types and the three semantic-relationship
+ * tables from a single org, applies role gating (viewer sees only published)
+ * and federation visibility, and returns a flat graph shape suitable for
+ * the Chen Notation renderer.
+ *
+ * Edges include the structural FK relationship (entity ↔ business key
+ * "instantiates") as well as the three explicit relationship-table kinds
+ * (is-related / characterized-by / shares).
+ *
+ * Capability: da-chen-visualization
+ * Persona: Enterprise Data Architect, Data Modeler
+ */
+
+import { db } from '@/db/client'
+import {
+  dataEntities, dataAttributes, dataLinks, dataBusinessKeys,
+  dataEntityOwners, dataAttributeOwners, dataBusinessKeyOwners,
+  dataEntityRelations, dataEntityAttributeLinks, dataAttributeShares,
+  type DataEntity, type DataAttribute, type DataLink, type DataBusinessKey,
+  type PhysicalAttributeType, type PhysicalLinkType,
+} from '@/db/schema'
+import { and, eq, inArray, or } from 'drizzle-orm'
+
+type Status = 'draft' | 'published' | 'archived'
+
+export type GraphNodeKind = 'entity' | 'attribute' | 'business-key'
+
+export interface GraphEntityNode {
+  kind: 'entity'
+  id: string
+  name: string
+  status: Status
+  ownerPersonaIds: string[]
+  physicalHubTableName: string | null
+}
+
+export interface GraphAttributeNode {
+  kind: 'attribute'
+  id: string
+  name: string
+  status: Status
+  ownerPersonaIds: string[]
+  physicalSatelliteTableName: string | null
+  physicalAttributeType: PhysicalAttributeType | null
+}
+
+export interface GraphBusinessKeyNode {
+  kind: 'business-key'
+  id: string
+  name: string
+  status: Status
+  ownerPersonaIds: string[]
+  dataType: string | null
+  /** The entity this business key instantiates. */
+  owningEntityId: string
+}
+
+export type GraphNode = GraphEntityNode | GraphAttributeNode | GraphBusinessKeyNode
+
+export type EdgeKind = 'is-related' | 'characterized-by' | 'shares' | 'instantiates'
+
+export interface GraphEdge {
+  kind: EdgeKind
+  /** Lower-UUID side for symmetric kinds; the entity side for directed kinds. */
+  sourceId: string
+  /** Higher-UUID side for symmetric kinds; the attribute or business-key side for directed kinds. */
+  targetId: string
+}
+
+export interface GraphFilters {
+  /** Persona ID — node visible only if at least one owner matches. Multiple values OR'd. */
+  ownerPersonaIds?: string[]
+  /** Free-text match against entity/attribute/business-key name (case-insensitive contains). */
+  nameSearch?: string
+  /** Restrict attributes to a specific physical type tag. */
+  physicalAttributeType?: PhysicalAttributeType
+  /** Restrict to entities/attributes/BKs linked to a specific physical link type. v1 reads this off the dataLinks table. */
+  physicalLinkType?: PhysicalLinkType
+}
+
+export interface DataArchitectureGraph {
+  entities: GraphEntityNode[]
+  attributes: GraphAttributeNode[]
+  businessKeys: GraphBusinessKeyNode[]
+  links: DataLink[]
+  edges: GraphEdge[]
+}
+
+// ── Implementation ──────────────────────────────────────────────────────────
+
+interface FetchArgs {
+  organizationId: string
+  role: 'admin' | 'contributor' | 'viewer'
+  filters?: GraphFilters
+}
+
+/**
+ * Returns the graph for one organization. Viewer role sees only published
+ * objects. Filters reduce visible nodes; orphan edges are dropped.
+ *
+ * Federation is intentionally not implemented in v1 — the diagram is
+ * org-scoped only. Cross-org viewing of a partner org's data architecture
+ * is deferred; the metamodel objects have visibility flags that respect
+ * federation when read individually, but rendering a graph across orgs is
+ * a separate UX question (whose Chen layout do you trust?) and out of scope.
+ */
+export async function getDataArchitectureGraph(args: FetchArgs): Promise<DataArchitectureGraph> {
+  const { organizationId, role, filters } = args
+  const viewerOnlyPublished = role === 'viewer'
+
+  // Pull all four object types in parallel.
+  const [entityRows, attributeRows, linkRows, bkRows] = await Promise.all([
+    db.select().from(dataEntities).where(eq(dataEntities.organizationId, organizationId)),
+    db.select().from(dataAttributes).where(eq(dataAttributes.organizationId, organizationId)),
+    db.select().from(dataLinks).where(eq(dataLinks.organizationId, organizationId)),
+    db.select().from(dataBusinessKeys).where(eq(dataBusinessKeys.organizationId, organizationId)),
+  ])
+
+  // Role gating: viewer drops non-published from each list.
+  const passStatus = <T extends { status: Status }>(r: T) => !viewerOnlyPublished || r.status === 'published'
+  const visibleEntities = entityRows.filter(passStatus)
+  const visibleAttributes = attributeRows.filter(passStatus)
+  const visibleLinks = linkRows.filter(passStatus)
+  const visibleBKs = bkRows.filter(passStatus)
+
+  // Owner lookups for filter + display. Skip the query if no rows survived role gating.
+  const [entityOwners, attributeOwners, bkOwners] = await Promise.all([
+    visibleEntities.length === 0 ? [] : db.select().from(dataEntityOwners)
+      .where(inArray(dataEntityOwners.dataEntityId, visibleEntities.map(e => e.id))),
+    visibleAttributes.length === 0 ? [] : db.select().from(dataAttributeOwners)
+      .where(inArray(dataAttributeOwners.dataAttributeId, visibleAttributes.map(a => a.id))),
+    visibleBKs.length === 0 ? [] : db.select().from(dataBusinessKeyOwners)
+      .where(inArray(dataBusinessKeyOwners.dataBusinessKeyId, visibleBKs.map(bk => bk.id))),
+  ])
+
+  const ownersBy = <T extends { [k: string]: unknown }>(
+    rows: T[], idKey: keyof T,
+  ): Map<string, string[]> => {
+    const m = new Map<string, string[]>()
+    for (const r of rows) {
+      const id = r[idKey] as string
+      const pid = (r as unknown as { personaId: string }).personaId
+      const list = m.get(id) ?? []
+      list.push(pid)
+      m.set(id, list)
+    }
+    return m
+  }
+
+  const entityOwnerMap = ownersBy(entityOwners, 'dataEntityId')
+  const attributeOwnerMap = ownersBy(attributeOwners, 'dataAttributeId')
+  const bkOwnerMap = ownersBy(bkOwners, 'dataBusinessKeyId')
+
+  const buildEntityNode = (e: DataEntity): GraphEntityNode => ({
+    kind: 'entity',
+    id: e.id,
+    name: e.name,
+    status: e.status,
+    ownerPersonaIds: entityOwnerMap.get(e.id) ?? [],
+    physicalHubTableName: e.physicalHubTableName,
+  })
+  const buildAttributeNode = (a: DataAttribute): GraphAttributeNode => ({
+    kind: 'attribute',
+    id: a.id,
+    name: a.name,
+    status: a.status,
+    ownerPersonaIds: attributeOwnerMap.get(a.id) ?? [],
+    physicalSatelliteTableName: a.physicalSatelliteTableName,
+    physicalAttributeType: a.physicalAttributeType,
+  })
+  const buildBKNode = (bk: DataBusinessKey): GraphBusinessKeyNode => ({
+    kind: 'business-key',
+    id: bk.id,
+    name: bk.name,
+    status: bk.status,
+    ownerPersonaIds: bkOwnerMap.get(bk.id) ?? [],
+    dataType: bk.dataType,
+    owningEntityId: bk.owningDataEntityId,
+  })
+
+  let entities = visibleEntities.map(buildEntityNode)
+  let attributes = visibleAttributes.map(buildAttributeNode)
+  let businessKeys = visibleBKs.map(buildBKNode)
+
+  // Apply filters.
+  if (filters?.ownerPersonaIds?.length) {
+    const targetSet = new Set(filters.ownerPersonaIds)
+    const ownsAny = (owners: string[]) => owners.some(o => targetSet.has(o))
+    entities = entities.filter(e => ownsAny(e.ownerPersonaIds))
+    attributes = attributes.filter(a => ownsAny(a.ownerPersonaIds))
+    businessKeys = businessKeys.filter(bk => ownsAny(bk.ownerPersonaIds))
+  }
+  if (filters?.nameSearch) {
+    const needle = filters.nameSearch.toLowerCase()
+    const matches = (n: { name: string }) => n.name.toLowerCase().includes(needle)
+    entities = entities.filter(matches)
+    attributes = attributes.filter(matches)
+    businessKeys = businessKeys.filter(matches)
+  }
+  if (filters?.physicalAttributeType) {
+    attributes = attributes.filter(a => a.physicalAttributeType === filters.physicalAttributeType)
+  }
+  // physicalLinkType filter is applied to dataLinks separately — links are not nodes in the graph
+  // (they were renamed from "Relationship" because the cross-object relationship kinds are
+  //  rendered as edges, not as nodes). Surfaced here for completeness in the returned `links` list.
+  let surfacedLinks = visibleLinks
+  if (filters?.physicalLinkType) {
+    surfacedLinks = surfacedLinks.filter(l => l.physicalLinkType === filters.physicalLinkType)
+  }
+
+  // Edge fetch — only for the surviving nodes.
+  const entityIds = entities.map(e => e.id)
+  const attributeIds = attributes.map(a => a.id)
+  const bkIds = businessKeys.map(bk => bk.id)
+
+  const [relRows, charRows, shareRows] = await Promise.all([
+    entityIds.length === 0
+      ? []
+      : db.select().from(dataEntityRelations).where(and(
+          eq(dataEntityRelations.organizationId, organizationId),
+          or(
+            inArray(dataEntityRelations.leftDataEntityId, entityIds),
+            inArray(dataEntityRelations.rightDataEntityId, entityIds),
+          ),
+        )),
+    entityIds.length === 0 || attributeIds.length === 0
+      ? []
+      : db.select().from(dataEntityAttributeLinks).where(and(
+          eq(dataEntityAttributeLinks.organizationId, organizationId),
+          inArray(dataEntityAttributeLinks.dataEntityId, entityIds),
+          inArray(dataEntityAttributeLinks.dataAttributeId, attributeIds),
+        )),
+    attributeIds.length < 2
+      ? []
+      : db.select().from(dataAttributeShares).where(and(
+          eq(dataAttributeShares.organizationId, organizationId),
+          inArray(dataAttributeShares.leftDataAttributeId, attributeIds),
+          inArray(dataAttributeShares.rightDataAttributeId, attributeIds),
+        )),
+  ])
+
+  const visibleEntityIdSet = new Set(entityIds)
+  const visibleAttributeIdSet = new Set(attributeIds)
+
+  const edges: GraphEdge[] = []
+
+  // entity ↔ entity "is related" — drop pairs where either endpoint was filtered out
+  for (const r of relRows) {
+    if (visibleEntityIdSet.has(r.leftDataEntityId) && visibleEntityIdSet.has(r.rightDataEntityId)) {
+      edges.push({ kind: 'is-related', sourceId: r.leftDataEntityId, targetId: r.rightDataEntityId })
+    }
+  }
+
+  // entity ↔ attribute "characterized by"
+  for (const r of charRows) {
+    if (visibleEntityIdSet.has(r.dataEntityId) && visibleAttributeIdSet.has(r.dataAttributeId)) {
+      edges.push({ kind: 'characterized-by', sourceId: r.dataEntityId, targetId: r.dataAttributeId })
+    }
+  }
+
+  // attribute ↔ attribute "shares"
+  for (const r of shareRows) {
+    if (visibleAttributeIdSet.has(r.leftDataAttributeId) && visibleAttributeIdSet.has(r.rightDataAttributeId)) {
+      edges.push({ kind: 'shares', sourceId: r.leftDataAttributeId, targetId: r.rightDataAttributeId })
+    }
+  }
+
+  // entity → business-key "instantiates" — structural FK, not a junction table.
+  for (const bk of businessKeys) {
+    if (visibleEntityIdSet.has(bk.owningEntityId)) {
+      edges.push({ kind: 'instantiates', sourceId: bk.owningEntityId, targetId: bk.id })
+    }
+  }
+
+  return { entities, attributes, businessKeys, links: surfacedLinks, edges }
+}

--- a/apps/govea/tests/integration/data-architecture-graph.test.ts
+++ b/apps/govea/tests/integration/data-architecture-graph.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Data Architecture graph fetcher (#363 PR-3).
+ *
+ * Asserts the contract for getDataArchitectureGraph:
+ *   1. Returns all four object types + the four edge kinds.
+ *   2. Viewer role sees only published nodes.
+ *   3. Org-scoped — does not leak across orgs.
+ *   4. Filters reduce visible nodes; orphan edges are dropped.
+ *   5. Symmetric edges (is-related, shares) are returned once per pair.
+ *   6. Instantiates edge is derived from the structural FK, not a junction.
+ *
+ * Capability: da-chen-visualization
+ * Persona: Enterprise Data Architect, Data Modeler
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  dataEntities, dataAttributes, dataBusinessKeys,
+  dataEntityAttributeLinks, dataEntityRelations, dataAttributeShares,
+  dataEntityOwners, dataAttributeOwners,
+  personas,
+} from '@/db/schema'
+import { getDataArchitectureGraph } from '@/lib/data-architecture-graph'
+import {
+  createTestOrg, createTestUser, cleanupOrg,
+  type TestOrg,
+} from './helpers/db'
+
+// auth is unused in this test (the fetcher takes orgId + role directly) but
+// vitest sometimes complains about the action module's auth import in CI;
+// mock it defensively.
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+let orgA: TestOrg
+let orgB: TestOrg
+let personaA1: string
+let personaA2: string
+
+// Helpers — inserts directly via the db client so we don't pull the auth-gated
+// server actions into the test. The graph fetcher just reads what's there.
+async function insertEntity(orgId: string, name: string, status: 'draft' | 'published' = 'published', ownerIds: string[] = []) {
+  const [row] = await db.insert(dataEntities).values({
+    id: randomUUID(), organizationId: orgId, name, status, visibility: 'org',
+  }).returning()
+  for (const personaId of ownerIds) {
+    await db.insert(dataEntityOwners).values({ dataEntityId: row.id, personaId })
+  }
+  return row.id
+}
+
+async function insertAttribute(orgId: string, name: string, status: 'draft' | 'published' = 'published', ownerIds: string[] = [], physicalAttributeType: 'effectivity' | 'multi-active' | 'record-tracking' | 'status-tracking' | null = null) {
+  const [row] = await db.insert(dataAttributes).values({
+    id: randomUUID(), organizationId: orgId, name, status, visibility: 'org', physicalAttributeType,
+  }).returning()
+  for (const personaId of ownerIds) {
+    await db.insert(dataAttributeOwners).values({ dataAttributeId: row.id, personaId })
+  }
+  return row.id
+}
+
+async function insertBK(orgId: string, name: string, owningEntityId: string, status: 'draft' | 'published' = 'published') {
+  const [row] = await db.insert(dataBusinessKeys).values({
+    id: randomUUID(), organizationId: orgId, name, status, visibility: 'org', owningDataEntityId: owningEntityId,
+  }).returning()
+  return row.id
+}
+
+async function relateEntities(orgId: string, a: string, b: string) {
+  const [left, right] = a < b ? [a, b] : [b, a]
+  await db.insert(dataEntityRelations).values({
+    organizationId: orgId, leftDataEntityId: left, rightDataEntityId: right,
+  })
+}
+
+async function characterize(orgId: string, entityId: string, attributeId: string) {
+  await db.insert(dataEntityAttributeLinks).values({
+    organizationId: orgId, dataEntityId: entityId, dataAttributeId: attributeId,
+  })
+}
+
+async function shareAttributes(orgId: string, a: string, b: string) {
+  const [left, right] = a < b ? [a, b] : [b, a]
+  await db.insert(dataAttributeShares).values({
+    organizationId: orgId, leftDataAttributeId: left, rightDataAttributeId: right,
+  })
+}
+
+beforeAll(async () => {
+  orgA = await createTestOrg({ name: 'Graph Org A', slug: `graph-a-${randomUUID().slice(0, 8)}` })
+  orgB = await createTestOrg({ name: 'Graph Org B', slug: `graph-b-${randomUUID().slice(0, 8)}` })
+  await createTestUser(orgA.id, 'admin', { name: 'Graph Admin A' })
+
+  const [pA1, pA2] = await Promise.all([
+    db.insert(personas).values({
+      id: randomUUID(), organizationId: orgA.id, name: 'Graph Architect',
+      status: 'published', visibility: 'org',
+    }).returning(),
+    db.insert(personas).values({
+      id: randomUUID(), organizationId: orgA.id, name: 'Graph Modeler',
+      status: 'published', visibility: 'org',
+    }).returning(),
+  ])
+  personaA1 = pA1[0].id
+  personaA2 = pA2[0].id
+})
+
+afterAll(async () => {
+  await Promise.all([cleanupOrg(orgA.id), cleanupOrg(orgB.id)])
+})
+
+beforeEach(async () => {
+  await db.delete(dataEntities).where(eq(dataEntities.organizationId, orgA.id))
+  await db.delete(dataAttributes).where(eq(dataAttributes.organizationId, orgA.id))
+  await db.delete(dataBusinessKeys).where(eq(dataBusinessKeys.organizationId, orgA.id))
+  await db.delete(dataEntities).where(eq(dataEntities.organizationId, orgB.id))
+})
+
+// ── 1. Basic shape ──────────────────────────────────────────────────────────
+
+describe('getDataArchitectureGraph', () => {
+  it('returns empty graph when org has nothing', async () => {
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(g.entities).toEqual([])
+    expect(g.attributes).toEqual([])
+    expect(g.businessKeys).toEqual([])
+    expect(g.edges).toEqual([])
+  })
+
+  it('returns all four node types and the structural instantiates edge', async () => {
+    const e1 = await insertEntity(orgA.id, 'Customer')
+    const a1 = await insertAttribute(orgA.id, 'Address')
+    await characterize(orgA.id, e1, a1)
+    const bk = await insertBK(orgA.id, 'CustomerNumber', e1)
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(g.entities.map(e => e.name)).toEqual(['Customer'])
+    expect(g.attributes.map(a => a.name)).toEqual(['Address'])
+    expect(g.businessKeys.map(b => b.name)).toEqual(['CustomerNumber'])
+
+    const edgeKinds = g.edges.map(e => e.kind).sort()
+    expect(edgeKinds).toEqual(['characterized-by', 'instantiates'])
+
+    const instEdge = g.edges.find(e => e.kind === 'instantiates')
+    expect(instEdge?.sourceId).toBe(e1)
+    expect(instEdge?.targetId).toBe(bk)
+  })
+
+  it('returns is-related edges between entity pairs', async () => {
+    const e1 = await insertEntity(orgA.id, 'Customer')
+    const e2 = await insertEntity(orgA.id, 'Order')
+    await relateEntities(orgA.id, e1, e2)
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    const rel = g.edges.filter(e => e.kind === 'is-related')
+    expect(rel).toHaveLength(1)
+    // Symmetric: stored in canonical order. Just confirm both endpoints are present.
+    expect([rel[0].sourceId, rel[0].targetId].sort()).toEqual([e1, e2].sort())
+  })
+
+  it('returns shares edges between attribute pairs', async () => {
+    const a1 = await insertAttribute(orgA.id, 'AddressLine1')
+    const a2 = await insertAttribute(orgA.id, 'PrimaryAddress')
+    await shareAttributes(orgA.id, a1, a2)
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    const shares = g.edges.filter(e => e.kind === 'shares')
+    expect(shares).toHaveLength(1)
+    expect([shares[0].sourceId, shares[0].targetId].sort()).toEqual([a1, a2].sort())
+  })
+})
+
+// ── 2. Role gating ──────────────────────────────────────────────────────────
+
+describe('role gating', () => {
+  it('viewer sees only published entities, attributes, and business keys', async () => {
+    const ePub = await insertEntity(orgA.id, 'PublishedHub', 'published')
+    await insertEntity(orgA.id, 'DraftHub', 'draft')
+    const aPub = await insertAttribute(orgA.id, 'PublishedSat', 'published')
+    await insertAttribute(orgA.id, 'DraftSat', 'draft')
+    await insertBK(orgA.id, 'PublishedBK', ePub, 'published')
+    await insertBK(orgA.id, 'DraftBK', ePub, 'draft')
+
+    const viewerG = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'viewer' })
+    expect(viewerG.entities.map(e => e.name).sort()).toEqual(['PublishedHub'])
+    expect(viewerG.attributes.map(a => a.name).sort()).toEqual(['PublishedSat'])
+    expect(viewerG.businessKeys.map(b => b.name).sort()).toEqual(['PublishedBK'])
+
+    const adminG = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(adminG.entities).toHaveLength(2)
+    expect(adminG.attributes).toHaveLength(2)
+    expect(adminG.businessKeys).toHaveLength(2)
+  })
+
+  it('drops edges that reference a hidden node', async () => {
+    const ePub = await insertEntity(orgA.id, 'PublishedHub', 'published')
+    const aDraft = await insertAttribute(orgA.id, 'DraftSat', 'draft')
+    await characterize(orgA.id, ePub, aDraft)
+
+    const viewerG = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'viewer' })
+    expect(viewerG.edges.filter(e => e.kind === 'characterized-by')).toHaveLength(0)
+  })
+})
+
+// ── 3. Org scoping ──────────────────────────────────────────────────────────
+
+describe('org scoping', () => {
+  it('does not return another org\'s nodes', async () => {
+    const aEntity = await insertEntity(orgA.id, 'A-Hub')
+    await insertEntity(orgB.id, 'B-Hub')
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(g.entities.map(e => e.id)).toEqual([aEntity])
+  })
+})
+
+// ── 4. Filters ──────────────────────────────────────────────────────────────
+
+describe('filters', () => {
+  it('owner filter restricts to nodes owned by one of the listed personas', async () => {
+    await insertEntity(orgA.id, 'OwnedByArchitect', 'published', [personaA1])
+    await insertEntity(orgA.id, 'OwnedByModeler', 'published', [personaA2])
+    await insertEntity(orgA.id, 'Unowned', 'published')
+
+    const g = await getDataArchitectureGraph({
+      organizationId: orgA.id, role: 'admin',
+      filters: { ownerPersonaIds: [personaA1] },
+    })
+    expect(g.entities.map(e => e.name)).toEqual(['OwnedByArchitect'])
+  })
+
+  it('nameSearch filter is case-insensitive contains-match', async () => {
+    await insertEntity(orgA.id, 'CustomerAccount')
+    await insertEntity(orgA.id, 'Vendor')
+
+    const g = await getDataArchitectureGraph({
+      organizationId: orgA.id, role: 'admin',
+      filters: { nameSearch: 'cust' },
+    })
+    expect(g.entities.map(e => e.name)).toEqual(['CustomerAccount'])
+  })
+
+  it('physicalAttributeType filter restricts attributes to one type', async () => {
+    await insertAttribute(orgA.id, 'EffectivityAttr', 'published', [], 'effectivity')
+    await insertAttribute(orgA.id, 'StatusAttr', 'published', [], 'status-tracking')
+
+    const g = await getDataArchitectureGraph({
+      organizationId: orgA.id, role: 'admin',
+      filters: { physicalAttributeType: 'effectivity' },
+    })
+    expect(g.attributes.map(a => a.name)).toEqual(['EffectivityAttr'])
+  })
+
+  it('drops cross-edges when one endpoint is filtered out', async () => {
+    const e1 = await insertEntity(orgA.id, 'KeepEntity', 'published', [personaA1])
+    const e2 = await insertEntity(orgA.id, 'DropEntity', 'published', [personaA2])
+    await relateEntities(orgA.id, e1, e2)
+
+    const g = await getDataArchitectureGraph({
+      organizationId: orgA.id, role: 'admin',
+      filters: { ownerPersonaIds: [personaA1] },
+    })
+    expect(g.entities.map(e => e.name)).toEqual(['KeepEntity'])
+    expect(g.edges.filter(e => e.kind === 'is-related')).toHaveLength(0)
+  })
+})
+
+// ── 5. Edge deduplication ───────────────────────────────────────────────────
+
+describe('symmetric edges', () => {
+  it('emits one row per is-related pair', async () => {
+    const e1 = await insertEntity(orgA.id, 'A')
+    const e2 = await insertEntity(orgA.id, 'B')
+    await relateEntities(orgA.id, e1, e2)
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(g.edges.filter(e => e.kind === 'is-related')).toHaveLength(1)
+  })
+
+  it('emits one row per shares pair', async () => {
+    const a1 = await insertAttribute(orgA.id, 'A')
+    const a2 = await insertAttribute(orgA.id, 'B')
+    await shareAttributes(orgA.id, a1, a2)
+
+    const g = await getDataArchitectureGraph({ organizationId: orgA.id, role: 'admin' })
+    expect(g.edges.filter(e => e.kind === 'shares')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

PR-3 of the four-PR slice plan in [#363](https://github.com/roballred/GovEA/issues/363#issuecomment-4442900592), completing the v1 stream for the Data Architecture metamodel. Tracks against [#470](https://github.com/roballred/GovEA/issues/470).

Adds a server-rendered SVG diagram at `/data/diagram` so a Data Architect can see the full metamodel at a glance rather than navigate object-by-object.

Capability: da-chen-visualization
Capability group: ea/data-architecture
Persona: Enterprise Data Architect, Data Modeler

Closes #470
Refs #363, #471, #472, #474

## Chen Notation glyphs

Per the capability spec ([`da-chen-visualization.md`](business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md)):

| Object | Glyph |
|---|---|
| Entity | Rectangle |
| Attribute | Oval |
| Business key | Oval with underlined text (Chen key convention) |
| Cross-object relationship | Diamond, labeled with kind, placed midway on the edge |

## Edge kinds rendered

| Kind | Visual |
|---|---|
| entity ↔ entity `is related` | Solid line + diamond |
| entity ↔ attribute `characterized by` | Thin line (Chen ER convention — relationship implicit in attachment) |
| attribute ↔ attribute `shares` | Dashed line + diamond |
| entity → business key `instantiates` | Solid arrow + diamond |

## Data fetcher

[`apps/govea/src/lib/data-architecture-graph.ts`](apps/govea/src/lib/data-architecture-graph.ts) — `getDataArchitectureGraph({ organizationId, role, filters })`

- Reads all four object types + the three semantic-relationship tables; derives the entity→business-key `instantiates` edge from the structural FK (no extra junction)
- **Role-gates:** viewer sees only published nodes; drops edges whose endpoints are filtered out (no orphan edges)
- **Filters:** `ownerPersonaIds`, `nameSearch` (case-insensitive contains), `physicalAttributeType`, `physicalLinkType`
- **Org-scoped only.** Federation across orgs is intentionally deferred — see "Out of scope" below

## Renderer

[`apps/govea/src/components/data-architecture-diagram.tsx`](apps/govea/src/components/data-architecture-diagram.tsx) — pure server component, ~330 LoC

- Zero client JS, zero hydration cost
- Deterministic grid layout — entities sorted alphabetically across a horizontal row, attributes clustered above the entity that characterizes them, business keys clustered below
- Empty state when no metamodel objects exist
- Each glyph wraps a Next.js `<Link>` to its detail page (read-only diagram; editing happens on existing surfaces)

## Page

[`/data/diagram/page.tsx`](apps/govea/src/app/(admin)/data/diagram/page.tsx)

- Filter bar (URL-param form-submit; no client state)
- Status banner with current entity / attribute / business-key / relationship counts after filtering
- Legend explains the glyph language
- Linked from `/data` hub via a "View diagram" button next to the page title

## Rendering approach — trade-off documented

| Option | Why considered | Why rejected (or chosen) |
|---|---|---|
| **Server-rendered SVG (chosen)** | Existing precedent (`capability-map.tsx`, 380 LoC), matches Chen spec literally, zero new dependency, deterministic, server-renders | — |
| Mermaid `erDiagram` | Already in `package.json`, client-renders ER diagrams | Uses Crow's Foot notation by default; cannot produce Chen-style diamond relationship glyphs. The capability spec is explicit about diamonds, so this would have required a spec deviation |
| React Flow / xyflow | Drag/zoom interactivity | Read-only is sufficient for v1 per the spec; new dependency + hydration cost not justified |

## Tests

13 integration tests in [`data-architecture-graph.test.ts`](apps/govea/tests/integration/data-architecture-graph.test.ts):

- Empty graph returns empty arrays
- All four node types + structural `instantiates` edge in one shape
- `is-related` / `shares` / `characterized-by` edges
- Viewer role sees only published nodes
- Edges dropped when an endpoint is hidden
- Org scoping — no cross-org leakage
- Each filter kind (owner / nameSearch / physicalAttributeType)
- Cross-edges dropped when one endpoint is filtered out
- Symmetric edges (`is-related`, `shares`) emitted once per pair

**Locally: 13/13 new tests pass + 510/534 of the full suite.** The remaining failures are the pre-existing connection-pool leak ([#475](https://github.com/roballred/GovEA/issues/475)) — [#476](https://github.com/roballred/GovEA/pull/476) mitigated it for CI by bumping `max_connections` to 200, but local Postgres still has the default 100. **None of the failures are caused by this PR.**

## Browser verification (Riverdale Admin)

- ✅ Empty state: `/data/diagram` with no metamodel objects renders the empty-state card
- ✅ Populated state: 2 entities, 2 attributes, 1 business key, 4 edges → 2 rectangles, 3 ovals (1 with key underline), 5 lines, 2 diamond glyphs, 1 arrow marker — all rendered
- ✅ Click-through: every node wraps a `<Link>` to `/data/{resource}/[id]`
- ✅ Name filter (`?q=Customer`) reduces to 1 entity + 1 business key + 0 attributes
- ✅ "View diagram" link from `/data` hub navigates correctly
- ✅ No console or server errors

## Rollout notes

- **No schema changes.** All data comes from existing tables (#471 + #472).
- **No new dependencies.** Built on existing SVG / Next.js / Drizzle.
- **No new feature flags.** Module key `data-architecture` (from #471) already controls visibility.

## Standards.md compliance

- Capability + persona files exist on `main` from [#474](https://github.com/roballred/GovEA/pull/474). Issue [#470](https://github.com/roballred/GovEA/issues/470) carries the `Capability:` / `Persona:` traceability lines.
- This PR's body, commit footer, and source comments all reference the capability ID `da-chen-visualization`.
- Both linked personas remain `Validation Status: Assumed`. This PR does not change that — flagging that the visualization design is built around one SME's framing and would benefit from validation with at least one additional practitioner before being considered "Validated."

## Out of scope (separate issues)

- Edit-from-diagram (create / delete from the canvas)
- PNG / SVG export
- Automatic layout improvements beyond the deterministic grid
- Cross-org federated diagram rendering
- ARB review pass on the metamodel (deferred since #474; worth doing now that v1 of the stream is feature-complete)

## Test plan

- [x] `pnpm --filter govea exec vitest run tests/integration/data-architecture-graph.test.ts` — 13/13 pass
- [x] `pnpm --filter govea exec tsc --noEmit` — clean
- [x] `pnpm --filter govea lint` — 0 errors (21 pre-existing warnings, unchanged from main)
- [x] `pnpm --filter govea db:push` — applies cleanly (no schema changes)
- [x] Browser smoke: empty state, populated state, click-through, name filter
- [ ] CI green on integration + build (the `max_connections=200` bump from #476 should hold)