### PR TITLE
[codex] fix docker pnpm pin for container builds

### DIFF
--- a/docker/Containerfile
+++ b/docker/Containerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine AS base
-RUN corepack enable pnpm
+RUN npm install -g pnpm@9.0.0 \
+  && corepack enable pnpm \
+  && corepack prepare pnpm@9.0.0 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:20 AS base
-RUN corepack enable pnpm
+RUN npm install -g pnpm@9.0.0 \
+  && corepack enable pnpm \
+  && corepack prepare pnpm@9.0.0 --activate
 
 # Install dependencies into the image so node_modules are pre-built.
 # Source is mounted as a volume at runtime, but node_modules are kept
@@ -15,10 +17,7 @@ RUN pnpm install --frozen-lockfile
 FROM base AS dev
 WORKDIR /app
 
-# Pre-download pnpm so corepack doesn't fetch it at container startup.
-# The deps stage downloads it too, but its cache lives in /root/.cache
-# which is not copied across stages, causing a runtime download on every
-# pnpm invocation in the entrypoint (migrate, seed, dev).
+# Keep pnpm pinned for runtime commands such as migrate, seed, and dev.
 RUN corepack prepare pnpm@9.0.0 --activate
 
 # Copy installed node_modules from deps stage


### PR DESCRIPTION
## Summary

Fixes the Azure/demo container build path by pinning the global pnpm binary to the repo's declared `pnpm@9.0.0` before any install runs.

## Root cause

The demo deploy uses `docker/Containerfile.dev` through `scripts/azure-dev.sh update`. The base devcontainer image had a newer global `pnpm` earlier on `PATH`. On Node 20 that pnpm version requires Node 22.13+ and crashes on `node:sqlite` during `pnpm install --frozen-lockfile`.

## Changes

- Install `pnpm@9.0.0` globally in both container base stages.
- Keep Corepack activated/prepared at `pnpm@9.0.0` as a second guard.
- Preserve the existing Node 20 base images and build behavior.

## Validation

- `git diff --check`
- `bash -n scripts/azure-dev.sh`
- Azure ACR build `ca2s` completed successfully using this patch.
- Demo deployed image `goveadevacr.azurecr.io/govea-dev:20260519-083719` digest `sha256:2fcd67458a7deb585d725111e22c23a1d9116b0eb2d7b0bef5c4a0e86c1b1f7b`.
- Container App revision `govea-dev--0000089` is healthy with 100% traffic.
- `/login` returns HTTP 200.

Capability: deployment-operations
Refs #504
