### PR TITLE
fix(seed): remove retired City of Lakeside org on reseed

### DIFF
--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -115,6 +115,17 @@ async function seed() {
   console.log('\nLoading dev fixtures...')
   const passwordHash = await bcrypt.hash('dev-password', 12)
 
+  // ── Cleanup: remove retired fixture orgs ─────────────────────────────────
+  // All child tables have onDelete: 'cascade', so deleting the org row is enough.
+  const RETIRED_ORG_SLUGS = ['city-of-lakeside']
+  for (const slug of RETIRED_ORG_SLUGS) {
+    const org = await db.query.organizations.findFirst({ where: (t, { eq: e }) => e(t.slug, slug) })
+    if (org) {
+      await db.delete(organizations).where(eq(organizations.id, org.id))
+      console.log(`  ✓ removed retired org: ${slug}`)
+    }
+  }
+
   // ── Org 1: City of Riverdale ─────────────────────────────────────────────
 
   console.log('\n[Org 1] City of Riverdale')


### PR DESCRIPTION
## Summary

- Adds a `RETIRED_ORG_SLUGS` list at the start of the seed function
- On each seed run, any org whose slug is in that list is deleted; all children cascade via `onDelete: cascade` on every FK
- Running against a database seeded before PR #488 will remove the orphaned `city-of-lakeside` org and all its records

## How to test

1. Seed a database with the PR #488 branch (produces the `city-of-lakeside` org)
2. Switch to this branch and run `pnpm --filter govea db:seed`
3. Verify no `city-of-lakeside` org or children remain in the database
4. Run `pnpm --filter govea db:seed` again — confirm it completes cleanly with no errors

## Capability

Capability: `ac-admin-dashboard`

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)