### PR TITLE
[codex] Fix Azure demo runtime deployment

### DIFF
--- a/apps/govea/src/db/client.ts
+++ b/apps/govea/src/db/client.ts
@@ -2,5 +2,18 @@ import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import * as schema from './schema'
 
-const client = postgres(process.env.DATABASE_URL!)
+type PostgresClient = ReturnType<typeof postgres>
+
+declare global {
+  var __goveaPostgresClient: PostgresClient | undefined
+}
+
+const maxConnections = Number.parseInt(process.env.DATABASE_POOL_MAX ?? '5', 10)
+
+const client = globalThis.__goveaPostgresClient ?? postgres(process.env.DATABASE_URL!, {
+  max: Number.isFinite(maxConnections) ? maxConnections : 5,
+})
+
+globalThis.__goveaPostgresClient = client
+
 export const db = drizzle(client, { schema })

--- a/apps/govea/tests/integration/data-architecture.test.ts
+++ b/apps/govea/tests/integration/data-architecture.test.ts
@@ -130,11 +130,11 @@ describe('createDataEntity', () => {
   it('writes a data_entity.create audit row', async () => {
     asUser(adminA)
     const baseline = await db.select().from(auditLog).where(eq(auditLog.organizationId, orgA.id))
-    await createDataEntity(fd({ name: 'Product', ownerPersonaIds: [personaA1] }))
+    const id = await createDataEntity(fd({ name: 'Product', ownerPersonaIds: [personaA1] }))
     const after = await db.select().from(auditLog).where(eq(auditLog.organizationId, orgA.id))
     const delta = after.length - baseline.length
     expect(delta).toBe(1)
-    expect(after[after.length - 1].action).toBe('data_entity.create')
+    expect(after.some(row => row.entityId === id && row.action === 'data_entity.create')).toBe(true)
   })
 })
 
@@ -158,7 +158,7 @@ describe('editDataEntity', () => {
     await editDataEntity(id, fd({ name: 'Order (renamed)' }))
     const after = await db.select().from(auditLog).where(eq(auditLog.organizationId, orgA.id))
     expect(after.length - baseline.length).toBe(1)
-    expect(after[after.length - 1].action).toBe('data_entity.update')
+    expect(after.some(row => row.entityId === id && row.action === 'data_entity.update')).toBe(true)
   })
 })
 
@@ -170,7 +170,7 @@ describe('deleteDataEntity', () => {
     await deleteDataEntity(id)
     const after = await db.select().from(auditLog).where(eq(auditLog.organizationId, orgA.id))
     expect(after.length - baseline.length).toBe(1)
-    expect(after[after.length - 1].action).toBe('data_entity.delete')
+    expect(after.some(row => row.entityId === id && row.action === 'data_entity.delete')).toBe(true)
 
     const row = await db.query.dataEntities.findFirst({ where: eq(dataEntities.id, id) })
     expect(row).toBeUndefined()

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM mcr.microsoft.com/devcontainers/javascript-node:20 AS base
 RUN corepack enable pnpm
 
 # Install dependencies into the image so node_modules are pre-built.

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -31,6 +31,9 @@ COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 COPY . .
 
 RUN pnpm --filter govea build
+RUN mkdir -p apps/govea/.next/standalone/apps/govea/.next \
+  && cp -R apps/govea/.next/static apps/govea/.next/standalone/apps/govea/.next/static \
+  && if [ -d apps/govea/public ]; then cp -R apps/govea/public apps/govea/.next/standalone/apps/govea/public; fi
 
 COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
 COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -30,6 +30,8 @@ COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 # but kept here so the image is self-contained if run without volumes.
 COPY . .
 
+RUN pnpm --filter govea build
+
 COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
 COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh
 RUN chmod +x /entrypoint.dev.sh /entrypoint.azure-dev.sh

--- a/docker/entrypoint.azure-dev.sh
+++ b/docker/entrypoint.azure-dev.sh
@@ -30,4 +30,5 @@ pnpm --filter govea db:seed:container
 
 echo ""
 echo "==> Starting server..."
-exec pnpm --filter govea start
+cd /app/apps/govea
+exec node .next/standalone/apps/govea/server.js

--- a/docker/entrypoint.azure-dev.sh
+++ b/docker/entrypoint.azure-dev.sh
@@ -30,4 +30,4 @@ pnpm --filter govea db:seed:container
 
 echo ""
 echo "==> Starting server..."
-exec pnpm --filter govea dev
+exec pnpm --filter govea start

--- a/scripts/azure-dev.sh
+++ b/scripts/azure-dev.sh
@@ -87,11 +87,17 @@ deploy_containerapp() {
   secret=$(auth_secret)
 
   if az containerapp show --name "$ACA_APP" --resource-group "$RG" &>/dev/null; then
-    # Already exists — just update the image
+    # Already exists — update the image and runtime env that the demo depends on.
     az containerapp update \
       --name "$ACA_APP" \
       --resource-group "$RG" \
       --image "$IMAGE" \
+      --set-env-vars \
+        "AUTH_SECRET=${secret}" \
+        "NEXT_PUBLIC_APP_URL=${app_url}" \
+        "AUTH_TRUST_HOST=true" \
+        "DEV=true" \
+        "NODE_ENV=production" \
       --output none
   else
     # First deploy: create app + add postgres sidecar
@@ -110,8 +116,9 @@ deploy_containerapp() {
         "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/govea" \
         "AUTH_SECRET=${secret}" \
         "NEXT_PUBLIC_APP_URL=${app_url}" \
+        "AUTH_TRUST_HOST=true" \
         "DEV=true" \
-        "NODE_ENV=development" \
+        "NODE_ENV=production" \
       --ingress external \
       --target-port 3000 \
       --min-replicas 1 \
@@ -181,12 +188,23 @@ cmd_update() {
   require_deploy
   build_and_push
 
+  local app_url_now
+  app_url_now="$(app_url)"
+  local secret
+  secret="$(auth_secret)"
+
   log "Rolling out new revision..."
   az containerapp update \
     --name "$ACA_APP" \
     --resource-group "$RG" \
     --container-name "$ACA_APP" \
     --image "$IMAGE" \
+    --set-env-vars \
+      "AUTH_SECRET=${secret}" \
+      "NEXT_PUBLIC_APP_URL=${app_url_now}" \
+      "AUTH_TRUST_HOST=true" \
+      "DEV=true" \
+      "NODE_ENV=production" \
     --output none
 
   echo ""


### PR DESCRIPTION
## Summary

Splits the Azure demo-server runtime fixes out from the already-merged settings work so they can be reviewed and merged independently.

## Root Cause

The demo was running Next in dev mode inside Azure Container Apps, which made server-action bundles unstable across redeploys. After switching to production standalone mode, two production-only gaps surfaced: Auth.js rejected the Azure hostname because `AUTH_TRUST_HOST` was not set, and the standalone server could render HTML but could not serve `_next/static` assets because they were not copied into the standalone directory.

The earlier auth/dashboard failures also exposed connection pressure against the local Postgres sidecar, so the demo now reuses a process-level postgres-js client with a small default pool.

## Changes

- Reuses the postgres-js client across hot/server reload paths and caps the default demo pool.
- Builds the demo image with a Microsoft-hosted Node base to avoid Docker Hub rate limits.
- Builds the Next app during the image build and starts the standalone production server in Azure.
- Persists Azure runtime env needed by Auth.js and Next: stable `AUTH_SECRET`, `AUTH_TRUST_HOST=true`, `NEXT_PUBLIC_APP_URL`, `DEV=true`, and `NODE_ENV=production`.
- Copies `.next/static` and `public` into the standalone server directory so CSS/JS assets return 200.

## Validation

- `bash -n scripts/azure-dev.sh`
- `pnpm --filter govea exec tsc --noEmit`
- Deployed equivalent branch state to Azure demo as `goveadevacr.azurecr.io/govea-dev:20260514-130922`.
- Verified live revision `govea-dev--0000085` healthy with 100% traffic.
- Verified Playwright login as `aria@govea-project.govea.dev` reaches `/dashboard` and `_next/static` assets return 200.
- Final Azure log grep found no `UntrustedHost`, `53300`, `CallbackRouteError`, `JWTSessionError`, stale Server Action, `next dev`, or `next start` signatures.
