### PR TITLE
feat(rbac): contributor-readable audit log scoped to architecture content

### DIFF
--- a/apps/govea/src/app/(admin)/audit/page.tsx
+++ b/apps/govea/src/app/(admin)/audit/page.tsx
@@ -1,9 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { isAdmin } from '@/lib/rbac'
-import { db } from '@/db/client'
-import { auditLog, users } from '@/db/schema'
-import { eq, desc } from 'drizzle-orm'
+import { canEdit, isAdmin } from '@/lib/rbac'
+import { getAuditEntries } from '@/lib/audit-view'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
@@ -11,21 +9,23 @@ import {
 export default async function AuditPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
-  if (!isAdmin(session.user)) redirect('/dashboard')
+  if (!canEdit(session.user)) redirect('/dashboard')
 
-  const entries = await db
-    .select({ log: auditLog, user: users })
-    .from(auditLog)
-    .leftJoin(users, eq(auditLog.userId, users.id))
-    .where(eq(auditLog.organizationId, session.user.organizationId!))
-    .orderBy(desc(auditLog.createdAt))
-    .limit(200)
+  const isUserAdmin = isAdmin(session.user)
+  const role: 'admin' | 'contributor' = isUserAdmin ? 'admin' : 'contributor'
+  const orgId = session.user.organizationId!
+
+  const entries = await getAuditEntries(orgId, role)
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Audit Log</h1>
-        <p className="text-muted-foreground mt-1">A record of all actions taken in this organization.</p>
+        <p className="text-muted-foreground mt-1">
+          {isUserAdmin
+            ? 'A record of all actions taken in this organization.'
+            : 'Changes to architecture content in this organization. Authentication, user management, and organization settings stay admin-only.'}
+        </p>
       </div>
       <div className="rounded-lg border bg-card">
         <Table>

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -66,6 +66,10 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { href: '/reports',    label: 'Reports' },
       { href: '/executive',  label: 'Executive Summary' },
+      // Audit Log is visible to Contributors and Admins. The page filters its
+      // own rows: contributors see the architecture-content slice only,
+      // admins see everything (#597).
+      { href: '/audit',      label: 'Audit Log', contributorOnly: true },
     ],
   },
   {
@@ -75,7 +79,6 @@ const NAV_GROUPS: NavGroup[] = [
       { href: '/taxonomy',    label: 'Taxonomy' },
       { href: '/users',       label: 'Users' },
       { href: '/connections', label: 'Connections' },
-      { href: '/audit',       label: 'Audit Log' },
       { href: '/settings',    label: 'Settings' },
       { href: '/settings/notices', label: 'Notices' },
     ],

--- a/apps/govea/src/lib/audit-view.ts
+++ b/apps/govea/src/lib/audit-view.ts
@@ -1,0 +1,76 @@
+import { db } from '@/db/client'
+import { auditLog, users } from '@/db/schema'
+import { and, eq, desc, inArray } from 'drizzle-orm'
+
+/**
+ * Entity types whose audit events are visible to Contributors (#597).
+ *
+ * This is an explicit allowlist, not a blocklist — new sensitive event types
+ * added in future code should default to admin-only unless someone reviews
+ * them and adds them here. Anything touching authentication, organization
+ * settings, user management, or instance scope is intentionally excluded.
+ *
+ * The Domain Architect, Consultant/SI, and Agency EA Coordinator persona walks
+ * all called this scope out: a contributor needs to read the recent past of
+ * the architecture content they edit, without an admin escalation.
+ *
+ * To keep this list in sync with new code: when adding a new entity type to
+ * audit events, deliberately decide whether it belongs here. The default is
+ * "no" — `users`, `org_connection`, `instance_settings`, `admin_notice`,
+ * `act_as_session`, `break_glass_session`, `organization`, `platform_config`
+ * are admin-scope by design and must not appear in this list.
+ */
+export const CONTRIBUTOR_VISIBLE_ENTITY_TYPES = [
+  'adr',
+  'application',
+  'architecture_debt_item',
+  'capability',
+  'cross_org_link',
+  'data_attribute',
+  'data_business_key',
+  'data_entity',
+  'data_link',
+  'decision',
+  'glossary',
+  'glossary term',
+  'goal',
+  'initiative',
+  'objective',
+  'persona',
+  'principle',
+  'service',
+  'taxonomy_term',
+  'value stream',
+  'value_stream',
+] as const
+
+export type AuditViewRole = 'admin' | 'contributor'
+
+/**
+ * Returns audit log entries scoped to the caller's role.
+ *
+ * - `admin`: every event for the org (full audit view).
+ * - `contributor`: only events on architecture-content entity types
+ *   (CONTRIBUTOR_VISIBLE_ENTITY_TYPES). Authentication, user management,
+ *   org settings, and instance scope are hidden.
+ *
+ * Viewers must be redirected away by the caller — they never reach this
+ * helper. The page-level gate is `canEdit(session.user)`; this helper
+ * assumes the caller already enforced that.
+ */
+export async function getAuditEntries(orgId: string, role: AuditViewRole, limit = 200) {
+  const where = role === 'admin'
+    ? eq(auditLog.organizationId, orgId)
+    : and(
+        eq(auditLog.organizationId, orgId),
+        inArray(auditLog.entityType, [...CONTRIBUTOR_VISIBLE_ENTITY_TYPES]),
+      )
+
+  return db
+    .select({ log: auditLog, user: users })
+    .from(auditLog)
+    .leftJoin(users, eq(auditLog.userId, users.id))
+    .where(where)
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit)
+}

--- a/apps/govea/tests/integration/audit-view.test.ts
+++ b/apps/govea/tests/integration/audit-view.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration tests: contributor-readable audit log (#597)
+ *
+ * Covers the getAuditEntries() helper that powers /audit:
+ *  - Admin sees every audit row for their org
+ *  - Contributor sees only architecture-content entity types
+ *  - Sensitive entity types (user, organization, instance_settings,
+ *    org_connection, admin_notice, act_as_session, break_glass_session,
+ *    platform_config) never appear in the contributor view
+ *  - Org scope is honoured for both roles (cross-org rows hidden)
+ *
+ * The page-level redirect for Viewers is enforced by canEdit() in the
+ * RBAC helper and exercised by other test suites; this suite assumes the
+ * page-level gate is in place and tests only the query the page issues
+ * after the gate passes.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/db/client'
+import { auditLog } from '@/db/schema'
+import {
+  CONTRIBUTOR_VISIBLE_ENTITY_TYPES,
+  getAuditEntries,
+} from '@/lib/audit-view'
+import {
+  createTestOrg, cleanupOrg,
+} from './helpers/db'
+
+const ADMIN_ONLY_ENTITY_TYPES = [
+  'user',
+  'organization',
+  'instance_settings',
+  'org_connection',
+  'admin_notice',
+  'act_as_session',
+  'break_glass_session',
+  'platform_config',
+] as const
+
+async function seedAuditRow(orgId: string, entityType: string, action: string) {
+  await db.insert(auditLog).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    entityType,
+    entityId: randomUUID(),
+    action,
+    userId: null,
+    after: { test: true },
+  })
+}
+
+describe('getAuditEntries (#597)', () => {
+  let orgA: string
+  let orgB: string
+
+  beforeAll(async () => {
+    const [a, b] = await Promise.all([createTestOrg(), createTestOrg()])
+    orgA = a.id
+    orgB = b.id
+
+    // Seed Org A with one row per entity type — both contributor-visible and
+    // admin-only — plus one row in Org B that should never leak.
+    for (const t of CONTRIBUTOR_VISIBLE_ENTITY_TYPES) {
+      await seedAuditRow(orgA, t, `${t}.create`)
+    }
+    for (const t of ADMIN_ONLY_ENTITY_TYPES) {
+      await seedAuditRow(orgA, t, `${t}.create`)
+    }
+    // Cross-org noise
+    await seedAuditRow(orgB, 'capability', 'capability.create')
+  })
+
+  afterAll(async () => {
+    await Promise.all([cleanupOrg(orgA), cleanupOrg(orgB)])
+  })
+
+  it('admin sees every entity type for their org', async () => {
+    const rows = await getAuditEntries(orgA, 'admin')
+    const seenTypes = new Set(rows.map(r => r.log.entityType))
+    for (const t of CONTRIBUTOR_VISIBLE_ENTITY_TYPES) {
+      expect(seenTypes.has(t)).toBe(true)
+    }
+    for (const t of ADMIN_ONLY_ENTITY_TYPES) {
+      expect(seenTypes.has(t)).toBe(true)
+    }
+  })
+
+  it('contributor sees architecture-content entity types', async () => {
+    const rows = await getAuditEntries(orgA, 'contributor')
+    const seenTypes = new Set(rows.map(r => r.log.entityType))
+    for (const t of CONTRIBUTOR_VISIBLE_ENTITY_TYPES) {
+      expect(seenTypes.has(t)).toBe(true)
+    }
+  })
+
+  it('contributor never sees admin-only entity types', async () => {
+    const rows = await getAuditEntries(orgA, 'contributor')
+    const seenTypes = new Set(rows.map(r => r.log.entityType))
+    for (const t of ADMIN_ONLY_ENTITY_TYPES) {
+      expect(seenTypes.has(t)).toBe(false)
+    }
+  })
+
+  it('admin only sees rows from their own org', async () => {
+    const rows = await getAuditEntries(orgA, 'admin')
+    expect(rows.every(r => r.log.organizationId === orgA)).toBe(true)
+  })
+
+  it('contributor only sees rows from their own org', async () => {
+    const rows = await getAuditEntries(orgA, 'contributor')
+    expect(rows.every(r => r.log.organizationId === orgA)).toBe(true)
+  })
+
+  it('allowlist does not include any of the explicit admin-only types', () => {
+    // Defensive check — if someone copy-pastes a new type into the allowlist
+    // we want a sharp failure rather than a silent leak.
+    const allowlist = new Set<string>(CONTRIBUTOR_VISIBLE_ENTITY_TYPES)
+    for (const t of ADMIN_ONLY_ENTITY_TYPES) {
+      expect(allowlist.has(t)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Allows Contributors to read the audit log for their org, scoped to the architecture-content slice. Hides authentication, user / role management, organization settings, org connections, instance settings, admin notices, act-as / break-glass sessions, and platform configuration from the contributor view. Viewers continue to be redirected away.

Surfaced by three persona walks — Domain Architect (#580), Consultant / SI (#595), Agency EA Coordinator (#541). All three persona files name audit-trail access as a relevant capability; the shared theme is that a contributor needs to read the recent past of the content they edit without an admin escalation.

## What changed

| | Before | After |
|---|---|---|
| `/audit` route gate | `isAdmin` | `canEdit` (admins + contributors) |
| Contributor visibility | Redirect → `/dashboard` | Architecture-content slice only |
| Admin visibility | Everything | Unchanged — everything |
| Viewer visibility | Redirect → `/dashboard` | Unchanged — redirect |
| Nav placement | `Configuration` group (admin-only) | `Reports` group with `contributorOnly` (admins + contributors) |
| Subtitle copy | Single string for all roles | Role-aware: admin sees \"A record of all actions...\"; contributor sees \"Changes to architecture content... Authentication, user management, and organization settings stay admin-only.\" |

## Implementation guard rails

- New `CONTRIBUTOR_VISIBLE_ENTITY_TYPES` allowlist in `apps/govea/src/lib/audit-view.ts` — explicit, not derived. **Defaults to \"no\"** for any new event types added in future code; sensitive types fail closed rather than open.
- Query is centralised in `getAuditEntries(orgId, role)` so the page is a thin shell. Tests exercise the helper directly.

## Test plan

- [x] 6 new integration tests in \`tests/integration/audit-view.test.ts\` — all pass (101 ms).
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] Browser walk on dev preview as all three roles:
  - **Carol Contributor**: \`Audit Log\` link visible under Reports; page renders with contributor subtitle.
  - **Alice Admin**: \`Audit Log\` link still visible (now under Reports); page renders with admin subtitle and full event set; Configuration group still shows Users / Connections / Settings / Notices.
  - **Victor Viewer**: \`Audit Log\` link not present in nav; direct \`/audit\` request redirects to \`/dashboard\`.

## Out of scope

- Filter UI (#531) — out of scope here; this PR keeps the existing table UI and adds the visibility-scope guarantee. The filter PR can land on top.
- Audit log CSV export for handover (#596 territory) — different ticket; the read-only viewing surface here is the foundational ask.
- Real-time change-notification (#581 territory).

## Capability traceability

Capability: \`ac-audit-trail\`; \`ac-feature-management\`
Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)