### PR TITLE
fix(settings): align module group controls

### DIFF
--- a/apps/govea/src/components/instance-module-toggles.tsx
+++ b/apps/govea/src/components/instance-module-toggles.tsx
@@ -5,7 +5,7 @@ import { MODULE_DEFS, type ModuleGroup, type ModuleKey } from '@/lib/modules'
 import { setInstanceModuleAvailability, setInstanceGroupAvailability } from '@/actions/instance'
 import { cn } from '@/lib/utils'
 
-const GROUPS: ModuleGroup[] = ['Business Architecture', 'Portfolio', 'Strategy', 'Framework']
+const GROUPS: ModuleGroup[] = ['Business Architecture', 'Data Architecture', 'Portfolio', 'Strategy', 'Framework']
 
 interface InstanceModuleTogglesProps {
   initialDisabledModules: Record<string, boolean>
@@ -71,12 +71,21 @@ export function InstanceModuleToggles({ initialDisabledModules }: InstanceModule
       {GROUPS.map(group => {
         const groupKeys = MODULE_DEFS.filter(m => m.group === group).map(m => m.key)
         const allAvailable = groupKeys.every(k => disabledModules[k] !== true)
+        const availableCount = groupKeys.filter(k => disabledModules[k] !== true).length
         return (
-          <div key={group} className="space-y-2">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {group}
-              </p>
+          <section key={group} className="space-y-2" aria-labelledby={`instance-module-group-${group.replace(/\s+/g, '-').toLowerCase()}`}>
+            <div className="flex items-center justify-between gap-4 rounded-md border border-border/80 bg-muted/60 px-4 py-3 shadow-sm">
+              <div className="space-y-0.5">
+                <p
+                  id={`instance-module-group-${group.replace(/\s+/g, '-').toLowerCase()}`}
+                  className="text-xs font-semibold uppercase tracking-wider text-foreground"
+                >
+                  {group}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {availableCount}/{groupKeys.length} available
+                </p>
+              </div>
               <Toggle
                 enabled={allAvailable}
                 disabled={isPending}
@@ -110,7 +119,7 @@ export function InstanceModuleToggles({ initialDisabledModules }: InstanceModule
                 )
               })}
             </div>
-          </div>
+          </section>
         )
       })}
       {isPending && (

--- a/apps/govea/src/components/module-toggles.tsx
+++ b/apps/govea/src/components/module-toggles.tsx
@@ -10,7 +10,7 @@ interface ModuleTogglesProps {
   lockedModules?: Record<string, boolean>
 }
 
-const GROUPS: ModuleGroup[] = ['Business Architecture', 'Portfolio', 'Strategy']
+const GROUPS: ModuleGroup[] = ['Business Architecture', 'Data Architecture', 'Portfolio', 'Strategy']
 
 function Toggle({
   enabled, disabled, label, onChange,
@@ -73,12 +73,21 @@ export function ModuleToggles({ initialModules, lockedModules = {} }: ModuleTogg
         const groupKeys = MODULE_DEFS.filter(m => m.group === group && m.href !== null).map(m => m.key)
         const allEnabled = groupKeys.every(k => lockedModules[k] !== true && isModuleEnabled(modules, k))
         const allLocked = groupKeys.every(k => lockedModules[k] === true)
+        const enabledCount = groupKeys.filter(k => lockedModules[k] !== true && isModuleEnabled(modules, k)).length
         return (
-          <div key={group} className="space-y-2">
-            <div className="flex items-center justify-between gap-4">
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {group}
-              </p>
+          <section key={group} className="space-y-2" aria-labelledby={`module-group-${group.replace(/\s+/g, '-').toLowerCase()}`}>
+            <div className="flex items-center justify-between gap-4 rounded-md border border-border/80 bg-muted/60 px-4 py-3 shadow-sm">
+              <div className="space-y-0.5">
+                <p
+                  id={`module-group-${group.replace(/\s+/g, '-').toLowerCase()}`}
+                  className="text-xs font-semibold uppercase tracking-wider text-foreground"
+                >
+                  {group}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {enabledCount}/{groupKeys.length} enabled
+                </p>
+              </div>
               <Toggle
                 enabled={allEnabled}
                 disabled={isPending || allLocked}
@@ -113,7 +122,7 @@ export function ModuleToggles({ initialModules, lockedModules = {} }: ModuleTogg
                 )
               })}
             </div>
-          </div>
+          </section>
         )
       })}
       {isPending && (

--- a/apps/govea/src/lib/modules.ts
+++ b/apps/govea/src/lib/modules.ts
@@ -26,7 +26,7 @@ export type ModuleKey =
   | 'data-architecture'
   | 'framework-overlay'
 
-export type ModuleGroup = 'Business Architecture' | 'Portfolio' | 'Strategy' | 'Framework'
+export type ModuleGroup = 'Business Architecture' | 'Data Architecture' | 'Portfolio' | 'Strategy' | 'Framework'
 
 export type ModuleStateMap = Record<string, boolean>
 
@@ -54,11 +54,12 @@ export const MODULE_DEFS: ModuleDef[] = [
   { key: 'services',      label: 'Services',            href: '/services',      group: 'Business Architecture' },
   { key: 'principles',    label: 'Principles',          href: '/principles',    group: 'Business Architecture' },
   { key: 'glossary',      label: 'Glossary',            href: '/glossary',      group: 'Business Architecture' },
+  // Data Architecture
+  { key: 'data-architecture', label: 'Data architecture', href: '/data',        group: 'Data Architecture' },
   // Portfolio
   { key: 'applications',  label: 'Applications',        href: '/applications',  group: 'Portfolio' },
   { key: 'adrs',          label: 'Decisions (ADRs)',    href: '/adrs',          group: 'Portfolio' },
   { key: 'debt',          label: 'Architecture debt',   href: '/debt',          group: 'Portfolio' },
-  { key: 'data-architecture', label: 'Data architecture', href: '/data',        group: 'Portfolio' },
   // Strategy
   { key: 'objectives',    label: 'Objectives',          href: '/objectives',    group: 'Strategy' },
   { key: 'initiatives',   label: 'Initiatives',         href: '/initiatives',   group: 'Strategy' },

--- a/apps/govea/tests/unit/modules.test.ts
+++ b/apps/govea/tests/unit/modules.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { isModuleEnabled, moduleForPath } from '@/lib/modules'
+import { MODULE_DEFS, isModuleEnabled, moduleForPath } from '@/lib/modules'
 
 // ---------------------------------------------------------------------------
 // isModuleEnabled
@@ -43,6 +43,9 @@ describe('isModuleEnabled', () => {
       objectives: false,
       initiatives: false,
       roadmap: false,
+      debt: false,
+      'data-architecture': false,
+      'framework-overlay': false,
     }
     expect(isModuleEnabled(allOff, 'roadmap')).toBe(false)
     expect(isModuleEnabled({}, 'roadmap')).toBe(true)
@@ -92,6 +95,21 @@ describe('moduleForPath', () => {
 
   it('matches roadmap', () => {
     expect(moduleForPath('/roadmap')).toMatchObject({ key: 'roadmap' })
+  })
+
+  it('matches data architecture to its own module group', () => {
+    expect(moduleForPath('/data/entities')).toMatchObject({
+      key: 'data-architecture',
+      group: 'Data Architecture',
+    })
+  })
+
+  it('keeps data architecture out of the portfolio module group', () => {
+    const portfolioKeys = MODULE_DEFS.filter(def => def.group === 'Portfolio').map(def => def.key)
+    expect(portfolioKeys).toEqual(['applications', 'adrs', 'debt'])
+    expect(MODULE_DEFS.find(def => def.key === 'data-architecture')).toMatchObject({
+      group: 'Data Architecture',
+    })
   })
 
   it('returns the full ModuleDef shape', () => {


### PR DESCRIPTION
## Summary
- make group-level module controls visually distinct from individual module rows
- move Data Architecture into its own module group to match sidebar navigation
- apply the same group model to org settings and instance-wide feature controls

Closes #506
Related #479
Capability: ac-feature-management

## Validation
- `pnpm --filter govea exec vitest run --config vitest.config.ts tests/unit/modules.test.ts`
- `pnpm --filter govea exec tsc --noEmit`
- `pnpm --filter govea lint`