### PR TITLE
[codex] docs(feature-management): clarify instance-wide module availability controls

### DIFF
--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -70,8 +70,8 @@ export default async function SettingsPage() {
           <h2 className="text-base font-semibold">Modules</h2>
           <p className="text-sm text-muted-foreground mt-0.5">
             Disable modules your organization does not use. Hidden modules are removed from navigation
-            — no data is deleted and you can re-enable them at any time. If a module is turned off
-            by the site admin for the whole instance, it will be locked here.
+            — no data is deleted and you can re-enable them at any time. If an instance admin makes a
+            module unavailable across the whole GovEA instance, it will be locked here.
           </p>
         </div>
         <ModuleToggles initialModules={enabledModules} lockedModules={instanceDisabledModules} />
@@ -84,6 +84,7 @@ export default async function SettingsPage() {
           <h2 className="text-base font-semibold">Framework Overlays</h2>
           <p className="text-sm text-muted-foreground mt-0.5">
             Optional framework integrations. These are opt-in and off by default — enable only what your organization actively uses.
+            Instance-wide module availability controls still override local choices here.
           </p>
         </div>
         <FrameworkToggles initialModules={enabledModules} lockedModules={instanceDisabledModules} />

--- a/apps/govea/src/app/(instance)/instance/features/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/features/page.tsx
@@ -11,14 +11,14 @@ export default async function InstanceFeaturesPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Feature Controls</h1>
         <p className="text-muted-foreground mt-1">
-          Control which GovEA modules are available anywhere on this instance. Turning a feature off here
-          forces it off for every organization, even if an org admin previously enabled it.
+          Control which GovEA modules are available anywhere on this instance. Making a module unavailable
+          here forces it off for every organization, even if an org admin previously enabled it.
         </p>
       </div>
 
       <div className="rounded-lg border bg-amber-50 px-4 py-3 text-sm text-amber-900 border-amber-200">
-        Instance-wide feature controls do not delete data. They only remove the related navigation and UI until
-        the module is made available again.
+        Instance-wide module availability controls do not delete data. They only remove the related navigation
+        and UI until the module is made available again.
       </div>
 
       <InstanceModuleToggles initialDisabledModules={disabledModules} />

--- a/apps/govea/src/components/framework-toggles.tsx
+++ b/apps/govea/src/components/framework-toggles.tsx
@@ -44,7 +44,7 @@ export function FrameworkToggles({ initialModules, lockedModules = {} }: Framewo
               )}
               {locked && (
                 <p className="text-xs text-muted-foreground">
-                  Disabled for the entire GovEA instance by a platform admin.
+                  Unavailable across the entire GovEA instance by an instance admin.
                 </p>
               )}
             </div>

--- a/apps/govea/src/components/instance-module-toggles.tsx
+++ b/apps/govea/src/components/instance-module-toggles.tsx
@@ -44,7 +44,7 @@ export function InstanceModuleToggles({ initialDisabledModules }: InstanceModule
                     <p className="text-xs text-muted-foreground">
                       {available
                         ? 'Available to organizations. Each org can still choose whether to use it.'
-                        : 'Disabled across the entire instance. It is hidden and forced off for every organization.'}
+                        : 'Unavailable across the entire instance. It is hidden and forced off for every organization.'}
                     </p>
                   </div>
                   <button

--- a/apps/govea/src/components/module-toggles.tsx
+++ b/apps/govea/src/components/module-toggles.tsx
@@ -45,7 +45,7 @@ export function ModuleToggles({ initialModules, lockedModules = {} }: ModuleTogg
                     <span className="text-sm font-medium">{mod.label}</span>
                     {locked && (
                       <p className="text-xs text-muted-foreground">
-                        Disabled for the entire GovEA instance by a platform admin.
+                        Unavailable across the entire GovEA instance by an instance admin.
                       </p>
                     )}
                   </div>

--- a/apps/govea/src/lib/modules.ts
+++ b/apps/govea/src/lib/modules.ts
@@ -85,9 +85,9 @@ export function isModuleEnabled(
 }
 
 /**
- * Applies instance-wide disable overrides to an org's module settings.
- * When an instance admin disables a module globally, it is OFF for every org
- * regardless of that org's local preference.
+ * Applies instance-wide module availability overrides to an org's module settings.
+ * When an instance admin makes a module unavailable across the instance, it is
+ * OFF for every org regardless of that org's local preference.
  */
 export function mergeModuleSettings(
   orgEnabledModules: ModuleStateMap,

--- a/business-architecture/capabilities/cms/admin-configuration/ac-feature-management.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-feature-management.md
@@ -1,11 +1,11 @@
 # Capability: Feature Management
 
 ## What It Does
-The system must allow administrators to enable and disable optional modules without code changes or restarts so each organization sees only the parts of GovEA it needs.
+The system must allow administrators to control optional module availability without code changes or restarts so each organization sees only the parts of GovEA it needs, while instance admins can make a module available or unavailable across the whole GovEA instance.
 
 ## Personas
 - **CMS Administrator** — enables features as the organization's needs grow; disables unused features to reduce complexity
-- **Instance Admin** — disables features across the entire GovEA installation when a capability should be unavailable to every tenant
+- **Instance Admin** — controls whether a module is available anywhere on the GovEA instance when a capability should be available to all tenants or unavailable to all tenants
 
 ## Behaviors
 - View the current module list in Settings with each module's enabled or disabled state
@@ -13,19 +13,20 @@ The system must allow administrators to enable and disable optional modules with
 - Disable a module and have it disappear from navigation without deleting its underlying data
 - Apply module visibility consistently across desktop and mobile navigation
 - Redirect direct navigation to a disabled module away from that route
-- Disable a module at the instance level and have it become unavailable to every organization, regardless of each org's local setting
-- Show org admins when a feature is locked off globally so the local settings UI matches the effective behavior
+- Make a module unavailable at the instance level and have it become unavailable to every organization, regardless of each org's local setting
+- Make a module available again at the instance level without restoring or changing each organization's local preference
+- Show org admins when a module is unavailable across the instance so the local settings UI matches the effective behavior
 
 ## Rules
-- Disabling a feature does not delete its data — re-enabling restores full functionality
+- Making a module unavailable does not delete its data — making it available again restores full functionality
 - Org-level feature changes are available to Admins
 - Instance-wide feature changes are available only to Instance Admins
 - Feature changes take effect without a server restart
-- Feature management in this capability is organization-scoped module visibility, not instance-wide platform configuration
+- Organization-level module choices remain separate from instance-wide module availability controls
 
 ## Implementation Status
 - **v1:** Org-level module toggles are implemented for the current module set.
-- **Current product:** Instance Admins can now disable modules for the entire instance, forcing them off for every organization without deleting data.
+- **Current product:** Instance Admins can now control module availability for the entire instance, making modules available or unavailable for every organization without deleting data.
 - **Future:** Dependency management, required-module rules, and broader feature-flag behavior remain future work.
 
 ## Links

--- a/capabilities.md
+++ b/capabilities.md
@@ -153,7 +153,7 @@ Organization-level settings and administrative tools.
 | Persona Type Management | Implemented | Manage persona type categories as taxonomy terms under the `Persona Type` branch |
 | Persona Tags | Implemented | Manage persona tag values as taxonomy terms under the `Persona Tag` branch |
 | Admin Dashboard | Implemented | Live practitioner dashboard with repository activity, coverage signals, and navigation shortcuts |
-| Feature Management | Partially implemented | Org-level module toggles and instance-wide global disables are shipped; richer dependency and feature-flag behavior remains future work |
+| Feature Management | Partially implemented | Org-level module toggles and instance-wide module availability controls are shipped; richer dependency and feature-flag behavior remains future work |
 | Email Configuration | Not implemented | SMTP setup for notifications and password reset |
 | Backup & Export | Not implemented | Data export and backup tooling |
 | Security Settings | Not implemented | Session timeouts, password policy, IP restrictions |


### PR DESCRIPTION
## Summary

Closes #445.

Refreshes feature-management wording so GovEA consistently describes the shipped behavior as **instance-wide module availability control** rather than only as "global disable" behavior.

Capability: ac-feature-management
Persona: Instance Administrator
Persona: CMS Administrator

## What changed

- Updated the feature-management capability doc to describe instance admins as controlling module availability across the whole instance, not only disabling modules
- Updated the capability summary in `capabilities.md` to match that wording
- Updated instance-admin feature-controls copy to use the same availability language
- Updated org-admin settings copy so it is still clear that instance-wide controls override local module choices
- Updated locked-state helper text in the module toggles and framework toggles so the UI matches the docs
- Updated the `mergeModuleSettings` comment so the implementation notes use the same product language

## Why

The product already supports both sides of the operator experience:
- an instance admin can make a module unavailable across the whole GovEA instance
- an instance admin can later make that module available again

Some docs and UI copy were describing only the "disable" half of that behavior. This change makes the terminology clearer without changing permissions, routing, or data behavior.

## User impact

- Instance admins get clearer language about what the platform-level control actually does
- Org admins get clearer explanation that local settings remain theirs, but instance-wide availability still overrides them when necessary
- No behavior change

## Validation

- Reviewed the diff across the capability doc, summary doc, instance-admin page, org settings page, and toggle helper text
- Attempted `pnpm --filter govea lint` but `eslint` was not available because this clean publish worktree has no `node_modules`
- Attempted `pnpm --filter govea exec tsc --noEmit` but `tsc` was not available for the same reason

## Out of scope

- Renaming "modules" to another product term
- Permission changes
- Routing or toggle behavior changes
