### PR TITLE
fix(seed): assign TOGAF Architecture Domain to Riverdale capabilities

### DIFF
--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -330,6 +330,33 @@ export const DEV_CAPABILITY_RELATIONSHIPS: { parentName: string; childName: stri
   { parentName: 'Digital Identity & Authentication', childName: 'IAM Audit Trail' },
 ]
 
+// ─── TOGAF Architecture Domain mappings (City of Riverdale capabilities) ─────
+// Illustrative assignments so the Application Landscape report renders non-empty
+// out of the box. These are demonstrative seed data, not authoritative TOGAF
+// classification — orgs are expected to assign their own mappings in practice.
+// See #582 / #580 (Domain Architect persona walk).
+export type TogafDomainLabel =
+  | 'Business Architecture'
+  | 'Application Architecture'
+  | 'Technology Architecture'
+  | 'Data Architecture'
+
+export const DEV_CAPABILITY_TOGAF_DOMAINS: Record<string, TogafDomainLabel> = {
+  'Online Permitting':                'Application Architecture',
+  'Business License Management':      'Business Architecture',
+  'HR Self-Service':                  'Business Architecture',
+  'GIS Mapping':                      'Application Architecture',
+  'Budget Reporting':                 'Application Architecture',
+  'Service Request Management':       'Business Architecture',
+  'Digital Identity & Authentication':'Application Architecture',
+  'Cross-Agency Data Sharing':        'Data Architecture',
+  'Print & Mail Services':            'Technology Architecture',
+  'User and Role Management':         'Application Architecture',
+  'Role-Based Access Control':        'Application Architecture',
+  'SSO and Local Authentication':     'Application Architecture',
+  'IAM Audit Trail':                  'Data Architecture',
+}
+
 // ─── Applications (City of Riverdale) ────────────────────────────────────────
 // Coverage: lifecycleStatus = active ✓, sunset ✓, decommissioned ✓, planned ✓
 //           hostingModel = saas ✓, on-prem ✓, hybrid ✓

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -5,7 +5,7 @@ import {
   DEV_USERS, STATE_USERS, SYSTEM_USERS,
   DEFAULT_PERSONA_TYPES, DEFAULT_PERSONA_TAGS,
   DEV_PERSONA_TAG_ASSIGNMENTS,
-  DEV_PERSONAS, DEV_CAPABILITIES, DEV_CAPABILITY_RELATIONSHIPS, DEV_APPLICATIONS,
+  DEV_PERSONAS, DEV_CAPABILITIES, DEV_CAPABILITY_RELATIONSHIPS, DEV_CAPABILITY_TOGAF_DOMAINS, DEV_APPLICATIONS,
   DEV_OBJECTIVES, DEV_GOALS, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   DEV_PRINCIPLES, DEV_GLOSSARY, DEV_SERVICES,
   DEV_DATA_ENTITIES, DEV_DATA_ATTRIBUTES, DEV_DATA_LINKS, DEV_DATA_BUSINESS_KEYS,
@@ -42,6 +42,7 @@ import {
   taxonomyTerms, entityTaxonomyDefinitions,
   services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
+  frameworkMappings,
   instanceSettings,
   dataEntities, dataAttributes, dataLinks, dataBusinessKeys,
   dataEntityOwners, dataAttributeOwners, dataLinkOwners, dataBusinessKeyOwners,
@@ -250,6 +251,35 @@ async function seed() {
     if (!exists) await db.insert(capabilityRelationships).values({ parentId, childId })
   }
   console.log(`  ✓ ${DEV_CAPABILITY_RELATIONSHIPS.length} capability parent-child relationships`)
+
+  // TOGAF Architecture Domain mappings for Riverdale capabilities (#582 — seed
+  // the Application Landscape report so it renders non-empty out of the box).
+  let togafMappingCount = 0
+  for (const [capName, domainLabel] of Object.entries(DEV_CAPABILITY_TOGAF_DOMAINS)) {
+    const capId = devCapabilityIds[capName]
+    if (!capId) continue
+    const exists = await db.query.frameworkMappings.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(
+          e(t.organizationId, devOrgId),
+          e(t.entityType, 'capability'),
+          e(t.entityId, capId),
+          e(t.framework, 'togaf'),
+          e(t.conceptLabel, domainLabel),
+        ),
+    })
+    if (!exists) {
+      await db.insert(frameworkMappings).values({
+        organizationId: devOrgId,
+        entityType: 'capability',
+        entityId: capId,
+        framework: 'togaf',
+        conceptLabel: domainLabel,
+      })
+      togafMappingCount++
+    }
+  }
+  console.log(`  ✓ ${togafMappingCount} TOGAF domain mappings (capabilities)`)
 
   // Applications + capability links
   const devApplicationIds: Record<string, string> = {}


### PR DESCRIPTION
## Summary

- Seeds `framework_mappings` rows (framework=`togaf`) for all 13 Riverdale capabilities so the Application Landscape report renders non-empty out of the box.
- Surfaced by the Domain Architect persona walk (#580) — the natural landing page for a domain specialist was empty on a fresh seed.

## Before / after

| | total | mapped | derived | unmapped |
|---|---:|---:|---:|---:|
| Before | 7 | 0 | 0 | 7 |
| After  | 7 | 0 | 7 | 0 |

After this change the report exercises the **capability-derived inference path** for every Riverdale application — direct-mapped applications can be demonstrated with a small follow-up if useful, but the derived path is the one practitioners use day-to-day.

## Test plan

- [x] `pnpm --filter govea db:seed` reports `✓ 13 TOGAF domain mappings (capabilities)` on first run, `✓ 0` on idempotent re-run.
- [x] DB verification: `SELECT concept_label, count(*) FROM framework_mappings WHERE framework='togaf' AND entity_type='capability' GROUP BY concept_label` returns Application=7, Business=3, Data=2, Technology=1.
- [x] Browser walk on `/reports/togaf/application-landscape` as `carol@govea.dev` shows derived mappings for all 7 applications.

Capability: fd-portfolio-views
Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)