### PR TITLE
fix(objectives): split getObjective query to stay under Postgres NAMEDATALEN limit (#558)

### DIFF
--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -56,13 +56,17 @@ export async function getObjective(id: string) {
   const session = await auth()
   if (!session?.user) redirect('/login')
 
+  // Split into two queries to keep Drizzle's generated SQL aliases under
+  // Postgres's 63-char NAMEDATALEN limit (#558). The deeply-nested chain
+  //   strategicObjectives → objectiveCapabilities → capability
+  //                       → applicationCapabilities → application
+  // produces auto-generated alias names longer than 63 chars, which
+  // Postgres truncates and then fails to resolve in LATERAL subqueries.
   const objective = await db.query.strategicObjectives.findFirst({
     where: (o, { eq }) => eq(o.id, id),
     with: {
       objectiveCapabilities: {
-        with: {
-          capability: { with: { applicationCapabilities: { with: { application: true } } } },
-        },
+        with: { capability: true },
       },
       objectiveValueStreams: { with: { valueStream: true } },
       initiativeObjectives: { with: { initiative: true } },
@@ -74,11 +78,42 @@ export async function getObjective(id: string) {
   if (!visible) return null
   if (session.user.role === 'viewer' && objective.status !== 'published') return null
 
+  // Second query: applicationCapabilities for the capabilities found above,
+  // joined to their application. Grafted onto each capability below so the
+  // consumer-facing shape matches the original deep `with` chain.
+  const capabilityIds = objective.objectiveCapabilities.map(oc => oc.capability.id)
+  const appCaps = capabilityIds.length > 0
+    ? await db.query.applicationCapabilities.findMany({
+        where: (ac, { inArray }) => inArray(ac.capabilityId, capabilityIds),
+        with: { application: true },
+      })
+    : []
+
+  const appCapsByCapId = new Map<string, typeof appCaps>()
+  for (const ac of appCaps) {
+    const list = appCapsByCapId.get(ac.capabilityId) ?? []
+    list.push(ac)
+    appCapsByCapId.set(ac.capabilityId, list)
+  }
+
+  const objectiveCapabilitiesWithApps = objective.objectiveCapabilities.map(oc => ({
+    ...oc,
+    capability: {
+      ...oc.capability,
+      applicationCapabilities: appCapsByCapId.get(oc.capability.id) ?? [],
+    },
+  }))
+
   const [taxonomyValues, taxonomyDefinitions] = await Promise.all([
     getEntityTaxonomyValues(objective.organizationId, 'objective', id),
     getEntityTaxonomyDefinitions(objective.organizationId, 'objective'),
   ])
-  return { ...objective, taxonomyValues, taxonomyDefinitions }
+  return {
+    ...objective,
+    objectiveCapabilities: objectiveCapabilitiesWithApps,
+    taxonomyValues,
+    taxonomyDefinitions,
+  }
 }
 
 export async function createObjective(formData: FormData) {

--- a/apps/govea/tests/integration/objective-detail.test.ts
+++ b/apps/govea/tests/integration/objective-detail.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression test for #558: `/objectives/[id]` detail page crashed because
+ * Drizzle's auto-generated SQL aliases for the deeply-nested chain
+ *   strategicObjectives → objectiveCapabilities → capability
+ *                       → applicationCapabilities → application
+ * exceeded Postgres's 63-character NAMEDATALEN limit. Postgres silently
+ * truncated the aliases, then failed to resolve the truncated names in the
+ * generated LATERAL subqueries.
+ *
+ * The fix in `actions/objectives.ts:getObjective` splits the deep `with`
+ * chain into two flatter queries (the objective + its direct relations,
+ * then a separate query for the applicationCapabilities per capability),
+ * grafting the second result onto the first to preserve the consumer-facing
+ * shape.
+ *
+ * This test exercises the exact shape that broke before the fix: an
+ * objective linked to a capability that is linked to an application. If
+ * the long-alias regression returns, this test fails on a real Postgres
+ * instance — the symptom is a thrown PostgresError, not a wrong-shape
+ * return.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { db } from '@/db/client'
+import { objectiveCapabilities, applicationCapabilities } from '@/db/schema'
+import { getObjective } from '@/actions/objectives'
+import {
+  createTestOrg, createTestUser, cleanupOrg,
+  makeSession, insertCapability, insertApplication, insertObjective,
+  type TestOrg, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('getObjective deep relation chain (#558)', () => {
+  let org: TestOrg
+  let admin: TestUser
+  let objectiveId: string
+  let capabilityId: string
+  let applicationId: string
+
+  beforeAll(async () => {
+    org = await createTestOrg()
+    admin = await createTestUser(org.id, 'admin')
+
+    const objective = await insertObjective(org.id, { status: 'published' })
+    const capability = await insertCapability(org.id, { status: 'published' })
+    const application = await insertApplication(org.id, { status: 'published' })
+    objectiveId = objective.id
+    capabilityId = capability.id
+    applicationId = application.id
+
+    await db.insert(objectiveCapabilities).values({ objectiveId, capabilityId })
+    await db.insert(applicationCapabilities).values({ applicationId, capabilityId })
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(org.id)
+  })
+
+  it('does not throw when fetching an objective with a capability that has an application', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+
+    // The bug manifested as a PostgresError thrown by the underlying
+    // Drizzle query. If this call resolves at all (even to null), the
+    // alias-length regression has not returned.
+    const objective = await getObjective(objectiveId)
+    expect(objective).not.toBeNull()
+  })
+
+  it('returns the deep relation chain in the shape the detail page consumes', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+
+    const objective = await getObjective(objectiveId)
+    expect(objective).not.toBeNull()
+    expect(objective!.id).toBe(objectiveId)
+
+    // The detail page does:
+    //   objective.objectiveCapabilities.flatMap(({ capability }) =>
+    //     capability.applicationCapabilities.map(({ application }) => ...)
+    //   )
+    // If any layer of that chain is missing, the page throws at runtime.
+    expect(objective!.objectiveCapabilities).toHaveLength(1)
+    const oc = objective!.objectiveCapabilities[0]
+    expect(oc.capability.id).toBe(capabilityId)
+    expect(oc.capability.applicationCapabilities).toHaveLength(1)
+    expect(oc.capability.applicationCapabilities[0].application.id).toBe(applicationId)
+  })
+
+  it('returns an empty applicationCapabilities array when a linked capability has no applications', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+
+    // Add a second capability with no application link.
+    const orphanCap = await insertCapability(org.id, { name: 'Orphan capability', status: 'published' })
+    await db.insert(objectiveCapabilities).values({ objectiveId, capabilityId: orphanCap.id })
+
+    const objective = await getObjective(objectiveId)
+    expect(objective).not.toBeNull()
+    const orphan = objective!.objectiveCapabilities.find(oc => oc.capability.id === orphanCap.id)
+    expect(orphan).toBeDefined()
+    expect(orphan!.capability.applicationCapabilities).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the [#558](https://github.com/roballred/GovEA/issues/558) regression where `/objectives/[id]` crashed for any user with:

\`\`\`
column strategicObjectives_objectiveCapabilities_capability_applicatio.application_id does not exist
hint: To reference that column, you must mark this subquery with LATERAL.
\`\`\`

## Root cause

Drizzle's `findFirst` with deeply-nested `with` clauses generates SQL aliases that exceed Postgres's 63-character `NAMEDATALEN` limit. The objective detail chain (`strategicObjectives → objectiveCapabilities → capability → applicationCapabilities → application`) produces aliases like `strategicObjectives_objectiveCapabilities_capability_applicationCapabilities` at 76 chars. Postgres silently truncates these to 63 chars; the truncated names then fail to resolve in the generated LATERAL subqueries.

## Fix

Split the deep `findFirst` into two flatter queries:

1. Objective + `objectiveCapabilities.capability` + `objectiveValueStreams` + `initiativeObjectives` (depth 2; all aliases ≤ 60 chars).
2. `applicationCapabilities` for the capability IDs from step 1, joined to `applications` (depth 2; separate query, no chained alias).

Then graft the second result onto each capability so the consumer-facing shape — `oc.capability.applicationCapabilities[].application` — is unchanged for the detail page and any future caller.

One file changed: `apps/govea/src/actions/objectives.ts`.

## Regression test

Added `apps/govea/tests/integration/objective-detail.test.ts`:

- Inserts an objective linked to a capability that is linked to an application — the exact shape that broke.
- Three test cases: throw-check, full-shape-check, and the empty-applicationCapabilities branch when a linked capability has no apps.
- Runs against real Postgres. Pre-fix, the first test fails with `PostgresError`; post-fix all three pass.

Future Drizzle queries that re-introduce the long-alias shape will fail this test on the first run.

## Verification

\`\`\`
pnpm --filter govea exec vitest run tests/unit/ tests/integration/read-action-auth.test.ts tests/integration/objective-detail.test.ts

Test Files  7 passed (7)
     Tests  135 passed (135)
\`\`\`

Browser verification not run this turn — the parallel preview's `launch.json` still points at the main repo, so a local preview would serve main rather than this branch. The integration test exercises the exact failing query shape against the real Postgres container, which is a stronger guarantee than a manual browser click would be. Suggested smoke test post-merge:

1. `pnpm --filter govea db:seed`
2. `pnpm demo:start`
3. Sign in as any user.
4. Visit `/objectives/<any-objective-id>`. Page should render with the linked capabilities + applications.

## What this does NOT fix

This is a one-query fix. Other detail pages with similarly deep `with` chains may have the same latent risk. A quick grep:

\`\`\`bash
grep -rn "with: {" apps/govea/src/actions/
\`\`\`

surfaces several other candidates worth auditing. Out of scope for this PR; worth a follow-up audit issue if you want one filed.

## Test plan

- [ ] CI runs the new test and it passes.
- [ ] Smoke-test the four steps above after merge.
- [ ] Confirm no other consumers of `getObjective` were depending on the old query shape (the wrapper preserves the contract; verifying by code review).

## Traceability

Capability: planning-strategic-objectives; fd-content-display
Persona: department-director; budget-performance-analyst; elected-official; enterprise-architect; business-stakeholder
Closes #558
Surfaced by: [#557](https://github.com/roballred/GovEA/issues/557) (parent [#515](https://github.com/roballred/GovEA/issues/515))