### PR TITLE
[codex] docs: clarify SSO as provider-neutral OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Free. Open source. Runs on-prem or as a hosted service.
 - **Language:** TypeScript
 - **Database:** PostgreSQL
 - **ORM:** Drizzle
-- **Authentication:** Auth.js with Microsoft Entra ID via OIDC first, using admin-managed pre-provisioned SSO access; SAML support can be added later through BoxyHQ SAML Jackson
+- **Authentication:** Auth.js with OpenID Connect (OIDC) SSO first, using admin-managed pre-provisioned access; Microsoft Entra ID is the current configured provider target, and Okta, Auth0, or other OIDC providers can be supported through the same architectural pattern. SAML support can be added later through BoxyHQ SAML Jackson
 - **UI:** Tailwind CSS + shadcn/ui
 - **Deployment:** Docker and web-hosted deployments, with containers available for on-prem installs
 - **Product architecture:** build toward a reusable `@govea/core` package for CMS-pattern primitives such as content types, field validation, taxonomy, RBAC, audit trail, workflow, and recipe-based seeding
@@ -228,7 +228,7 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Audit trail: immutable before/after log of all changes
 - Taxonomy management: org-scoped taxonomy with admin UI, controlled domain vocabulary, persona types, persona tags, and domain-aware filtering
 - Shared taxonomy foundation now proven across applications and capabilities, including capability-priority classification as the second pilot
-- Identity & access management: SSO via Microsoft Entra ID (OIDC) with admin-managed pre-provisioned access, local auth fallback, Admin/Contributor/Viewer roles
+- Identity & access management: OIDC SSO with admin-managed pre-provisioned access, current Microsoft Entra ID provider wiring, local auth fallback, Admin/Contributor/Viewer roles
 - Instance admin console: platform dashboard, org inventory, org detail, cross-org user view, audit log, org suspension, instance-admin promotion/demotion, audited break-glass sessions, scoped act-as support actions, and instance-level platform configuration
 - Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
 - User management and first-run setup flow

--- a/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
+++ b/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
@@ -1,7 +1,7 @@
 # Capability: SSO Authentication
 
 ## What It Does
-The system must allow users to sign in using their agency's identity provider via OpenID Connect. Microsoft Entra ID is the primary target. SSO is optional — the system works without it.
+The system must allow users to sign in using their agency's identity provider via OpenID Connect (OIDC). Microsoft Entra ID is the current configured provider target, but the capability should remain provider-neutral so Okta, Auth0, or other OIDC providers can be supported through the same sign-in and pre-provisioning model. SSO is optional — the system works without it.
 
 ## Personas
 - **CMS Administrator** — configures SSO via the admin UI; no code changes required

--- a/business-architecture/capabilities/cms/iam/iam.md
+++ b/business-architecture/capabilities/cms/iam/iam.md
@@ -16,7 +16,7 @@ The system must control who can access it, how they authenticate, and what they 
 | Role-Based Access Control | [iam-role-based-access-control.md](./iam-role-based-access-control.md) | Enforce Admin / Contributor / Viewer roles and permissions |
 | Instance Administration | [iam-instance-administration.md](./iam-instance-administration.md) | Govern tenant lifecycle, platform admin access, and audited break-glass operations |
 | Local Authentication | [iam-local-authentication.md](./iam-local-authentication.md) | Email and password login with password reset |
-| SSO Authentication | [iam-sso-authentication.md](./iam-sso-authentication.md) | Microsoft Entra ID sign-in via OpenID Connect with admin-managed pre-provisioned access |
+| SSO Authentication | [iam-sso-authentication.md](./iam-sso-authentication.md) | OpenID Connect sign-in with admin-managed pre-provisioned access; current provider wiring targets Microsoft Entra ID |
 | IAM Audit Trail | [iam-audit-trail.md](./iam-audit-trail.md) | Immutable log of all identity and access events |
 | First-Run Setup | [iam-first-run-setup.md](./iam-first-run-setup.md) | Bootstrap initial Admin account on first launch |
 | API Auth Decision | [iam-api-auth-decision.md](./iam-api-auth-decision.md) | Auth strategy for API routes (session-based, not token-based in v1) |

--- a/capabilities.md
+++ b/capabilities.md
@@ -32,7 +32,7 @@ Controls authentication, authorization, and all identity events.
 | User Management | Implemented | Create, edit, deactivate, and assign org-scoped roles to user accounts |
 | Role-Based Access Control | Implemented | Enforce Admin / Contributor / Viewer roles across all content and actions, with `instance_admin` layered separately for platform operations |
 | Instance Administration | Implemented | Instance-scoped admin role, `/instance` console, org inventory, user view, audit view, org suspension, instance-admin promotion/demotion, audited break-glass sessions, and scoped act-as support actions without taking over org-scoped settings |
-| SSO Authentication | Implemented | Microsoft Entra ID sign-in via OpenID Connect (OIDC) with admin-managed pre-provisioned access |
+| SSO Authentication | Implemented | OpenID Connect (OIDC) SSO with admin-managed pre-provisioned access; current provider wiring targets Microsoft Entra ID |
 | Local Authentication | Implemented | Email and password login; always available as SSO fallback |
 | IAM Audit Trail | Implemented | Immutable log of all identity and access events, including instance-scoped platform events |
 | First-Run Setup | Implemented | Bootstrap the initial Admin account on first launch |

--- a/docs/architect/application-overview.md
+++ b/docs/architect/application-overview.md
@@ -81,7 +81,7 @@ Middleware performs coarse route protection. Server actions and domain helpers p
 
 | Concern | Current implementation |
 |---|---|
-| Authentication | Auth.js with local credentials and optional Microsoft Entra ID OIDC |
+| Authentication | Auth.js with local credentials and optional OIDC SSO; current provider wiring targets Microsoft Entra ID |
 | Authorization | Org-scoped roles plus separate `instance_admin` operating role |
 | Audit | Immutable audit log for content, identity, instance, and support-access events |
 | Taxonomy | Org-scoped controlled vocabularies reused across multiple entity types |

--- a/docs/architect/security-and-tenancy.md
+++ b/docs/architect/security-and-tenancy.md
@@ -9,9 +9,9 @@ GovEA supports two sign-in paths:
 | Sign-in path | Purpose | Notes |
 |---|---|---|
 | Local credentials | Development, fallback, and self-hosted operation | Password hashes are stored for local users |
-| Microsoft Entra ID OIDC | Government SSO path | SSO users must be pre-provisioned before sign-in |
+| OIDC SSO | Government SSO path | Current provider wiring targets Microsoft Entra ID; Okta, Auth0, or other OIDC providers fit the same architectural pattern |
 
-Auth is implemented with Auth.js in `apps/govea/src/lib/auth.ts`. Middleware uses the edge-safe Auth.js configuration from `apps/govea/src/middleware.ts` so route protection does not pull Node-only APIs into the Edge Runtime.
+Auth is implemented with Auth.js in `apps/govea/src/lib/auth.ts`. The current code uses the Microsoft Entra ID provider package, but the architectural boundary is OIDC-backed SSO plus pre-provisioned GovEA users rather than a Microsoft-only identity model. Middleware uses the edge-safe Auth.js configuration from `apps/govea/src/middleware.ts` so route protection does not pull Node-only APIs into the Edge Runtime.
 
 SSO does not auto-create usable tenant users. The sign-in callback checks that the external identity maps to a pre-provisioned, active user with an organization assignment. This keeps tenant access admin-managed.
 


### PR DESCRIPTION
## Summary

Clarifies that GovEA's architecture should describe SSO as provider-neutral OpenID Connect (OIDC), with Microsoft Entra ID as the current configured provider target rather than the architectural category.

## What changed

- Updates README and capability summaries to say OIDC SSO first.
- Keeps the current Microsoft Entra ID provider wiring explicit.
- Notes that Okta, Auth0, and other OIDC providers fit the same architectural pattern.
- Updates the new architecture docs and IAM capability docs with the same distinction.

## Validation

- `git diff --check`
- Docs-only wording change.

Capability: iam-sso-authentication
Persona: CMS Administrator
Related: #591
