### PR TITLE
[codex] docs: refresh backlog grooming priorities

### DIFF
--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-14 (architecture-debt PR-4 and feature-management wording PR open)
+Last groomed: 2026-05-14 (architecture-debt stream merged; feature-management and settings PRs open)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -17,29 +17,31 @@ The repository-completeness and repository-confidence stream from [#380](https:/
 - [#454](https://github.com/roballred/GovEA/pull/454) — drill-downs + ranked actions + RAG indicators
 - [#457](https://github.com/roballred/GovEA/pull/457) — trend line + stakeholder surfaces + auto-suppression
 
-The next repository-modelling stream, [#381](https://github.com/roballred/GovEA/issues/381), is now mostly implemented rather than merely planned. PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), and [#467](https://github.com/roballred/GovEA/pull/467) are merged. The final open step is [#486](https://github.com/roballred/GovEA/pull/486), which adds lifecycle-based auto-flagging and the system-detected debt badge.
+The architecture-debt stream from [#381](https://github.com/roballred/GovEA/issues/381) is now merged end-to-end. PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), [#467](https://github.com/roballred/GovEA/pull/467), and [#486](https://github.com/roballred/GovEA/pull/486) shipped the debt model, CRUD surface, linked-debt panels, dashboard priority signal, publish-time acknowledgment gate, and lifecycle-based system-detected debt.
 
 The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) has also become a real shipped module: schema and CRUD foundation, business-architecture docs, Chen Notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
 
-There are two open PRs at this grooming point:
+There are three open PRs at this grooming point:
 
-- [#486](https://github.com/roballred/GovEA/pull/486) — final architecture-debt slice for #381
+- [#489](https://github.com/roballred/GovEA/pull/489) — this backlog-grooming documentation refresh
+- [#488](https://github.com/roballred/GovEA/pull/488) — Principles navigation move, group-level module toggles, and default-on framework overlay
 - [#487](https://github.com/roballred/GovEA/pull/487) — documentation and UI copy alignment for instance-wide module availability controls
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Review and merge PR #486, then close or narrow #381 | Architecture debt is now the strongest unfinished product stream. PR #486 completes the planned four-PR sequence by adding system-detected lifecycle debt, idempotent severity updates, and visible human-vs-system distinction. After merge, #381 should either close or explicitly list any residual ADR-decision-support gaps. | [#486](https://github.com/roballred/GovEA/pull/486), [#381](https://github.com/roballred/GovEA/issues/381) |
-| 2 | Review and merge PR #487, then close #445 | This is a small clarity PR with high process value. It aligns docs and UI language around instance-wide module availability controls, reducing confusion between org-level settings and platform-wide controls. | [#487](https://github.com/roballred/GovEA/pull/487), [#445](https://github.com/roballred/GovEA/issues/445) |
+| 1 | Review and merge PR #487, then close #445 | This is a small clarity PR with high process value. It aligns docs and UI language around instance-wide module availability controls, reducing confusion between org-level settings and platform-wide controls. | [#487](https://github.com/roballred/GovEA/pull/487), [#445](https://github.com/roballred/GovEA/issues/445) |
+| 2 | Review PR #488 carefully against the module-settings roadmap | #488 is broader than a copy change: it moves Principles into Business Architecture, adds group-level module toggles, and changes framework overlay default behavior. That could be the right product direction, but it needs explicit review because it changes defaults and navigation semantics at the same time. | [#488](https://github.com/roballred/GovEA/pull/488), [#446](https://github.com/roballred/GovEA/issues/446) |
 | 3 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, diagram, nav, and fixtures shipped, the issue should not remain an open-ended request. Make the product call on conceptual/logical expansion and create focused follow-ups if that work remains in scope. | [#363](https://github.com/roballred/GovEA/issues/363) |
 | 4 | Run the persona-validation and feedback-capture slice | GovEA is now shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, and architecture-debt surfaces based on assumed personas. Validate the highest-risk assumptions before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
 | 5 | Give break-glass a real production caller | Break-glass controls are implemented, but operational credibility depends on a real support/debugging flow that consults `requireBreakGlass`. Ship #437 before treating the control as proven in incident scenarios. | [#437](https://github.com/roballred/GovEA/issues/437) |
 
 ## Product Manager Notes
 
-- #486 is the highest-leverage immediate action because it finishes an already-reviewed stream rather than starting a new one.
+- #381 can leave the top-five implementation list now that #486 has merged. The next architecture-debt move should be validation and ADR decision-support refinement, not another immediate build stream.
 - #487 should stay ahead of broader terminology work in #446. First make the current "module availability" language clear; then decide whether "module" should become "tool" in user-facing copy.
+- #488 needs product review because "group-level toggle" and "framework overlay defaults on" are not just UI conveniences; they change what new organizations experience by default.
 - #479 remains a good follow-up once the two open PRs are cleared. The Data Architecture sidebar group makes collapsible navigation more valuable, but it is still a usability improvement rather than a product-risk reducer.
 - #382 is the next major roadmap candidate after the current repository-modelling and validation items. It should not jump the queue until the team decides how much integration scope belongs in v1.
 - #482 is important process work, but it has an explicit maintainer-review-first workflow. Do not bypass that by bundling an AI-session-start document into ordinary grooming PRs.

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-10 (security regression coverage merged; repository-completeness slice 1-3 merged; PR-4 open)
+Last groomed: 2026-05-14 (architecture-debt PR-4 and feature-management wording PR open)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -8,61 +8,56 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-The 2026-05-07 security hardening wave is closed end-to-end. The production fixes merged via PRs #424, #425, #426, #428, #429, #433, and #438, and the two regression-test follow-ups are also merged:
+The security hardening wave remains closed end-to-end. The remaining security-adjacent backlog is productized control work, not emergency remediation.
 
-- [#421](https://github.com/roballred/GovEA/issues/421) — closed by PR #440
-- [#422](https://github.com/roballred/GovEA/issues/422) — closed by PR #441
+The repository-completeness and repository-confidence stream from [#380](https://github.com/roballred/GovEA/issues/380) has moved from "active build" to "shipped baseline":
 
-That means security is no longer the immediate planning bottleneck. The bottleneck has shifted back to repository trust and product fit.
+- [#448](https://github.com/roballred/GovEA/pull/448) — snapshot foundation + indexes
+- [#450](https://github.com/roballred/GovEA/pull/450) — settings model + admin config
+- [#454](https://github.com/roballred/GovEA/pull/454) — drill-downs + ranked actions + RAG indicators
+- [#457](https://github.com/roballred/GovEA/pull/457) — trend line + stakeholder surfaces + auto-suppression
 
-The repository-completeness slice in [#380](https://github.com/roballred/GovEA/issues/380) is also no longer merely "planned":
+The next repository-modelling stream, [#381](https://github.com/roballred/GovEA/issues/381), is now mostly implemented rather than merely planned. PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), and [#467](https://github.com/roballred/GovEA/pull/467) are merged. The final open step is [#486](https://github.com/roballred/GovEA/pull/486), which adds lifecycle-based auto-flagging and the system-detected debt badge.
 
-- PR-1 merged: [#448](https://github.com/roballred/GovEA/pull/448) — snapshot foundation + indexes
-- PR-2 merged: [#450](https://github.com/roballred/GovEA/pull/450) — settings model + admin config
-- PR-3 merged: [#454](https://github.com/roballred/GovEA/pull/454) — drill-downs + ranked actions + RAG indicators
-- PR-4 open: [#457](https://github.com/roballred/GovEA/pull/457) — trend line + stakeholder surfaces + auto-suppression, tracking [#455](https://github.com/roballred/GovEA/issues/455)
+The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) has also become a real shipped module: schema and CRUD foundation, business-architecture docs, Chen Notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
 
-Only one PR is currently open in the repo: **#457**. So the highest-leverage next move is to finish that slice cleanly, close #455, and then either close #380 or reduce it to whatever remains after PR-4 merges.
+There are two open PRs at this grooming point:
 
-Two break-glass follow-up issues remain open from #418:
-
-- [#437](https://github.com/roballred/GovEA/issues/437) — wire a real cross-tenant mutation/impersonation caller through `requireBreakGlass`
-- [#436](https://github.com/roballred/GovEA/issues/436) — later Option 1 promotion to gate cross-tenant reads
-
-These are not new vulnerabilities, but they do matter for operational credibility. #437 is the earlier one because it gives the new break-glass control an actual caller; #436 is stricter follow-on hardening and reads as post-v1 unless operator experience says otherwise.
+- [#486](https://github.com/roballred/GovEA/pull/486) — final architecture-debt slice for #381
+- [#487](https://github.com/roballred/GovEA/pull/487) — documentation and UI copy alignment for instance-wide module availability controls
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Merge PR #457 and close out the repository-confidence slice | PRs #448, #450, and #454 already landed, so #457 is the last open step in the highest-value current feature stream. It puts the confidence summary onto `/roadmap` and `/executive`, adds the trend line, and finishes the suppression loop. That closes #455 and likely most or all of #380. | [#457](https://github.com/roballred/GovEA/pull/457), [#455](https://github.com/roballred/GovEA/issues/455), [#380](https://github.com/roballred/GovEA/issues/380) |
-| 2 | Start architecture debt tracking and ADR decision support | The product can now show impact and repository quality, but it still cannot record durable constraints, debt severity, or remediation paths. This is the clean next step in the repository-modelling roadmap, and PR-3 already laid groundwork for a future unified priority queue. | `rm-architecture-debt`, `po-architecture-decisions`, [#381](https://github.com/roballred/GovEA/issues/381) |
-| 3 | Run the persona-validation and feedback-capture slice | The riskiest product assumption is now fit, not infrastructure. The research materials already exist in `docs/research/`, and #103's manual feedback log is still unstarted. Before building more stakeholder-facing analytics, validate who actually uses these views and what they trust. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
-| 4 | Give break-glass a real production caller via #437 | #418 shipped the control machinery, but today it is still mostly governance scaffolding. If GovEA expects instance admins to rely on break-glass in real support/debugging scenarios, #437 is the issue that turns it into a functional control. | [#437](https://github.com/roballred/GovEA/issues/437) |
-| 5 | Make the v1-vs-future scope decision on the Data Architecture Metamodel | #363 is active, externally visible, and now has enough discussion to require a product call. The next move is not engineering; it is deciding whether GovEA should absorb conceptual/logical/physical data-model concerns in v1 scope or explicitly defer them. | [#363](https://github.com/roballred/GovEA/issues/363) |
+| 1 | Review and merge PR #486, then close or narrow #381 | Architecture debt is now the strongest unfinished product stream. PR #486 completes the planned four-PR sequence by adding system-detected lifecycle debt, idempotent severity updates, and visible human-vs-system distinction. After merge, #381 should either close or explicitly list any residual ADR-decision-support gaps. | [#486](https://github.com/roballred/GovEA/pull/486), [#381](https://github.com/roballred/GovEA/issues/381) |
+| 2 | Review and merge PR #487, then close #445 | This is a small clarity PR with high process value. It aligns docs and UI language around instance-wide module availability controls, reducing confusion between org-level settings and platform-wide controls. | [#487](https://github.com/roballred/GovEA/pull/487), [#445](https://github.com/roballred/GovEA/issues/445) |
+| 3 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, diagram, nav, and fixtures shipped, the issue should not remain an open-ended request. Make the product call on conceptual/logical expansion and create focused follow-ups if that work remains in scope. | [#363](https://github.com/roballred/GovEA/issues/363) |
+| 4 | Run the persona-validation and feedback-capture slice | GovEA is now shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, and architecture-debt surfaces based on assumed personas. Validate the highest-risk assumptions before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
+| 5 | Give break-glass a real production caller | Break-glass controls are implemented, but operational credibility depends on a real support/debugging flow that consults `requireBreakGlass`. Ship #437 before treating the control as proven in incident scenarios. | [#437](https://github.com/roballred/GovEA/issues/437) |
 
 ## Product Manager Notes
 
-- The hardening wave is fully closed, including regression coverage. The remaining security-labeled backlog is productized control work, not emergency remediation.
-- #457 is now the natural "finish what is already 75% shipped" priority. It has the best effort-to-value ratio in the repo because it completes an existing four-PR sequence instead of starting a new stream.
-- #381 is the next major implementation stream after #457. It is the cleanest continuation of the trust story: repository confidence tells users whether to trust the repository; architecture debt tells them what to worry about inside it.
-- #384 and #103 should run as a product-management workstream, not wait until after more analytics are built. The interview guide and assumption register are already good enough to execute.
-- [#402](https://github.com/roballred/GovEA/issues/402) is still a good opportunistic one-PR win, but it no longer belongs in the top five ahead of #437 or #363.
+- #486 is the highest-leverage immediate action because it finishes an already-reviewed stream rather than starting a new one.
+- #487 should stay ahead of broader terminology work in #446. First make the current "module availability" language clear; then decide whether "module" should become "tool" in user-facing copy.
+- #479 remains a good follow-up once the two open PRs are cleared. The Data Architecture sidebar group makes collapsible navigation more valuable, but it is still a usability improvement rather than a product-risk reducer.
+- #382 is the next major roadmap candidate after the current repository-modelling and validation items. It should not jump the queue until the team decides how much integration scope belongs in v1.
+- #482 is important process work, but it has an explicit maintainer-review-first workflow. Do not bypass that by bundling an AI-session-start document into ordinary grooming PRs.
 
-## Security Remediation Status (as of 2026-05-10)
+## Security Remediation Status
 
 | Issue | Severity | Status |
 |---|---|---|
-| #411 — `getUsers` cross-tenant + secret exposure | High | ✅ Fixed (PR #424) |
-| #412 — cross-org-link helpers reachable as RPC | High | ✅ Fixed (PR #425) |
-| #413 — read actions trust caller `organizationId` | High | ✅ Fixed (PR #426) |
-| #414 — read actions trust caller `role` | High | ✅ Fixed (PR #426) |
-| #427 — entity-taxonomy helpers reachable as RPC | High | ✅ Fixed (PR #428) |
-| #415 — junction writes skip target-entity org check | High | ✅ Fixed (PR #429) |
-| #416 — audit writes not transactional with mutation | High | ✅ Fixed |
-| #417 — `audit_log` has no DB-level append-only constraint | High | ✅ Fixed (PR #433) |
-| #418 — break-glass TTL 24h; no dual control | High | ✅ Fixed (PR #438) |
-| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | ✅ Fixed (PR #440) |
-| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | ✅ Fixed (PR #441) |
+| #411 — `getUsers` cross-tenant + secret exposure | High | Fixed (PR #424) |
+| #412 — cross-org-link helpers reachable as RPC | High | Fixed (PR #425) |
+| #413 — read actions trust caller `organizationId` | High | Fixed (PR #426) |
+| #414 — read actions trust caller `role` | High | Fixed (PR #426) |
+| #427 — entity-taxonomy helpers reachable as RPC | High | Fixed (PR #428) |
+| #415 — junction writes skip target-entity org check | High | Fixed (PR #429) |
+| #416 — audit writes not transactional with mutation | High | Fixed |
+| #417 — `audit_log` has no DB-level append-only constraint | High | Fixed (PR #433) |
+| #418 — break-glass TTL 24h; no dual control | High | Fixed (PR #438) |
+| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | Fixed (PR #440) |
+| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | Fixed (PR #441) |
 | #436 — promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 per triage) |
 | #437 — wire cross-tenant impersonation through break-glass | Medium | Open (recommended before relying on break-glass operationally) |

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -24,7 +24,7 @@ This register is intentionally lightweight:
 
 | ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
 |---|---|---|---|---|---|---|---|---|
-| R-001 | Architecture debt will remain incomplete until the final lifecycle auto-flagging PR lands | Delivery / Product | High | Medium | Merge PR #486, verify system-detected debt behavior, then close or narrow #381 | Product / Engineering | Open | 2026-05-14 |
+| R-001 | Module/settings changes can blur product boundaries if #487 and #488 are reviewed independently | Product / UX | Medium | Medium | Review #487 and #488 together for language, defaults, navigation semantics, and terminology follow-up to #446 | Product / Engineering | Open | 2026-05-14 |
 | R-002 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-14 |
 | R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-14 |
 | R-004 | Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice | Operational / Security | High | Medium | Ship #437 before treating break-glass as an operationally credible control | Product / Engineering | Open | 2026-05-14 |
@@ -33,19 +33,19 @@ This register is intentionally lightweight:
 
 ## Risk Details
 
-### R-001 — Architecture debt will remain incomplete until the final lifecycle auto-flagging PR lands
+### R-001 — Module/settings changes can blur product boundaries if #487 and #488 are reviewed independently
 
-- **Category:** Delivery / Product
-- **Impact:** High
+- **Category:** Product / UX
+- **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
 - **Last reviewed:** 2026-05-14
-- **Mitigation:** Merge PR #486, verify system-detected debt behavior, then close or narrow #381 based on any residual ADR-decision-support gaps.
+- **Mitigation:** Review #487 and #488 together for language, defaults, navigation semantics, and terminology follow-up to #446.
 
 #### Details
 
-PRs #459, #466, and #467 already shipped the architecture-debt model, CRUD surface, linked-debt panels, dashboard priority signal, and publish-time acknowledgment gate. The remaining risk is that the final planned behavior, automatic lifecycle-risk detection, remains outside main until #486 merges. Without that final slice, the debt workflow relies on users to name lifecycle debt manually.
+PR #487 aligns language around instance-wide module availability controls. PR #488 goes further by adding group-level module toggles, moving Principles into Business Architecture, and making framework overlay default-on. These changes touch the same mental model even though they are separate PRs. If reviewed independently, GovEA could end up with clear copy but surprising defaults, or useful defaults with terminology still unsettled.
 
 ### R-002 — Data Architecture can keep expanding without a deliberate v1 boundary
 
@@ -115,4 +115,4 @@ The product already supports org-level module toggles and instance-wide availabi
 
 #### Details
 
-This risk showed up again on 2026-05-14: the checked-in priority note still described PR #457 as open even though main had moved through the architecture-debt and Data Architecture streams. The consequence is not just cosmetic; stale docs distort prioritization.
+This risk showed up again on 2026-05-14: the checked-in priority note still described PR #457 as open even though main had moved through the architecture-debt and Data Architecture streams, and #486 merged during the grooming run. The consequence is not just cosmetic; stale docs distort prioritization.

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -24,42 +24,42 @@ This register is intentionally lightweight:
 
 | ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
 |---|---|---|---|---|---|---|---|---|
-| R-001 | Repository confidence rollout is only partially finished until PR #457 lands | Delivery / Product | High | Medium | Merge PR #457, verify stakeholder surfaces, then close #455 and revisit #380 scope | Product / Engineering | Open | 2026-05-10 |
-| R-002 | GovEA can show impact and quality signals but still cannot track architecture debt as a first-class object | Product | High | High | Start #381 after #457 and keep the first slice tightly scoped to debt model + ADR linkage | Product | Open | 2026-05-10 |
-| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-10 |
-| R-004 | Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice | Operational / Security | High | Medium | Ship #437 before treating break-glass as an operationally credible control | Product / Engineering | Open | 2026-05-10 |
-| R-005 | The Data Architecture Metamodel request could pull v1 scope into a broad adjacent domain without a product boundary decision | Scope | Medium | Medium | Make an explicit v1-vs-future decision on #363 before design or implementation expands | Product | Open | 2026-05-10 |
-| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-10 |
+| R-001 | Architecture debt will remain incomplete until the final lifecycle auto-flagging PR lands | Delivery / Product | High | Medium | Merge PR #486, verify system-detected debt behavior, then close or narrow #381 | Product / Engineering | Open | 2026-05-14 |
+| R-002 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-14 |
+| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-14 |
+| R-004 | Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice | Operational / Security | High | Medium | Ship #437 before treating break-glass as an operationally credible control | Product / Engineering | Open | 2026-05-14 |
+| R-005 | Feature-management wording can confuse org-level settings with instance-wide availability controls | Documentation / Product Clarity | Medium | Low | Merge PR #487, close #445, then handle the broader "module" vs "tool" terminology decision in #446 | Product | Watching | 2026-05-14 |
+| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-14 |
 
 ## Risk Details
 
-### R-001 — Repository confidence rollout is only partially finished until PR #457 lands
+### R-001 — Architecture debt will remain incomplete until the final lifecycle auto-flagging PR lands
 
 - **Category:** Delivery / Product
 - **Impact:** High
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-10
-- **Mitigation:** Merge PR #457, verify `/dashboard`, `/roadmap`, and `/executive`, then close #455 and reduce or close #380 based on what remains.
+- **Last reviewed:** 2026-05-14
+- **Mitigation:** Merge PR #486, verify system-detected debt behavior, then close or narrow #381 based on any residual ADR-decision-support gaps.
 
 #### Details
 
-PRs #448, #450, and #454 are already merged, which means most of the repository-confidence slice is shipped. The remaining risk is not "whether to start" but "whether the final stakeholder-facing rollout lands cleanly." Until PR #457 merges, the confidence story is still incomplete across the roadmap and executive surfaces, and the suppression/trend behavior is not fully in place.
+PRs #459, #466, and #467 already shipped the architecture-debt model, CRUD surface, linked-debt panels, dashboard priority signal, and publish-time acknowledgment gate. The remaining risk is that the final planned behavior, automatic lifecycle-risk detection, remains outside main until #486 merges. Without that final slice, the debt workflow relies on users to name lifecycle debt manually.
 
-### R-002 — GovEA can show impact and quality signals but still cannot track architecture debt as a first-class object
+### R-002 — Data Architecture can keep expanding without a deliberate v1 boundary
 
-- **Category:** Product
-- **Impact:** High
-- **Likelihood:** High
+- **Category:** Scope
+- **Impact:** Medium
+- **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-10
-- **Mitigation:** Start #381 after #457. Keep the first slice small: debt item model, status/severity rules, ADR linkage, and dashboard hooks.
+- **Last reviewed:** 2026-05-14
+- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, docs, visualization, nav, and fixtures; if not, split conceptual/logical expansion into focused follow-up issues.
 
 #### Details
 
-This is now the largest product gap in the repository-modelling story. GovEA can surface affected applications and incomplete repository areas, but it still cannot represent durable constraints, known shortcuts, decision drift, or remediation intent. That limits how well the product supports actual prioritization and governance conversations.
+The Data Architecture Metamodel is now a shipped module, not only a request. That increases the need for a product boundary. Leaving #363 open as a broad umbrella risks sliding from an enterprise-architecture support surface into a much larger data-modelling product without a deliberate sequence.
 
 ### R-003 — Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
 
@@ -68,12 +68,12 @@ This is now the largest product gap in the repository-modelling story. GovEA can
 - **Likelihood:** High
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-10
+- **Last reviewed:** 2026-05-14
 - **Mitigation:** Execute #384 and start #103 Phase 1 with a manual feedback log tied to recently shipped stakeholder-facing surfaces.
 
 #### Details
 
-The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, and guided-answer surfaces, what formats they trust, and whether they act on freshness/confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
+The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, guided-answer, Data Architecture, and architecture-debt surfaces; what formats they trust; and whether they act on freshness or confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
 
 ### R-004 — Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice
 
@@ -82,26 +82,26 @@ The research artifacts already identify high-risk assumptions about who uses roa
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-10
+- **Last reviewed:** 2026-05-14
 - **Mitigation:** Ship #437 before treating break-glass as operationally credible. Defer #436 unless operator experience shows read-gating is immediately required.
 
 #### Details
 
 The hardening work for #418 shipped TTL reduction, dual control, approval flow, and the `requireBreakGlass` helper. The remaining risk is practical rather than theoretical: until GovEA uses that control in a real support/debugging flow, the control is only partially proven. That matters if the platform team expects to rely on break-glass under incident conditions.
 
-### R-005 — The Data Architecture Metamodel request could pull v1 scope into a broad adjacent domain without a product boundary decision
+### R-005 — Feature-management wording can confuse org-level settings with instance-wide availability controls
 
-- **Category:** Scope
+- **Category:** Documentation / Product Clarity
 - **Impact:** Medium
-- **Likelihood:** Medium
+- **Likelihood:** Low
 - **Owner:** Product
-- **Status:** Open
-- **Last reviewed:** 2026-05-10
-- **Mitigation:** Decide on #363 whether this is a v1 concern, a post-v1 expansion area, or a separate capability stream with explicit constraints.
+- **Status:** Watching
+- **Last reviewed:** 2026-05-14
+- **Mitigation:** Merge PR #487, close #445, then decide the broader "module" vs "tool" terminology question in #446.
 
 #### Details
 
-The request is valid and externally visible, but it reaches beyond the current GovEA center of gravity. Without a firm scope call, the team risks sliding from enterprise architecture repository work into a much larger data-architecture and data-modelling product surface without deliberate sequencing.
+The product already supports org-level module toggles and instance-wide availability controls. Uneven wording makes the operator boundary harder to explain: org admins choose what their organization uses, while instance admins decide which modules are available anywhere on the shared instance. This is not a behavior gap, but clear language matters for a multi-tenant government tool.
 
 ### R-006 — Documentation can drift behind shipped repo state during fast-moving backlog turns
 
@@ -110,9 +110,9 @@ The request is valid and externally visible, but it reaches beyond the current G
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Watching
-- **Last reviewed:** 2026-05-10
-- **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
+- **Last reviewed:** 2026-05-14
+- **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
 
 #### Details
 
-This risk showed up directly on 2026-05-10: the checked-in priority note still described the completeness work as largely unstarted even though PRs #448, #450, and #454 had already merged and only PR #457 remained open. The consequence is not just cosmetic; stale docs distort prioritization.
+This risk showed up again on 2026-05-14: the checked-in priority note still described PR #457 as open even though main had moved through the architecture-debt and Data Architecture streams. The consequence is not just cosmetic; stale docs distort prioritization.


### PR DESCRIPTION
## Summary

Refreshes the backlog grooming docs for the 2026-05-14 product-management pass, including the fact that #486 merged during this automation run.

## What changed

- Updates `docs/product-priorities.md` so the top 5 next things reflect current GitHub state: PR #487, PR #488, Data Architecture boundary decision for #363, persona validation / feedback capture, and break-glass operational caller work.
- Updates `docs/risk-register.md` so active risks match the shipped repository-confidence baseline, now-merged architecture-debt stream, shipped Data Architecture module, and open module/settings PRs.

## Notes

- The local shell could not push because network is restricted and `gh` has an invalid token, so this branch was created through the GitHub connector.
- This PR intentionally does not implement #482 because that issue requires maintainer-approved draft text before an AI-session-start doc is added.

## Validation

- `git diff --check` passes locally.
- Documentation-only change; no app tests run.

Capability: process/methodology
Automation: backlog-grooming-for-govea