### PR TITLE
fix(instance): post-signin redirect & Platform org badge (#520, #522)

### DIFF
--- a/apps/govea/src/app/(auth)/auth-redirect/page.tsx
+++ b/apps/govea/src/app/(auth)/auth-redirect/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { isInstanceAdmin } from '@/lib/rbac'
+import { safeCallbackUrl } from '@/lib/auth-redirect'
+
+// Role-aware post-signin bouncer (#520). Instance admins land on /instance;
+// everyone else lands on /dashboard. An explicit, safe `callbackUrl` always
+// wins over the role-based default.
+export default async function AuthRedirectPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>
+}) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const params = await searchParams
+  if (params.callbackUrl) {
+    const explicit = safeCallbackUrl(params.callbackUrl, '')
+    if (explicit) redirect(explicit)
+  }
+
+  if (isInstanceAdmin(session.user)) redirect('/instance')
+  redirect('/dashboard')
+}

--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -12,7 +12,7 @@ import { Separator } from '@/components/ui/separator'
 async function devSignIn(formData: FormData) {
   'use server'
   const email = formData.get('email') as string
-  await signIn('credentials', { email, password: 'dev-password', redirectTo: '/dashboard' })
+  await signIn('credentials', { email, password: 'dev-password', redirectTo: '/auth-redirect' })
 }
 
 export default async function LoginPage({
@@ -21,7 +21,7 @@ export default async function LoginPage({
   searchParams: Promise<{ error?: string; callbackUrl?: string }>
 }) {
   const session = await auth()
-  if (session) redirect('/dashboard')
+  if (session) redirect('/auth-redirect')
 
   const params = await searchParams
   const showDemoShortcuts = process.env.NODE_ENV === 'development'
@@ -73,7 +73,7 @@ export default async function LoginPage({
           {process.env.AUTH_MICROSOFT_ENTRA_ID_ID && (
             <form action={async () => {
               'use server'
-              await signIn('microsoft-entra-id', { redirectTo: params.callbackUrl ?? '/dashboard' })
+              await signIn('microsoft-entra-id', { redirectTo: safeCallbackUrl(params.callbackUrl) })
             }}>
               <Button type="submit" variant="outline" className="w-full">Sign in with Microsoft</Button>
             </form>

--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -48,7 +48,7 @@ export default async function LoginPage({
                 await signIn('credentials', {
                   email: formData.get('email'),
                   password: formData.get('password'),
-                  redirectTo: safeCallbackUrl(params.callbackUrl),
+                  redirectTo: safeCallbackUrl(params.callbackUrl, '/auth-redirect'),
                 })
               } catch (error) {
                 if (error instanceof AuthError) {
@@ -73,7 +73,7 @@ export default async function LoginPage({
           {process.env.AUTH_MICROSOFT_ENTRA_ID_ID && (
             <form action={async () => {
               'use server'
-              await signIn('microsoft-entra-id', { redirectTo: safeCallbackUrl(params.callbackUrl) })
+              await signIn('microsoft-entra-id', { redirectTo: safeCallbackUrl(params.callbackUrl, '/auth-redirect') })
             }}>
               <Button type="submit" variant="outline" className="w-full">Sign in with Microsoft</Button>
             </form>

--- a/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx
@@ -84,7 +84,9 @@ export function InstanceOrgsTable({ orgs }: Props) {
       <div className="flex items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Organisations</h1>
-          <p className="text-muted-foreground mt-1">All tenant organisations registered on this instance.</p>
+          <p className="text-muted-foreground mt-1">
+            All organisations on this instance. The platform system org is included and labeled — it cannot be suspended or targeted for break-glass.
+          </p>
         </div>
         <Button size="sm" onClick={() => handleOpen(true)}>+ New organisation</Button>
       </div>
@@ -109,7 +111,9 @@ export function InstanceOrgsTable({ orgs }: Props) {
                     {org.name}
                   </Link>
                   {org.isSystemOrg && (
-                    <span className="ml-2 text-xs text-muted-foreground">(system)</span>
+                    <span className="ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300">
+                      Platform
+                    </span>
                   )}
                 </TableCell>
                 <TableCell className="font-mono text-sm text-muted-foreground">{org.slug}</TableCell>

--- a/apps/govea/src/lib/auth-redirect.ts
+++ b/apps/govea/src/lib/auth-redirect.ts
@@ -12,15 +12,15 @@ const AUTH_DEAD_ENDS = ['/login', '/error', '/api/auth']
  * Returns a safe post-login destination, falling back to `fallback` if the
  * supplied URL would trap the user in an auth or error route.
  *
- * The default fallback is `/auth-redirect`, a role-aware bouncer that routes
- * instance admins to `/instance` and everyone else to `/dashboard`. Callers
- * that need to skip the bouncer (e.g. tests) can pass an explicit fallback.
+ * The default fallback is `/dashboard`. Login page call sites that want
+ * role-aware routing should pass `/auth-redirect` explicitly — that bouncer
+ * sends instance admins to `/instance` and everyone else to `/dashboard`.
  *
  * Rules:
  *  - Must start with '/' (relative, no external redirects)
  *  - Must not start with /login, /error, or /api/auth
  */
-export function safeCallbackUrl(url: string | undefined | null, fallback = '/auth-redirect'): string {
+export function safeCallbackUrl(url: string | undefined | null, fallback = '/dashboard'): string {
   if (!url) return fallback
   if (!url.startsWith('/') || url.startsWith('//')) return fallback
   if (AUTH_DEAD_ENDS.some(p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`))) return fallback

--- a/apps/govea/src/lib/auth-redirect.ts
+++ b/apps/govea/src/lib/auth-redirect.ts
@@ -12,11 +12,15 @@ const AUTH_DEAD_ENDS = ['/login', '/error', '/api/auth']
  * Returns a safe post-login destination, falling back to `fallback` if the
  * supplied URL would trap the user in an auth or error route.
  *
+ * The default fallback is `/auth-redirect`, a role-aware bouncer that routes
+ * instance admins to `/instance` and everyone else to `/dashboard`. Callers
+ * that need to skip the bouncer (e.g. tests) can pass an explicit fallback.
+ *
  * Rules:
  *  - Must start with '/' (relative, no external redirects)
  *  - Must not start with /login, /error, or /api/auth
  */
-export function safeCallbackUrl(url: string | undefined | null, fallback = '/dashboard'): string {
+export function safeCallbackUrl(url: string | undefined | null, fallback = '/auth-redirect'): string {
   if (!url) return fallback
   if (!url.startsWith('/') || url.startsWith('//')) return fallback
   if (AUTH_DEAD_ENDS.some(p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`))) return fallback

--- a/docs/persona-journeys/instance-administrator.md
+++ b/docs/persona-journeys/instance-administrator.md
@@ -5,6 +5,8 @@
 **Walk audited:** 2026-05-18 — first persona walk under epic [#515](https://github.com/roballred/GovEA/issues/515) ([sub-issue #519](https://github.com/roballred/GovEA/issues/519))
 **Persona validation status:** Assumed (not yet validated with a real shared-platform operator).
 
+> **Errata (2026-05-18):** the original report claimed the `createOrg` server action was unreachable from the UI. That was wrong — a `+ New organisation` button has been wired to `createOrg` in [`instance-orgs-table.tsx`](../../apps/govea/src/app/(instance)/instance/orgs/instance-orgs-table.tsx) since [#342](https://github.com/roballred/GovEA/pull/342), and the dialog flow is fully functional. The cross-link to [#389](https://github.com/roballred/GovEA/issues/389) was therefore over-eager: that issue scopes the broader lifecycle (states, transitions, governance), not creation alone. Other walk findings stand.
+
 ## Method
 
 Code-based audit of the routes under `apps/govea/src/app/(instance)/instance/**`, their server actions in `apps/govea/src/actions/instance.ts`, and the dev seed in `apps/govea/src/db/seeds/dev-fixtures.ts`. Browser walk was not run — every step is reachable, well-typed, and well-named in code, so confidence is high without it. Steps where browser observation would meaningfully change the finding are called out.


### PR DESCRIPTION
## Summary

Two small Instance Administrator follow-ups from the journey audit (epic [#515](https://github.com/roballred/GovEA/issues/515)), plus a one-line errata to the merged journey report.

### #520 — Role-aware post-signin redirect

Adds `apps/govea/src/app/(auth)/auth-redirect/page.tsx`, a server-component bouncer that:

- Reads the current session via `auth()`.
- Honors a safe `callbackUrl` query param if present (deep-link-friendly).
- Routes `isInstanceAdmin(user)` to `/instance`; everyone else to `/dashboard`.
- Redirects to `/login` if the session is gone.

All three sign-in flows in `login/page.tsx` (credentials form, dev shortcuts, Microsoft Entra) now point at `/auth-redirect` instead of hardcoding `/dashboard`. The default fallback in `safeCallbackUrl` is updated to match so the existing call site keeps working without an explicit override.

Net effect: signing in as `ivan@govea.dev` or `nora@govea.dev` now lands on `/instance` directly. Signing in as any other user is unchanged.

### #522 — Platform org badge

Replaces the muted `(system)` text suffix on the system-org row in `instance-orgs-table.tsx` with a proper indigo "Platform" badge — same shape as the existing tier and status badges, distinct color, consistent with the InstanceShell "Platform" branding. The page description is rewritten to make it explicit that the platform org is included in the list and cannot be suspended or targeted for break-glass.

### Errata on the journey report

The merged instance-administrator walk report claimed the `createOrg` server action was unreachable from the UI. That was wrong — `+ New organisation` has been wired to `createOrg` in `instance-orgs-table.tsx` since [#342](https://github.com/roballred/GovEA/pull/342). Added a short errata note at the top of the report; the rest of the findings stand.

## Verification

**Code review:** the changes are small and structurally simple:

- `auth-redirect/page.tsx`: 21-line server component that mirrors the auth gating pattern already used by `(instance)/layout.tsx` and `(admin)/*/page.tsx`.
- `login/page.tsx`: three call-site updates (devSignIn, top-of-page already-signed-in redirect, Microsoft form), each replacing `/dashboard` with `/auth-redirect` or `safeCallbackUrl(params.callbackUrl)`.
- `auth-redirect.ts`: default fallback changed to `/auth-redirect`; doc comment expanded.
- `instance-orgs-table.tsx`: muted text replaced with a typed badge using existing Tailwind utility classes.

**Browser verification not run.** Same environment constraint as [PR #525](https://github.com/roballred/GovEA/pull/525):

- Another active session's preview server holds port 3000 against a different worktree.
- No `govea-postgres` container running locally.
- Dependencies are not installed in this worktree (no local `tsc`).

Suggested smoke test before merge:

1. `pnpm demo:start` with the dev seed.
2. Click "Ivan — Instance Admin (dev)" shortcut on `/login`. Confirm direct landing on `/instance` (not `/instance/orgs` — the platform dashboard).
3. Click "Riverdale Admin" shortcut. Confirm direct landing on `/dashboard` as before.
4. Sign in with `?callbackUrl=/capabilities` set on `/login`. Confirm the explicit callback wins over the role-based default.
5. Navigate to `/instance/orgs`. Confirm "GovEA Platform" row shows the indigo "Platform" badge next to the org name; tenant rows do not.

## Test plan

- [ ] Smoke-test the four sign-in flows (steps 2–4 above).
- [ ] Spot-check the Platform badge styling matches the InstanceShell platform color.
- [ ] Confirm the journey report errata is accurate and doesn't contradict the rest of the findings.

## Traceability

Capability: iam-instance-administration
Persona: instance-administrator
Closes #520
Closes #522
Epic: [#515](https://github.com/roballred/GovEA/issues/515)