### PR TITLE
feat(nav): promote Data Architecture to its own nav group

### DIFF
--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -26,13 +26,30 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
+    // Data Architecture surfaces the full metamodel (entity / attribute /
+    // link / business-key + the Chen Notation diagram) the same way
+    // Business Architecture surfaces its object types. Every entry is
+    // gated on the `data-architecture` module key so toggling the module
+    // hides the whole group. Diagram lives behind PR-3 (#470/#477) — the
+    // link is included here so the nav is complete once that PR lands;
+    // if this PR ships first the link 404s until #477 lands.
+    label: 'Data Architecture',
+    items: [
+      { href: '/data',                label: 'Overview',      moduleKey: 'data-architecture' },
+      { href: '/data/entities',       label: 'Entities',      moduleKey: 'data-architecture' },
+      { href: '/data/attributes',     label: 'Attributes',    moduleKey: 'data-architecture' },
+      { href: '/data/links',          label: 'Links',         moduleKey: 'data-architecture' },
+      { href: '/data/business-keys',  label: 'Business keys', moduleKey: 'data-architecture' },
+      { href: '/data/diagram',        label: 'Diagram',       moduleKey: 'data-architecture' },
+    ],
+  },
+  {
     label: 'Portfolio',
     items: [
       { href: '/applications', label: 'Applications', moduleKey: 'applications' },
       { href: '/adrs',         label: 'Decisions',    moduleKey: 'adrs' },
       { href: '/principles',   label: 'Principles',   moduleKey: 'principles' },
       { href: '/debt',         label: 'Debt',         moduleKey: 'debt' },
-      { href: '/data',         label: 'Data architecture', moduleKey: 'data-architecture' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Closes #478. Companion follow-up issue: #479 (collapsible groups).

Moves the Data Architecture module out from under Portfolio and into its own nav group between Business Architecture and Portfolio. Surfaces the metamodel's six pages (Overview / Entities / Attributes / Links / Business keys / Diagram) directly in the sidebar instead of behind a single "Data architecture" link.

Capability: da-physical-metamodel, da-chen-visualization
Capability group: ea/data-architecture
Persona: Enterprise Data Architect, Data Modeler

## The change

One file, 18 insertions / 1 deletion in [`apps/govea/src/components/app-shell.tsx`](apps/govea/src/components/app-shell.tsx):

```diff
 BUSINESS ARCHITECTURE        BUSINESS ARCHITECTURE
   Personas                     Personas
   Value Streams                Value Streams
   Capabilities                 Capabilities
   Services                     Services
   Glossary                     Glossary

+                             DATA ARCHITECTURE   (new)
+                               Overview
+                               Entities
+                               Attributes
+                               Links
+                               Business keys
+                               Diagram

 PORTFOLIO                    PORTFOLIO
   Applications                 Applications
   Decisions                    Decisions
   Principles                   Principles
   Debt                         Debt
-  Data architecture
```

Every new sub-entry is gated on `moduleKey: 'data-architecture'` so toggling the module off hides the whole group — identical behavior to existing module-gated entries.

## Diagram entry and merge order

The `Diagram` entry points at `/data/diagram`, which is the route from PR-3 ([#477](https://github.com/roballred/GovEA/pull/477)). That PR is open against `main`. **If this PR merges first, the `Diagram` link 404s until #477 lands.** The window is short and the maintainer controls both merges; including the entry here means the nav is correct in one shot without a follow-up.

If you'd rather avoid the 404 window: merge #477 first, then this PR rebases cleanly. Or tell me to drop the `Diagram` entry from this PR and file a small follow-up after #477 lands — I'll do whichever you prefer.

## Browser verification

Dev server smoke as Riverdale Admin:

- ✅ Group order in the rendered HTML: Business Architecture → **Data Architecture** → Portfolio → Strategy → Reports → Configuration
- ✅ All six Data Architecture sub-entries present: Overview, Entities, Attributes, Links, Business keys, Diagram
- ✅ Portfolio still has its four remaining entries: Applications, Decisions, Principles, Debt — and no longer lists Data architecture
- ✅ Lint + typecheck clean

## Why no test changes

The change is a single literal array. A test asserting "this array has these literals" would be tautological and would not protect against any plausible regression. The right test is the browser smoke (above) and a human review. Per Standards.md §6, this is a "clear rationale for why tests are not applicable" case.

## Test plan

- [x] `pnpm --filter govea exec tsc --noEmit` — clean
- [x] `pnpm --filter govea lint` — 0 errors (18 pre-existing warnings, unchanged)
- [x] Browser smoke: group order, sub-entries, Portfolio retained correctly
- [ ] CI green on integration + build (no expected impact since no test or schema changes)

## Out of scope

- Collapsible groups — tracked in [#479](https://github.com/roballred/GovEA/issues/479)