### PR TITLE
feat(onboarding): EasyEA starter content + empty-state CTAs

### DIFF
--- a/apps/govea/src/actions/starter-content.ts
+++ b/apps/govea/src/actions/starter-content.ts
@@ -1,0 +1,238 @@
+'use server'
+
+import { db } from '@/db/client'
+import {
+  personas, capabilities, applications, strategicObjectives, adrs,
+  capabilityPersonas, applicationCapabilities, objectiveCapabilities, adrCapabilities,
+} from '@/db/schema'
+import { and, eq, inArray } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { redirect } from 'next/navigation'
+import { writeAuditLog } from '@/lib/audit'
+import { revalidatePath } from 'next/cache'
+import { EASYEA_STARTER, STARTER_CONTENT_MARKER, type StarterPack } from '@/lib/starter-content/easyea-starter'
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+  return session
+}
+
+export type StarterApplyResult = {
+  packName: string
+  personasCreated: number
+  personasSkipped: number
+  capabilitiesCreated: number
+  capabilitiesSkipped: number
+  applicationsCreated: number
+  applicationsSkipped: number
+  objectivesCreated: number
+  objectivesSkipped: number
+  adrsCreated: number
+  adrsSkipped: number
+}
+
+/**
+ * Apply a starter content pack to the caller's org (#587).
+ *
+ * Idempotent — names that already exist in the org are skipped, not
+ * overwritten. The action returns per-entity created/skipped counts so
+ * the UI can show "added N of M items" framing rather than pretending
+ * everything is new on a re-run.
+ *
+ * Admin-gated: starter content is an org-shaping action, not routine
+ * content editing.
+ */
+export async function applyStarterPack(packName: string): Promise<StarterApplyResult> {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const pack = resolvePack(packName)
+  if (!pack) throw new Error(`Unknown starter pack: ${packName}`)
+
+  const result: StarterApplyResult = {
+    packName: pack.packName,
+    personasCreated: 0, personasSkipped: 0,
+    capabilitiesCreated: 0, capabilitiesSkipped: 0,
+    applicationsCreated: 0, applicationsSkipped: 0,
+    objectivesCreated: 0, objectivesSkipped: 0,
+    adrsCreated: 0, adrsSkipped: 0,
+  }
+
+  await db.transaction(async (tx) => {
+    // ── Personas ────────────────────────────────────────────────────────
+    const existingPersonas = await tx.select({ id: personas.id, name: personas.name })
+      .from(personas).where(eq(personas.organizationId, orgId))
+    const personaIdByName = new Map(existingPersonas.map(p => [p.name.toLowerCase(), p.id]))
+
+    for (const p of pack.personas) {
+      if (personaIdByName.has(p.name.toLowerCase())) {
+        result.personasSkipped++
+        continue
+      }
+      const [row] = await tx.insert(personas).values({
+        organizationId: orgId, name: p.name, description: p.description, type: p.type,
+        status: 'published', visibility: 'org',
+        createdBy: session.user.id, updatedBy: session.user.id,
+      }).returning({ id: personas.id, name: personas.name })
+      personaIdByName.set(row.name.toLowerCase(), row.id)
+      result.personasCreated++
+    }
+
+    // ── Capabilities + persona links ────────────────────────────────────
+    const existingCaps = await tx.select({ id: capabilities.id, name: capabilities.name })
+      .from(capabilities).where(eq(capabilities.organizationId, orgId))
+    const capIdByName = new Map(existingCaps.map(c => [c.name.toLowerCase(), c.id]))
+
+    for (const c of pack.capabilities) {
+      if (capIdByName.has(c.name.toLowerCase())) {
+        result.capabilitiesSkipped++
+        continue
+      }
+      const [row] = await tx.insert(capabilities).values({
+        organizationId: orgId, name: c.name, description: c.description, domain: c.domain,
+        behaviors: c.behaviors, rules: c.rules, capabilityType: c.capabilityType,
+        status: 'published', visibility: 'org',
+        createdBy: session.user.id, updatedBy: session.user.id,
+      }).returning({ id: capabilities.id, name: capabilities.name })
+      capIdByName.set(row.name.toLowerCase(), row.id)
+      result.capabilitiesCreated++
+
+      const personaIds = c.personas
+        .map(name => personaIdByName.get(name.toLowerCase()))
+        .filter((id): id is string => Boolean(id))
+      if (personaIds.length > 0) {
+        await tx.insert(capabilityPersonas).values(
+          personaIds.map(personaId => ({ capabilityId: row.id, personaId }))
+        )
+      }
+    }
+
+    // ── Applications + capability links ─────────────────────────────────
+    const existingApps = await tx.select({ id: applications.id, name: applications.name })
+      .from(applications).where(eq(applications.organizationId, orgId))
+    const appNameSet = new Set(existingApps.map(a => a.name.toLowerCase()))
+
+    for (const a of pack.applications) {
+      if (appNameSet.has(a.name.toLowerCase())) {
+        result.applicationsSkipped++
+        continue
+      }
+      const [row] = await tx.insert(applications).values({
+        organizationId: orgId, name: a.name, description: a.description, vendor: a.vendor,
+        hostingModel: a.hostingModel, lifecycleStatus: a.lifecycleStatus,
+        status: 'published', visibility: 'org',
+        createdBy: session.user.id, updatedBy: session.user.id,
+      }).returning({ id: applications.id, name: applications.name })
+      appNameSet.add(row.name.toLowerCase())
+      result.applicationsCreated++
+
+      const capIds = a.capabilities
+        .map(name => capIdByName.get(name.toLowerCase()))
+        .filter((id): id is string => Boolean(id))
+      if (capIds.length > 0) {
+        await tx.insert(applicationCapabilities).values(
+          capIds.map(capabilityId => ({ applicationId: row.id, capabilityId }))
+        )
+      }
+    }
+
+    // ── Objectives + capability links ───────────────────────────────────
+    const existingObjs = await tx.select({ id: strategicObjectives.id, name: strategicObjectives.name })
+      .from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId))
+    const objNameSet = new Set(existingObjs.map(o => o.name.toLowerCase()))
+
+    for (const o of pack.objectives) {
+      if (objNameSet.has(o.name.toLowerCase())) {
+        result.objectivesSkipped++
+        continue
+      }
+      const [row] = await tx.insert(strategicObjectives).values({
+        organizationId: orgId, name: o.name, description: o.description,
+        successMetric: o.successMetric, timeHorizon: o.timeHorizon,
+        status: 'published', visibility: 'org',
+        createdBy: session.user.id, updatedBy: session.user.id,
+      }).returning({ id: strategicObjectives.id, name: strategicObjectives.name })
+      objNameSet.add(row.name.toLowerCase())
+      result.objectivesCreated++
+
+      const capIds = o.capabilities
+        .map(name => capIdByName.get(name.toLowerCase()))
+        .filter((id): id is string => Boolean(id))
+      if (capIds.length > 0) {
+        await tx.insert(objectiveCapabilities).values(
+          capIds.map(capabilityId => ({ objectiveId: row.id, capabilityId }))
+        )
+      }
+    }
+
+    // ── ADRs + capability links ─────────────────────────────────────────
+    // Match existing ADRs by title (number is bumpable if the org already
+    // has an ADR-001 of their own).
+    const existingAdrs = await tx.select({ id: adrs.id, number: adrs.number, title: adrs.title })
+      .from(adrs).where(eq(adrs.organizationId, orgId))
+    const adrTitleSet = new Set(existingAdrs.map(a => a.title.toLowerCase()))
+    const adrNumberSet = new Set(existingAdrs.map(a => a.number.toLowerCase()))
+
+    for (const adr of pack.adrs) {
+      if (adrTitleSet.has(adr.title.toLowerCase())) {
+        result.adrsSkipped++
+        continue
+      }
+      // If the canonical number is taken, find the next free slot.
+      let number = adr.number
+      let suffix = 1
+      while (adrNumberSet.has(number.toLowerCase())) {
+        number = `${adr.number}-${suffix}`
+        suffix++
+      }
+      const [row] = await tx.insert(adrs).values({
+        organizationId: orgId, number, title: adr.title,
+        context: adr.context, decision: adr.decision, consequences: adr.consequences,
+        status: adr.status, visibility: 'org',
+        createdBy: session.user.id, updatedBy: session.user.id,
+      }).returning({ id: adrs.id, title: adrs.title, number: adrs.number })
+      adrTitleSet.add(row.title.toLowerCase())
+      adrNumberSet.add(row.number.toLowerCase())
+      result.adrsCreated++
+
+      const capIds = adr.capabilities
+        .map(name => capIdByName.get(name.toLowerCase()))
+        .filter((id): id is string => Boolean(id))
+      if (capIds.length > 0) {
+        await tx.insert(adrCapabilities).values(
+          capIds.map(capabilityId => ({ adrId: row.id, capabilityId }))
+        )
+      }
+    }
+
+    await writeAuditLog(tx, {
+      action: 'starter_content.apply',
+      entityType: 'organization',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { ...result },
+    })
+  })
+
+  // Revalidate the catalog routes the user will navigate to next.
+  for (const path of ['/personas', '/capabilities', '/applications', '/objectives', '/adrs', '/dashboard', '/settings']) {
+    revalidatePath(path)
+  }
+
+  return result
+}
+
+function resolvePack(packName: string): StarterPack | null {
+  switch (packName) {
+    case 'easyea-starter': return EASYEA_STARTER
+    default: return null
+  }
+}
+
+// Note: AVAILABLE_STARTER_PACKS and STARTER_CONTENT_MARKER live in the
+// data module (`lib/starter-content/easyea-starter.ts`) so the UI can import
+// them directly. `'use server'` files cannot export non-function constants.

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -530,10 +530,23 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
             <TableBody>
               {filtered.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={canEdit ? 8 : 7} className="text-center text-muted-foreground py-8">
-                    {applications.length === 0
-                      ? 'No applications yet. Add one to get started.'
-                      : 'No applications match the current filters.'}
+                  <TableCell colSpan={canEdit ? 8 : 7} className="text-center text-muted-foreground py-10">
+                    {applications.length === 0 ? (
+                      <div className="space-y-3">
+                        <p>No applications yet.</p>
+                        {canEdit && (
+                          <p className="text-xs">
+                            Add your first application, or{' '}
+                            <Link href="/settings" className="underline underline-offset-2 hover:text-foreground">
+                              apply a starter pack in Settings
+                            </Link>{' '}
+                            to populate a small example city.
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      'No applications match the current filters.'
+                    )}
                   </TableCell>
                 </TableRow>
               )}
@@ -631,11 +644,24 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       {viewMode === 'portfolio' && (
         <div>
           {portfolioSorted.length === 0 ? (
-            <p className="py-12 text-center text-muted-foreground text-sm">
-              {applications.length === 0
-                ? 'No applications yet. Add one to get started.'
-                : 'No applications match the current filters.'}
-            </p>
+            applications.length === 0 ? (
+              <div className="py-12 text-center text-muted-foreground text-sm space-y-3">
+                <p>No applications yet.</p>
+                {canEdit && (
+                  <p className="text-xs">
+                    Add your first application, or{' '}
+                    <Link href="/settings" className="underline underline-offset-2 hover:text-foreground">
+                      apply a starter pack in Settings
+                    </Link>{' '}
+                    to populate a small example city.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="py-12 text-center text-muted-foreground text-sm">
+                No applications match the current filters.
+              </p>
+            )
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {portfolioSorted.map(a => (

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -260,10 +260,23 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           <TableBody>
             {displayRows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={canEdit ? 7 : 6} className="text-center text-muted-foreground py-8">
-                  {capabilities.length === 0
-                    ? 'No capabilities yet. Add one to get started.'
-                    : 'No capabilities match the current filters.'}
+                <TableCell colSpan={canEdit ? 7 : 6} className="text-center text-muted-foreground py-10">
+                  {capabilities.length === 0 ? (
+                    <div className="space-y-3">
+                      <p>No capabilities yet.</p>
+                      {canEdit && (
+                        <p className="text-xs">
+                          Add your first capability, or{' '}
+                          <Link href="/settings" className="underline underline-offset-2 hover:text-foreground">
+                            apply a starter pack in Settings
+                          </Link>{' '}
+                          to populate a small example city.
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    'No capabilities match the current filters.'
+                  )}
                 </TableCell>
               </TableRow>
             )}

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -183,10 +183,23 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           <TableBody>
             {filtered.length === 0 && (
               <TableRow>
-                <TableCell colSpan={canEdit ? 7 : 6} className="text-center text-muted-foreground py-8">
-                  {personas.length === 0
-                    ? 'No personas yet. Add one to get started.'
-                    : 'No personas match the current filters.'}
+                <TableCell colSpan={canEdit ? 7 : 6} className="text-center text-muted-foreground py-10">
+                  {personas.length === 0 ? (
+                    <div className="space-y-3">
+                      <p>No personas yet.</p>
+                      {canEdit && (
+                        <p className="text-xs">
+                          Add your first persona, or{' '}
+                          <Link href="/settings" className="underline underline-offset-2 hover:text-foreground">
+                            apply a starter pack in Settings
+                          </Link>{' '}
+                          to populate a small example city.
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    'No personas match the current filters.'
+                  )}
                 </TableCell>
               </TableRow>
             )}

--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -4,6 +4,7 @@ import { db } from '@/db/client'
 import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { ThemeSelector } from '@/components/theme-selector'
+import { StarterContentSection } from '@/components/starter-content-section'
 import { ModuleToggles } from '@/components/module-toggles'
 import { FrameworkToggles } from '@/components/framework-toggles'
 import { ConfidenceSettingsForm } from '@/components/confidence-settings'
@@ -54,6 +55,20 @@ export default async function SettingsPage() {
         <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
         <p className="text-muted-foreground mt-1">Organization configuration and preferences.</p>
       </div>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Starter Content</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Apply an example content pack so the catalog isn&rsquo;t empty before you&rsquo;ve built your own.
+            Each item ends with a plain-language marker so you can replace or delete it later.
+            Re-applying the same pack skips items that already exist.
+          </p>
+        </div>
+        <StarterContentSection />
+      </section>
+
+      <hr />
 
       <section className="space-y-4">
         <div>

--- a/apps/govea/src/components/starter-content-section.tsx
+++ b/apps/govea/src/components/starter-content-section.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { applyStarterPack, type StarterApplyResult } from '@/actions/starter-content'
+import { AVAILABLE_STARTER_PACKS } from '@/lib/starter-content/easyea-starter'
+
+/**
+ * Settings card for applying a starter content pack (#587).
+ *
+ * Shows each available pack with its counts, an "Apply" button, and the
+ * result of the most recent apply. Idempotent on the server: re-applying
+ * the same pack skips existing items rather than duplicating them.
+ */
+export function StarterContentSection() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [result, setResult] = useState<StarterApplyResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [activePack, setActivePack] = useState<string | null>(null)
+
+  function handleApply(packName: string) {
+    if (isPending) return
+    setError(null)
+    setResult(null)
+    setActivePack(packName)
+    startTransition(async () => {
+      try {
+        const r = await applyStarterPack(packName)
+        setResult(r)
+        router.refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        setActivePack(null)
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {AVAILABLE_STARTER_PACKS.map(pack => (
+        <div key={pack.name} className="rounded-lg border bg-card p-4 space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1 min-w-0">
+              <p className="text-sm font-medium">{pack.label}</p>
+              <p className="text-xs text-muted-foreground">{pack.summary}</p>
+              <p className="text-xs text-muted-foreground">
+                Includes: {pack.counts.personas} personas · {pack.counts.capabilities} capabilities · {pack.counts.applications} applications · {pack.counts.objectives} objective · {pack.counts.adrs} ADRs
+              </p>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => handleApply(pack.name)}
+              disabled={isPending}
+            >
+              {isPending && activePack === pack.name ? 'Applying…' : 'Apply'}
+            </Button>
+          </div>
+        </div>
+      ))}
+
+      {result && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 dark:bg-emerald-950/20 dark:border-emerald-800 p-3 text-sm space-y-1 text-emerald-800 dark:text-emerald-300">
+          <p className="font-medium">Starter pack applied: {result.packName}</p>
+          <ul className="text-xs space-y-0.5">
+            <li>{result.personasCreated} personas added · {result.personasSkipped} already present</li>
+            <li>{result.capabilitiesCreated} capabilities added · {result.capabilitiesSkipped} already present</li>
+            <li>{result.applicationsCreated} applications added · {result.applicationsSkipped} already present</li>
+            <li>{result.objectivesCreated} objectives added · {result.objectivesSkipped} already present</li>
+            <li>{result.adrsCreated} ADRs added · {result.adrsSkipped} already present</li>
+          </ul>
+          <p className="text-xs text-emerald-700 dark:text-emerald-400">
+            Items end with the marker &ldquo;Example starter content — replace or delete.&rdquo; in their description so you can find them later.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/lib/starter-content/easyea-starter.ts
+++ b/apps/govea/src/lib/starter-content/easyea-starter.ts
@@ -1,0 +1,236 @@
+/**
+ * EasyEA Starter — the smallest credible city's EA content (#587).
+ *
+ * Intent: give a brand-new admin something to demo in week 2 without
+ * forcing them through the blank-canvas problem the Early-Maturity EA
+ * Practice Lead persona file calls out as the most acute setup pain.
+ *
+ * Every item ends with the marker `STARTER_CONTENT_MARKER` in its
+ * description so the admin (and future archive tooling) can identify
+ * starter content unambiguously even if names or fields drift. The
+ * marker is plain language so it reads naturally on the detail page.
+ *
+ * The pack is **idempotent**: applying it twice doesn't create
+ * duplicates. The upsert key for every entity type is `name` (or
+ * `title` for ADRs) within the caller's org.
+ */
+
+export const STARTER_CONTENT_MARKER = 'Example starter content — replace or delete.'
+
+function markStarter(description: string): string {
+  return `${description}\n\n${STARTER_CONTENT_MARKER}`
+}
+
+export type StarterPersona = {
+  name: string
+  description: string
+  type: string
+}
+
+export type StarterCapability = {
+  name: string
+  description: string
+  domain: string
+  behaviors: string
+  rules: string
+  capabilityType: 'business' | 'technical'
+  personas: string[] // names matching StarterPersona.name
+}
+
+export type StarterApplication = {
+  name: string
+  description: string
+  vendor: string
+  hostingModel: 'saas' | 'on-prem' | 'hybrid'
+  lifecycleStatus: 'active' | 'planned' | 'sunset' | 'decommissioned'
+  capabilities: string[] // names matching StarterCapability.name
+}
+
+export type StarterObjective = {
+  name: string
+  description: string
+  successMetric: string
+  timeHorizon: string
+  capabilities: string[]
+}
+
+export type StarterADR = {
+  number: string
+  title: string
+  context: string
+  decision: string
+  consequences: string
+  status: 'proposed' | 'accepted' | 'deprecated' | 'superseded'
+  capabilities: string[]
+}
+
+export type StarterPack = {
+  packName: string
+  personas: StarterPersona[]
+  capabilities: StarterCapability[]
+  applications: StarterApplication[]
+  objectives: StarterObjective[]
+  adrs: StarterADR[]
+}
+
+/**
+ * For UI use — list of available starter packs. Exposed here (not from the
+ * server action module) because Next.js `'use server'` files can only export
+ * async functions; importing constants from them crashes at runtime.
+ */
+export const AVAILABLE_STARTER_PACKS = [
+  {
+    name: 'easyea-starter',
+    label: 'EasyEA Starter',
+    summary: 'A small canonical city: 4 personas, 6 capabilities, 3 applications, 1 strategic objective, 2 ADRs. Tagged with a plain-language marker so it never gets confused with your own content.',
+    counts: {
+      personas: 4,
+      capabilities: 6,
+      applications: 3,
+      objectives: 1,
+      adrs: 2,
+    },
+  },
+] as const
+
+export const EASYEA_STARTER: StarterPack = {
+  packName: 'easyea-starter',
+
+  personas: [
+    {
+      name: 'Resident',
+      type: 'Citizen',
+      description: markStarter('A member of the public interacting with city services online or in person. Primary user of public-facing digital services.'),
+    },
+    {
+      name: 'Small Business Owner',
+      type: 'External Partner',
+      description: markStarter('Local business operator interacting with the city for permits, licenses, and inspections. High value, time-sensitive needs.'),
+    },
+    {
+      name: 'Department Director',
+      type: 'Staff',
+      description: markStarter('Senior agency leader making decisions on technology investment, modernization sequencing, and service delivery improvements.'),
+    },
+    {
+      name: 'IT Staff',
+      type: 'Staff',
+      description: markStarter('Internal technical staff responsible for operating, maintaining, and integrating the technology platforms supporting city services.'),
+    },
+  ],
+
+  capabilities: [
+    {
+      name: 'Online Permitting',
+      domain: 'Community Development',
+      capabilityType: 'business',
+      description: markStarter('Residents and businesses submit, pay for, and track permit applications without visiting a counter.'),
+      behaviors: 'Submit a permit application online with required documents and fee payment\nTrack the status of an in-progress application\nReceive automated notifications when application status changes',
+      rules: 'Applications must be scoped to an organization\nFee collection must occur before an application is accepted for review',
+      personas: ['Resident', 'Small Business Owner'],
+    },
+    {
+      name: 'Business License Management',
+      domain: 'Community Development',
+      capabilityType: 'business',
+      description: markStarter('Issue, renew, and revoke business licenses. Notify owners of expiry and compliance requirements.'),
+      behaviors: 'Issue a new business operating license upon successful application and payment\nSend renewal reminders before license expiry',
+      rules: 'A license may only be issued after all required inspections are passed\nRenewal notices must be sent at least 60 days before expiry',
+      personas: ['Small Business Owner'],
+    },
+    {
+      name: 'Service Request Management',
+      domain: 'Infrastructure & Public Works',
+      capabilityType: 'business',
+      description: markStarter('Residents submit and track non-emergency service requests such as pothole repairs, graffiti removal, and missed pickups.'),
+      behaviors: 'Accept non-emergency service requests via web and mobile\nRoute requests to the responsible department automatically\nSend status updates at each workflow stage',
+      rules: 'Emergency-level requests must be redirected and not accepted through this channel\nService requests must be acknowledged within one business day of submission',
+      personas: ['Resident'],
+    },
+    {
+      name: 'Budget Reporting',
+      domain: 'Finance & Revenue',
+      capabilityType: 'business',
+      description: markStarter('Directors and elected officials access real-time budget vs. actuals and forecast dashboards.'),
+      behaviors: 'View budget vs. actuals comparisons by department and fund\nGenerate forecast dashboards for the current fiscal year',
+      rules: 'Budget data is read-only in this capability — modifications are made in the source financial system',
+      personas: ['Department Director'],
+    },
+    {
+      name: 'Digital Identity & Authentication',
+      domain: 'Information Technology',
+      capabilityType: 'technical',
+      description: markStarter('Unified login for residents and staff across city digital services. Supports local accounts and optional SSO.'),
+      behaviors: 'Authenticate residents and staff via local credentials or SSO\nIssue and refresh short-lived access tokens\nEnforce multi-factor authentication for privileged roles',
+      rules: 'All resident-facing authentication flows must use OAuth 2.0 with OIDC\nTokens must expire within 8 hours for staff and 24 hours for residents',
+      personas: ['Resident', 'IT Staff'],
+    },
+    {
+      name: 'HR Self-Service',
+      domain: 'Administrative Services',
+      capabilityType: 'business',
+      description: markStarter('Employees view pay stubs, request leave, update personal information, and access benefits.'),
+      behaviors: 'View current and historical pay stubs\nRequest time off and view leave balances',
+      rules: 'Employees may only access their own payroll and personal records',
+      personas: ['IT Staff'],
+    },
+  ],
+
+  applications: [
+    {
+      name: 'Example Permitting Platform',
+      vendor: 'Example Vendor',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      description: markStarter('Cloud permitting and licensing platform used by Community Development and Code Enforcement.'),
+      capabilities: ['Online Permitting', 'Business License Management'],
+    },
+    {
+      name: 'Example Identity Provider',
+      vendor: 'Example Vendor',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      description: markStarter('Cloud identity provider used for staff SSO. Residents use a separate local credential store.'),
+      capabilities: ['Digital Identity & Authentication'],
+    },
+    {
+      name: 'Example Budget System',
+      vendor: 'Example Vendor',
+      hostingModel: 'saas',
+      lifecycleStatus: 'active',
+      description: markStarter('Modern cloud-based budgeting and financial reporting platform.'),
+      capabilities: ['Budget Reporting'],
+    },
+  ],
+
+  objectives: [
+    {
+      name: 'Improve Digital Service Delivery',
+      timeHorizon: 'FY2026',
+      description: markStarter('Make city services faster and easier to access online, reducing in-person visits and processing times.'),
+      successMetric: '80% of permit applications submitted online by end of FY2026',
+      capabilities: ['Online Permitting', 'Service Request Management', 'Digital Identity & Authentication'],
+    },
+  ],
+
+  adrs: [
+    {
+      number: 'ADR-001',
+      title: 'Adopt SaaS-first hosting for new application acquisitions',
+      status: 'accepted',
+      context: markStarter('Most government agencies of similar size cannot sustain a deep on-premises operations team. New application acquisitions favour SaaS where the data classification permits.'),
+      decision: 'All new application acquisitions evaluate SaaS hosting first. On-premises is the fallback when data residency, integration, or regulatory constraints rule SaaS out.',
+      consequences: 'Reduces operational burden on internal IT. Increases dependence on vendor SLAs and creates new procurement / contract review obligations.',
+      capabilities: ['Digital Identity & Authentication', 'Online Permitting'],
+    },
+    {
+      number: 'ADR-002',
+      title: 'Use OAuth 2.0 / OIDC for all resident-facing authentication flows',
+      status: 'accepted',
+      context: markStarter('Fragmented authentication across citizen-facing services creates security risk and a poor user experience.'),
+      decision: 'All resident-facing authentication flows implement OAuth 2.0 with OIDC. Staff use a designated cloud identity provider; residents have a separate credential store.',
+      consequences: 'Improves security posture and enables single sign-on for residents. Increases dependency on the identity provider\'s availability.',
+      capabilities: ['Digital Identity & Authentication'],
+    },
+  ],
+}

--- a/apps/govea/tests/integration/starter-content.test.ts
+++ b/apps/govea/tests/integration/starter-content.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration tests: applyStarterPack server action (#587)
+ *
+ * Covers:
+ *  - Admin can apply the EasyEA starter pack into a fresh org and gets
+ *    expected per-entity created counts.
+ *  - Contributor + viewer are rejected (admin-only).
+ *  - Re-applying the same pack is idempotent — existing items skip,
+ *    create counts go to zero.
+ *  - Junctions are created (capability ↔ persona, application ↔ capability,
+ *    objective ↔ capability, ADR ↔ capability).
+ *  - Items carry the STARTER_CONTENT_MARKER in their description so the
+ *    admin can find them later.
+ *  - ADR number collisions are resolved with a numeric suffix rather than
+ *    failing the row.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  personas, capabilities, applications, strategicObjectives, adrs,
+  capabilityPersonas, applicationCapabilities, objectiveCapabilities, adrCapabilities,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { applyStarterPack } from '@/actions/starter-content'
+import { STARTER_CONTENT_MARKER, EASYEA_STARTER } from '@/lib/starter-content/easyea-starter'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('applyStarterPack — EasyEA starter (#587)', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects contributor and viewer (admin-only)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    await expect(applyStarterPack('easyea-starter')).rejects.toThrow('Forbidden')
+
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(applyStarterPack('easyea-starter')).rejects.toThrow('Forbidden')
+  })
+
+  it('throws on unknown pack name', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    await expect(applyStarterPack('not-a-real-pack')).rejects.toThrow('Unknown starter pack')
+  })
+
+  it('admin can apply EasyEA starter into a fresh org', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const result = await applyStarterPack('easyea-starter')
+
+    expect(result.packName).toBe('easyea-starter')
+    expect(result.personasCreated).toBe(EASYEA_STARTER.personas.length)
+    expect(result.capabilitiesCreated).toBe(EASYEA_STARTER.capabilities.length)
+    expect(result.applicationsCreated).toBe(EASYEA_STARTER.applications.length)
+    expect(result.objectivesCreated).toBe(EASYEA_STARTER.objectives.length)
+    expect(result.adrsCreated).toBe(EASYEA_STARTER.adrs.length)
+    // Nothing skipped on a fresh org
+    expect(result.personasSkipped).toBe(0)
+    expect(result.capabilitiesSkipped).toBe(0)
+    expect(result.applicationsSkipped).toBe(0)
+    expect(result.objectivesSkipped).toBe(0)
+    expect(result.adrsSkipped).toBe(0)
+  })
+
+  it('tags every item with STARTER_CONTENT_MARKER in description', async () => {
+    const allPersonas = await db.select().from(personas).where(eq(personas.organizationId, orgId))
+    const allCaps = await db.select().from(capabilities).where(eq(capabilities.organizationId, orgId))
+    const allApps = await db.select().from(applications).where(eq(applications.organizationId, orgId))
+    const allObjs = await db.select().from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId))
+    const allAdrs = await db.select().from(adrs).where(eq(adrs.organizationId, orgId))
+
+    for (const p of allPersonas) expect(p.description).toContain(STARTER_CONTENT_MARKER)
+    for (const c of allCaps) expect(c.description).toContain(STARTER_CONTENT_MARKER)
+    for (const a of allApps) expect(a.description).toContain(STARTER_CONTENT_MARKER)
+    for (const o of allObjs) expect(o.description).toContain(STARTER_CONTENT_MARKER)
+    for (const adr of allAdrs) expect(adr.context).toContain(STARTER_CONTENT_MARKER)
+  })
+
+  it('creates capability ↔ persona junctions', async () => {
+    const onlinePermitting = await db.query.capabilities.findFirst({
+      where: and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Online Permitting')),
+    })
+    expect(onlinePermitting).toBeDefined()
+    const links = await db.select().from(capabilityPersonas).where(eq(capabilityPersonas.capabilityId, onlinePermitting!.id))
+    // Pack says Online Permitting links to Resident + Small Business Owner
+    expect(links).toHaveLength(2)
+  })
+
+  it('creates application ↔ capability junctions', async () => {
+    const permittingApp = await db.query.applications.findFirst({
+      where: and(eq(applications.organizationId, orgId), eq(applications.name, 'Example Permitting Platform')),
+    })
+    expect(permittingApp).toBeDefined()
+    const links = await db.select().from(applicationCapabilities).where(eq(applicationCapabilities.applicationId, permittingApp!.id))
+    expect(links).toHaveLength(2) // Online Permitting + Business License Management
+  })
+
+  it('creates objective ↔ capability junctions', async () => {
+    const obj = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'Improve Digital Service Delivery')),
+    })
+    expect(obj).toBeDefined()
+    const links = await db.select().from(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, obj!.id))
+    expect(links).toHaveLength(3) // Online Permitting, Service Request Management, Digital Identity & Authentication
+  })
+
+  it('creates ADR ↔ capability junctions', async () => {
+    const adr = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.title, 'Adopt SaaS-first hosting for new application acquisitions')),
+    })
+    expect(adr).toBeDefined()
+    const links = await db.select().from(adrCapabilities).where(eq(adrCapabilities.adrId, adr!.id))
+    expect(links).toHaveLength(2) // Digital Identity & Authentication, Online Permitting
+  })
+
+  it('is idempotent — re-applying skips existing items', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const result = await applyStarterPack('easyea-starter')
+
+    expect(result.personasCreated).toBe(0)
+    expect(result.capabilitiesCreated).toBe(0)
+    expect(result.applicationsCreated).toBe(0)
+    expect(result.objectivesCreated).toBe(0)
+    expect(result.adrsCreated).toBe(0)
+
+    expect(result.personasSkipped).toBe(EASYEA_STARTER.personas.length)
+    expect(result.capabilitiesSkipped).toBe(EASYEA_STARTER.capabilities.length)
+    expect(result.applicationsSkipped).toBe(EASYEA_STARTER.applications.length)
+    expect(result.objectivesSkipped).toBe(EASYEA_STARTER.objectives.length)
+    expect(result.adrsSkipped).toBe(EASYEA_STARTER.adrs.length)
+  })
+
+  it('avoids ADR number collisions by appending a numeric suffix', async () => {
+    // Seed a separate org with a pre-existing ADR-001 with a different title,
+    // then apply the starter and confirm the inserted ADR-001 from the pack
+    // becomes ADR-001-1 (collision-avoidance, not overwrite).
+    const isolatedOrg = await createTestOrg()
+    const isolatedAdmin = await createTestUser(isolatedOrg.id, 'admin')
+
+    await db.insert(adrs).values({
+      id: randomUUID(),
+      organizationId: isolatedOrg.id,
+      number: 'ADR-001',
+      title: 'Existing decision unrelated to the starter',
+      status: 'accepted',
+      visibility: 'org',
+    })
+
+    mockAuth.mockResolvedValue(makeSession(isolatedAdmin))
+    const result = await applyStarterPack('easyea-starter')
+    expect(result.adrsCreated).toBe(EASYEA_STARTER.adrs.length)
+
+    const allAdrs = await db.select({ number: adrs.number, title: adrs.title })
+      .from(adrs).where(eq(adrs.organizationId, isolatedOrg.id))
+    // We now have: existing ADR-001 + starter's ADR-001 (which became ADR-001-1) + ADR-002.
+    const adrNumbers = allAdrs.map(a => a.number).sort()
+    expect(adrNumbers).toEqual(['ADR-001', 'ADR-001-1', 'ADR-002'])
+
+    await cleanupOrg(isolatedOrg.id)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the blank-canvas problem the Early-Maturity EA Practice Lead persona file names as its most acute pain (#587 / #586). A brand-new admin no longer lands in an empty org with no path to a credible week-2 leadership demo.

## What ships

1. **Starter Content section** in \`/settings\` (admin-only):
   - **EasyEA Starter pack** — 4 personas, 6 capabilities, 3 applications, 1 strategic objective, 2 ADRs. All junctions wired (capability ↔ persona, application ↔ capability, objective ↔ capability, ADR ↔ capability). The smallest credible city.
   - **\`applyStarterPack\` server action** — idempotent. Re-running skips existing items rather than duplicating. ADR number collisions resolve with a numeric suffix.
   - **Plain-language marker** on every item: *\"Example starter content — replace or delete.\"* added to descriptions so the admin can identify starter rows later.

2. **Inline empty-state CTAs** on \`/capabilities\`, \`/applications\`, \`/personas\`:
   - Existing "No X yet. Add one to get started." → upgraded to point at both the inline "+ New X" action and "apply a starter pack in Settings" — two clear forward paths instead of an empty table.

## Test plan

- [x] 10 new integration tests (\`tests/integration/starter-content.test.ts\`):
  - Admin-only enforcement (contributor + viewer rejected)
  - Unknown-pack-name throws
  - Full apply into a fresh org with expected per-entity counts
  - STARTER_CONTENT_MARKER tagged on every item's description
  - All 4 junction types created with correct cardinality
  - Idempotency: re-apply reports 0 created, N skipped
  - ADR number collision resolution (ADR-001-1 fallback)
- [x] All 10 pass (504 ms)
- [x] \`tsc --noEmit\` clean
- [x] Browser walk on dev preview as Alice Admin:
  - \`/settings\` renders the new "Starter Content" section first
  - Apply on Riverdale (already has most pack content) reports the expected mixed counts: \`0 personas added · 4 already present\`, \`0 capabilities added · 6 already present\`, \`3 applications added · 0 already present\`, etc. — proving idempotency end-to-end
  - Settings result panel shows the per-entity counts with the marker explanation

## Architecture note: where the data lives

\`AVAILABLE_STARTER_PACKS\` and \`STARTER_CONTENT_MARKER\` live in the data module (\`lib/starter-content/easyea-starter.ts\`), **not** the server-action module. Next.js \`'use server'\` files can only export async functions; importing constants from them crashes at runtime. Caught this during the live verification — fixed before merge.

## Out of scope (follow-up under same issue)

- **First-sign-in three-choice gate** (tour / starter / from-scratch modal). Needs a per-user "first-seen" flag the schema doesn't have. Not a blocker — Settings discovery + empty-state CTA covers the same ground at lower cost.
- **Archive all starter content** one-click action. The marker is the identification mechanism today; a side table tracking which rows came from which pack would let us archive cleanly later.
- **Federal / state agency reference packs.** Pattern is extensible — add to \`AVAILABLE_STARTER_PACKS\` + \`resolvePack()\`.

## Capability traceability

Capability: candidate new \`ac-starter-content\`; supports \`rm-repository-completeness\`
Persona: early-maturity-practice-lead (primary); also serves consultant-si, agency-ea-coordinator
Closes #587 (core starter content + empty-state CTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)