### PR TITLE
[codex] docs: add application architecture guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Personas -> Capabilities -> Applications
 
 For the implementation-level schema reference, including field metadata, enums, and junction tables, see [`docs/data-model.md`](./docs/data-model.md).
 
+For the application architecture overview, including runtime shape, tenancy, traceability, and deployment notes, see [`docs/architect/`](./docs/architect/).
+
 ---
 
 ## Development Approach

--- a/docs/architect/README.md
+++ b/docs/architect/README.md
@@ -1,0 +1,27 @@
+# GovEA Application Architecture
+
+This folder captures the current application architecture for GovEA. It is intended for maintainers, contributors, and reviewers who need to understand how the product is assembled before changing it.
+
+These documents are implementation-facing. Product intent, personas, and capability definitions remain in `business-architecture/`; schema detail remains in `docs/data-model.md`.
+
+## Documents
+
+| Document | Purpose |
+|---|---|
+| [Application Overview](./application-overview.md) | High-level application shape, module boundaries, and request flow |
+| [Security and Tenancy](./security-and-tenancy.md) | Authentication, authorization, organization isolation, federation, and support access |
+| [Data and Traceability](./data-and-traceability.md) | Core repository model, relationship patterns, and traceability conventions |
+| [Runtime and Deployment](./runtime-and-deployment.md) | Local runtime, container runtime, Azure demo deployment, and operational notes |
+
+## Maintenance Rule
+
+Update these docs when a change alters one of the main architectural seams:
+
+- routing or shell layout
+- authentication or role behavior
+- tenancy, visibility, federation, or support-access rules
+- data model relationships or traceability rules
+- runtime, container, or deployment behavior
+- cross-cutting concerns such as audit, taxonomy, module toggles, or search
+
+These docs do not replace ADRs. If a change records a decision or tradeoff that should remain reviewable over time, add or update an ADR under `docs/decisions/` and link to it from the relevant architecture document.

--- a/docs/architect/application-overview.md
+++ b/docs/architect/application-overview.md
@@ -1,0 +1,101 @@
+# Application Overview
+
+GovEA is a Next.js App Router application for maintaining an enterprise architecture repository. The implementation is intentionally simple: server-rendered pages, server actions for mutations, Drizzle for typed database access, and PostgreSQL as the system of record.
+
+## Primary Runtime Shape
+
+```mermaid
+flowchart LR
+  Browser["Authenticated browser"] --> Middleware["Next.js middleware"]
+  Middleware --> Routes["App Router route groups"]
+  Routes --> Pages["Server components and route pages"]
+  Pages --> Actions["Server actions"]
+  Actions --> DomainLib["Domain helpers in src/lib"]
+  DomainLib --> Drizzle["Drizzle ORM"]
+  Drizzle --> Postgres["PostgreSQL"]
+
+  Pages --> Components["Shared React components"]
+  Actions --> Audit["Audit writer"]
+  Audit --> Postgres
+```
+
+## Application Layers
+
+| Layer | Location | Responsibility |
+|---|---|---|
+| Routes and pages | `apps/govea/src/app/` | URL structure, server-rendered pages, route groups, and page-level data loading |
+| Server actions | `apps/govea/src/actions/` | Mutations, role gates, validation, relationship updates, and audit calls |
+| Domain helpers | `apps/govea/src/lib/` | Cross-cutting behavior such as RBAC, federation, confidence, audit, search, URL helpers, and support access |
+| Database schema | `apps/govea/src/db/schema/` | Drizzle table definitions, enums, and relationship tables |
+| Seed data | `apps/govea/src/db/seeds/` | Demo, dogfood, test, scale, and TOGAF-overlay fixture data |
+| UI components | `apps/govea/src/components/` | Shared page widgets, shell components, forms, banners, diagrams, and controls |
+
+## Route Groups
+
+GovEA uses App Router route groups to separate user experiences without adding visible path segments.
+
+| Route group | Path examples | Purpose |
+|---|---|---|
+| `(auth)` | `/login`, `/setup`, `/auth-redirect`, `/error` | Authentication and bootstrap flows |
+| `(admin)` | `/dashboard`, `/applications`, `/capabilities`, `/roadmap`, `/settings` | Main organization-scoped EA workspace |
+| `(instance)` | `/instance`, `/instance/orgs`, `/instance/users` | Instance-admin platform operations |
+| root routes | `/`, `/maintenance` | Landing redirect and maintenance surface |
+
+The main workspace is organization-scoped. The instance console is deliberately separate because `instance_admin` is an operating role for platform support, not a blanket content role inside every tenant.
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant M as Middleware
+  participant P as Page
+  participant A as Server Action
+  participant DB as PostgreSQL
+
+  U->>M: Request protected route
+  M->>M: Check session and route family
+  M->>P: Allow request
+  P->>DB: Load org-scoped data
+  U->>A: Submit mutation
+  A->>A: Re-check role and target org
+  A->>DB: Write data in transaction when needed
+  A->>DB: Write audit event
+  A-->>U: Redirect or refresh rendered state
+```
+
+Middleware performs coarse route protection. Server actions and domain helpers perform the authoritative checks for write behavior, target organization, and support-access boundaries.
+
+## Main Product Areas
+
+| Product area | Architectural role |
+|---|---|
+| Business Architecture | Personas, capabilities, services, value streams, principles, glossary, and relationship context |
+| Portfolio | Applications, ADRs, architecture debt, and technology impact context |
+| Strategy and Planning | Goals, strategic objectives, initiatives, roadmap, and executive views |
+| Data Architecture | Data entities, attributes, business keys, links, semantic relationships, and diagram views |
+| Reports and Answers | Read-oriented summaries built from existing repository relationships |
+| Configuration | Users, taxonomy, org settings, notices, modules, and instance feature controls |
+
+## Cross-Cutting Services
+
+| Concern | Current implementation |
+|---|---|
+| Authentication | Auth.js with local credentials and optional Microsoft Entra ID OIDC |
+| Authorization | Org-scoped roles plus separate `instance_admin` operating role |
+| Audit | Immutable audit log for content, identity, instance, and support-access events |
+| Taxonomy | Org-scoped controlled vocabularies reused across multiple entity types |
+| Modules | Org-level module settings and instance-wide module availability controls |
+| Search | Embedded repository-wide search over core content |
+| Federation | Connection-aware visibility and approval-based cross-org links |
+| Demo data | Seeded Riverdale, GovEA Project dogfood org, Hartfield TOGAF demo, scale data, and system org |
+
+## Design Bias
+
+GovEA should stay biased toward:
+
+- plain-language architecture content over formal notation
+- relationship-driven traceability over heavy workflow engines
+- organization isolation by default
+- small product slices tied to personas and capability IDs
+- demo/sample data that exercises real GovEA behavior instead of decorative examples

--- a/docs/architect/data-and-traceability.md
+++ b/docs/architect/data-and-traceability.md
@@ -1,0 +1,125 @@
+# Data and Traceability Architecture
+
+GovEA's repository model is centered on mission-first traceability. The basic chain is:
+
+```text
+Personas -> Capabilities -> Applications
+```
+
+The rest of the model adds planning, services, decisions, principles, data architecture, and reporting context around that chain.
+
+For field-level schema detail, see `docs/data-model.md`.
+
+## Core Traceability Model
+
+```mermaid
+flowchart LR
+  Personas --> Capabilities
+  Capabilities --> Applications
+  Services --> Personas
+  Services --> Capabilities
+  Services --> ValueStreams["Value Streams"]
+  Goals --> Objectives["Strategic Objectives"]
+  Objectives --> Capabilities
+  Objectives --> ValueStreams
+  Initiatives --> Objectives
+  Initiatives --> Capabilities
+  Initiatives --> Applications
+  ADRs --> Capabilities
+  ADRs --> Applications
+  ADRs --> Initiatives
+  ADRs --> Objectives
+  Principles --> Capabilities
+  Principles --> ADRs
+```
+
+Applications are intentionally surfaced for services and objectives through linked capabilities rather than through direct service-to-application or objective-to-application joins. That keeps mission traceability anchored in capabilities.
+
+## Relationship Patterns
+
+| Pattern | Used for | Notes |
+|---|---|---|
+| Direct FK | Ownership and parent-child relationships | Example: content records to `organizations` |
+| Junction table | Many-to-many relationships | Example: `application_capabilities`, `capability_personas` |
+| Junction with metadata | Relationship plus meaning | Example: initiative capability/application impact labels |
+| Relationship table without FK to target entity table | Cross-org links | Used where target entity type and organization vary |
+| Derived relationship | Read model assembled from existing links | Example: applications shown on service/objective views through capabilities |
+
+## Content Lifecycle
+
+Most publishable content uses `workflow_status`:
+
+| Status | Meaning |
+|---|---|
+| `draft` | Work in progress; generally hidden from viewers |
+| `published` | Viewer-visible when route and visibility allow |
+| `archived` | Retained for history but not current |
+
+Some entities use domain-specific statuses:
+
+- ADRs: `proposed`, `accepted`, `deprecated`, `superseded`
+- Initiatives: `proposed`, `active`, `on-hold`, `complete`, `cancelled`
+
+This split is intentional for now. Planning entities represent work lifecycle, while most architecture content follows publish/archive semantics.
+
+## Data Architecture Module
+
+The Data Architecture module adds a dedicated metamodel for data architecture work:
+
+| Object | Purpose |
+|---|---|
+| Data entity | Business data concept or object being described |
+| Data attribute | Data element or attribute with physical classification |
+| Business key | Identifier associated with a data entity |
+| Data link | Data Vault-style relationship/link object |
+| Semantic relationship | Cross-object relation among entities and attributes |
+| Diagram | Read-only Chen-style visualization of the current metamodel |
+
+Data Architecture is connected to the same organization, role, workflow, and visibility rules as the rest of the repository.
+
+## Taxonomy
+
+Taxonomy is the shared controlled-vocabulary foundation. It supports domain and classification values across several product areas instead of creating one-off vocabulary tables for each entity.
+
+Current uses include:
+
+- capability domains
+- persona types
+- persona tags
+- application type
+- capability priority
+- objective category
+- initiative type
+- decision category
+- principle scope
+
+When adding a new classification, prefer taxonomy if the value is user-manageable, org-scoped, and likely to be reused across records.
+
+## Audit and Completeness
+
+The repository is designed to be self-auditing:
+
+- mutations should write audit events
+- completeness signals identify missing or stale relationships
+- repository-confidence summaries convert maintenance state into stakeholder-facing trust cues
+- architecture debt records capture known concerns and system-detected lifecycle risk
+
+Completeness and confidence should remain signals for better human judgment, not hidden automation that changes architecture content without review.
+
+## Traceability Rules for New Work
+
+When adding a new content type or major relationship:
+
+1. Identify the persona and capability reason for the data.
+2. Decide whether the relationship should be direct, many-to-many, derived, or cross-org.
+3. Define viewer visibility and workflow behavior up front.
+4. Add audit coverage for writes.
+5. Update seed data when the feature should appear in the demo or GovEA Project dogfood org.
+6. Update `docs/data-model.md` when the schema surface changes.
+
+New implementation issues and PRs should continue using the traceability convention from `Standards.md`:
+
+```text
+Capability: <capability-id>
+Persona: <persona name>
+```

--- a/docs/architect/runtime-and-deployment.md
+++ b/docs/architect/runtime-and-deployment.md
@@ -1,0 +1,131 @@
+# Runtime and Deployment Architecture
+
+GovEA is designed to run locally for development, in containers for self-hosted demos, and in Azure Container Apps for the shared demo environment.
+
+## Runtime Components
+
+```mermaid
+flowchart TD
+  User["Browser"] --> ACA["Azure Container App: govea-dev"]
+  ACA --> App["Next.js standalone server"]
+  ACA --> Pg["PostgreSQL sidecar"]
+  App --> Pg
+  App --> Logs["Container logs"]
+  Logs --> LAW["Log Analytics workspace"]
+  ACR["Azure Container Registry"] --> ACA
+```
+
+The Azure demo currently uses a single Container App with:
+
+- the GovEA app container
+- a PostgreSQL sidecar reachable on `localhost:5432`
+- production Next.js standalone runtime
+- demo flags enabled through environment variables
+
+## Local Development
+
+Common local paths:
+
+| Command | Purpose |
+|---|---|
+| `pnpm demo:start` | Start local app with containerized Postgres |
+| `pnpm demo:db` | Start only the database |
+| `pnpm demo:container` | Run the full container stack |
+| `pnpm --filter govea dev` | Start the Next.js app after database setup |
+| `pnpm --filter govea db:migrate` | Run local migrations |
+| `pnpm --filter govea db:seed` | Load demo seed data |
+
+Podman is preferred when available, but the compose helper can fall back to Docker.
+
+## Azure Demo Deployment
+
+The demo deployment script is `scripts/azure-dev.sh`.
+
+| Command | Purpose |
+|---|---|
+| `bash scripts/azure-dev.sh deploy` | Create Azure resources and first deployment |
+| `bash scripts/azure-dev.sh update` | Build a new image in ACR and roll out a new revision |
+| `bash scripts/azure-dev.sh status` | Show current image and replica settings |
+| `bash scripts/azure-dev.sh logs` | Stream app logs |
+| `bash scripts/azure-dev.sh stop` | Scale to zero replicas |
+| `bash scripts/azure-dev.sh start` | Restore one replica |
+
+The update path builds remotely with `az acr build`, pushes a timestamped image tag, then updates the Container App image reference.
+
+## Demo Runtime Environment
+
+The demo should run as production Next.js with explicit demo behavior enabled:
+
+| Variable | Expected demo value | Reason |
+|---|---|---|
+| `NODE_ENV` | `production` | Stable server-action bundles and standalone runtime |
+| `DEMO_MODE` | `true` | Shows demo affordances such as login shortcuts |
+| `DEV` | `true` | Enables seeded/demo behavior where still used |
+| `AUTH_TRUST_HOST` | `true` | Allows Auth.js behind the Azure hostname |
+| `NEXT_PUBLIC_APP_URL` | Demo URL | Used for auth and app URL generation |
+| `AUTH_SECRET` | Stable secret | Keeps auth sessions stable across revisions |
+| `DATABASE_URL` | Local sidecar URL | Points app to the Postgres sidecar |
+
+Do not set the Azure demo back to `next dev` just to expose sample data. Demo data and shortcuts should be controlled through explicit demo flags while keeping the runtime production-like.
+
+## Container Build Notes
+
+The container files pin pnpm to the repository package-manager version before dependency installation. This matters because base images can ship a newer global pnpm that does not support the repo's Node version.
+
+Build-sensitive files:
+
+- `docker/Containerfile.dev`
+- `docker/Containerfile`
+- `docker/entrypoint.azure-dev.sh`
+- `scripts/azure-dev.sh`
+- `package.json`
+- `pnpm-lock.yaml`
+
+When changing package-manager, Node, or container base-image behavior, validate both CI and the Azure ACR build path. CI can pass while the Azure image build fails if the container base image has a different global toolchain.
+
+## Startup Flow in Azure
+
+```mermaid
+sequenceDiagram
+  participant ACA as Container App
+  participant Entry as entrypoint.azure-dev.sh
+  participant DB as Postgres sidecar
+  participant App as Next.js server
+
+  ACA->>Entry: Start app container
+  Entry->>DB: Wait for localhost:5432
+  Entry->>DB: drizzle-kit push --force
+  Entry->>DB: db:seed:container
+  Entry->>App: node standalone server.js
+  App-->>ACA: Listen on port 3000
+```
+
+The demo currently uses schema push plus idempotent seed data because it is a disposable demo environment. Persistent production tenants should move to explicit migrations and more conservative seed behavior.
+
+## Operational Checks
+
+After deployment, verify:
+
+- Container App revision is healthy
+- traffic is 100 percent on the new revision
+- `/login` returns HTTP 200
+- logs show schema sync, seed completion, and Next server ready
+- no recurring auth, database pool, server-action, or static asset errors
+
+Useful commands:
+
+```bash
+bash scripts/azure-dev.sh status
+az containerapp revision list --name govea-dev --resource-group govea-dev-rg -o table
+az containerapp logs show --name govea-dev --resource-group govea-dev-rg --tail 120
+curl -I -L https://govea-dev.wittyocean-795e193a.eastus.azurecontainerapps.io/login
+```
+
+## Current Limitations
+
+- There is not yet a traceable release pipeline from merge to deploy.
+- The demo uses a sidecar Postgres instance, not a managed production database.
+- Rollback is manual through Container Apps image/revision operations.
+- The deployment script records image tags in output, but the repository does not yet persist a release record automatically.
+
+Issue #504 tracks the release-pipeline work needed to make demo deployment traceable by commit, image digest, revision, smoke result, and rollback path.

--- a/docs/architect/security-and-tenancy.md
+++ b/docs/architect/security-and-tenancy.md
@@ -1,0 +1,111 @@
+# Security and Tenancy Architecture
+
+GovEA is multi-tenant at the application layer. The normal operating boundary is the organization. Users belong to one organization, content records carry `organization_id`, and cross-organization behavior is explicit rather than implicit.
+
+## Identity Model
+
+GovEA supports two sign-in paths:
+
+| Sign-in path | Purpose | Notes |
+|---|---|---|
+| Local credentials | Development, fallback, and self-hosted operation | Password hashes are stored for local users |
+| Microsoft Entra ID OIDC | Government SSO path | SSO users must be pre-provisioned before sign-in |
+
+Auth is implemented with Auth.js in `apps/govea/src/lib/auth.ts`. Middleware uses the edge-safe Auth.js configuration from `apps/govea/src/middleware.ts` so route protection does not pull Node-only APIs into the Edge Runtime.
+
+SSO does not auto-create usable tenant users. The sign-in callback checks that the external identity maps to a pre-provisioned, active user with an organization assignment. This keeps tenant access admin-managed.
+
+## Roles
+
+| Role | Scope | Intent |
+|---|---|---|
+| `admin` | Organization | Full tenant administration and content management |
+| `contributor` | Organization | Create and edit EA content, without user management or destructive admin powers |
+| `viewer` | Organization | Read viewer-visible published content |
+| `instance_admin` | Instance | Platform operations across organizations through the instance console |
+
+`instance_admin` is stored separately from the org-scoped role. It does not mean the user owns every organization's architecture content.
+
+## Route Protection
+
+Middleware handles coarse protection:
+
+- public paths: `/login`, `/setup`, `/error`, `/api/auth`, `/maintenance`
+- static assets are allowed
+- unauthenticated users are redirected to `/login`
+- maintenance mode redirects non-admin users to `/maintenance`
+- `/instance` routes require `instance_admin`
+
+This is only the outer gate. Server actions still need to enforce role, organization, and target-record rules.
+
+## Tenant Boundary
+
+Most business records include `organization_id`. Server actions should follow this pattern:
+
+1. Read the current session.
+2. Resolve the caller's organization and role from trusted session fields.
+3. Load target records by both `id` and `organization_id`.
+4. Reject cross-org writes unless a specific federation or support path allows them.
+5. Write an audit event for security-relevant changes.
+
+```mermaid
+flowchart TD
+  Session["Session user"] --> Role["Org role"]
+  Session --> Org["organizationId"]
+  Org --> Query["Read target with organization_id filter"]
+  Role --> Gate["Role gate"]
+  Query --> Mutate["Mutation"]
+  Gate --> Mutate
+  Mutate --> Audit["Audit log"]
+```
+
+## Visibility and Federation
+
+Content visibility is explicit:
+
+| Visibility | Meaning |
+|---|---|
+| `org` | Visible only inside the owning organization |
+| `connections` | Visible to directly connected organizations when federation rules allow it |
+| `instance` | Visible across the GovEA instance where supported |
+
+Federation uses:
+
+- `org_connections` for explicit organization relationships
+- `cross_org_links` for approved relationships between content objects
+- read-only remote detail views for linked external content
+
+Cross-org links must not become a back door around source visibility. Org-private source content should not be exposed through federation.
+
+## Support Access
+
+Instance support access is deliberately narrower than tenant administration.
+
+| Mechanism | Purpose |
+|---|---|
+| Break-glass session | Time-bound, audited support access request for a target organization |
+| Act-as session | Scoped support action path tied to an active break-glass parent |
+| Instance audit log | Operator-visible record of platform and support actions |
+
+Every cross-tenant support action should record the real actor, target tenant, reason/context, and support-session identifiers. A revoked or expired break-glass session must terminate dependent support behavior.
+
+## Audit Requirements
+
+Audit events are part of the security model, not just diagnostics. Mutations that affect identity, tenant status, support access, content visibility, relationships, or published architecture state should write audit records.
+
+The audit log stores:
+
+- actor user id when known
+- organization id when applicable
+- action name
+- entity type and entity id
+- before/after snapshots when useful
+- metadata for support context, reasons, impersonated orgs, or request details
+
+## Security Design Notes
+
+- Never trust caller-supplied `organizationId` or `role` for authorization.
+- Prefer server-side relationship checks over client-side hiding.
+- Keep instance-admin features visibly separate from org-admin features.
+- Treat federation as read/link coordination, not ownership transfer.
+- Keep local auth available as an SSO fallback so administrators are not locked out when an identity provider is unavailable.


### PR DESCRIPTION
## Summary

Adds an application architecture documentation folder under `docs/architect/`.

## What changed

- Adds a `docs/architect/README.md` index.
- Adds an application overview covering route groups, layers, request flow, product areas, and cross-cutting services.
- Adds security and tenancy notes covering Auth.js, roles, org boundaries, federation, support access, and audit expectations.
- Adds data and traceability notes covering repository relationships, lifecycle patterns, taxonomy, Data Architecture, and traceability rules.
- Adds runtime and deployment notes covering local development, Azure demo deployment, container build behavior, environment variables, startup flow, and operational checks.
- Links the new docs folder from `README.md`.

## Validation

- `git diff --cached --check`
- Verified new Markdown files end with newlines.

Capability: process/methodology
Persona: Enterprise Architect
