### PR TITLE
fix(quality): tour title/element alignment and capability pluralization

### DIFF
--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -425,7 +425,7 @@ export default async function ExecutiveDashboardPage() {
           <SectionLabel>Architecture Gaps</SectionLabel>
           <div className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/20 px-5 py-4 space-y-1">
             <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
-              {gapCaps} capability{gapCaps !== 1 ? 'ies' : 'y'} without supporting technology
+              {gapCaps} {gapCaps === 1 ? 'capability' : 'capabilities'} without supporting technology
             </p>
             <p className="text-xs text-amber-700 dark:text-amber-400">
               These business capabilities have no application recorded as delivering them.

--- a/apps/govea/src/app/(admin)/reports/architecture-vision/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/architecture-vision/page.tsx
@@ -214,7 +214,7 @@ export default async function ArchitectureVisionPage() {
   if (hasPrinciples && principleRows.length === 0) gaps.push('No published architecture principles — guiding constraints are not recorded.')
   if (hasAdrs && adrRows.length === 0) gaps.push('No architecture decisions recorded — key choices are undocumented.')
   if (hasInitiatives && activeInitiatives.length === 0) gaps.push('No active or proposed initiatives — the change roadmap is empty.')
-  if (capsWithNoDomain.length > 0) gaps.push(`${capsWithNoDomain.length} capability${capsWithNoDomain.length !== 1 ? 'ies' : 'y'} have no domain assigned.`)
+  if (capsWithNoDomain.length > 0) gaps.push(`${capsWithNoDomain.length} ${capsWithNoDomain.length === 1 ? 'capability has' : 'capabilities have'} no domain assigned.`)
   if (hasApps && appsWithNoCap.length > 0) gaps.push(`${appsWithNoCap.length} application${appsWithNoCap.length !== 1 ? 's' : ''} have no capability link — architecture role is unclear.`)
 
   let sectionNum = 0
@@ -264,7 +264,7 @@ export default async function ArchitectureVisionPage() {
                             {obj.name}
                           </Link>
                           <span className="text-xs text-muted-foreground shrink-0">
-                            {obj.objectiveCapabilities.length} capability{obj.objectiveCapabilities.length !== 1 ? 'ies' : 'y'} linked
+                            {obj.objectiveCapabilities.length} {obj.objectiveCapabilities.length === 1 ? 'capability' : 'capabilities'} linked
                           </span>
                         </div>
                         {obj.description && <p className="text-xs text-muted-foreground">{obj.description}</p>}

--- a/apps/govea/src/app/(admin)/reports/heatmap/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/heatmap/page.tsx
@@ -359,7 +359,7 @@ export default async function HeatmapPage() {
               {totalUnsupported > 0 && (
                 <div className="mb-3 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-4 py-3">
                   <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
-                    {totalUnsupported} capability{totalUnsupported > 1 ? 'ies' : 'y'} across{' '}
+                    {totalUnsupported} {totalUnsupported === 1 ? 'capability' : 'capabilities'} across{' '}
                     {coverageDomains.filter(d => (coverageByDomain[d]?.unsupported ?? 0) > 0).length} domain{coverageDomains.filter(d => (coverageByDomain[d]?.unsupported ?? 0) > 0).length > 1 ? 's' : ''}{' '}
                     have no application support.
                   </p>

--- a/apps/govea/src/components/product-tour.tsx
+++ b/apps/govea/src/components/product-tour.tsx
@@ -92,7 +92,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-strategy"]',
+        element: '[data-tour="nav-adrs"]',
         popover: {
           title: 'Decisions',
           description: 'Record the why behind major technology choices. Superseded decisions stay visible so future teams understand the full context.',
@@ -101,7 +101,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-roadmap"]',
+        element: '[data-tour="nav-strategy"]',
         popover: {
           title: 'Strategy',
           description: 'Link capabilities to objectives and running initiatives to show which parts of your architecture are connected to mission outcomes.',
@@ -110,7 +110,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-reports"]',
+        element: '[data-tour="nav-roadmap"]',
         popover: {
           title: 'Roadmap',
           description: 'A timeline of active and planned initiatives. Useful for stakeholder reviews and communicating what\'s changing and when.',


### PR DESCRIPTION
## Summary

Two surface-level quality bugs surfaced by the Early-Maturity EA Practice Lead persona walk (#586). Both ride on stakeholder-facing surfaces (Architecture Vision report, Executive Summary, in-product tour) and undercut the credibility of the first-deliverable demo path.

**1. Tour step misalignment** — Steps 9-11 anchored to the wrong nav elements:

| Step | Was → element | Was → title | Now → element |
|---|---|---|---|
| 9 | `nav-strategy` | "Decisions" | `nav-adrs` |
| 10 | `nav-roadmap` | "Strategy" | `nav-strategy` |
| 11 | `nav-reports` | "Roadmap" | `nav-roadmap` |

Each step now has element + title + description aligned. (No tour length change; the rationale for not adding a separate "Reports" step is that the Reports section already gets its own visual treatment in the nav and the tour's purpose is orientation rather than enumeration.)

**2. Pluralization** — three call sites built the plural form as `capability${n !== 1 ? 'ies' : 'y'}` → "capabilityies" for any n ≠ 1, because the base string already ends in "y". Replaced with explicit `${n === 1 ? 'capability' : 'capabilities'}` in:

- `reports/architecture-vision/page.tsx` (Strategic Drivers panel + Gaps line)
- `executive/page.tsx` (Architecture Gaps callout)
- `reports/heatmap/page.tsx` (Unsupported callout — found while sweeping)

## Test plan

- [x] `/reports/architecture-vision` shows "3 capabilities linked" / "2 capabilities linked" (was "capabilityies")
- [x] `/executive` shows "4 capabilities without supporting technology" (was "capabilityies")
- [x] Source diff confirms tour element/title pairs aligned in `product-tour.tsx`
- [x] `grep -rE "\? 'ies' :"` in `apps/govea/src` returns no remaining buggy template literals

Capability: fd-traceability-views; fd-portfolio-views
Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)