### PR TITLE
fix(instance-nav): add Feature Controls nav item to instance-admin sidebar

### DIFF
--- a/apps/govea/src/components/instance-shell.tsx
+++ b/apps/govea/src/components/instance-shell.tsx
@@ -6,11 +6,12 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
 const NAV_ITEMS = [
-  { href: '/instance',        label: 'Dashboard',      exact: true },
-  { href: '/instance/orgs',   label: 'Organizations' },
-  { href: '/instance/users',  label: 'Users' },
-  { href: '/instance/audit',  label: 'Audit Log' },
-  { href: '/instance/config', label: 'Configuration' },
+  { href: '/instance',          label: 'Dashboard',         exact: true },
+  { href: '/instance/orgs',     label: 'Organizations' },
+  { href: '/instance/users',    label: 'Users' },
+  { href: '/instance/features', label: 'Feature Controls' },
+  { href: '/instance/audit',    label: 'Audit Log' },
+  { href: '/instance/config',   label: 'Configuration' },
 ]
 
 const BG    = '#1e1b4b' // indigo-950 — distinct from agency admin


### PR DESCRIPTION
## Summary

- Adds `Feature Controls` to the instance-admin sidebar (`NAV_ITEMS` in `instance-shell.tsx`), between Users and Audit Log
- Label matches the existing page heading (`Feature Controls`) — consistent and neutral relative to the open terminology question in #446
- No behavior change to the underlying feature-control page

Closes #447

## Test plan

- [ ] Sign in as an instance admin (seed: `ivan@govea.dev` / `dev-password`)
- [ ] Verify "Feature Controls" appears in the instance-admin sidebar between Users and Audit Log
- [ ] Click the link — confirm it navigates to `/instance/features` and the active-state highlight applies
- [ ] Confirm non-instance-admin users do not see the instance-admin shell at all (unchanged middleware behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)