### PR TITLE
seed: add Nora as a second instance admin (#521)

### DIFF
--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -89,7 +89,8 @@ export default async function LoginPage({
                 { label: 'GovEA Project Admin',   email: 'aria@govea-project.govea.dev',  cls: 'bg-teal-50 text-teal-800 border-teal-200 hover:bg-teal-100' },
                 { label: 'State Admin',           email: 'sam@state.govea.dev',           cls: 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100' },
                 { label: 'Hartfield EA Admin',    email: 'maya@hartfield.govea.dev',      cls: 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100' },
-                { label: 'Instance Admin (dev)',  email: 'ivan@govea.dev',                cls: 'bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100' },
+                { label: 'Ivan — Instance Admin (dev)',  email: 'ivan@govea.dev',         cls: 'bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100' },
+                { label: 'Nora — Instance Admin (dev)',  email: 'nora@govea.dev',         cls: 'bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100' },
                 { label: 'Scale Test Admin (500 apps)',  email: 'scale@govea.dev',         cls: 'bg-slate-50 text-slate-800 border-slate-300 hover:bg-slate-100' },
               ] as const).map(({ label, email, cls }) => (
                 <form key={email} action={devSignIn}>

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -20,6 +20,7 @@
 //   sam@state.govea.dev                — Office of Digital Services, Admin
 //   maya@hartfield.govea.dev           — City of Hartfield (TOGAF demo), Admin
 //   ivan@govea.dev                     — GovEA Platform, Instance Admin (dev tools only)
+//   nora@govea.dev                     — GovEA Platform, Instance Admin (dev tools only) — pair partner for break-glass approval workflows
 //
 // victor@govea.dev remains seeded as a Riverdale Viewer for automated role
 // coverage, but is intentionally not shown as a dev login shortcut.
@@ -55,6 +56,7 @@ export const STATE_USERS = [
 
 export const SYSTEM_USERS = [
   { name: 'Ivan InstanceAdmin', email: 'ivan@govea.dev', role: 'admin' as const, instanceRole: 'instance_admin' as const },
+  { name: 'Nora InstanceAdmin', email: 'nora@govea.dev', role: 'admin' as const, instanceRole: 'instance_admin' as const },
 ]
 
 // ─── GovEA Project ────────────────────────────────────────────────────────────

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -1969,7 +1969,7 @@ async function seed() {
       })
     }
   }
-  console.log(`  ✓ ${SYSTEM_USERS.length} users (ivan@govea.dev / dev-password, instanceRole=instance_admin)`)
+  console.log(`  ✓ ${SYSTEM_USERS.length} users with instanceRole=instance_admin (dev-password): ${SYSTEM_USERS.map(u => u.email).join(', ')}`)
 
   // ── Instance settings — enable all modules for dev ────────────────────────
   // Production instances start with every module disabled (opt-in). For dev,


### PR DESCRIPTION
## Summary

- Adds `nora@govea.dev` to `SYSTEM_USERS` in `apps/govea/src/db/seeds/dev-fixtures.ts` with `instanceRole: 'instance_admin'`, matching the existing Ivan entry's shape.
- Adds a corresponding dev login shortcut on `/login`, color-matched to Ivan's orange theme so the pair reads as a related set.
- Relabels the existing "Instance Admin (dev)" button to "Ivan — Instance Admin (dev)" so the two instance admins are unambiguous in the dev login list.
- Generalizes the seed-runner console log to list all `SYSTEM_USERS` emails rather than hard-coding `ivan@govea.dev`.

## Why

Surfaced by the Instance Administrator persona journey audit ([#519](https://github.com/roballred/GovEA/issues/519), part of epic [#515](https://github.com/roballred/GovEA/issues/515)). The break-glass approval gate kicks in for sessions > 60 minutes and requires a second instance admin to approve — but the seed shipped only one. With a second instance admin seeded, the full approval handoff (Ivan grants → Nora approves, or vice versa) can be exercised end-to-end with seeded data alone.

## Verification

**Code review:** the changes are three small additions, each following an existing typed pattern in the same file:

- `dev-fixtures.ts`: new array entry with identical shape and `as const` annotations as the existing one.
- `run.ts`: one-line console-log template change.
- `login/page.tsx`: new object literal in an existing `as const` array of `{ label, email, cls }` shortcut definitions.

**Browser verification not run.** The verification environment was unavailable in this session:

- Another active session's preview server holds port 3000 against a different worktree, so the running preview cannot observe these edits.
- `govea-postgres` is not running locally (`podman ps -a` returned no container).
- Dependencies are not installed in this worktree (`tsc` and other binaries unavailable), so a static type-check could not be run either.

The change surface is small and structurally trivial, but please re-seed and click both shortcuts before merge to confirm. Suggested smoke test:

1. `pnpm --filter govea db:push` (if needed) and `pnpm --filter govea db:seed`.
2. `pnpm demo:start`.
3. On `/login`, confirm "Ivan — Instance Admin (dev)" and "Nora — Instance Admin (dev)" both render.
4. Click each in turn; confirm both land in `/dashboard` (or `/instance` if [#520](https://github.com/roballred/GovEA/issues/520) lands first).
5. As one instance admin, grant break-glass with TTL > 60min on a tenant org; as the other, approve from `/instance/orgs/[id]` or `/instance`.

## Test plan

- [ ] Confirm both dev shortcuts render on the login page with the orange instance-admin styling.
- [ ] Confirm both `ivan@govea.dev` and `nora@govea.dev` sign in successfully after a fresh seed.
- [ ] Confirm the >1hr break-glass approval handoff works end-to-end between the two.

## Traceability

Capability: iam-instance-administration
Persona: instance-administrator
Closes #521
Surfaced by: [#519](https://github.com/roballred/GovEA/issues/519) (parent [#515](https://github.com/roballred/GovEA/issues/515))