### PR TITLE
[codex] docs: refresh backlog grooming priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Azure deployments build images in the cloud via `az acr build` and do not requir
 
 ## Capabilities
 
-GovEA's capability surface spans 9 groups, each driven by government EA practitioner personas and validated through the EasyEA workflow:
+GovEA's capability surface spans 10 groups, each driven by government EA practitioner personas and validated through the EasyEA workflow:
 
 | Group | Description |
 |---|---|
@@ -191,6 +191,7 @@ GovEA's capability surface spans 9 groups, each driven by government EA practiti
 | Collaboration & Stakeholder Engagement | Role-based access, stakeholder views, change notifications |
 | Reporting & Documentation | Plain-language outputs, configurable reports, KPI tracking |
 | Framework Alignment | Optional TOGAF/SAFe-style overlays, mappings, and framework-aware reports |
+| Data Architecture | Data entities, attributes, categories, business keys, and semantic relationships for data-architecture work |
 
 For the full capability inventory, including implementation status, see [`capabilities.md`](./capabilities.md).
 
@@ -213,7 +214,9 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Application custom fields with CSV import/export so agencies can extend and load portfolio metadata without schema changes
 - Impact analysis on application and capability detail pages to surface decommission and change consequences from existing relationship data
 - Live dashboard for EA practitioners with repository activity, coverage signals, and review-health tracking
-- Repository completeness workflow foundations: daily snapshot model, configurable staleness windows, ranked cleanup actions, and domain-target RAG indicators on the admin dashboard
+- Repository completeness and confidence workflow: daily snapshot model, configurable staleness windows, ranked cleanup actions, domain-target RAG indicators, trend history, stakeholder-facing trust cues, and auto-suppression behavior
+- Architecture debt tracking with CRUD, linked-debt panels, dashboard priority signals, publish-time acknowledgement, and lifecycle-based system-detected debt
+- Data Architecture module with entities, attributes, categories, business keys, semantic relationships, Chen notation visualization, and dedicated navigation
 - Demo-ready planning module: goals, strategic objectives, and initiatives with roadmap grid and executive timeline views
 - Goals layer above strategic objectives, with objective rollup and traceability into initiatives and capabilities
 - Reports hub with generated Architecture Vision, Executive Summary, Heatmap Analysis, and TOGAF Application Landscape outputs from existing repository content
@@ -224,12 +227,12 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Shared taxonomy foundation now proven across applications and capabilities, including capability-priority classification as the second pilot
 - Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
-- Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, audited break-glass sessions, and instance-level platform configuration
+- Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, audited break-glass sessions, scoped act-as support actions, and instance-level platform configuration
 - Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
-- Two-city demo seed data and dev login roster for Riverdale, Lakeside, state admin, and dev-only instance-admin scenarios
+- Demo seed data and dev login roster for Riverdale, GovEA Project dogfooding, Office of Digital Services, Hartfield TOGAF overlay, and dev-only instance-admin scenarios
 - Reusable `@govea/core` package: RBAC, audit, taxonomy, workflow, content type, and recipe primitives
 - E2E smoke test coverage across all routes x roles (Playwright)
 - Containerized local development plus Azure Container Apps dev deployment support
@@ -239,25 +242,27 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Planning semantics: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Long-form authoring: markdown now renders on detail pages, but editing still uses plain textareas rather than a richer toolbar/preview workflow
 - Admin configuration beyond core settings
-- Repository completeness, broader repository confidence, deeper end-to-end traceability analysis, and architecture debt tooling
+- Risk tracking is defined as a proposed Repository & Modelling capability, but the first-class product surface has not been implemented yet
+- Deeper end-to-end traceability analysis and conceptual/logical Data Architecture expansion
 
 **Active work:**
-- Completing the repository-confidence slice with trend history, stakeholder-facing confidence surfaces, and auto-suppression behavior
-- Maturing ADRs and decision support into stronger architecture-debt and tradeoff visibility
+- Building a traceable release pipeline for the Azure demo so deployments are tied to a known commit, image digest, and post-deploy smoke result
+- Implementing the inherited system glossary and menu definitions so glossary, tour, onboarding, and contextual help use the same language
+- Deciding the Data Architecture v1 boundary before expanding conceptual/logical modeling
 - Validating assumed stakeholder personas and starting a lightweight feedback loop for analysis surfaces
-- Wiring break-glass to a real cross-tenant operational caller before relying on it in support scenarios
+- Deciding whether user-facing product language should remain "module" or shift to "tool"
 - Expanding automated test coverage
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
-- Merge PR #457 to finish the repository-confidence rollout across `/dashboard`, `/roadmap`, and `/executive`
-- Add architecture debt tracking tied to ADRs, impact analysis, and reporting
-- Start lightweight user feedback capture and persona validation for the analysis surfaces
-- Decide v1-vs-future scope for the Data Architecture Metamodel contribution thread
-- Start the integration foundation with a REST API plus the first Tier 1 operational sync slice
+- Ship #504 for traceable demo releases and rollback
+- Implement #499 for inherited glossary/menu definitions
+- Split or close #363 based on the Data Architecture v1 boundary decision
+- Run #384 and #103 Phase 1 feedback capture for stakeholder-facing analysis surfaces
+- Resolve #446 before broader onboarding, glossary, or tour copy work
 
 **Longer-term:**
-- End-to-end traceability and architecture debt tracking
+- End-to-end traceability expansion and risk-informed decision support
 - ARB review simulation using reviewer personas
 - Broader hosted SaaS deployment options
 - Progressive coverage across remaining capability groups

--- a/capabilities.md
+++ b/capabilities.md
@@ -17,8 +17,9 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 | 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
 | 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
 | 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Prototype |
-| 8 | [Repository & Modelling](#8-repository--modelling) | Scaffolded |
-| 9 | [Framework Alignment](#9-framework-alignment) | Partially implemented |
+| 8 | [Repository & Modelling](#8-repository--modelling) | Partially implemented |
+| 9 | [Data Architecture](#9-data-architecture) | Partially implemented |
+| 10 | [Framework Alignment](#10-framework-alignment) | Partially implemented |
 
 ---
 
@@ -30,7 +31,7 @@ Controls authentication, authorization, and all identity events.
 |---|---|---|
 | User Management | Implemented | Create, edit, deactivate, and assign org-scoped roles to user accounts |
 | Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions, with `instance_admin` layered separately for platform operations |
-| Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, and audited break-glass sessions without taking over org-scoped settings |
+| Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, audited break-glass sessions, and scoped act-as support actions without taking over org-scoped settings |
 | SSO Authentication | Implemented | Microsoft Entra ID sign-in via OpenID Connect (OIDC) with admin-managed pre-provisioned access |
 | Local Authentication | Implemented | Email and password login; always available as SSO fallback |
 | IAM Audit Trail | Implemented | Immutable log of all identity and access events, including instance-scoped platform events |
@@ -136,7 +137,7 @@ How content is presented to authenticated users and, optionally, the public.
 | Content Display | Implemented | Detail pages with status badges, metadata, linked records, contributor-friendly edit affordances, and markdown-rendered narrative fields on shipped surfaces |
 | Product Tour | Implemented | Role-aware guided tour covering the main dashboard, architecture, portfolio, strategy, search, and role-specific workflows |
 | Public / Authenticated Views | Not implemented | Opt-in public access to published content without login |
-| Repository Confidence Summary | Not implemented | Plain-language freshness and trust cue for stakeholder-facing views |
+| Repository Confidence Summary | Implemented | Plain-language freshness and trust cue for stakeholder-facing roadmap and executive views, backed by completeness settings, trend history, and suppression behavior |
 | Application Risk Portfolio | Implemented | Leadership-oriented portfolio card view on the Applications page, with lifecycle and dependency risk cues derived from existing data |
 | Responsive Layout | Partially implemented | Desktop-first; mobile not a v1 priority |
 | Theming | Implemented | Organization-selected predefined themes applied through settings |
@@ -192,11 +193,12 @@ Reliability, navigability, and self-auditing of the architecture store.
 | Capability | Status | Description |
 |---|---|---|
 | Audit Trail | Implemented | Immutable log of all create/update/delete events with before/after JSON |
-| Repository Completeness | Scaffolded | Early coverage signals exist, but this is not yet a dedicated repository-quality workflow |
-| End-to-End Traceability | Partially implemented | Read-only traceability views exist for strategic objectives, capabilities, and services, but broader repository-wide impact analysis remains future work |
-| Architecture Debt Tracking | Not implemented | Surface and track decisions and conditions that constrain future options |
+| Repository Completeness | Partially implemented | Snapshot foundations, configurable staleness windows, ranked cleanup actions, domain-target RAG indicators, trend history, and stakeholder confidence cues are shipped |
+| End-to-End Traceability | Partially implemented | Objective, capability, service, application, data-architecture, and debt-linked views exist, but broader repository-wide traversal remains future work |
+| Architecture Debt Tracking | Implemented | CRUD, linked-debt panels, dashboard priority signals, publish-time acknowledgement, and lifecycle-based system-detected debt |
+| Risk Tracking | Proposed | First-class architecture and delivery risk tracking has a capability definition and design note, but no product surface yet |
 
-This group is strategically important, but today it is still mostly documented direction plus a small amount of shipped dashboarding rather than a mature product surface.
+This group is strategically important and now has several shipped trust-building surfaces. The remaining risk is product focus: risk tracking, traceability expansion, and Data Architecture growth should stay tied to validated user decisions rather than becoming broad modelling or GRC platforms.
 
 **Out of scope for v1:**
 - Multi-framework modelling (ArchiMate, BPMN, UML): GovEA uses enforced relationship chains and plain-language descriptions, not formal notation
@@ -204,7 +206,21 @@ This group is strategically important, but today it is still mostly documented d
 
 ---
 
-## 9. Framework Alignment
+## 9. Data Architecture
+
+First-class modelling support for data architecture and data asset context.
+
+| Capability | Status | Description |
+|---|---|---|
+| Data Architecture Metamodel | Partially implemented | Data entities, attributes, categories, business keys, and semantic relationships are shipped; conceptual/logical/physical boundary decisions remain open |
+| Chen Notation Visualization | Implemented | Data entity relationship visualization is available for the shipped metamodel |
+| Data Architecture Navigation | Implemented | Data Architecture has its own sidebar group and representative demo fixtures |
+
+Current reality: GovEA now supports a concrete Data Architecture v1 surface. The next product decision is whether #363 is complete for v1 or should split conceptual/logical expansion into focused follow-up issues.
+
+---
+
+## 10. Framework Alignment
 
 Optional alignment to external architecture frameworks such as TOGAF without replacing GovEA's EasyEA-based model.
 
@@ -216,7 +232,7 @@ Optional alignment to external architecture frameworks such as TOGAF without rep
 | TOGAF-Aligned Reporting | Partially implemented | Reports hub ships an Architecture Vision summary for all orgs and a TOGAF Application Landscape report when the overlay is enabled |
 | Framework Overlay Configuration | Partially implemented | Org admins can enable or disable the TOGAF overlay module; richer per-framework configuration remains future work |
 
-Current reality: GovEA now ships the first framework-alignment slice. The TOGAF overlay is opt-in and off by default, application and capability records can carry TOGAF Architecture Domain mappings, and the Reports area includes a TOGAF Application Landscape report. ADM phase tagging, admin-managed framework references, and broader mapping depth remain future work.
+Current reality: GovEA now ships the first framework-alignment slice. Application and capability records can carry TOGAF Architecture Domain mappings, the Reports area includes a TOGAF Application Landscape report, and module settings can control whether the overlay is available and enabled. ADM phase tagging, admin-managed framework references, and broader mapping depth remain future work.
 
 **Design principle:** Framework support should increase credibility without increasing friction. TOGAF-aware architects should be able to recognize familiar concepts and reporting structures, while ordinary GovEA users continue working with plain-language personas, capabilities, services, applications, objectives, initiatives, principles, and decisions.
 
@@ -230,14 +246,15 @@ GovEA's longer-horizon capability direction spans the major themes below, each d
 
 | Group | Near-term priorities |
 |---|---|
-| Identity & Access Management | Tenant-boundary tests, production hardening for instance-admin operations |
-| Repository & Modelling | End-to-end traceability, architecture debt tracking, repository confidence summary |
+| Identity & Access Management | Operational experience with act-as sessions, then decide whether to promote #436 read gating |
+| Repository & Modelling | Risk tracking validation, end-to-end traceability expansion, repository confidence calibration |
 | Application & IT Portfolio | Technology lifecycle tracking, custom-field reuse, import/export maturation, richer rationalization views |
-| Business & Capability Architecture | Operating model views, typed principle sets, stronger cross-entity classification and relationship visualisation |
+| Business & Capability Architecture | Inherited system glossary, menu definitions, operating model views, stronger cross-entity classification and relationship visualisation |
+| Data Architecture | Decide #363 v1 boundary, then split conceptual/logical expansion if needed |
 | Planning & Analysis | Scenario planning, value stream analytics |
 | Governance & Compliance | ARB review workflow, regulatory mapping |
 | Integration | Tier 1: ITSM/CMDB sync, DevOps pipeline links, cloud discovery — Tier 2 (critical gaps): PPM/project portfolio, ERP/financial, HR/org design — Tier 3: data governance platform, API management platform, BI analytics feed — Tier 4 (emerging): IaC, AI/ML registry, low-code platforms — Foundational: REST API |
-| Collaboration & Stakeholder Engagement | Stakeholder validation, repository confidence summaries, stakeholder-facing plain-language views, feedback capture |
+| Collaboration & Stakeholder Engagement | Stakeholder validation, stakeholder-facing plain-language views, feedback capture |
 | Reporting & Documentation | Configurable reports, KPI tracking, elected-official summaries |
 | Framework Alignment | Optional TOGAF mapping, ADM phase alignment, and framework-aware reporting |
 

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-14 (architecture-debt stream merged; feature-management and settings PRs open)
+Last groomed: 2026-05-15 (no open PRs; release-pipeline issue created as #504)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -10,56 +10,54 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 The security hardening wave remains closed end-to-end. The remaining security-adjacent backlog is productized control work, not emergency remediation.
 
-The repository-completeness and repository-confidence stream from [#380](https://github.com/roballred/GovEA/issues/380) has moved from "active build" to "shipped baseline":
+The repository-completeness, repository-confidence, and architecture-debt streams are now shipped baselines rather than active build streams:
 
-- [#448](https://github.com/roballred/GovEA/pull/448) — snapshot foundation + indexes
-- [#450](https://github.com/roballred/GovEA/pull/450) — settings model + admin config
-- [#454](https://github.com/roballred/GovEA/pull/454) — drill-downs + ranked actions + RAG indicators
-- [#457](https://github.com/roballred/GovEA/pull/457) — trend line + stakeholder surfaces + auto-suppression
+- [#380](https://github.com/roballred/GovEA/issues/380) shipped snapshot foundations, settings, drill-downs, ranked cleanup actions, RAG indicators, trend history, stakeholder surfaces, and auto-suppression through PRs [#448](https://github.com/roballred/GovEA/pull/448), [#450](https://github.com/roballred/GovEA/pull/450), [#454](https://github.com/roballred/GovEA/pull/454), and [#457](https://github.com/roballred/GovEA/pull/457).
+- [#381](https://github.com/roballred/GovEA/issues/381) shipped architecture debt CRUD, linked-debt panels, dashboard priority signals, publish-time acknowledgement, and lifecycle-based system-detected debt through PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), [#467](https://github.com/roballred/GovEA/pull/467), and [#486](https://github.com/roballred/GovEA/pull/486).
+- [#437](https://github.com/roballred/GovEA/issues/437) is now complete through [#502](https://github.com/roballred/GovEA/pull/502), which added scoped act-as sessions gated by break-glass and a first cross-tenant support action.
 
-The architecture-debt stream from [#381](https://github.com/roballred/GovEA/issues/381) is now merged end-to-end. PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), [#467](https://github.com/roballred/GovEA/pull/467), and [#486](https://github.com/roballred/GovEA/pull/486) shipped the debt model, CRUD surface, linked-debt panels, dashboard priority signal, publish-time acknowledgment gate, and lifecycle-based system-detected debt.
+The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) is also a real shipped module: schema and CRUD foundation, relationship editing, business-architecture docs, Chen notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
 
-The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) has also become a real shipped module: schema and CRUD foundation, business-architecture docs, Chen Notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
+Recent merged PRs changed the next-work queue:
 
-There are three open PRs at this grooming point:
-
-- [#489](https://github.com/roballred/GovEA/pull/489) — this backlog-grooming documentation refresh
-- [#488](https://github.com/roballred/GovEA/pull/488) — Principles navigation move, group-level module toggles, and default-on framework overlay
-- [#487](https://github.com/roballred/GovEA/pull/487) — documentation and UI copy alignment for instance-wide module availability controls
+- [#493](https://github.com/roballred/GovEA/pull/493) and [#498](https://github.com/roballred/GovEA/pull/498) stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`.
+- [#496](https://github.com/roballred/GovEA/pull/496) and [#497](https://github.com/roballred/GovEA/pull/497) cleaned up retired seed data and made the GovEA Project dogfood org more useful for demonstrations.
+- [#501](https://github.com/roballred/GovEA/pull/501) documented first-class risk tracking and closed [#500](https://github.com/roballred/GovEA/issues/500) as a design/capability-definition slice.
+- No PRs are open at this grooming point.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Review and merge PR #487, then close #445 | This is a small clarity PR with high process value. It aligns docs and UI language around instance-wide module availability controls, reducing confusion between org-level settings and platform-wide controls. | [#487](https://github.com/roballred/GovEA/pull/487), [#445](https://github.com/roballred/GovEA/issues/445) |
-| 2 | Review PR #488 carefully against the module-settings roadmap | #488 is broader than a copy change: it moves Principles into Business Architecture, adds group-level module toggles, and changes framework overlay default behavior. That could be the right product direction, but it needs explicit review because it changes defaults and navigation semantics at the same time. | [#488](https://github.com/roballred/GovEA/pull/488), [#446](https://github.com/roballred/GovEA/issues/446) |
-| 3 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, diagram, nav, and fixtures shipped, the issue should not remain an open-ended request. Make the product call on conceptual/logical expansion and create focused follow-ups if that work remains in scope. | [#363](https://github.com/roballred/GovEA/issues/363) |
-| 4 | Run the persona-validation and feedback-capture slice | GovEA is now shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, and architecture-debt surfaces based on assumed personas. Validate the highest-risk assumptions before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
-| 5 | Give break-glass a real production caller | Break-glass controls are implemented, but operational credibility depends on a real support/debugging flow that consults `requireBreakGlass`. Ship #437 before treating the control as proven in incident scenarios. | [#437](https://github.com/roballred/GovEA/issues/437) |
+| 1 | Build a traceable release pipeline for the Azure demo | Demo stability is now good enough to protect. Manual deploys still make it too hard to know which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
+| 2 | Implement the inherited system glossary and menu definitions | This turns the existing glossary into a shared product vocabulary layer, supports tours/contextual help, and makes GovEA's EasyEA language clearer for new organizations. | [#499](https://github.com/roballred/GovEA/issues/499) |
+| 3 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, relationships, diagram, nav, and fixtures shipped, the remaining conceptual/logical scope needs a deliberate follow-up shape. | [#363](https://github.com/roballred/GovEA/issues/363) |
+| 4 | Run the persona-validation and feedback-capture slice | GovEA is shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, risk, and architecture-debt concepts based on assumed personas. Validate before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
+| 5 | Decide module/tool terminology before more onboarding copy ships | Group toggles and instance-wide availability controls are merged. Before glossary, tour, or contextual-help copy spreads further, decide whether user-facing language stays "module" or becomes "tool." | [#446](https://github.com/roballred/GovEA/issues/446) |
 
 ## Product Manager Notes
 
-- #381 can leave the top-five implementation list now that #486 has merged. The next architecture-debt move should be validation and ADR decision-support refinement, not another immediate build stream.
-- #487 should stay ahead of broader terminology work in #446. First make the current "module availability" language clear; then decide whether "module" should become "tool" in user-facing copy.
-- #488 needs product review because "group-level toggle" and "framework overlay defaults on" are not just UI conveniences; they change what new organizations experience by default.
-- #479 remains a good follow-up once the two open PRs are cleared. The Data Architecture sidebar group makes collapsible navigation more valuable, but it is still a usability improvement rather than a product-risk reducer.
-- #382 is the next major roadmap candidate after the current repository-modelling and validation items. It should not jump the queue until the team decides how much integration scope belongs in v1.
+- #504 should be treated as operational product work, not infrastructure polish. The demo is how many users will first understand GovEA.
+- #499 is the best next product capability because it strengthens onboarding, navigation comprehension, product-tour content, and shared EasyEA vocabulary without adding a broad new modeling surface.
+- #500/#501 created the risk-tracking capability definition. Do not jump straight to implementation until persona validation clarifies which risk summaries leadership and practitioners actually trust.
+- #479 remains a strong usability follow-up now that Data Architecture and Framework Alignment make the sidebar denser. It sits just outside the top five because release traceability, glossary, boundary decisions, and validation reduce higher product risk.
 - #482 is important process work, but it has an explicit maintainer-review-first workflow. Do not bypass that by bundling an AI-session-start document into ordinary grooming PRs.
+- #436 remains a future security hardening option after enough operational experience with #502's act-as flow. It is not the next security item unless read-surface risk becomes urgent.
 
 ## Security Remediation Status
 
 | Issue | Severity | Status |
 |---|---|---|
-| #411 — `getUsers` cross-tenant + secret exposure | High | Fixed (PR #424) |
-| #412 — cross-org-link helpers reachable as RPC | High | Fixed (PR #425) |
-| #413 — read actions trust caller `organizationId` | High | Fixed (PR #426) |
-| #414 — read actions trust caller `role` | High | Fixed (PR #426) |
-| #427 — entity-taxonomy helpers reachable as RPC | High | Fixed (PR #428) |
-| #415 — junction writes skip target-entity org check | High | Fixed (PR #429) |
-| #416 — audit writes not transactional with mutation | High | Fixed |
-| #417 — `audit_log` has no DB-level append-only constraint | High | Fixed (PR #433) |
-| #418 — break-glass TTL 24h; no dual control | High | Fixed (PR #438) |
-| #421 — test: unauthenticated server-action POSTs blocked | Enhancement | Fixed (PR #440) |
-| #422 — test: read actions ignore caller-supplied orgId/role | Enhancement | Fixed (PR #441) |
-| #436 — promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 per triage) |
-| #437 — wire cross-tenant impersonation through break-glass | Medium | Open (recommended before relying on break-glass operationally) |
+| #411 - `getUsers` cross-tenant + secret exposure | High | Fixed (PR #424) |
+| #412 - cross-org-link helpers reachable as RPC | High | Fixed (PR #425) |
+| #413 - read actions trust caller `organizationId` | High | Fixed (PR #426) |
+| #414 - read actions trust caller `role` | High | Fixed (PR #426) |
+| #427 - entity-taxonomy helpers reachable as RPC | High | Fixed (PR #428) |
+| #415 - junction writes skip target-entity org check | High | Fixed (PR #429) |
+| #416 - audit writes not transactional with mutation | High | Fixed |
+| #417 - `audit_log` has no DB-level append-only constraint | High | Fixed (PR #433) |
+| #418 - break-glass TTL 24h; no dual control | High | Fixed (PR #438) |
+| #421 - test: unauthenticated server-action POSTs blocked | Enhancement | Fixed (PR #440) |
+| #422 - test: read actions ignore caller-supplied orgId/role | Enhancement | Fixed (PR #441) |
+| #437 - wire cross-tenant impersonation through break-glass | Medium | Fixed (PR #502) |
+| #436 - promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 / after act-as operating experience) |

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -21,7 +21,7 @@ The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issu
 Recent merged PRs changed the next-work queue:
 
 - [#493](https://github.com/roballred/GovEA/pull/493) and [#498](https://github.com/roballred/GovEA/pull/498) stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`.
-- [#496](https://github.com/roballred/GovEA/pull/496) and [#497](https://github.com/roballred/GovEA/pull/497) cleaned up retired seed data and made the GovEA Project dogfood org more useful for demonstrations.
+- [#503](https://github.com/roballred/GovEA/pull/503) recovered the seed cleanup and GovEA Project value-chain enrichment from [#496](https://github.com/roballred/GovEA/pull/496) and [#497](https://github.com/roballred/GovEA/pull/497) onto `main`, closing [#492](https://github.com/roballred/GovEA/issues/492) and adding a PR base-check workflow.
 - [#501](https://github.com/roballred/GovEA/pull/501) documented first-class risk tracking and closed [#500](https://github.com/roballred/GovEA/issues/500) as a design/capability-definition slice.
 - No PRs are open at this grooming point.
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -24,95 +24,95 @@ This register is intentionally lightweight:
 
 | ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
 |---|---|---|---|---|---|---|---|---|
-| R-001 | Module/settings changes can blur product boundaries if #487 and #488 are reviewed independently | Product / UX | Medium | Medium | Review #487 and #488 together for language, defaults, navigation semantics, and terminology follow-up to #446 | Product / Engineering | Open | 2026-05-14 |
-| R-002 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-14 |
-| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-14 |
-| R-004 | Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice | Operational / Security | High | Medium | Ship #437 before treating break-glass as an operationally credible control | Product / Engineering | Open | 2026-05-14 |
-| R-005 | Feature-management wording can confuse org-level settings with instance-wide availability controls | Documentation / Product Clarity | Medium | Low | Merge PR #487, close #445, then handle the broader "module" vs "tool" terminology decision in #446 | Product | Watching | 2026-05-14 |
-| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-14 |
+| R-001 | Manual demo deployment can obscure which commit, image, and runtime configuration are live | Operational / Release | High | Medium | Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear | Product / Engineering | Open | 2026-05-15 |
+| R-002 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-15 |
+| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-15 |
+| R-004 | Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately | Product / UX | Medium | Medium | Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499 | Product | Open | 2026-05-15 |
+| R-005 | First-class risk tracking can become too broad if implementation starts before validation | Product Scope | Medium | Medium | Treat #501 as capability definition only; validate risk-summary audiences through #384 before opening implementation slices | Product | Watching | 2026-05-15 |
+| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-15 |
 
 ## Risk Details
 
-### R-001 — Module/settings changes can blur product boundaries if #487 and #488 are reviewed independently
+### R-001 - Manual demo deployment can obscure which commit, image, and runtime configuration are live
 
-- **Category:** Product / UX
-- **Impact:** Medium
+- **Category:** Operational / Release
+- **Impact:** High
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-14
-- **Mitigation:** Review #487 and #488 together for language, defaults, navigation semantics, and terminology follow-up to #446.
+- **Last reviewed:** 2026-05-15
+- **Mitigation:** Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear.
 
 #### Details
 
-PR #487 aligns language around instance-wide module availability controls. PR #488 goes further by adding group-level module toggles, moving Principles into Business Architecture, and making framework overlay default-on. These changes touch the same mental model even though they are separate PRs. If reviewed independently, GovEA could end up with clear copy but surprising defaults, or useful defaults with terminology still unsettled.
+PRs #493 and #498 stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`. That fixed the immediate runtime mismatch, but the process is still too manual for a demo environment that users and reviewers depend on. Without a traceable release pipeline, maintainers can lose time reconstructing which commit, image digest, and Container Apps revision are actually live.
 
-### R-002 — Data Architecture can keep expanding without a deliberate v1 boundary
+### R-002 - Data Architecture can keep expanding without a deliberate v1 boundary
 
 - **Category:** Scope
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-14
-- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, docs, visualization, nav, and fixtures; if not, split conceptual/logical expansion into focused follow-up issues.
+- **Last reviewed:** 2026-05-15
+- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, relationships, docs, visualization, nav, and fixtures; if not, split conceptual/logical expansion into focused follow-up issues.
 
 #### Details
 
 The Data Architecture Metamodel is now a shipped module, not only a request. That increases the need for a product boundary. Leaving #363 open as a broad umbrella risks sliding from an enterprise-architecture support surface into a much larger data-modelling product without a deliberate sequence.
 
-### R-003 — Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
+### R-003 - Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
 
 - **Category:** Product Fit
 - **Impact:** High
 - **Likelihood:** High
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-14
+- **Last reviewed:** 2026-05-15
 - **Mitigation:** Execute #384 and start #103 Phase 1 with a manual feedback log tied to recently shipped stakeholder-facing surfaces.
 
 #### Details
 
-The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, guided-answer, Data Architecture, and architecture-debt surfaces; what formats they trust; and whether they act on freshness or confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
+The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, guided-answer, Data Architecture, risk, and architecture-debt surfaces; what formats they trust; and whether they act on freshness or confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
 
-### R-004 — Break-glass controls exist, but there is still no real cross-tenant operational caller proving they work in practice
+### R-004 - Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately
 
-- **Category:** Operational / Security
-- **Impact:** High
+- **Category:** Product / UX
+- **Impact:** Medium
 - **Likelihood:** Medium
-- **Owner:** Product / Engineering
+- **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-14
-- **Mitigation:** Ship #437 before treating break-glass as operationally credible. Defer #436 unless operator experience shows read-gating is immediately required.
+- **Last reviewed:** 2026-05-15
+- **Mitigation:** Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499.
 
 #### Details
 
-The hardening work for #418 shipped TTL reduction, dual control, approval flow, and the `requireBreakGlass` helper. The remaining risk is practical rather than theoretical: until GovEA uses that control in a real support/debugging flow, the control is only partially proven. That matters if the platform team expects to rely on break-glass under incident conditions.
+PRs #487 and #488 clarified instance-wide module availability and shipped group-level module toggles. Issue #499 now proposes glossary-backed menu definitions and reusable tour/contextual-help language. If #499 moves first, the product may encode terminology that #446 later changes, creating avoidable copy churn across onboarding, glossary, settings, and navigation surfaces.
 
-### R-005 — Feature-management wording can confuse org-level settings with instance-wide availability controls
+### R-005 - First-class risk tracking can become too broad if implementation starts before validation
 
-- **Category:** Documentation / Product Clarity
+- **Category:** Product Scope
 - **Impact:** Medium
-- **Likelihood:** Low
+- **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Watching
-- **Last reviewed:** 2026-05-14
-- **Mitigation:** Merge PR #487, close #445, then decide the broader "module" vs "tool" terminology question in #446.
+- **Last reviewed:** 2026-05-15
+- **Mitigation:** Treat #501 as a capability-definition PR only; validate risk-summary audiences through #384 before opening implementation slices.
 
 #### Details
 
-The product already supports org-level module toggles and instance-wide availability controls. Uneven wording makes the operator boundary harder to explain: org admins choose what their organization uses, while instance admins decide which modules are available anywhere on the shared instance. This is not a behavior gap, but clear language matters for a multi-tenant government tool.
+PR #501 defines `rm-risk-tracking` and a design note for architecture and delivery risk tracking. That is the right product direction, but risk tracking can easily become a full GRC platform if the first implementation slice is not tightly tied to GovEA's architecture repository, roadmap decisions, and validated stakeholder needs.
 
-### R-006 — Documentation can drift behind shipped repo state during fast-moving backlog turns
+### R-006 - Documentation can drift behind shipped repo state during fast-moving backlog turns
 
 - **Category:** Process
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Watching
-- **Last reviewed:** 2026-05-14
+- **Last reviewed:** 2026-05-15
 - **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
 
 #### Details
 
-This risk showed up again on 2026-05-14: the checked-in priority note still described PR #457 as open even though main had moved through the architecture-debt and Data Architecture streams, and #486 merged during the grooming run. The consequence is not just cosmetic; stale docs distort prioritization.
+The latest grooming pass again found stale docs: the checked-in priority note still treated PRs #487 and #488 as active and #437 as open after those streams had moved on. The consequence is not just cosmetic; stale docs distort prioritization and make automation repeat work that should already be closed.


### PR DESCRIPTION
## Summary

Refreshes the backlog grooming docs for the 2026-05-15 product-management pass.

## What changed

- Updates `docs/product-priorities.md` with the current top 5 next things: #504 release pipeline, #499 inherited glossary/menu definitions, #363 Data Architecture boundary, #384/#103 validation and feedback capture, and #446 module/tool terminology.
- Updates `docs/risk-register.md` so active risks reflect manual demo release traceability, Data Architecture scope, persona validation, glossary terminology, first-class risk tracking scope, and documentation drift.
- Updates `capabilities.md` and `README.md` to reflect shipped repository confidence, architecture debt, Data Architecture, GovEA Project seed/demo state, and break-glass act-as support.
- Creates #504 for the release-pipeline follow-up called out by #498.
- Notes #503 as the mainline recovery PR for #492/#496/#497 seed work.

## Validation

- `git diff --check`
- GitHub connector compare: branch touches only docs files and is mergeable against current `main`.

Capability: process/methodology
Automation: backlog-grooming-for-govea