### PR TITLE
docs(capabilities): backfill Implementation Status across capability docs (#575)

### DIFF
--- a/business-architecture/capabilities/cms/admin-configuration/ac-backup-export.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-backup-export.md
@@ -19,6 +19,10 @@ The system must allow administrators to export the full site configuration and c
 - Only Admins can perform exports and imports
 - Export files are available for download immediately — no background job required for v1
 
+## Implementation Status
+
+**Not yet implemented.** No operational backup / export surface exists under `apps/govea/src/app/(admin)/**`. The dashboard does not show a last-export timestamp. Distinct from data portability (which is scoped separately as [#86](https://github.com/roballred/GovEA/issues/86) and concerns external-tool consumption rather than operational restore). Confirmed during the CMS Administrator persona journey audit ([#526](https://github.com/roballred/GovEA/issues/526)). Tracked at [#529](https://github.com/roballred/GovEA/issues/529).
+
 ## Links
 - Depends on: IAM — Role-Based Access Control
 - Related: Site Settings, Feature Management, Admin Dashboard

--- a/business-architecture/capabilities/cms/admin-configuration/ac-email-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-email-configuration.md
@@ -19,6 +19,10 @@ The system must allow administrators to configure outbound email so that transac
 - Only Admins can access email configuration
 - The test email must be sent to the Admin's own address — not an arbitrary address
 
+## Implementation Status
+
+**Not yet implemented.** No SMTP / email configuration surface exists under `apps/govea/src/app/(admin)/**`. `/dashboard` does not surface an "email not configured" warning. No email-sending dependency in `package.json`. Confirmed during the CMS Administrator persona journey audit ([#526](https://github.com/roballred/GovEA/issues/526)). Tracked at [#528](https://github.com/roballred/GovEA/issues/528).
+
 ## Links
 - Depends on: IAM — Role-Based Access Control
 - Related: Site Settings, IAM — Local Authentication

--- a/business-architecture/capabilities/cms/admin-configuration/ac-security-settings.md
+++ b/business-architecture/capabilities/cms/admin-configuration/ac-security-settings.md
@@ -20,6 +20,10 @@ The system must allow administrators to configure security policies — password
 - Only Admins can access security settings
 - Minimum password length cannot be set below 8 characters
 
+## Implementation Status
+
+**Not yet implemented.** No security-settings surface exists under `apps/govea/src/app/(admin)/**`. The only password rule today is a hard-coded `PASSWORD_MIN_LENGTH = 8` constant in [`apps/govea/src/lib/password.ts`](../../../../apps/govea/src/lib/password.ts) — no configurable surface, no session timeout, no account lockout, no password expiry, no 2FA. Confirmed during the CMS Administrator persona journey audit ([#526](https://github.com/roballred/GovEA/issues/526)). Tracked at [#527](https://github.com/roballred/GovEA/issues/527).
+
 ## Links
 - Depends on: IAM — Role-Based Access Control, IAM — Local Authentication
 - Related: Site Settings, IAM — SSO Authentication

--- a/business-architecture/capabilities/cms/frontend-display/fd-executive-roadmap-timeline.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-executive-roadmap-timeline.md
@@ -21,6 +21,12 @@ The system must present a roadmap timeline view that shows what is changing, whe
 - The visual should prioritize sequencing and stakeholder impact over detailed project-management semantics
 - Viewer-visible items must follow the current planning visibility rules for initiatives and objectives
 
+## Implementation Status
+
+**Shipped (v1).** `/roadmap` renders the documented timeline view with Timeline / Grid toggle, plain-language impact statements per initiative, status badges (Underway / Complete / planned), time-window labels (e.g. "Q1 FY2026 → Q4 FY2026"), linked capabilities with impact type (improve / extend), and the strategic objective each initiative serves. Confidence badge is rendered consistently across reader surfaces. Confirmed during the Elected Official ([#546](https://github.com/roballred/GovEA/issues/546)) and Department Director ([#557](https://github.com/roballred/GovEA/issues/557)) persona journey audits.
+
+Future work: department / domain / capability-domain / service-area filtering ([#549](https://github.com/roballred/GovEA/issues/549) covers the related traceability hub gap that would feed this), risk-vs-investment framing ([#563](https://github.com/roballred/GovEA/issues/563) covers the financial-dimension prerequisite), print / presentation-ready export ([#559](https://github.com/roballred/GovEA/issues/559)).
+
 ## Links
 - Depends on: Planning — Roadmap, Planning — Initiatives, Planning — Strategic Objectives
 - Related: Mission-to-Technology Traceability Views, Front-end Display — Portfolio Views

--- a/business-architecture/capabilities/cms/frontend-display/fd-guided-answer-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-guided-answer-views.md
@@ -22,6 +22,12 @@ The system must answer common stakeholder questions with a structured result vie
 - The generated answer framing must avoid jargon and internal field names
 - Search and answer confidence should be explainable when multiple related records are returned
 
+## Implementation Status
+
+**Shipped (v1, with entry-path friction).** `/answers?q=<query>` renders an assembled briefing-ready view grouped by Capabilities / Services / Applications / Initiatives / Objectives with a "Why relevant" rationale on each item. Confirmed during the Elected Official persona journey audit ([#546](https://github.com/roballred/GovEA/issues/546)).
+
+Known gap: `/answers` with no query has no direct input field — the user has to detour through `/search` and click "Get guided answer →" to assemble an answer. Tracked at [#550](https://github.com/roballred/GovEA/issues/550) along with the "Capabilitys" pluralisation typo in the search results headings.
+
 ## Links
 - Depends on: Content Management — Content Search & Filtering, Front-end Display — Content Display, Front-end Display — Relationship Navigation
 - Related: Mission-to-Technology Traceability Views, Front-end Display — Portfolio Views

--- a/business-architecture/capabilities/cms/frontend-display/fd-portfolio-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-portfolio-views.md
@@ -43,6 +43,12 @@ The system must provide curated, structured views of the EA repository that give
 - Views must be useful without EA training — labels, groupings, and filters use plain language
 - Navigation into portfolio views must be accessible without JavaScript
 
+## Implementation Status
+
+**Shipped (v1).** Application portfolio view at `/applications` (Portfolio toggle) renders the documented plain-language risk cards (e.g. "N applications retiring while still supporting active capabilities — review or re-map before decommission"). Executive Summary tile at `/executive` aggregates portfolio counts and surfaces coverage gaps. Confirmed during the Elected Official ([#546](https://github.com/roballred/GovEA/issues/546)), Department Director ([#557](https://github.com/roballred/GovEA/issues/557)), and Budget & Performance Analyst ([#562](https://github.com/roballred/GovEA/issues/562)) persona journey audits.
+
+Future work: financial / investment dimensions on the portfolio view ([#563](https://github.com/roballred/GovEA/issues/563)), print / presentation-ready export ([#559](https://github.com/roballred/GovEA/issues/559)), duplicate-application detection ([#538](https://github.com/roballred/GovEA/issues/538) covers the related capability concern).
+
 ## Links
 - Depends on: Content Display, Relationship Navigation, Content Management — Content Workflow
 - Related: Navigation, Responsive Layout

--- a/business-architecture/capabilities/cms/frontend-display/fd-relationship-navigation.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-relationship-navigation.md
@@ -33,6 +33,10 @@ The system must allow users to traverse the connections between content items �
 - Broken relationships (linked item deleted or unpublished) must not surface as errors to the Viewer — they are silently excluded
 - Inline relationship edits must respect role and ownership checks before persisting changes
 
+## Implementation Status
+
+**Shipped (v1).** Linked entities (capabilities, personas, applications, ADRs, initiatives, objectives) render as clickable links on every detail page exercised so far. "View map →" and "View traceability →" affordances on capability detail pages provide drill-down paths into richer relationship views. Confirmed during the Content Viewer ([#552](https://github.com/roballred/GovEA/issues/552)) and Department Director ([#557](https://github.com/roballred/GovEA/issues/557)) persona journey audits.
+
 ## Links
 - Depends on: Content Display, Content Management — Content Relationships
 - Related: Portfolio Views, Navigation

--- a/business-architecture/capabilities/cms/frontend-display/fd-repository-confidence-summary.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-repository-confidence-summary.md
@@ -20,6 +20,12 @@ The system must present a concise, plain-language summary of how trustworthy and
 - The summary must be suppressible when repository quality falls below an admin-defined threshold
 - Confidence messaging must describe repository currency and completeness, not system uptime or infrastructure health
 
+## Implementation Status
+
+**Shipped (v1).** A plain-language confidence badge ("Actively Maintained · Last updated <month>") renders on `/dashboard`, `/executive`, and `/roadmap` as a small, non-intrusive trust signal. Confirmed during the Elected Official persona journey audit ([#546](https://github.com/roballred/GovEA/issues/546)).
+
+Future work: extend the confidence-summary placement to detail pages (capability, application, ADR) — currently missing per [#553](https://github.com/roballred/GovEA/issues/553).
+
 ## Links
 - Depends on: Repository & Modelling — Repository Completeness, Front-end Display — Content Display
 - Related: Front-end Display — Portfolio Views, Executive Roadmap Timeline

--- a/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
+++ b/business-architecture/capabilities/cms/frontend-display/fd-traceability-views.md
@@ -23,6 +23,12 @@ Capabilities are the required bridge from mission/service context to application
 - The visual must avoid EA jargon in headings, legends, and labels
 - Missing capability links should surface as plain-language gaps because those links are now the path to supporting applications
 
+## Implementation Status
+
+**Shipped (v1, drill-down only — no top-level entry).** Traceability is rendered via `/traceability?from=<entityType>&id=<id>`, reachable from any capability / objective / initiative detail page via a "View traceability →" link. The view itself matches the documented behaviors. Confirmed during the Elected Official ([#546](https://github.com/roballred/GovEA/issues/546)) and Content Viewer ([#552](https://github.com/roballred/GovEA/issues/552)) persona journey audits.
+
+Known gap: visiting `/traceability` with no query params returns 404 — there is no top-level entry surface (a hub of starting points, or a default featured trace). Tracked at [#549](https://github.com/roballred/GovEA/issues/549).
+
 ## Links
 - Depends on: Front-end Display - Content Display, Front-end Display - Relationship Navigation, Repository & Modelling - End-to-End Traceability
 - Related: Planning - Strategic Objectives, Planning - Initiatives, Front-end Display - Portfolio Views

--- a/business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md
+++ b/business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md
@@ -39,7 +39,9 @@ Chen Notation is the SME's preferred conceptual / logical-layer convention. Usin
 
 ## Implementation Status
 
-**Planned — not yet implemented.** Tracked at [#470](https://github.com/roballred/GovEA/issues/470). Working assumption is React Flow for the layout / interaction library; the implementation PR should confirm tree-shakeability or fall back to a hand-rolled SVG renderer if not.
+**Shipped (v1).** `/data/diagram` renders the metamodel as a Chen Notation graph with the documented node conventions (rectangles for entities, ovals for attributes, underlined ovals for business keys, diamonds for relationships labeled "is related" / "shares" / "instantiates"). The four documented filters (owner persona / attribute type / link type / free-text name) are all functional. Live counts are surfaced ("Showing N entities, M attributes, P business keys, Q relationships"). Read-only with edit links navigating back to detail pages — the documented "no write path on the canvas" intent is honored.
+
+Tracked at [#470](https://github.com/roballred/GovEA/issues/470) (now closed by the implementation PR). Confirmed during the Data Modeler persona journey audit ([#569](https://github.com/roballred/GovEA/issues/569)).
 
 ## Out of Scope (v1)
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -8,7 +8,13 @@ Debt that is named and tracked is manageable. Debt that is invisible becomes the
 
 ## Implementation Status
 
-**Not yet implemented.** No architecture debt tracking surface exists in the current product. This document is the design specification for a future capability. The severity tier definitions here are referenced by `rm-end-to-end-traceability` and `rm-repository-completeness` as a shared vocabulary for a future unified priority signal.
+**Shipped (v1, partial).** `/debt` route is live with the documented severity / status / type filter chips (`lifecycle-risk` / `capability-gap` / `decision-drift` / `known-shortcut` / `unreviewed`) and full CRUD pages (`/debt/new`, `/debt/[id]`, `/debt/[id]/edit`). The severity tier definitions and security-classification guidance below describe the implemented behavior. Confirmed during the Enterprise Data Architect persona journey audit ([#572](https://github.com/roballred/GovEA/issues/572)).
+
+Future work tracked separately:
+- Data-layer-specific debt types (query performance, schema drift, space utilization) — see [#573](https://github.com/roballred/GovEA/issues/573).
+- Unified priority signal panel on the admin dashboard combining debt + broken-chain + staleness signals — not yet implemented.
+- Auto-flagged debt queue distinct from human-created items — not yet implemented.
+- Federation behavior per the section below — implementation status unverified by the audit; requires a follow-up walk to confirm.
 
 ## Personas
 
@@ -85,11 +91,11 @@ Debt items are always owned by the organization that creates them. Federation do
 
 **Auto-flagged debt and cross-org objects:** The system-detected debt queue (lifecycle-based flags) only fires against objects the org owns. An agency is never auto-flagged for debt conditions in a cross-org linked object that belongs to another org.
 
-## Implementation Status
+## Implementation History
 
-Not yet implemented. No architecture debt tracking surface exists in the current product. This document is the design specification for that future build.
+The `security_sensitive` flag and the Security Classification Guidance section above were added in response to ARB finding #135 (Omar Singh, Security Architect). These constraints were incorporated in the initial implementation — retrofitting security classification onto an existing debt store would have been significantly harder than building it in from the start.
 
-The `security_sensitive` flag and the Security Classification Guidance section above were added in response to ARB finding #135 (Omar Singh, Security Architect). These constraints must be incorporated in the initial implementation — retrofitting security classification onto an existing debt store is significantly harder than building it in from the start.
+(Earlier revisions of this doc had a second "Not yet implemented" status block here; superseded by the Implementation Status section near the top of the file. See [#575](https://github.com/roballred/GovEA/issues/575) for the doc backfill that consolidated the two.)
 
 ## Links
 


### PR DESCRIPTION
## Summary

Eleven capability docs touched. Closes [#575](https://github.com/roballred/GovEA/issues/575) — the cumulative docs-hygiene finding from six persona walks.

## Two patterns addressed

### A — Doc said feature was unbuilt but it's shipped (2 files)

| File | Was | Now |
|---|---|---|
| [`da-chen-visualization.md`](business-architecture/capabilities/ea/data-architecture/da-chen-visualization.md) | "Planned — not yet implemented" | Shipped (v1). Confirmed at `/data/diagram` during the Data Modeler walk ([#569](https://github.com/roballred/GovEA/issues/569)). |
| [`rm-architecture-debt.md`](business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md) | "Not yet implemented" (twice) | Shipped (v1, partial). `/debt` is live with all 5 documented filter chips and full CRUD. Confirmed during the Enterprise Data Architect walk ([#572](https://github.com/roballred/GovEA/issues/572)). |

### B — Doc had no Implementation Status section despite walk-confirmed status (9 files)

**Frontend-display — shipped:**
- `fd-executive-roadmap-timeline.md` — walks [#557](https://github.com/roballred/GovEA/issues/557) / [#546](https://github.com/roballred/GovEA/issues/546)
- `fd-guided-answer-views.md` — walk [#546](https://github.com/roballred/GovEA/issues/546); entry-path gap [#550](https://github.com/roballred/GovEA/issues/550)
- `fd-portfolio-views.md` — walks [#546](https://github.com/roballred/GovEA/issues/546) / [#557](https://github.com/roballred/GovEA/issues/557) / [#562](https://github.com/roballred/GovEA/issues/562)
- `fd-relationship-navigation.md` — walks [#552](https://github.com/roballred/GovEA/issues/552) / [#557](https://github.com/roballred/GovEA/issues/557)
- `fd-repository-confidence-summary.md` — walk [#546](https://github.com/roballred/GovEA/issues/546); detail-page gap [#553](https://github.com/roballred/GovEA/issues/553)
- `fd-traceability-views.md` — walks [#546](https://github.com/roballred/GovEA/issues/546) / [#552](https://github.com/roballred/GovEA/issues/552); top-level entry gap [#549](https://github.com/roballred/GovEA/issues/549)

**Admin-configuration — not yet implemented:**
- `ac-security-settings.md` → tracked at [#527](https://github.com/roballred/GovEA/issues/527)
- `ac-email-configuration.md` → tracked at [#528](https://github.com/roballred/GovEA/issues/528)
- `ac-backup-export.md` → tracked at [#529](https://github.com/roballred/GovEA/issues/529)

Each new section is short (~3 lines) and cross-links to the gap issues that scope follow-up work. No code changes — docs only.

## Out of scope

Seven capability files that no journey walk has formally audited:
- `fd-content-display`, `fd-navigation`, `fd-responsive-layout`, `fd-theming`, `fd-value-streams`
- `ac-persona-tags`, `ac-persona-type-management`

Adding Implementation Status to these would require fabrication. Better to leave for future walks that touch them directly — pattern is now established for how to backfill them when the time comes.

## Test plan

- [ ] Spot-check the eleven edits for accuracy against the linked walks / gap issues.
- [ ] Confirm the "out of scope" list is the right deferral — i.e., that you'd rather wait for a direct walk on those seven than have me guess their status.

## Traceability

Capability: governance/standards
Persona: all (this is reader-of-docs hygiene)
Closes #575
Epic: [#515](https://github.com/roballred/GovEA/issues/515)