### PR TITLE
feat(seed): dev fixtures for Data Architecture metamodel

### DIFF
--- a/apps/govea/src/components/instance-shell.tsx
+++ b/apps/govea/src/components/instance-shell.tsx
@@ -6,11 +6,12 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
 const NAV_ITEMS = [
-  { href: '/instance',        label: 'Dashboard',      exact: true },
-  { href: '/instance/orgs',   label: 'Organizations' },
-  { href: '/instance/users',  label: 'Users' },
-  { href: '/instance/audit',  label: 'Audit Log' },
-  { href: '/instance/config', label: 'Configuration' },
+  { href: '/instance',          label: 'Dashboard',         exact: true },
+  { href: '/instance/orgs',     label: 'Organizations' },
+  { href: '/instance/users',    label: 'Users' },
+  { href: '/instance/features', label: 'Feature Controls' },
+  { href: '/instance/audit',    label: 'Audit Log' },
+  { href: '/instance/config',   label: 'Configuration' },
 ]
 
 const BG    = '#1e1b4b' // indigo-950 — distinct from agency admin

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -1531,6 +1531,192 @@ export const DEV_SERVICES = [
   },
 ]
 
+// ─── Data Architecture metamodel (City of Riverdale) ─────────────────────────
+// Fixtures for the Data Architecture stream (#363 / #481).
+// Covers all physical attribute types, both link types, and all four cross-object
+// relationship kinds. Product + its children are 'draft' so the Viewer role-gate
+// is exercisable (Victor cannot see them; Alice/Carol can).
+
+export const DEV_DATA_ENTITIES = [
+  {
+    name: 'Customer',
+    description: 'Represents a resident or business with a registered relationship with the City. Source of truth for identity and contact data across source systems.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalHubTableName: 'h_customer',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    owners: ['Enterprise Data Architect'],
+  },
+  {
+    name: 'Order',
+    description: 'A transactional request submitted by a Customer — permit application, service request, license renewal, or similar.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalHubTableName: 'h_order',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    owners: ['Enterprise Data Architect'],
+  },
+  {
+    name: 'Product',
+    description: 'A service or permit type offered by the City. Draft — pending data governance approval to publish.',
+    status: 'draft' as const,
+    visibility: 'org' as const,
+    physicalHubTableName: 'h_product',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    owners: ['Enterprise Data Architect'],
+  },
+]
+
+export const DEV_DATA_ATTRIBUTES = [
+  {
+    name: 'Customer Profile Details',
+    description: 'Core demographic and contact attributes for a Customer. Tracked with effectivity dates to capture historical changes.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalSatelliteTableName: 's_customer_profile',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalAttributeType: 'effectivity' as const,
+    owners: ['Data Modeler'],
+    entityLinks: ['Customer'],
+  },
+  {
+    name: 'Customer Contact Preferences',
+    description: 'Multi-active list of communication channels a Customer has opted into. One row per active channel per load date.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalSatelliteTableName: 's_customer_contact',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalAttributeType: 'multi-active' as const,
+    owners: ['Data Modeler'],
+    entityLinks: ['Customer'],
+  },
+  {
+    name: 'Order Status Tracking',
+    description: 'Lifecycle states for an Order (submitted, under review, approved, rejected). Status-tracking satellite with current-state projection.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalSatelliteTableName: 's_order_status',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalAttributeType: 'status-tracking' as const,
+    owners: ['Data Modeler'],
+    entityLinks: ['Order'],
+  },
+  {
+    name: 'Order Record Details',
+    description: 'Descriptive attributes of an Order captured at submission time with full record-tracking audit columns.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalSatelliteTableName: 's_order_record',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalAttributeType: 'record-tracking' as const,
+    owners: ['Data Modeler'],
+    entityLinks: ['Order'],
+  },
+  {
+    name: 'Product Details',
+    description: 'Descriptive attributes for a City service or permit type. Draft — not yet approved for publication.',
+    status: 'draft' as const,
+    visibility: 'org' as const,
+    physicalSatelliteTableName: 's_product_details',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalAttributeType: 'effectivity' as const,
+    owners: ['Data Modeler'],
+    entityLinks: ['Product'],
+  },
+]
+
+export const DEV_DATA_LINKS = [
+  {
+    name: 'Customer-Order Association',
+    description: 'Relates a Customer to the Orders they have submitted. Same-As link used to resolve potential duplicate Customer references across source systems.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalLinkTableName: 'l_customer_order',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalLinkType: 'same-as' as const,
+    owners: ['Enterprise Data Architect'],
+  },
+  {
+    name: 'Product Hierarchy',
+    description: 'Hierarchical link capturing parent-child relationships between City service product types (e.g. Electrical Permit is a child of Building Permit).',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    physicalLinkTableName: 'l_product_hierarchy',
+    serverName: 'dw01',
+    databaseName: 'riverdale_dv',
+    schemaName: 'raw_vault',
+    physicalLinkType: 'hierarchical' as const,
+    owners: ['Enterprise Data Architect'],
+  },
+]
+
+export const DEV_DATA_BUSINESS_KEYS = [
+  {
+    name: 'Customer ID',
+    description: 'Primary business key for a Customer — the city-assigned resident or business identifier.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    dataType: 'VARCHAR(50)',
+    entityName: 'Customer',
+    owners: ['Data Modeler'],
+  },
+  {
+    name: 'Customer Email',
+    description: 'Secondary business key sourced from the identity provider registration record.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    dataType: 'VARCHAR(255)',
+    entityName: 'Customer',
+    owners: ['Data Modeler'],
+  },
+  {
+    name: 'Order Number',
+    description: 'Unique permit or service request reference number assigned at submission time.',
+    status: 'published' as const,
+    visibility: 'org' as const,
+    dataType: 'CHAR(10)',
+    entityName: 'Order',
+    owners: ['Data Modeler'],
+  },
+  {
+    name: 'Product SKU',
+    description: 'Internal code identifying a City service or permit product type. Draft — pending approval.',
+    status: 'draft' as const,
+    visibility: 'org' as const,
+    dataType: 'VARCHAR(20)',
+    entityName: 'Product',
+    owners: ['Data Modeler'],
+  },
+]
+
+// Entity ↔ Entity "is related" — canonical ordering enforced at seed time (smaller UUID as left)
+export const DEV_DATA_ENTITY_RELATIONS = [
+  { leftEntityName: 'Customer', rightEntityName: 'Order' },
+]
+
+// Attribute ↔ Attribute "shares" — canonical ordering enforced at seed time
+export const DEV_DATA_ATTRIBUTE_SHARES = [
+  { leftAttributeName: 'Customer Profile Details', rightAttributeName: 'Product Details' },
+]
+
 // ─── Cross-org links ──────────────────────────────────────────────────────────
 
 export const DEV_CROSS_ORG_LINKS = [

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -8,6 +8,8 @@ import {
   DEV_PERSONAS, DEV_CAPABILITIES, DEV_CAPABILITY_RELATIONSHIPS, DEV_APPLICATIONS,
   DEV_OBJECTIVES, DEV_GOALS, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   DEV_PRINCIPLES, DEV_GLOSSARY, DEV_SERVICES,
+  DEV_DATA_ENTITIES, DEV_DATA_ATTRIBUTES, DEV_DATA_LINKS, DEV_DATA_BUSINESS_KEYS,
+  DEV_DATA_ENTITY_RELATIONS, DEV_DATA_ATTRIBUTE_SHARES,
   STATE_PERSONAS, STATE_CAPABILITIES, STATE_APPLICATIONS,
   DEV_CROSS_ORG_LINKS,
   LAKESIDE_ORG, LAKESIDE_USERS,
@@ -40,6 +42,9 @@ import {
   services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
   instanceSettings,
+  dataEntities, dataAttributes, dataLinks, dataBusinessKeys,
+  dataEntityOwners, dataAttributeOwners, dataLinkOwners, dataBusinessKeyOwners,
+  dataEntityRelations, dataEntityAttributeLinks, dataAttributeShares,
 } from '../schema'
 import { MODULE_DEFS } from '../../lib/modules'
 import bcrypt from 'bcryptjs'
@@ -911,6 +916,184 @@ async function seed() {
     sortOrder: 0,
   }).onConflictDoNothing()
   console.log('  ✓ Principle Scope taxonomy type + entity definition')
+
+  // Data Architecture metamodel (#363 / #481) ──────────────────────────────
+
+  const devDataEntityIds: Record<string, string> = {}
+  for (const e of DEV_DATA_ENTITIES) {
+    const existing = await db.query.dataEntities.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.organizationId, devOrgId), eq2(t.name, e.name)),
+    })
+    let entityId: string
+    if (existing) {
+      await db.update(dataEntities).set({
+        description: e.description, status: e.status, visibility: e.visibility,
+        physicalHubTableName: e.physicalHubTableName, serverName: e.serverName,
+        databaseName: e.databaseName, schemaName: e.schemaName, updatedAt: new Date(),
+      }).where(eq(dataEntities.id, existing.id))
+      entityId = existing.id
+    } else {
+      const [inserted] = await db.insert(dataEntities).values({
+        organizationId: devOrgId,
+        name: e.name, description: e.description, status: e.status, visibility: e.visibility,
+        physicalHubTableName: e.physicalHubTableName, serverName: e.serverName,
+        databaseName: e.databaseName, schemaName: e.schemaName,
+      }).returning()
+      entityId = inserted.id
+    }
+    devDataEntityIds[e.name] = entityId
+    for (const personaName of e.owners) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const ownerExists = await db.query.dataEntityOwners.findFirst({
+        where: (t, { eq: eq2, and }) => and(eq2(t.dataEntityId, entityId), eq2(t.personaId, personaId)),
+      })
+      if (!ownerExists) await db.insert(dataEntityOwners).values({ dataEntityId: entityId, personaId })
+    }
+  }
+  console.log(`  ✓ ${DEV_DATA_ENTITIES.length} data entities`)
+
+  const devDataAttributeIds: Record<string, string> = {}
+  for (const a of DEV_DATA_ATTRIBUTES) {
+    const existing = await db.query.dataAttributes.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.organizationId, devOrgId), eq2(t.name, a.name)),
+    })
+    let attrId: string
+    if (existing) {
+      await db.update(dataAttributes).set({
+        description: a.description, status: a.status, visibility: a.visibility,
+        physicalSatelliteTableName: a.physicalSatelliteTableName, serverName: a.serverName,
+        databaseName: a.databaseName, schemaName: a.schemaName,
+        physicalAttributeType: a.physicalAttributeType, updatedAt: new Date(),
+      }).where(eq(dataAttributes.id, existing.id))
+      attrId = existing.id
+    } else {
+      const [inserted] = await db.insert(dataAttributes).values({
+        organizationId: devOrgId,
+        name: a.name, description: a.description, status: a.status, visibility: a.visibility,
+        physicalSatelliteTableName: a.physicalSatelliteTableName, serverName: a.serverName,
+        databaseName: a.databaseName, schemaName: a.schemaName,
+        physicalAttributeType: a.physicalAttributeType,
+      }).returning()
+      attrId = inserted.id
+    }
+    devDataAttributeIds[a.name] = attrId
+    for (const personaName of a.owners) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const ownerExists = await db.query.dataAttributeOwners.findFirst({
+        where: (t, { eq: eq2, and }) => and(eq2(t.dataAttributeId, attrId), eq2(t.personaId, personaId)),
+      })
+      if (!ownerExists) await db.insert(dataAttributeOwners).values({ dataAttributeId: attrId, personaId })
+    }
+    for (const entityName of a.entityLinks) {
+      const entityId = devDataEntityIds[entityName]
+      if (!entityId) continue
+      const linkExists = await db.query.dataEntityAttributeLinks.findFirst({
+        where: (t, { eq: eq2, and }) => and(eq2(t.dataEntityId, entityId), eq2(t.dataAttributeId, attrId)),
+      })
+      if (!linkExists) await db.insert(dataEntityAttributeLinks).values({
+        organizationId: devOrgId, dataEntityId: entityId, dataAttributeId: attrId,
+      })
+    }
+  }
+  console.log(`  ✓ ${DEV_DATA_ATTRIBUTES.length} data attributes with owner and entity links`)
+
+  const devDataLinkIds: Record<string, string> = {}
+  for (const l of DEV_DATA_LINKS) {
+    const existing = await db.query.dataLinks.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.organizationId, devOrgId), eq2(t.name, l.name)),
+    })
+    let linkId: string
+    if (existing) {
+      await db.update(dataLinks).set({
+        description: l.description, status: l.status, visibility: l.visibility,
+        physicalLinkTableName: l.physicalLinkTableName, serverName: l.serverName,
+        databaseName: l.databaseName, schemaName: l.schemaName,
+        physicalLinkType: l.physicalLinkType, updatedAt: new Date(),
+      }).where(eq(dataLinks.id, existing.id))
+      linkId = existing.id
+    } else {
+      const [inserted] = await db.insert(dataLinks).values({
+        organizationId: devOrgId,
+        name: l.name, description: l.description, status: l.status, visibility: l.visibility,
+        physicalLinkTableName: l.physicalLinkTableName, serverName: l.serverName,
+        databaseName: l.databaseName, schemaName: l.schemaName,
+        physicalLinkType: l.physicalLinkType,
+      }).returning()
+      linkId = inserted.id
+    }
+    devDataLinkIds[l.name] = linkId
+    for (const personaName of l.owners) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const ownerExists = await db.query.dataLinkOwners.findFirst({
+        where: (t, { eq: eq2, and }) => and(eq2(t.dataLinkId, linkId), eq2(t.personaId, personaId)),
+      })
+      if (!ownerExists) await db.insert(dataLinkOwners).values({ dataLinkId: linkId, personaId })
+    }
+  }
+  console.log(`  ✓ ${DEV_DATA_LINKS.length} data links`)
+
+  for (const bk of DEV_DATA_BUSINESS_KEYS) {
+    const entityId = devDataEntityIds[bk.entityName]
+    if (!entityId) continue
+    const existing = await db.query.dataBusinessKeys.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.organizationId, devOrgId), eq2(t.name, bk.name)),
+    })
+    let bkId: string
+    if (existing) {
+      await db.update(dataBusinessKeys).set({
+        description: bk.description, status: bk.status, visibility: bk.visibility,
+        dataType: bk.dataType, updatedAt: new Date(),
+      }).where(eq(dataBusinessKeys.id, existing.id))
+      bkId = existing.id
+    } else {
+      const [inserted] = await db.insert(dataBusinessKeys).values({
+        organizationId: devOrgId,
+        name: bk.name, description: bk.description, status: bk.status, visibility: bk.visibility,
+        dataType: bk.dataType, owningDataEntityId: entityId,
+      }).returning()
+      bkId = inserted.id
+    }
+    for (const personaName of bk.owners) {
+      const personaId = devPersonaIds[personaName]
+      if (!personaId) continue
+      const ownerExists = await db.query.dataBusinessKeyOwners.findFirst({
+        where: (t, { eq: eq2, and }) => and(eq2(t.dataBusinessKeyId, bkId), eq2(t.personaId, personaId)),
+      })
+      if (!ownerExists) await db.insert(dataBusinessKeyOwners).values({ dataBusinessKeyId: bkId, personaId })
+    }
+  }
+  console.log(`  ✓ ${DEV_DATA_BUSINESS_KEYS.length} business keys`)
+
+  // Entity ↔ Entity "is related" + Attribute ↔ Attribute "shares"
+  // Both tables have a canonical-ordering check (left < right). Sort UUIDs at seed time.
+  for (const rel of DEV_DATA_ENTITY_RELATIONS) {
+    const idA = devDataEntityIds[rel.leftEntityName]
+    const idB = devDataEntityIds[rel.rightEntityName]
+    if (!idA || !idB) continue
+    const [leftId, rightId] = idA < idB ? [idA, idB] : [idB, idA]
+    const exists = await db.query.dataEntityRelations.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.leftDataEntityId, leftId), eq2(t.rightDataEntityId, rightId)),
+    })
+    if (!exists) await db.insert(dataEntityRelations).values({
+      organizationId: devOrgId, leftDataEntityId: leftId, rightDataEntityId: rightId,
+    })
+  }
+  for (const share of DEV_DATA_ATTRIBUTE_SHARES) {
+    const idA = devDataAttributeIds[share.leftAttributeName]
+    const idB = devDataAttributeIds[share.rightAttributeName]
+    if (!idA || !idB) continue
+    const [leftId, rightId] = idA < idB ? [idA, idB] : [idB, idA]
+    const exists = await db.query.dataAttributeShares.findFirst({
+      where: (t, { eq: eq2, and }) => and(eq2(t.leftDataAttributeId, leftId), eq2(t.rightDataAttributeId, rightId)),
+    })
+    if (!exists) await db.insert(dataAttributeShares).values({
+      organizationId: devOrgId, leftDataAttributeId: leftId, rightDataAttributeId: rightId,
+    })
+  }
+  console.log(`  ✓ entity-entity and attribute-attribute cross-object relationships`)
 
   // ── Org 2: Office of Digital Services (state agency) ────────────────────
 


### PR DESCRIPTION
## Summary

- Seeds Riverdale org with a representative Data Architecture metamodel so `pnpm db:seed` produces a populated `/data` hub out of the box
- 3 entities: Customer (published), Order (published), Product (draft)
- 5 attributes covering all 4 physical types: effectivity, multi-active, status-tracking, record-tracking — plus a draft `Product Details`
- 2 Data Vault links: Customer-Order Association (same-as), Product Hierarchy (hierarchical)
- 4 business keys with `dataType` populated; Product SKU is draft
- Cross-object relationships for all four kinds: entity↔entity, entity↔attribute, attribute↔attribute, entity→business-key (via FK)
- Owner assignments: Enterprise Data Architect owns entities/links; Data Modeler owns attributes/business keys
- Draft objects (Product, Product Details, Product SKU) are invisible to Victor (Viewer), exercising role gating

Closes #481

## Test plan

- [ ] `pnpm db:seed` on a fresh DB completes without error
- [ ] Alice (Riverdale Admin) at `/data` sees non-zero counts on all four hub cards
- [ ] Alice at `/data/diagram` sees a non-empty Chen Notation diagram
- [ ] Victor (Viewer) at `/data` sees 1 fewer entity, 1 fewer attribute, 1 fewer business key than Alice (draft objects hidden)
- [ ] Re-running seed is idempotent — no duplicates, mutable fields updated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)