### PR TITLE
feat(instance): filter platform audit by actor, action, time window (#523)

### DIFF
--- a/apps/govea/src/app/(instance)/instance/audit/audit-filters.tsx
+++ b/apps/govea/src/app/(instance)/instance/audit/audit-filters.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useRouter, usePathname } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export type AdminOption = { id: string; email: string }
+
+interface Props {
+  admins: AdminOption[]
+  actions: string[]
+  current: {
+    actor: string
+    action: string[]
+    since: string
+  }
+}
+
+const SINCE_OPTIONS: { value: string; label: string }[] = [
+  { value: '24h', label: 'Last 24h' },
+  { value: '7d',  label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: 'all', label: 'All time' },
+]
+
+export function AuditFilters({ admins, actions, current }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  function update(patch: Partial<typeof current>) {
+    const next = { ...current, ...patch }
+    const sp = new URLSearchParams()
+    if (next.actor) sp.set('actor', next.actor)
+    if (next.action.length > 0) sp.set('action', next.action.join(','))
+    if (next.since && next.since !== 'all') sp.set('since', next.since)
+    const qs = sp.toString()
+    router.push(qs ? `${pathname}?${qs}` : pathname)
+  }
+
+  function toggleAction(code: string) {
+    update({
+      action: current.action.includes(code)
+        ? current.action.filter(a => a !== code)
+        : [...current.action, code],
+    })
+  }
+
+  const hasAny = current.actor || current.action.length > 0 || (current.since && current.since !== 'all')
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold">Filters</h2>
+        {hasAny && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => update({ actor: '', action: [], since: 'all' })}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="space-y-1.5">
+          <label htmlFor="audit-since" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Time window
+          </label>
+          <div className="flex flex-wrap gap-1.5">
+            {SINCE_OPTIONS.map(opt => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => update({ since: opt.value })}
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors',
+                  current.since === opt.value
+                    ? 'bg-foreground text-background border-foreground'
+                    : 'bg-background text-muted-foreground hover:bg-muted',
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="audit-actor" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Actor
+          </label>
+          <select
+            id="audit-actor"
+            value={current.actor}
+            onChange={e => update({ actor: e.target.value })}
+            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="">Any instance admin</option>
+            {admins.map(a => (
+              <option key={a.id} value={a.id}>{a.email}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Action {current.action.length > 0 && `(${current.action.length})`}
+          </span>
+          <details className="rounded-md border bg-background">
+            <summary className="cursor-pointer list-none px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground">
+              {current.action.length === 0
+                ? 'Any action'
+                : current.action.length <= 2
+                  ? current.action.join(', ')
+                  : `${current.action.length} selected`}
+            </summary>
+            <div className="max-h-60 overflow-y-auto border-t p-2 space-y-1">
+              {actions.length === 0 && (
+                <p className="px-2 py-1 text-xs text-muted-foreground">No actions logged yet.</p>
+              )}
+              {actions.map(code => (
+                <label
+                  key={code}
+                  className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-muted cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={current.action.includes(code)}
+                    onChange={() => toggleAction(code)}
+                  />
+                  <code className="font-mono text-xs">{code}</code>
+                </label>
+              ))}
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(instance)/instance/audit/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/audit/page.tsx
@@ -1,20 +1,54 @@
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { auditLog, users, breakGlassSessions, organizations } from '@/db/schema'
-import { eq, desc, isNull } from 'drizzle-orm'
+import { and, eq, desc, isNull, gte, inArray } from 'drizzle-orm'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
+import { AuditFilters } from './audit-filters'
 
-export default async function InstanceAuditPage() {
+function cutoffForSince(since: string | undefined): Date | null {
+  switch (since) {
+    case '24h': return new Date(Date.now() - 24 * 60 * 60 * 1000)
+    case '7d':  return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    case '30d': return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    default:    return null
+  }
+}
+
+export default async function InstanceAuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ actor?: string; action?: string; since?: string }>
+}) {
   await requireInstanceAdmin()
 
-  const [instanceEvents, bgSessions] = await Promise.all([
+  const params = await searchParams
+  const actor = params.actor ?? ''
+  const actionFilter = params.action ? params.action.split(',').filter(Boolean) : []
+  const since = params.since ?? 'all'
+  const cutoff = cutoffForSince(since)
+
+  // Platform Events: instance-scoped audit (organizationId IS NULL) + filters
+  const eventWhere = and(
+    isNull(auditLog.organizationId),
+    actor ? eq(auditLog.userId, actor) : undefined,
+    actionFilter.length > 0 ? inArray(auditLog.action, actionFilter) : undefined,
+    cutoff ? gte(auditLog.createdAt, cutoff) : undefined,
+  )
+
+  // Break-Glass Sessions: same actor / time filters where applicable
+  const bgWhere = and(
+    actor ? eq(breakGlassSessions.instanceAdminId, actor) : undefined,
+    cutoff ? gte(breakGlassSessions.grantedAt, cutoff) : undefined,
+  )
+
+  const [instanceEvents, bgSessions, adminRows, actionRows] = await Promise.all([
     db
       .select({ log: auditLog, actor: users })
       .from(auditLog)
       .leftJoin(users, eq(auditLog.userId, users.id))
-      .where(isNull(auditLog.organizationId))
+      .where(eventWhere)
       .orderBy(desc(auditLog.createdAt))
       .limit(200),
     db
@@ -22,20 +56,41 @@ export default async function InstanceAuditPage() {
       .from(breakGlassSessions)
       .leftJoin(users, eq(breakGlassSessions.instanceAdminId, users.id))
       .leftJoin(organizations, eq(breakGlassSessions.targetOrgId, organizations.id))
+      .where(bgWhere)
       .orderBy(desc(breakGlassSessions.grantedAt))
       .limit(100),
+    db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.instanceRole, 'instance_admin'))
+      .orderBy(users.email),
+    db
+      .selectDistinct({ action: auditLog.action })
+      .from(auditLog)
+      .where(isNull(auditLog.organizationId))
+      .orderBy(auditLog.action),
   ])
 
+  const knownActions = actionRows.map(r => r.action).filter(Boolean) as string[]
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Platform Audit Log</h1>
         <p className="text-muted-foreground mt-1">Instance-level events and break-glass session history.</p>
       </div>
 
+      <AuditFilters
+        admins={adminRows}
+        actions={knownActions}
+        current={{ actor, action: actionFilter, since }}
+      />
+
       {/* Instance events */}
       <section>
-        <h2 className="text-base font-semibold mb-3">Platform Events</h2>
+        <h2 className="text-base font-semibold mb-3">
+          Platform Events <span className="text-muted-foreground text-sm font-normal">({instanceEvents.length})</span>
+        </h2>
         <div className="rounded-lg border bg-card">
           <Table>
             <TableHeader>
@@ -62,7 +117,7 @@ export default async function InstanceAuditPage() {
               {instanceEvents.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
-                    No platform events recorded yet
+                    No platform events match these filters
                   </TableCell>
                 </TableRow>
               )}
@@ -73,7 +128,14 @@ export default async function InstanceAuditPage() {
 
       {/* Break-glass sessions */}
       <section>
-        <h2 className="text-base font-semibold mb-3">Break-Glass Sessions</h2>
+        <h2 className="text-base font-semibold mb-3">
+          Break-Glass Sessions <span className="text-muted-foreground text-sm font-normal">({bgSessions.length})</span>
+        </h2>
+        {actionFilter.length > 0 && (
+          <p className="text-xs text-muted-foreground mb-2">
+            Action filter applies to Platform Events only; break-glass sessions are unfiltered by action.
+          </p>
+        )}
         <div className="rounded-lg border bg-card">
           <Table>
             <TableHeader>
@@ -116,7 +178,7 @@ export default async function InstanceAuditPage() {
               {bgSessions.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
-                    No break-glass sessions recorded
+                    No break-glass sessions match these filters
                   </TableCell>
                 </TableRow>
               )}


### PR DESCRIPTION
## Summary

Adds URL-backed filter controls to `/instance/audit` so an instance admin can answer common operator questions ("what did admin X do?", "show only suspensions", "last 7 days only") without scrolling 200 rows.

## What changed

**New client component** — `apps/govea/src/app/(instance)/instance/audit/audit-filters.tsx`:

- Time window pills: All time (default) / Last 24h / Last 7 days / Last 30 days.
- Actor dropdown: sourced from users with `instanceRole = 'instance_admin'`, ordered by email.
- Action multi-select: distinct codes observed in instance-scoped audit, shown in a `<details>` disclosure with checkboxes.
- `Clear` button appears when any filter is active.
- Each change pushes a new URL via `router.push` so the server component re-renders with the narrowed query.

**Updated server component** — `apps/govea/src/app/(instance)/instance/audit/page.tsx`:

- Reads `?actor`, `?action=a,b,c`, `?since` from `searchParams`.
- Builds `eventWhere` and `bgWhere` clauses (drizzle `and(...)` skips `undefined` predicates), preserving the existing `isNull(organizationId)` namespacing for Platform Events.
- `Platform Events` query applies all three filters; `Break-Glass Sessions` apply actor + time window (no action column).
- A small inline note explains the action-filter scope when active.
- Empty-state copy switches from "No platform events recorded yet" to "No platform events match these filters" so the empty case is unambiguous with filters on.

No schema changes. No new dependencies.

## Verification

**Code review:** drizzle's `and(undefined, undefined)` returns `undefined` and `where(undefined)` is a no-op, so the unfiltered case matches the previous behavior byte-for-byte. The `selectDistinct` for action codes only scans `organizationId IS NULL` rows so the list cannot leak org-scoped action namespaces.

**Browser verification not run.** Same environment constraint as [PR #525](https://github.com/roballred/goveaapp/pull/525) and [PR #533](https://github.com/roballred/GovEA/pull/533) — another worktree's preview server holds port 3000, no `govea-postgres` running locally, deps not installed in this worktree.

Suggested smoke test before merge:

1. `pnpm demo:start` with the dev seed (and merge [PR #525](https://github.com/roballred/GovEA/pull/525) first if you want both instance admins).
2. Sign in as `ivan@govea.dev`. Navigate to `/instance/audit`.
3. Toggle "Last 7 days" — confirm both tables narrow.
4. Pick `nora@govea.dev` from the Actor dropdown — confirm Platform Events filter to her actions; Break-Glass Sessions filter to ones she granted.
5. Expand Action and check `instance.org.suspend` — confirm Platform Events narrow; the inline "action filter applies to Platform Events only" note appears above Break-Glass Sessions.
6. Click Clear — confirm URL drops the params and both tables return to the full view.
7. Copy the URL with filters set and paste into a new tab — confirm filters survive (URL is the source of truth, not local state).

## Test plan

- [ ] Smoke-test the seven steps above.
- [ ] Confirm the empty-state copy reads sensibly with filters on and off.
- [ ] Confirm the action `<details>` disclosure scales gracefully when more than ~10 distinct actions exist (it scrolls).
- [ ] Eyeball-check that the filter bar doesn't visually compete with the Platform Events / Break-Glass Sessions headings.

## Future / out of scope

- The same filter pattern applies to `/audit` (org-scoped, [#531](https://github.com/roballred/GovEA/issues/531)) — a follow-up could extract `AuditFilters` to a shared component. Intentionally not done here to keep this PR small and focused.

## Traceability

Capability: iam-instance-administration; iam-audit-trail
Persona: instance-administrator
Closes #523
Epic: [#515](https://github.com/roballred/GovEA/issues/515)
Surfaced by: [#519](https://github.com/roballred/GovEA/issues/519)