### PR TITLE
[codex] Keep demo shortcuts in production runtime

### DIFF
--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -24,7 +24,9 @@ export default async function LoginPage({
   if (session) redirect('/dashboard')
 
   const params = await searchParams
-  const isDev = process.env.NODE_ENV === 'development'
+  const showDemoShortcuts = process.env.NODE_ENV === 'development'
+    || process.env.DEV === 'true'
+    || process.env.DEMO_MODE === 'true'
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-muted/30">
@@ -77,7 +79,7 @@ export default async function LoginPage({
             </form>
           )}
 
-          {isDev && (
+          {showDemoShortcuts && (
             <div className="space-y-2 pt-2">
               <Separator />
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-2">Dev shortcuts</p>

--- a/apps/govea/tests/e2e/global-setup.ts
+++ b/apps/govea/tests/e2e/global-setup.ts
@@ -8,7 +8,8 @@
  *
  * Requires:
  *   - The app is already running (Playwright's webServer config starts it).
- *   - The database has been seeded with DEV=true so dev-shortcut buttons exist.
+ *   - The database has been seeded with DEV=true and the app exposes demo
+ *     shortcuts via NODE_ENV=development, DEV=true, or DEMO_MODE=true.
  */
 
 import { chromium } from '@playwright/test'
@@ -41,7 +42,7 @@ export default async function globalSetup() {
     await page.goto(`${baseURL}/login`)
 
     if ('shortcutLabel' in role) {
-      // Dev-shortcut buttons only appear in development mode; they call the
+      // Demo shortcut buttons call the
       // server action with a pre-set email and the shared dev-password.
       await page.getByRole('button', { name: role.shortcutLabel }).click()
     } else {

--- a/scripts/azure-dev.sh
+++ b/scripts/azure-dev.sh
@@ -97,6 +97,7 @@ deploy_containerapp() {
         "NEXT_PUBLIC_APP_URL=${app_url}" \
         "AUTH_TRUST_HOST=true" \
         "DEV=true" \
+        "DEMO_MODE=true" \
         "NODE_ENV=production" \
       --output none
   else
@@ -118,6 +119,7 @@ deploy_containerapp() {
         "NEXT_PUBLIC_APP_URL=${app_url}" \
         "AUTH_TRUST_HOST=true" \
         "DEV=true" \
+        "DEMO_MODE=true" \
         "NODE_ENV=production" \
       --ingress external \
       --target-port 3000 \
@@ -204,6 +206,7 @@ cmd_update() {
       "NEXT_PUBLIC_APP_URL=${app_url_now}" \
       "AUTH_TRUST_HOST=true" \
       "DEV=true" \
+      "DEMO_MODE=true" \
       "NODE_ENV=production" \
     --output none
 


### PR DESCRIPTION
## Summary

Separates demo-mode UI affordances from `NODE_ENV` so the Azure demo can run as a production Next.js server while still showing demo login shortcuts.

## Root Cause

The Azure demo now correctly runs with `NODE_ENV=production` to avoid server-action churn and standalone runtime issues. The login page still used `process.env.NODE_ENV === 'development'` to decide whether to show demo shortcut buttons, so the deployed demo looked like a normal production login even though the seeded demo data was present.

## Changes

- Shows demo shortcut buttons when any explicit demo flag is present: `NODE_ENV=development`, `DEV=true`, or `DEMO_MODE=true`.
- Persists `DEMO_MODE=true` in the Azure demo deploy/update script.
- Updates the E2E setup comment to describe demo shortcuts instead of development-only shortcuts.

## Validation

- `bash -n scripts/azure-dev.sh`
- `pnpm --filter govea exec tsc --noEmit`
- `pnpm --filter govea lint` passes with existing warnings only.

## Follow-up

This fixes the immediate demo-mode mismatch. We should still add a real release pipeline so demo deploys are traceable, automatic, and tied to a known main commit/image digest.
