### PR TITLE
fix(cross-org): keep approved inbound links visible; validate source visibility (#536)

### DIFF
--- a/apps/govea/src/actions/cross-org-links.ts
+++ b/apps/govea/src/actions/cross-org-links.ts
@@ -182,11 +182,16 @@ export async function getCrossOrgLinkContext(type: CrossOrgEntityType, entityId:
     if (!peer) continue
 
     const visible = canReadWithContext(peer.organizationId, peer.visibility)
-    // Always show inbound pending links regardless of source visibility —
-    // the target org needs to see who is requesting approval even if the
-    // source entity is not yet shared with them.
-    const isInboundPending = link.status === 'pending' && !outbound
-    if (!visible && peer.organizationId !== callerOrgId && !isInboundPending) continue
+    // Inbound links (pending or active) bypass the visibility check on the
+    // target side — the target org needs to see who is requesting and what
+    // they have approved. Without the active-side bypass, approving a link
+    // whose source has been dropped back to org-private would silently
+    // hide it (#536). New requests are validated up-front to require the
+    // source be ≥ connections; the bypass here is a safety net for
+    // historical state and for visibility drops after approval.
+    const isInbound = !outbound
+    const isInboundPendingOrActive = isInbound && (link.status === 'pending' || link.status === 'active')
+    if (!visible && peer.organizationId !== callerOrgId && !isInboundPendingOrActive) continue
 
     const item: CrossOrgLinkItem = {
       id: link.id,
@@ -267,6 +272,13 @@ export async function requestCrossOrgLink(
   if (!source || !target) throw new Error('Content not found')
   if (source.organizationId !== session.user.organizationId) throw new Error('Forbidden')
   if (target.organizationId === session.user.organizationId) throw new Error('Use local relationships for same-org links')
+
+  // Source must be published at connections or instance visibility before
+  // federating. An org-private source would become invisible to the target
+  // after approval, breaking the federation feedback loop (#536).
+  if (source.visibility !== 'connections' && source.visibility !== 'instance') {
+    throw new Error('Source must be published at connections or instance visibility before linking.')
+  }
 
   const targetVisible = await canReadFederatedEntity(target.organizationId, target.visibility, session.user.organizationId!)
   if (!targetVisible) throw new Error('Target is not visible through the current federation rules')

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -237,7 +237,7 @@ export const DEV_CAPABILITIES = [
     behaviors: 'View budget vs. actuals comparisons by department and fund\nGenerate forecast dashboards for the current fiscal year\nExport budget reports to PDF or spreadsheet',
     rules: 'Budget data is read-only in this capability — modifications are made in the source financial system\nOnly published budget reports are visible to elected officials',
     status: 'published' as const,
-    visibility: 'org' as const,
+    visibility: 'connections' as const,
     personas: ['Department Director', 'City Council Member'],
   },
   {
@@ -257,7 +257,7 @@ export const DEV_CAPABILITIES = [
     behaviors: 'Authenticate residents and staff via local credentials or SSO\nIssue and refresh short-lived access tokens\nEnforce multi-factor authentication for privileged roles\nProvide self-service password reset for local accounts',
     rules: 'All resident-facing authentication flows must use OAuth 2.0 with OIDC\nTokens must expire within 8 hours for staff and 24 hours for residents',
     status: 'published' as const,
-    visibility: 'org' as const,
+    visibility: 'connections' as const,
     personas: ['Resident', 'Small Business Owner', 'IT Staff'],
   },
   {

--- a/apps/govea/tests/integration/cross-org-link-validation.test.ts
+++ b/apps/govea/tests/integration/cross-org-link-validation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration tests: cross-org link request-time validation (#536)
+ *
+ * requestCrossOrgLink must reject a request whose source content has
+ * visibility='org', because the source would become invisible to the
+ * target after approval and the approved link would silently disappear
+ * from the target's view. Source must be published at 'connections' or
+ * 'instance' visibility before federating.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { requestCrossOrgLink } from '@/actions/cross-org-links'
+import { db } from '@/db/client'
+import { crossOrgLinks } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import {
+  createTestOrg, createTestUser, cleanupOrg,
+  makeSession, insertCapability,
+  type TestOrg, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('cross-org link request-time visibility validation (#536)', () => {
+  let orgA: TestOrg, orgB: TestOrg
+  let adminA: TestUser
+  let orgPrivateSourceId: string
+  let connectionsSourceId: string
+  let instanceTargetId: string
+
+  beforeAll(async () => {
+    ;[orgA, orgB] = await Promise.all([createTestOrg(), createTestOrg()])
+    adminA = await createTestUser(orgA.id, 'admin')
+
+    const [orgPrivate, connectionsSrc, instanceTgt] = await Promise.all([
+      insertCapability(orgA.id, { name: 'Org-Private Source', visibility: 'org' }),
+      insertCapability(orgA.id, { name: 'Connections Source', visibility: 'connections' }),
+      insertCapability(orgB.id, { name: 'Instance Target', visibility: 'instance' }),
+    ])
+    orgPrivateSourceId = orgPrivate.id
+    connectionsSourceId = connectionsSrc.id
+    instanceTargetId = instanceTgt.id
+  })
+
+  afterAll(() =>
+    Promise.all([cleanupOrg(orgA.id), cleanupOrg(orgB.id)]),
+  )
+
+  it('rejects a cross-org link request when source visibility is "org"', async () => {
+    mockAuth.mockResolvedValue(makeSession(adminA))
+
+    await expect(
+      requestCrossOrgLink('capability', orgPrivateSourceId, instanceTargetId, 'implements'),
+    ).rejects.toThrow(/connections or instance visibility/)
+
+    // No row was inserted
+    const rows = await db.query.crossOrgLinks.findMany({
+      where: and(
+        eq(crossOrgLinks.sourceEntityId, orgPrivateSourceId),
+        eq(crossOrgLinks.targetEntityId, instanceTargetId),
+      ),
+    })
+    expect(rows).toHaveLength(0)
+  })
+
+  it('allows a cross-org link request when source visibility is "connections"', async () => {
+    mockAuth.mockResolvedValue(makeSession(adminA))
+
+    await expect(
+      requestCrossOrgLink('capability', connectionsSourceId, instanceTargetId, 'implements'),
+    ).resolves.not.toThrow()
+
+    const rows = await db.query.crossOrgLinks.findMany({
+      where: and(
+        eq(crossOrgLinks.sourceEntityId, connectionsSourceId),
+        eq(crossOrgLinks.targetEntityId, instanceTargetId),
+      ),
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('pending')
+  })
+})


### PR DESCRIPTION
## Summary

Closes [#536](https://github.com/roballred/GovEA/issues/536) — the cross-org link bug surfaced during the Enterprise Architect persona journey walk ([#535](https://github.com/roballred/GovEA/issues/535)).

### The bug

`approveCrossOrgLink` flips status to `active` correctly, but `getCrossOrgLinkContext` then drops the link when the caller cannot read the source content. The pending case had a special-case bypass; the active case did not. When a source capability has `visibility: 'org'`, the approved link silently disappears from the target's view — "No cross-org links yet" — even though the row still exists.

### The fix — both halves

**1. Request-time validation in `requestCrossOrgLink`**

Reject when `source.visibility === 'org'`. The source must be published at `connections` or `instance` before federating. Matches the federation contract: we cannot federate content we have not shared.

```ts
if (source.visibility !== 'connections' && source.visibility !== 'instance') {
  throw new Error('Source must be published at connections or instance visibility before linking.')
}
```

**2. Display fallback in `getCrossOrgLinkContext`**

Extend the visibility-bypass to cover **inbound active** links, not just inbound pending:

```ts
const isInbound = !outbound
const isInboundPendingOrActive = isInbound && (link.status === 'pending' || link.status === 'active')
if (!visible && peer.organizationId !== callerOrgId && !isInboundPendingOrActive) continue
```

Safety net for historical state and for any visibility drop on the source side after approval. The two changes work together: new requests cannot create the broken state; existing rows in the broken state still render.

### Seed correction

The dev seed had `Digital Identity & Authentication` and `Budget Reporting` with `visibility: 'org'`, silently producing broken federation state across all three seeded cross-org links. Both are now `visibility: 'connections'`. `Cross-Agency Data Sharing` was already correct.

⚠️ **Note for reviewers running locally:** `findOrCreateCapability` in the seed runner skips existing rows, so a plain `pnpm --filter govea db:seed` will not update existing seeded data. To get the corrected visibility, either truncate and reseed (per `docs/data-model.md`) or run:

```sql
UPDATE capabilities SET visibility = 'connections'
WHERE name IN ('Digital Identity & Authentication', 'Budget Reporting')
  AND visibility = 'org';
```

This seed-upsert limitation is a known issue tracked separately in the `feedback_seed_idempotency` notes — intentionally out of scope here.

## Verification

**Tests:**

- New `tests/integration/cross-org-link-validation.test.ts` asserts both branches: rejects when source is `org`, accepts when source is `connections`.
- All 9 cross-org integration tests pass locally (`pnpm --filter govea exec vitest run tests/integration/cross-org`).

**Browser:**

- Signed in as `sam@state.govea.dev` on the worktree preview.
- Opened `/capabilities/<Statewide Identity Verification>`.
- Clicked **Approve** on the inbound pending link.
- The Cross-Org Links section now renders:

  > **Approved** — Digital Identity & Authentication · City of Riverdale · implements · *Revoke*

  Pre-fix behavior was "No cross-org links yet."

## Test plan

- [ ] Pull, reseed (truncate-and-reseed for a clean state), `pnpm demo:start`.
- [ ] Sign in as Sam, open Statewide Identity Verification, approve the inbound link, confirm the Approved section renders.
- [ ] Try requesting a new cross-org link from an org-private capability (Alice → Riverdale's "Service Request Management" or similar) — confirm the error message.
- [ ] Spot-check the other two seeded inbound links (Open Data Platform, State Grants Management) still work end-to-end after approval.

## Traceability

Capability: mo-cross-org-linking; mo-connection-approval
Persona: enterprise-architect
Closes #536
Surfaced by: [#535](https://github.com/roballred/GovEA/issues/535) (epic [#515](https://github.com/roballred/GovEA/issues/515))