### PR TITLE
docs(risk): define risk tracking capability

### DIFF
--- a/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
+++ b/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
@@ -16,6 +16,7 @@ The system must maintain a reliable, navigable, and self-auditing store of all a
 |---|---|---|---|
 | End-to-End Traceability | [rm-end-to-end-traceability.md](./rm-end-to-end-traceability.md) | Partially implemented | Objective, capability, and service trace views exist, and application/capability impact analysis is shipped; broader cross-layer and cross-agency traversal remains future work |
 | Architecture Debt Tracking | [rm-architecture-debt.md](./rm-architecture-debt.md) | Not implemented | Surface and track decisions and conditions that constrain future options |
+| Risk Tracking | [rm-risk-tracking.md](./rm-risk-tracking.md) | Proposed | Record and manage architecture and delivery risks linked to repository objects and mitigation decisions |
 | Repository Completeness | [rm-repository-completeness.md](./rm-repository-completeness.md) | Scaffolded | Early signals and dashboards showing where the EA object store has gaps |
 
 ## Capabilities Covered Elsewhere

--- a/business-architecture/capabilities/ea/repository-modelling/rm-risk-tracking.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-risk-tracking.md
@@ -1,0 +1,60 @@
+# Capability: Risk Tracking
+
+## What It Does
+
+The system must allow architecture teams to record, manage, and explain risks that affect architecture decisions, delivery outcomes, public services, and stakeholder trust. Risks should be linked to the architecture repository so uncertainty is visible in the same place as capabilities, applications, initiatives, services, data, personas, ADRs, and architecture debt.
+
+Risk tracking exists to make uncertainty discussable and actionable. It should help teams decide what to mitigate, what to monitor, what to accept, and what should influence roadmap sequencing.
+
+## Personas
+
+- **Enterprise Architect (Central IT)** - needs to surface architecture risks in plain language and connect them to roadmap, capability, and decision context before leadership makes investment choices
+- **Agency EA Coordinator** - needs to document local risks without turning GovEA into an audit mechanism or exposing sensitive agency details by default
+- **Department Director** - needs to understand which risks could affect service delivery, funding, or public outcomes
+- **Budget & Performance Analyst** - needs to see where risk could drive cost, timing, or performance impacts
+
+> Enterprise Architect, Agency EA Coordinator, Department Director, and Budget & Performance Analyst are **Assumed** personas for this capability. Implementation should treat stakeholder-facing risk summaries as elevated product-fit risk until these personas are validated through direct research.
+
+## Behaviors
+
+- Create a risk with a plain-language statement, category, likelihood, impact, severity, status, owner, mitigation, review date, and optional accepted-risk rationale
+- Encourage risk statements in an `If / then` or equivalent structure that describes the uncertain event and its consequence
+- Link risks to capabilities, applications, services, value streams, initiatives, goals, objectives, personas, data entities, ADRs, architecture debt, and glossary terms as those object types become supported
+- View all risks for the active organization in a list filtered by category, severity, status, owner, and review date
+- Show linked risks on object detail pages so users can see uncertainty in context
+- Surface executive rollups for top risks by capability, service area, initiative, or application
+- Distinguish organization-owned risks from risks shared through federation or connections
+- Require rationale and review date when a risk is accepted
+- Restrict security-sensitive risk details to Admin and Contributor roles
+- Audit accepted-risk rationale, sensitivity classification changes, and classification overrides
+
+## Rules
+
+- Risks belong to an organization and default to organization-only visibility
+- Risk creation and editing use the user's active organization and that organization's role
+- A person may be an Admin in one organization and a Viewer in another; risk permissions must be evaluated per organization
+- Risk is distinct from architecture debt:
+  - debt is a known current compromise or weakness
+  - risk is possible future harm or uncertainty
+- A debt item may create one or more risks, and a risk may exist without a debt item
+- Accepted risks require written rationale and a review date
+- Closed risks must preserve history rather than disappearing from linked objects
+- Viewer-facing risk summaries must avoid precise vulnerability, exploit, or sensitive control details
+- Security-sensitive risks remain hidden from Viewer-role users even if their parent object is published
+- Federation must not turn risk tracking into central surveillance; other organizations only see risks that the owning organization explicitly shares
+
+## Implementation Status
+
+Proposed. No first-class risk object exists yet. GovEA currently has related but narrower concepts:
+
+- a process risk register for backlog grooming in `docs/risk-register.md`
+- application risk portfolio cues in `fd-application-risk-portfolio`
+- architecture debt tracking in `rm-architecture-debt`
+
+This capability defines the missing product surface for architecture and delivery risk tracking.
+
+## Links
+
+- Depends on: `rm-end-to-end-traceability`, `rm-architecture-debt`, `po-application-portfolio`, `po-capability-map`, `pl-initiatives`, `mo-content-visibility`
+- Enables: stakeholder-friendly executive risk rollups, roadmap risk review, accepted-risk governance, risk-informed architecture decisions
+- Related: `fd-application-risk-portfolio`, `rm-repository-completeness`, `po-architecture-decisions`, `iam-audit-trail`

--- a/docs/design/risk-tracking.md
+++ b/docs/design/risk-tracking.md
@@ -1,0 +1,207 @@
+# Risk Tracking Capability
+
+**Related issue:** [#500](https://github.com/roballred/GovEA/issues/500)  
+**Capability:** `rm-risk-tracking`  
+**Status:** Proposed
+
+---
+
+## Summary
+
+GovEA should track architecture and delivery risks that affect government enterprise architecture decisions. This should be a lightweight product capability, not a full governance, risk, and compliance platform.
+
+The core purpose is to help users explain uncertainty in plain language:
+
+- what could go wrong
+- what would be affected
+- who owns the response
+- what mitigation is underway
+- which decisions, initiatives, or architecture objects depend on the outcome
+
+## Product Boundary
+
+Risk tracking should stay close to GovEA's architecture repository and EasyEA workflow.
+
+GovEA should track:
+
+- risks to capabilities, services, initiatives, applications, data, personas, and decisions
+- risks created by architecture debt or incomplete repository knowledge
+- risks that should influence roadmap sequencing or leadership discussion
+- accepted risks that need a visible rationale and review date
+
+GovEA should not try to replace:
+
+- enterprise risk management systems
+- audit case management
+- compliance evidence repositories
+- cybersecurity vulnerability management tools
+- incident response platforms
+
+The design center is practical architecture decision support for state and local government teams.
+
+## Risk Versus Architecture Debt
+
+Risk and architecture debt are related, but they are not the same object.
+
+| Concept | Meaning | Example |
+|---|---|---|
+| Architecture Debt | A known compromise, weakness, or constraint that exists today | The permitting application is past vendor support |
+| Risk | A possible future harm or uncertainty that may affect outcomes | If the unsupported permitting application fails during renewal season, service requests may be delayed |
+
+Rules:
+
+- A debt item may create one or more risks.
+- A risk may exist without a debt item.
+- A risk can be mitigated, monitored, accepted, transferred, or closed.
+- Accepted risks require rationale and review date.
+- Security-sensitive risk details must be protected even when summary information is useful to leadership.
+
+## Core Fields
+
+The initial Risk object should include:
+
+| Field | Purpose |
+|---|---|
+| Risk statement | Plain-language `If / then` or equivalent statement |
+| Category | Architecture, delivery, operational, data, security, adoption, funding, compliance, or custom org category |
+| Likelihood | Low, medium, high |
+| Impact | Low, medium, high |
+| Severity | Derived or selected priority signal, aligned with existing severity language where practical |
+| Status | Open, monitoring, mitigating, accepted, transferred, closed |
+| Owner | Person or role responsible for monitoring and response |
+| Mitigation | What is being done or planned |
+| Review date | When the risk must be revisited |
+| Accepted rationale | Required when status is accepted |
+| Security-sensitive flag | Restricts details when disclosure would expose exploitable information |
+
+## Relationships
+
+Risks should link to the architecture objects they affect.
+
+Candidate links:
+
+- capabilities
+- applications
+- services
+- value streams
+- initiatives
+- goals and objectives
+- personas
+- data entities
+- ADRs
+- architecture debt items
+- glossary terms
+
+Risk links should support two questions:
+
+1. From this object, what risks should I know about?
+2. From this risk, what architecture or delivery work is affected?
+
+## User Experience
+
+Risk tracking should feel like normal architecture work, not a compliance ceremony.
+
+Expected surfaces:
+
+- a Risk list page with filters for category, severity, status, owner, and review date
+- an object detail section showing linked risks
+- a create/edit form that encourages plain-language risk statements
+- executive rollups for top risks by capability, initiative, service area, or application
+- dashboard signals for overdue reviews and high-severity open risks
+
+The UI should distinguish:
+
+- risk owned by the active organization
+- risk shared through federation or connections
+- system-derived risk signals, if added later
+
+## Federation and Multi-Organization Behavior
+
+Risks belong to the organization that creates them.
+
+Default visibility should be organization-only. Sharing risk records across organizations should require explicit visibility or federation rules.
+
+If GovEA later supports one person belonging to multiple organizations, risk creation and editing should use the active organization and that organization's role. A person may be able to view a shared risk from another organization without being allowed to edit it.
+
+## Viewer-Facing Behavior
+
+Risk information can be valuable to viewers, but raw risk details can also be politically or operationally sensitive.
+
+Viewer-facing surfaces should:
+
+- use plain-language summaries
+- hide implementation details marked security-sensitive
+- avoid precise vulnerability or exploit information
+- show accepted risks only when the owning organization has chosen to publish them
+- make uncertainty explicit instead of implying false precision
+
+## Security Classification
+
+Risk records should include a `security_sensitive` control similar to architecture debt.
+
+Sensitive examples:
+
+- references to specific unpatched vulnerabilities
+- details about exploitable configuration weaknesses
+- internal control gaps not already public
+- accepted-risk rationale explaining why a known vulnerability remains unresolved
+
+Generally safe examples:
+
+- public end-of-support dates
+- general funding or adoption uncertainty
+- broad dependency risk without exploitable details
+- plain-language operational impact summaries
+
+When in doubt, details should remain restricted to Admin and Contributor roles.
+
+## Example Risks
+
+| Risk | Category | Linked object |
+|---|---|---|
+| If the permitting system is not modernized before vendor support ends, permit processing may be disrupted during peak renewal periods | Operational | Application, Initiative |
+| If the licensing capability has no named owner, roadmap decisions may be delayed or made without clear accountability | Governance | Capability |
+| If agency coordinators do not trust repository completeness scores, leadership may ignore the executive dashboard | Adoption | Dashboard, Persona |
+| If an accepted architecture debt item is not reviewed before budget planning, mitigation work may miss the next funding cycle | Funding | Architecture Debt, Initiative |
+
+## Implementation Slices
+
+### Slice 1: Documentation and model agreement
+
+- Create the issue and supporting capability documentation.
+- Confirm Risk versus Architecture Debt language.
+- Decide whether Risk belongs in Repository & Modelling navigation or a broader planning/decision-support area.
+
+### Slice 2: Risk object foundation
+
+- Add schema and server actions for organization-owned risks.
+- Add list, create, edit, and detail surfaces.
+- Support basic links to at least one core object type.
+
+### Slice 3: Cross-object surfacing
+
+- Show linked risks on object detail pages.
+- Add dashboard signals for top risks and overdue reviews.
+- Add executive-friendly rollups.
+
+### Slice 4: Federation and sensitive disclosure hardening
+
+- Apply cross-org visibility rules.
+- Enforce `security_sensitive` restrictions.
+- Add audit logging for accepted risk rationale and classification overrides.
+
+## Open Questions
+
+- Should severity be user-selected, derived from likelihood and impact, or both?
+- Should Risk have its own navigation item, or live under Architecture Repository / Decision Support?
+- Which object type should be the first link target: application, capability, initiative, or architecture debt?
+- Should accepted risk require approval by an Admin, or is Contributor ownership enough?
+- Should risk categories be fixed system terms, organization taxonomy, or a hybrid?
+
+## Related Work
+
+- [#219](https://github.com/roballred/GovEA/issues/219) - application risk portfolio view
+- [#381](https://github.com/roballred/GovEA/issues/381) - architecture debt tracking and ADR decision support
+- [#463](https://github.com/roballred/GovEA/issues/463) - process risk register for backlog grooming
+- [Architecture Debt Tracking](../../business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md)
+- [Application Risk Portfolio View](../../business-architecture/capabilities/cms/frontend-display/fd-application-risk-portfolio.md)


### PR DESCRIPTION
## Summary
- add a supporting design note for first-class GovEA risk tracking
- add the `rm-risk-tracking` EasyEA capability definition
- list Risk Tracking under the Repository & Modelling capability group

Closes #500
Capability: rm-risk-tracking

## Validation
- `git diff --check`