### PR TITLE
[codex] docs: refresh backlog grooming after recent merges

### DIFF
--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-15 (no open PRs; release-pipeline issue created as #504)
+Last groomed: 2026-05-16 (no open PRs; #507 and #508 merged after the prior grooming pass)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -14,33 +14,35 @@ The repository-completeness, repository-confidence, and architecture-debt stream
 
 - [#380](https://github.com/roballred/GovEA/issues/380) shipped snapshot foundations, settings, drill-downs, ranked cleanup actions, RAG indicators, trend history, stakeholder surfaces, and auto-suppression through PRs [#448](https://github.com/roballred/GovEA/pull/448), [#450](https://github.com/roballred/GovEA/pull/450), [#454](https://github.com/roballred/GovEA/pull/454), and [#457](https://github.com/roballred/GovEA/pull/457).
 - [#381](https://github.com/roballred/GovEA/issues/381) shipped architecture debt CRUD, linked-debt panels, dashboard priority signals, publish-time acknowledgement, and lifecycle-based system-detected debt through PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), [#467](https://github.com/roballred/GovEA/pull/467), and [#486](https://github.com/roballred/GovEA/pull/486).
-- [#437](https://github.com/roballred/GovEA/issues/437) is now complete through [#502](https://github.com/roballred/GovEA/pull/502), which added scoped act-as sessions gated by break-glass and a first cross-tenant support action.
+- [#437](https://github.com/roballred/GovEA/issues/437) is complete through [#502](https://github.com/roballred/GovEA/pull/502), which added scoped act-as sessions gated by break-glass and a first cross-tenant support action.
 
 The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) is also a real shipped module: schema and CRUD foundation, relationship editing, business-architecture docs, Chen notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
 
 Recent merged PRs changed the next-work queue:
 
-- [#493](https://github.com/roballred/GovEA/pull/493) and [#498](https://github.com/roballred/GovEA/pull/498) stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`.
 - [#503](https://github.com/roballred/GovEA/pull/503) recovered the seed cleanup and GovEA Project value-chain enrichment from [#496](https://github.com/roballred/GovEA/pull/496) and [#497](https://github.com/roballred/GovEA/pull/497) onto `main`, closing [#492](https://github.com/roballred/GovEA/issues/492) and adding a PR base-check workflow.
 - [#501](https://github.com/roballred/GovEA/pull/501) documented first-class risk tracking and closed [#500](https://github.com/roballred/GovEA/issues/500) as a design/capability-definition slice.
-- No PRs are open at this grooming point.
+- [#505](https://github.com/roballred/GovEA/pull/505) merged the 2026-05-15 backlog-grooming refresh into `main`.
+- [#507](https://github.com/roballred/GovEA/pull/507) aligned module group controls with the sidebar group model and closed [#506](https://github.com/roballred/GovEA/issues/506).
+- [#508](https://github.com/roballred/GovEA/pull/508) shipped the org-scoped half of admin notices from [#456](https://github.com/roballred/GovEA/issues/456). Instance-wide notices remain the planned second slice.
+- There are no open pull requests at this grooming point.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Build a traceable release pipeline for the Azure demo | Demo stability is now good enough to protect. Manual deploys still make it too hard to know which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
-| 2 | Implement the inherited system glossary and menu definitions | This turns the existing glossary into a shared product vocabulary layer, supports tours/contextual help, and makes GovEA's EasyEA language clearer for new organizations. | [#499](https://github.com/roballred/GovEA/issues/499) |
-| 3 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, relationships, diagram, nav, and fixtures shipped, the remaining conceptual/logical scope needs a deliberate follow-up shape. | [#363](https://github.com/roballred/GovEA/issues/363) |
-| 4 | Run the persona-validation and feedback-capture slice | GovEA is shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, risk, and architecture-debt concepts based on assumed personas. Validate before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
-| 5 | Decide module/tool terminology before more onboarding copy ships | Group toggles and instance-wide availability controls are merged. Before glossary, tour, or contextual-help copy spreads further, decide whether user-facing language stays "module" or becomes "tool." | [#446](https://github.com/roballred/GovEA/issues/446) |
+| 1 | Finish admin notices with the instance-wide slice | #508 shipped org-scoped notices, but #456 is only complete when instance admins can post distinct instance-wide notices and the UI handles both scopes clearly. | [#456](https://github.com/roballred/GovEA/issues/456) |
+| 2 | Build a traceable release pipeline for the Azure demo | Demo stability is now good enough to protect. Manual deploys still make it too hard to know which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
+| 3 | Decide module/tool terminology, then implement inherited glossary/menu definitions | Glossary-backed menu definitions and product tours will spread language across the app. Make the #446 wording decision first, then use #499 to seed shared definitions. | [#446](https://github.com/roballred/GovEA/issues/446), [#499](https://github.com/roballred/GovEA/issues/499) |
+| 4 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, relationships, diagram, nav, fixtures, and settings alignment shipped, the remaining conceptual/logical scope needs a deliberate follow-up shape. | [#363](https://github.com/roballred/GovEA/issues/363) |
+| 5 | Run the persona-validation and feedback-capture slice | GovEA is shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, risk, and architecture-debt concepts based on assumed personas. Validate before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
 
 ## Product Manager Notes
 
+- #456 should now be split into an instance-notice PR rather than reopened as another broad design pass. #508 already settled most of the shared notice semantics.
 - #504 should be treated as operational product work, not infrastructure polish. The demo is how many users will first understand GovEA.
-- #499 is the best next product capability because it strengthens onboarding, navigation comprehension, product-tour content, and shared EasyEA vocabulary without adding a broad new modeling surface.
+- #507 reduces the settings/navigation mismatch, so #479 can move when the team wants a usability-focused navigation-density slice. It sits just outside the top five because the current top items reduce broader product and operating risk.
 - #500/#501 created the risk-tracking capability definition. Do not jump straight to implementation until persona validation clarifies which risk summaries leadership and practitioners actually trust.
-- #479 remains a strong usability follow-up now that Data Architecture and Framework Alignment make the sidebar denser. It sits just outside the top five because release traceability, glossary, boundary decisions, and validation reduce higher product risk.
 - #482 is important process work, but it has an explicit maintainer-review-first workflow. Do not bypass that by bundling an AI-session-start document into ordinary grooming PRs.
 - #436 remains a future security hardening option after enough operational experience with #502's act-as flow. It is not the next security item unless read-surface risk becomes urgent.
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -24,84 +24,84 @@ This register is intentionally lightweight:
 
 | ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
 |---|---|---|---|---|---|---|---|---|
-| R-001 | Manual demo deployment can obscure which commit, image, and runtime configuration are live | Operational / Release | High | Medium | Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear | Product / Engineering | Open | 2026-05-15 |
-| R-002 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-15 |
-| R-003 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-15 |
-| R-004 | Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately | Product / UX | Medium | Medium | Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499 | Product | Open | 2026-05-15 |
-| R-005 | First-class risk tracking can become too broad if implementation starts before validation | Product Scope | Medium | Medium | Treat #501 as capability definition only; validate risk-summary audiences through #384 before opening implementation slices | Product | Watching | 2026-05-15 |
-| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-15 |
+| R-001 | Admin notices can remain half-shipped if the instance-wide scope does not follow #508 | Product / Operations | Medium | Medium | Treat #508 as PR 1 of #456 and ship the instance-admin notice management and rendering slice next | Product / Engineering | Open | 2026-05-16 |
+| R-002 | Manual demo deployment can obscure which commit, image, and runtime configuration are live | Operational / Release | High | Medium | Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear | Product / Engineering | Open | 2026-05-16 |
+| R-003 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-16 |
+| R-004 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-16 |
+| R-005 | Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately | Product / UX | Medium | Medium | Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499 | Product | Open | 2026-05-16 |
+| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-16 |
 
 ## Risk Details
 
-### R-001 - Manual demo deployment can obscure which commit, image, and runtime configuration are live
+### R-001 - Admin notices can remain half-shipped if the instance-wide scope does not follow #508
+
+- **Category:** Product / Operations
+- **Impact:** Medium
+- **Likelihood:** Medium
+- **Owner:** Product / Engineering
+- **Status:** Open
+- **Last reviewed:** 2026-05-16
+- **Mitigation:** Treat #508 as PR 1 of #456 and ship the instance-admin notice management and rendering slice next.
+
+#### Details
+
+PR #508 shipped org-scoped admin notices and settled much of the shared behavior: severity, single active notice per scope, audit trail, authenticated-page rendering, and optional learn-more URLs. Issue #456 remains broader. If the instance-wide slice does not follow, GovEA will have agency-level operational messaging but still lack a shared-instance operator channel for maintenance windows, migrations, and platform-level warnings.
+
+### R-002 - Manual demo deployment can obscure which commit, image, and runtime configuration are live
 
 - **Category:** Operational / Release
 - **Impact:** High
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-15
+- **Last reviewed:** 2026-05-16
 - **Mitigation:** Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear.
 
 #### Details
 
 PRs #493 and #498 stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`. That fixed the immediate runtime mismatch, but the process is still too manual for a demo environment that users and reviewers depend on. Without a traceable release pipeline, maintainers can lose time reconstructing which commit, image digest, and Container Apps revision are actually live.
 
-### R-002 - Data Architecture can keep expanding without a deliberate v1 boundary
+### R-003 - Data Architecture can keep expanding without a deliberate v1 boundary
 
 - **Category:** Scope
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-15
-- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, relationships, docs, visualization, nav, and fixtures; if not, split conceptual/logical expansion into focused follow-up issues.
+- **Last reviewed:** 2026-05-16
+- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, relationships, docs, visualization, nav, fixtures, and settings alignment; if not, split conceptual/logical expansion into focused follow-up issues.
 
 #### Details
 
 The Data Architecture Metamodel is now a shipped module, not only a request. That increases the need for a product boundary. Leaving #363 open as a broad umbrella risks sliding from an enterprise-architecture support surface into a much larger data-modelling product without a deliberate sequence.
 
-### R-003 - Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
+### R-004 - Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
 
 - **Category:** Product Fit
 - **Impact:** High
 - **Likelihood:** High
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-15
+- **Last reviewed:** 2026-05-16
 - **Mitigation:** Execute #384 and start #103 Phase 1 with a manual feedback log tied to recently shipped stakeholder-facing surfaces.
 
 #### Details
 
 The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, guided-answer, Data Architecture, risk, and architecture-debt surfaces; what formats they trust; and whether they act on freshness or confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
 
-### R-004 - Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately
+### R-005 - Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately
 
 - **Category:** Product / UX
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-15
+- **Last reviewed:** 2026-05-16
 - **Mitigation:** Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499.
 
 #### Details
 
-PRs #487 and #488 clarified instance-wide module availability and shipped group-level module toggles. Issue #499 now proposes glossary-backed menu definitions and reusable tour/contextual-help language. If #499 moves first, the product may encode terminology that #446 later changes, creating avoidable copy churn across onboarding, glossary, settings, and navigation surfaces.
-
-### R-005 - First-class risk tracking can become too broad if implementation starts before validation
-
-- **Category:** Product Scope
-- **Impact:** Medium
-- **Likelihood:** Medium
-- **Owner:** Product
-- **Status:** Watching
-- **Last reviewed:** 2026-05-15
-- **Mitigation:** Treat #501 as a capability-definition PR only; validate risk-summary audiences through #384 before opening implementation slices.
-
-#### Details
-
-PR #501 defines `rm-risk-tracking` and a design note for architecture and delivery risk tracking. That is the right product direction, but risk tracking can easily become a full GRC platform if the first implementation slice is not tightly tied to GovEA's architecture repository, roadmap decisions, and validated stakeholder needs.
+Issue #499 proposes glossary-backed menu definitions and reusable tour/contextual-help language. If #499 moves before #446, the product may encode terminology that #446 later changes, creating avoidable copy churn across onboarding, glossary, settings, and navigation surfaces. The #507 module-settings work makes this decision more visible, not less.
 
 ### R-006 - Documentation can drift behind shipped repo state during fast-moving backlog turns
 
@@ -110,9 +110,9 @@ PR #501 defines `rm-risk-tracking` and a design note for architecture and delive
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Watching
-- **Last reviewed:** 2026-05-15
+- **Last reviewed:** 2026-05-16
 - **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
 
 #### Details
 
-The latest grooming pass again found stale docs: the checked-in priority note still treated PRs #487 and #488 as active and #437 as open after those streams had moved on. The consequence is not just cosmetic; stale docs distort prioritization and make automation repeat work that should already be closed.
+The current grooming pass found that the 2026-05-15 docs were correct when opened, but #505, #507, and #508 all merged before the next run completed. The consequence is not just cosmetic; stale docs distort prioritization and make automation repeat work that should already be closed.


### PR DESCRIPTION
## Summary

Refreshes the backlog-grooming docs after the 2026-05-16 merge sequence.

## What changed

- Updates `docs/product-priorities.md` now that #505, #507, and #508 have merged and there are no open PRs.
- Re-ranks the top 5 next things: finish instance-wide admin notices for #456, ship #504 release pipeline, decide #446 before #499 glossary/menu definitions, close or split #363, and run #384/#103 validation.
- Updates `docs/risk-register.md` so active risks match the current queue: partial admin-notice scope, manual demo release traceability, Data Architecture boundary, persona validation, terminology/glossary coupling, and docs drift.

## Validation

- GitHub connector compare: branch is 2 commits ahead of `main`, 0 behind, and touches only `docs/product-priorities.md` and `docs/risk-register.md`.

Capability: process/methodology
Automation: backlog-grooming-for-govea