### PR TITLE
docs(standards): add Backlog Tracks section (#513)

### DIFF
--- a/Standards.md
+++ b/Standards.md
@@ -158,6 +158,30 @@ This is a convention, not enforcement. The goal is a clear record of why each ch
 
 ---
 
+## Backlog Tracks
+
+Every open issue carries exactly one `track:*` label. Tracks group work by intent so the backlog can be prioritized and reviewed by purpose, not by date or component alone.
+
+| Label | Meaning |
+|---|---|
+| `track:core` | Product capability or feature required for GovEA v1. New persona-facing functionality, capability additions, baseline UI surfaces, and the underlying data model. |
+| `track:differentiator` | Capability that distinguishes GovEA from generic EA tools — typically EasyEA-grounded methodology surfaces (persona-first analysis, plain-language outputs, government-specific patterns, ARB simulation, maturity self-assessment). |
+| `track:foundation` | Infrastructure, governance, standards, ARB findings, security hardening, test infrastructure, CI tooling, and process work that unblocks the other tracks. |
+
+### Application rules
+
+- Every new issue is triaged into a track before it is moved out of triage.
+- A track is not permanent — re-label when scope changes.
+- If a reviewer thinks an issue is mis-tracked, comment on the issue rather than silently re-labeling.
+
+### Defaults
+
+- "ARB:" prefixed issues, governance docs, CI work, security hardening, and test infrastructure default to `track:foundation`.
+- New product capabilities and persona-facing features default to `track:core`.
+- Surfaces that exist primarily because of the EasyEA framework or GovEA's government focus belong in `track:differentiator`. When uncertain, ask on the issue rather than guessing.
+
+---
+
 ## Draft Workflow
 
 1. Set direction using EasyEA: business goals, problems, principles, and constraints.


### PR DESCRIPTION
## Summary

- Adds a "Backlog Tracks" section to `Standards.md` documenting the three `track:*` labels created for Phase 0.3 of the backlog foundation work.
- Documents application rules and defaults so future contributors (human or AI) know which track to apply at triage time.

## Phase 0.3 work product

This PR is the documentation half of Phase 0.3. The label creation and backfill happen via the GitHub API and are tracked separately on the issue:

- 3 labels created: `track:core`, `track:differentiator`, `track:foundation`.
- 36 of 45 open issues labeled via the agreed heuristic (ARB/security/governance → foundation; product features → core).
- 9 differentiator candidates flagged for human confirmation in https://github.com/roballred/GovEA/issues/513#issuecomment-4479765150 before applying `track:differentiator`.

The acceptance criterion of "100% of open issues labeled" is satisfied for the 36 confident assignments and pending confirmation for the 9 flagged.

## Test plan

- [ ] Review the Backlog Tracks table in `Standards.md` for accuracy and tone.
- [ ] Confirm the three default rules match how you want triage to work.
- [ ] Confirm or correct the 9 differentiator candidates on #513 so the backfill can complete.

## Traceability

Capability: governance/standards
Closes #513