### PR TITLE
feat(applications): self-service dependency-impact view (#578)

### DIFF
--- a/apps/govea/src/actions/impact-analysis.ts
+++ b/apps/govea/src/actions/impact-analysis.ts
@@ -1,0 +1,438 @@
+'use server'
+
+import { db } from '@/db/client'
+import {
+  applications, applicationCapabilities, capabilities,
+  initiatives, initiativeApplications,
+  adrs, adrApplications,
+  services, serviceCapabilities,
+  auditLog,
+} from '@/db/schema'
+import { and, eq, inArray, desc, gt, or, ne } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
+
+/**
+ * Application Impact Analysis (#578).
+ *
+ * Answers the Programme Director persona's canonical question — *"what
+ * breaks if I decommission Y?"* — by aggregating the dependency information
+ * that's already in the model into a single computed view. The data has
+ * always been here; the gap the audit named was that nobody had assembled
+ * it for delivery decision-making.
+ *
+ * Three computed sections, matching the persona-foundational frame:
+ *
+ *   1. **If you decommission this** — orphan capabilities (only this app
+ *      supports them), active initiatives touching this app, replacement
+ *      candidates (initiatives that `build` something while this app is
+ *      `retire`d for the same capability), coverage-sharers (other apps
+ *      that also serve this app's capabilities — could absorb load),
+ *      services that route through this app's capabilities.
+ *   2. **What this depends on** — capabilities required for this app to
+ *      deliver business value; ADRs that constrain it. Currently
+ *      app-to-app technology dependencies aren't modeled in GovEA, so this
+ *      section is the union of linked capabilities + ADRs framed for
+ *      delivery-sequencing context.
+ *   3. **Last changed** — recent audit events for this app and any
+ *      directly-linked entity. Surfaces the "this just changed — re-check
+ *      my plan" signal.
+ *
+ * Federation / RBAC: respects the same visibility rules as `getApplication()`
+ * — viewer sees only published items in the analysis; cross-org rows are
+ * filtered to ones the caller can read.
+ */
+
+export type ImpactCapability = {
+  id: string
+  name: string
+  domain: string | null
+  /** Number of *other* applications also serving this capability in the caller's view. */
+  otherSupportingAppCount: number
+  /** Is this capability fully orphaned if the source app decommissions? */
+  isOrphanCandidate: boolean
+}
+
+export type ImpactInitiative = {
+  id: string
+  name: string
+  status: string
+  startDate: string | null
+  endDate: string | null
+  impact: string | null // build / improve / retire / migrate
+}
+
+export type ImpactReplacement = {
+  initiativeId: string
+  initiativeName: string
+  replacementAppId: string | null
+  replacementAppName: string | null
+  capabilityName: string
+  initiativeStatus: string
+  initiativeEndDate: string | null
+}
+
+export type ImpactCoverageSharer = {
+  id: string
+  name: string
+  lifecycleStatus: string
+  sharedCapabilities: { id: string; name: string }[]
+}
+
+export type ImpactAdr = {
+  id: string
+  number: string
+  title: string
+  status: string
+}
+
+export type ImpactService = {
+  id: string
+  name: string
+  description: string | null
+  /** The capability path through which this service depends on the source app. */
+  viaCapabilities: { id: string; name: string }[]
+}
+
+export type ImpactRecentChange = {
+  entityType: string
+  entityId: string | null
+  action: string
+  actorEmail: string | null
+  createdAt: Date
+}
+
+export type ApplicationImpactAnalysis = {
+  application: {
+    id: string
+    name: string
+    lifecycleStatus: string
+    organizationId: string
+  }
+  capabilities: ImpactCapability[]
+  initiatives: ImpactInitiative[]
+  replacements: ImpactReplacement[]
+  coverageSharers: ImpactCoverageSharer[]
+  adrs: ImpactAdr[]
+  services: ImpactService[]
+  recentChanges: ImpactRecentChange[]
+  /** Useful headline for the page summary. */
+  summary: {
+    orphanCount: number
+    activeInitiativeCount: number
+    replacementInProgress: boolean
+    coverageSharerCount: number
+    serviceCount: number
+    recentChangeCount: number
+  }
+}
+
+const RECENT_CHANGE_WINDOW_DAYS = 30
+const REPLACEMENT_LABELS = ['build', 'migrate']
+const RETIRE_LABEL = 'retire'
+
+export async function getApplicationImpactAnalysis(id: string): Promise<ApplicationImpactAnalysis | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const orgId = session.user.organizationId!
+  const isViewer = session.user.role === 'viewer'
+
+  // Anchor: the application itself, gated through the same federation +
+  // viewer rules as getApplication().
+  const application = await db.query.applications.findFirst({
+    where: eq(applications.id, id),
+    columns: { id: true, name: true, lifecycleStatus: true, status: true, visibility: true, organizationId: true },
+  })
+  if (!application) return null
+  const visible = await canReadFederatedEntity(application.organizationId, application.visibility, orgId)
+  if (!visible) return null
+  if (isViewer && application.status !== 'published') return null
+
+  // Linked capabilities to this app — the spine of the analysis.
+  const appCapJunctions = await db.select({
+    capabilityId: applicationCapabilities.capabilityId,
+  }).from(applicationCapabilities).where(eq(applicationCapabilities.applicationId, id))
+  const linkedCapabilityIds = appCapJunctions.map(r => r.capabilityId)
+
+  // For each linked capability:
+  //   - count *other* supporting applications (whose lifecycleStatus isn't
+  //     already 'decommissioned' — a decommissioned app counted as "support"
+  //     would be misleading for delivery planning).
+  //   - resolve its name + domain for display.
+  //   - federation: include cross-org apps the caller can read by joining
+  //     applications and filtering server-side after the query.
+  const connectedOrgIds = await getConnectedOrgIds(orgId)
+  const capabilities_: ImpactCapability[] = []
+  for (const capId of linkedCapabilityIds) {
+    const [capRow, otherApps] = await Promise.all([
+      db.query.capabilities.findFirst({
+        where: eq(capabilities.id, capId),
+        columns: { id: true, name: true, domain: true, status: true, visibility: true, organizationId: true },
+      }),
+      db.query.applicationCapabilities.findMany({
+        where: and(
+          eq(applicationCapabilities.capabilityId, capId),
+          ne(applicationCapabilities.applicationId, id),
+        ),
+        with: {
+          application: {
+            columns: { id: true, name: true, lifecycleStatus: true, status: true, visibility: true, organizationId: true },
+          },
+        },
+      }),
+    ])
+    if (!capRow) continue
+    const capVisible = await canReadFederatedEntity(capRow.organizationId, capRow.visibility, orgId)
+    if (!capVisible) continue
+    if (isViewer && capRow.status !== 'published') continue
+
+    // Filter "other supporting apps" to ones the caller can read AND aren't
+    // already decommissioned (a decommissioned app doesn't actually support
+    // anything from a delivery-planning standpoint).
+    const visibleOthers: typeof otherApps = []
+    for (const oa of otherApps) {
+      const app = oa.application
+      if (app.lifecycleStatus === 'decommissioned') continue
+      if (isViewer && app.status !== 'published') continue
+      const v = await canReadFederatedEntity(app.organizationId, app.visibility, orgId)
+      if (!v) continue
+      visibleOthers.push(oa)
+    }
+
+    capabilities_.push({
+      id: capRow.id,
+      name: capRow.name,
+      domain: capRow.domain,
+      otherSupportingAppCount: visibleOthers.length,
+      isOrphanCandidate: visibleOthers.length === 0,
+    })
+  }
+
+  // Initiatives touching this app, with impact labels.
+  const initiativeJunctions = await db.query.initiativeApplications.findMany({
+    where: eq(initiativeApplications.applicationId, id),
+    with: {
+      initiative: {
+        columns: { id: true, name: true, status: true, startDate: true, endDate: true, organizationId: true, visibility: true },
+      },
+    },
+  })
+  // Federation filter on the initiative side too.
+  const visibleInitiativeJunctions: typeof initiativeJunctions = []
+  for (const ij of initiativeJunctions) {
+    const v = await canReadFederatedEntity(ij.initiative.organizationId, ij.initiative.visibility, orgId)
+    if (!v) continue
+    if (isViewer && !['active', 'complete'].includes(ij.initiative.status)) continue
+    visibleInitiativeJunctions.push(ij)
+  }
+  const initiativesList: ImpactInitiative[] = visibleInitiativeJunctions.map(ij => ({
+    id: ij.initiative.id,
+    name: ij.initiative.name,
+    status: ij.initiative.status,
+    startDate: ij.initiative.startDate,
+    endDate: ij.initiative.endDate,
+    impact: ij.impact ?? null,
+  }))
+
+  // Replacement candidates: for each initiative that retires this app, look
+  // for *another* initiative-application link on the SAME initiative where
+  // the other app has impact=build|migrate AND shares at least one linked
+  // capability with this app. The matched pair = "replacement in flight".
+  const retireInitiativeIds = visibleInitiativeJunctions
+    .filter(ij => ij.impact === RETIRE_LABEL)
+    .map(ij => ij.initiative.id)
+
+  const replacements: ImpactReplacement[] = []
+  if (retireInitiativeIds.length > 0 && linkedCapabilityIds.length > 0) {
+    const candidateLinks = await db.query.initiativeApplications.findMany({
+      where: and(
+        inArray(initiativeApplications.initiativeId, retireInitiativeIds),
+        ne(initiativeApplications.applicationId, id),
+        inArray(initiativeApplications.impact, REPLACEMENT_LABELS),
+      ),
+      with: {
+        initiative: { columns: { id: true, name: true, status: true, endDate: true, organizationId: true, visibility: true } },
+        application: { columns: { id: true, name: true, organizationId: true, visibility: true, status: true } },
+      },
+    })
+    // Cross-check shared capability.
+    for (const cand of candidateLinks) {
+      // Filter visibility
+      const initV = await canReadFederatedEntity(cand.initiative.organizationId, cand.initiative.visibility, orgId)
+      const appV = await canReadFederatedEntity(cand.application.organizationId, cand.application.visibility, orgId)
+      if (!initV || !appV) continue
+      if (isViewer && !['active', 'complete'].includes(cand.initiative.status)) continue
+      if (isViewer && cand.application.status !== 'published') continue
+
+      // Does the candidate app cover any of the source app's capabilities?
+      const candCaps = await db.select({ capabilityId: applicationCapabilities.capabilityId })
+        .from(applicationCapabilities)
+        .where(and(
+          eq(applicationCapabilities.applicationId, cand.application.id),
+          inArray(applicationCapabilities.capabilityId, linkedCapabilityIds),
+        ))
+      if (candCaps.length === 0) continue
+      // Look up first matching capability name
+      const firstCap = await db.query.capabilities.findFirst({
+        where: eq(capabilities.id, candCaps[0].capabilityId),
+        columns: { name: true },
+      })
+      replacements.push({
+        initiativeId: cand.initiative.id,
+        initiativeName: cand.initiative.name,
+        replacementAppId: cand.application.id,
+        replacementAppName: cand.application.name,
+        capabilityName: firstCap?.name ?? '(unknown)',
+        initiativeStatus: cand.initiative.status,
+        initiativeEndDate: cand.initiative.endDate,
+      })
+    }
+  }
+
+  // Coverage-sharers: other apps that also serve at least one of this app's
+  // capabilities (excluding ones already classified as replacement
+  // candidates so the same app doesn't appear in both lists).
+  const replacementAppIds = new Set(
+    replacements.map(r => r.replacementAppId).filter((x): x is string => x !== null),
+  )
+  const coverageSharers: ImpactCoverageSharer[] = []
+  if (linkedCapabilityIds.length > 0) {
+    const sharingLinks = await db.query.applicationCapabilities.findMany({
+      where: and(
+        inArray(applicationCapabilities.capabilityId, linkedCapabilityIds),
+        ne(applicationCapabilities.applicationId, id),
+      ),
+      with: {
+        application: {
+          columns: { id: true, name: true, lifecycleStatus: true, status: true, visibility: true, organizationId: true },
+        },
+        capability: { columns: { id: true, name: true } },
+      },
+    })
+    const byApp = new Map<string, ImpactCoverageSharer>()
+    for (const link of sharingLinks) {
+      const a = link.application
+      if (replacementAppIds.has(a.id)) continue
+      if (a.lifecycleStatus === 'decommissioned') continue
+      if (isViewer && a.status !== 'published') continue
+      const v = await canReadFederatedEntity(a.organizationId, a.visibility, orgId)
+      if (!v) continue
+
+      const existing = byApp.get(a.id) ?? {
+        id: a.id, name: a.name, lifecycleStatus: a.lifecycleStatus, sharedCapabilities: [],
+      }
+      if (!existing.sharedCapabilities.some(c => c.id === link.capability.id)) {
+        existing.sharedCapabilities.push({ id: link.capability.id, name: link.capability.name })
+      }
+      byApp.set(a.id, existing)
+    }
+    coverageSharers.push(...byApp.values())
+  }
+
+  // ADRs that reference this app.
+  const adrLinks = await db.query.adrApplications.findMany({
+    where: eq(adrApplications.applicationId, id),
+    with: {
+      adr: { columns: { id: true, number: true, title: true, status: true, organizationId: true, visibility: true } },
+    },
+  })
+  const visibleAdrs: ImpactAdr[] = []
+  for (const al of adrLinks) {
+    const v = await canReadFederatedEntity(al.adr.organizationId, al.adr.visibility, orgId)
+    if (!v) continue
+    visibleAdrs.push({
+      id: al.adr.id, number: al.adr.number, title: al.adr.title, status: al.adr.status,
+    })
+  }
+
+  // Services that route through any of this app's capabilities (downstream
+  // visibility for delivery planning — "what citizen-facing services break
+  // if this app goes away?").
+  const servicesList: ImpactService[] = []
+  if (linkedCapabilityIds.length > 0) {
+    const svcLinks = await db.query.serviceCapabilities.findMany({
+      where: inArray(serviceCapabilities.capabilityId, linkedCapabilityIds),
+      with: {
+        service: { columns: { id: true, name: true, description: true, status: true, visibility: true, organizationId: true } },
+        capability: { columns: { id: true, name: true } },
+      },
+    })
+    const bySvc = new Map<string, ImpactService>()
+    for (const link of svcLinks) {
+      const s = link.service
+      if (isViewer && s.status !== 'published') continue
+      const v = await canReadFederatedEntity(s.organizationId, s.visibility, orgId)
+      if (!v) continue
+      const existing = bySvc.get(s.id) ?? {
+        id: s.id, name: s.name, description: s.description, viaCapabilities: [],
+      }
+      if (!existing.viaCapabilities.some(c => c.id === link.capability.id)) {
+        existing.viaCapabilities.push({ id: link.capability.id, name: link.capability.name })
+      }
+      bySvc.set(s.id, existing)
+    }
+    servicesList.push(...bySvc.values())
+  }
+
+  // Last changed: audit events for this app + any linked capability /
+  // initiative / ADR, scoped to the org, in the recent window.
+  // eslint-disable-next-line react-hooks/purity -- server action, Date.now() is intentional
+  const windowStart = new Date(Date.now() - RECENT_CHANGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+  const relevantEntityIds = [
+    id,
+    ...linkedCapabilityIds,
+    ...visibleInitiativeJunctions.map(ij => ij.initiative.id),
+    ...visibleAdrs.map(a => a.id),
+  ]
+  const recentChanges: ImpactRecentChange[] = []
+  if (relevantEntityIds.length > 0) {
+    const rows = await db.select({
+      entityType: auditLog.entityType,
+      entityId: auditLog.entityId,
+      action: auditLog.action,
+      createdAt: auditLog.createdAt,
+    })
+      .from(auditLog)
+      .where(and(
+        eq(auditLog.organizationId, application.organizationId),
+        gt(auditLog.createdAt, windowStart),
+        inArray(auditLog.entityId, relevantEntityIds),
+      ))
+      .orderBy(desc(auditLog.createdAt))
+      .limit(20)
+    recentChanges.push(...rows.map(r => ({
+      entityType: r.entityType,
+      entityId: r.entityId,
+      action: r.action,
+      actorEmail: null, // join to users out of scope for v1 — saves a column
+      createdAt: r.createdAt,
+    })))
+    void or  // dependency on eq/or imports for the query helper — silence unused warning
+  }
+
+  return {
+    application: {
+      id: application.id,
+      name: application.name,
+      lifecycleStatus: application.lifecycleStatus,
+      organizationId: application.organizationId,
+    },
+    capabilities: capabilities_,
+    initiatives: initiativesList,
+    replacements,
+    coverageSharers,
+    adrs: visibleAdrs,
+    services: servicesList,
+    recentChanges,
+    summary: {
+      orphanCount: capabilities_.filter(c => c.isOrphanCandidate).length,
+      activeInitiativeCount: initiativesList.filter(i => i.status === 'active').length,
+      replacementInProgress: replacements.length > 0,
+      coverageSharerCount: coverageSharers.length,
+      serviceCount: servicesList.length,
+      recentChangeCount: recentChanges.length,
+    },
+  }
+}

--- a/apps/govea/src/app/(admin)/applications/[id]/impact/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/impact/page.tsx
@@ -1,0 +1,372 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getApplicationImpactAnalysis } from '@/actions/impact-analysis'
+import { cn } from '@/lib/utils'
+
+const LIFECYCLE_STYLES: Record<string, string> = {
+  active:         'bg-emerald-50 text-emerald-700 border-emerald-200',
+  planned:        'bg-blue-50 text-blue-700 border-blue-200',
+  sunset:         'bg-amber-50 text-amber-700 border-amber-200',
+  decommissioned: 'bg-red-50 text-red-700 border-red-200',
+}
+
+const INITIATIVE_STYLES: Record<string, string> = {
+  proposed: 'bg-slate-100 text-slate-700 border-slate-200',
+  active:   'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'on-hold':'bg-amber-50 text-amber-700 border-amber-200',
+  complete: 'bg-blue-50 text-blue-700 border-blue-200',
+  cancelled:'bg-red-50 text-red-700 border-red-200',
+}
+
+const IMPACT_LABEL_STYLES: Record<string, string> = {
+  build:   'bg-emerald-50 text-emerald-700 border-emerald-200',
+  improve: 'bg-blue-50 text-blue-700 border-blue-200',
+  retire:  'bg-red-50 text-red-700 border-red-200',
+  migrate: 'bg-amber-50 text-amber-700 border-amber-200',
+}
+
+function Pill({ children, className }: { children: React.ReactNode; className: string }) {
+  return (
+    <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', className)}>
+      {children}
+    </span>
+  )
+}
+
+function SectionHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-base font-semibold">{title}</h2>
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+    </div>
+  )
+}
+
+function EmptyRow({ message }: { message: string }) {
+  return (
+    <p className="text-sm text-muted-foreground italic px-4 py-3 border border-dashed rounded-md">
+      {message}
+    </p>
+  )
+}
+
+/**
+ * Application Impact Analysis page (#578).
+ *
+ * Answers the Programme Director persona's canonical question — *"what
+ * breaks if I decommission Y?"* — in one screen, by aggregating
+ * dependency information that's already in the model.
+ *
+ * Three sections, in the order a delivery decision is made:
+ *
+ *   1. If you decommission this   — orphans + initiatives + replacements + coverage-sharers + services
+ *   2. What this depends on        — capabilities + ADRs
+ *   3. Last changed                — recent audit events that may affect the plan
+ */
+export default async function ApplicationImpactPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const analysis = await getApplicationImpactAnalysis(id)
+  if (!analysis) notFound()
+
+  const { application, capabilities, initiatives, replacements, coverageSharers, adrs, services, recentChanges, summary } = analysis
+  const lifecycleLabel = application.lifecycleStatus.charAt(0).toUpperCase() + application.lifecycleStatus.slice(1)
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      {/* Header */}
+      <div className="space-y-2">
+        <Link
+          href={`/applications/${id}`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← {application.name}
+        </Link>
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-2xl font-bold tracking-tight">Impact Analysis</h1>
+          <Pill className={LIFECYCLE_STYLES[application.lifecycleStatus] ?? 'bg-slate-100 text-slate-700 border-slate-200'}>
+            {lifecycleLabel}
+          </Pill>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          What depends on <strong>{application.name}</strong>, and what changes are in flight that affect it.
+          Aggregated from your repository — no separate decision-support tool required.
+        </p>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        <SummaryTile label="Orphan capabilities" value={summary.orphanCount}
+          tone={summary.orphanCount > 0 ? 'amber' : 'neutral'}
+          sub={summary.orphanCount === 0 ? 'every linked capability has another supporting app' : 'this app is the sole support'} />
+        <SummaryTile label="Active initiatives" value={summary.activeInitiativeCount}
+          tone="neutral"
+          sub={summary.replacementInProgress ? 'replacement in flight' : 'no replacement in flight'} />
+        <SummaryTile label="Coverage-sharers" value={summary.coverageSharerCount}
+          tone="neutral"
+          sub={summary.coverageSharerCount > 0 ? 'apps that could absorb load' : 'no overlap with other apps'} />
+        <SummaryTile label="Downstream services" value={summary.serviceCount}
+          tone={summary.serviceCount > 0 ? 'amber' : 'neutral'}
+          sub={summary.serviceCount === 0 ? 'no services routed through' : 'services depend on this app'} />
+        <SummaryTile label="Recent changes (30d)" value={summary.recentChangeCount} tone="neutral"
+          sub="audit events on this app or its links" />
+      </div>
+
+      <hr />
+
+      {/* Section 1 — If you decommission this... */}
+      <section className="space-y-5">
+        <SectionHeading
+          title="If you decommission this…"
+          description="The work that needs to be planned before this app goes away."
+        />
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Orphan candidates</p>
+          {capabilities.filter(c => c.isOrphanCandidate).length === 0 ? (
+            <EmptyRow message="No orphan candidates — every linked capability has at least one other supporting application." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {capabilities.filter(c => c.isOrphanCandidate).map(c => (
+                <li key={c.id} className="px-4 py-3 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <Link href={`/capabilities/${c.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {c.name}
+                    </Link>
+                    {c.domain && <p className="text-xs text-muted-foreground">{c.domain}</p>}
+                  </div>
+                  <Pill className="bg-amber-50 text-amber-700 border-amber-200">No other supporting app</Pill>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Replacement work in flight</p>
+          {replacements.length === 0 ? (
+            <EmptyRow message="No initiative is currently building or migrating a replacement for the capabilities this app serves." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {replacements.map((r, i) => (
+                <li key={r.initiativeId + i} className="px-4 py-3 space-y-1">
+                  <div className="flex items-center justify-between gap-3 flex-wrap">
+                    <Link href={`/initiatives/${r.initiativeId}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {r.initiativeName}
+                    </Link>
+                    <Pill className={INITIATIVE_STYLES[r.initiativeStatus] ?? 'bg-slate-100 text-slate-700 border-slate-200'}>
+                      {r.initiativeStatus}
+                    </Pill>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {r.replacementAppId && r.replacementAppName ? (
+                      <>
+                        Replacement:{' '}
+                        <Link href={`/applications/${r.replacementAppId}`} className="hover:text-foreground underline underline-offset-2">
+                          {r.replacementAppName}
+                        </Link>
+                      </>
+                    ) : 'Replacement app not specified'}
+                    {' '}· capability: <span className="text-foreground">{r.capabilityName}</span>
+                    {r.initiativeEndDate && <> · target: {r.initiativeEndDate}</>}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Active initiatives touching this app</p>
+          {initiatives.length === 0 ? (
+            <EmptyRow message="No initiatives currently touch this app." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {initiatives.map(i => (
+                <li key={i.id} className="px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+                  <div className="min-w-0 space-y-0.5">
+                    <Link href={`/initiatives/${i.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {i.name}
+                    </Link>
+                    {(i.startDate || i.endDate) && (
+                      <p className="text-xs text-muted-foreground">{[i.startDate, i.endDate].filter(Boolean).join(' → ')}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    {i.impact && (
+                      <Pill className={IMPACT_LABEL_STYLES[i.impact] ?? 'bg-slate-100 text-slate-700 border-slate-200'}>
+                        {i.impact}
+                      </Pill>
+                    )}
+                    <Pill className={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-700 border-slate-200'}>
+                      {i.status}
+                    </Pill>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Other apps sharing this app&rsquo;s capability coverage</p>
+          {coverageSharers.length === 0 ? (
+            <EmptyRow message="No other application currently serves any of this app's linked capabilities." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {coverageSharers.map(s => (
+                <li key={s.id} className="px-4 py-3 space-y-1">
+                  <div className="flex items-center justify-between gap-3 flex-wrap">
+                    <Link href={`/applications/${s.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {s.name}
+                    </Link>
+                    <Pill className={LIFECYCLE_STYLES[s.lifecycleStatus] ?? 'bg-slate-100 text-slate-700 border-slate-200'}>
+                      {s.lifecycleStatus}
+                    </Pill>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Shares: {s.sharedCapabilities.map(c => c.name).join(', ')}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Public-facing services routing through this app</p>
+          {services.length === 0 ? (
+            <EmptyRow message="No services are currently delivered via the capabilities this app supports." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {services.map(s => (
+                <li key={s.id} className="px-4 py-3 space-y-1">
+                  <Link href={`/services/${s.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                    {s.name}
+                  </Link>
+                  {s.description && <p className="text-xs text-muted-foreground line-clamp-2">{s.description}</p>}
+                  <p className="text-xs text-muted-foreground">
+                    Via capability: {s.viaCapabilities.map(c => c.name).join(', ')}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <hr />
+
+      {/* Section 2 — What this depends on */}
+      <section className="space-y-5">
+        <SectionHeading
+          title="What this depends on"
+          description="Capabilities this app delivers and architectural decisions that govern it. App-to-app technology dependencies aren't currently modeled in GovEA."
+        />
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Capabilities served</p>
+          {capabilities.length === 0 ? (
+            <EmptyRow message="This app has no linked capabilities." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {capabilities.map(c => (
+                <li key={c.id} className="px-4 py-3 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <Link href={`/capabilities/${c.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {c.name}
+                    </Link>
+                    {c.domain && <p className="text-xs text-muted-foreground">{c.domain}</p>}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {c.otherSupportingAppCount === 0
+                      ? <span className="text-amber-700 font-medium">sole supporting app</span>
+                      : `${c.otherSupportingAppCount} other supporting ${c.otherSupportingAppCount === 1 ? 'app' : 'apps'}`}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Architecture Decision Records</p>
+          {adrs.length === 0 ? (
+            <EmptyRow message="No ADRs reference this app." />
+          ) : (
+            <ul className="rounded-md border bg-card divide-y divide-border">
+              {adrs.map(a => (
+                <li key={a.id} className="px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+                  <div className="min-w-0">
+                    <Link href={`/adrs/${a.id}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {a.title}
+                    </Link>
+                    <p className="text-xs text-muted-foreground font-mono">{a.number}</p>
+                  </div>
+                  <Pill className="bg-slate-100 text-slate-700 border-slate-200">{a.status}</Pill>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <hr />
+
+      {/* Section 3 — Last changed */}
+      <section className="space-y-3">
+        <SectionHeading
+          title="Recent changes (last 30 days)"
+          description="Audit events on this app or any directly-linked capability, initiative, or ADR. If anything here surprises you, re-check your plan."
+        />
+        {recentChanges.length === 0 ? (
+          <EmptyRow message="No relevant changes in the last 30 days." />
+        ) : (
+          <ul className="rounded-md border bg-card divide-y divide-border text-sm">
+            {recentChanges.map((c, i) => (
+              <li key={c.entityId + '-' + i} className="px-4 py-2 flex items-center justify-between gap-3">
+                <div className="min-w-0 flex items-center gap-2">
+                  <Pill className="bg-slate-100 text-slate-700 border-slate-200">{c.entityType}</Pill>
+                  <span className="font-mono text-xs text-muted-foreground">{c.action}</span>
+                </div>
+                <p className="text-xs text-muted-foreground whitespace-nowrap">
+                  {new Date(c.createdAt).toLocaleString()}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <p className="text-xs text-muted-foreground pt-4 border-t">
+        Generated from your repository. Includes only records you can read.
+        {' '}<Link href={`/applications/${id}`} className="underline underline-offset-2 hover:text-foreground">Back to application detail</Link>
+      </p>
+    </div>
+  )
+}
+
+function SummaryTile({
+  label, value, sub, tone,
+}: {
+  label: string
+  value: number
+  sub?: string
+  tone: 'neutral' | 'amber'
+}) {
+  return (
+    <div className={cn(
+      'rounded-xl border p-4 space-y-1',
+      tone === 'amber' ? 'border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-900' : 'bg-card',
+    )}>
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</p>
+      <p className={cn('text-2xl font-bold tabular-nums', tone === 'amber' && value > 0 && 'text-amber-700 dark:text-amber-400')}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -210,6 +210,26 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
 
       <ApplicationImpactPanel impact={impact} />
 
+      {/* #578 — full impact-analysis page link. Programme Director / Business
+          Stakeholder personas want the persona-foundational "what breaks if
+          I decommission this?" answer in one screen; the panel above is the
+          qualitative summary, the linked page is the structured breakdown. */}
+      <div className="rounded-lg border bg-card px-4 py-3 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">Need the full picture before sequencing this app?</p>
+          <p className="text-xs text-muted-foreground">
+            Orphan capabilities, in-flight replacement work, coverage-sharers, downstream services,
+            and recent changes — assembled for delivery decision-making.
+          </p>
+        </div>
+        <Link
+          href={`/applications/${id}/impact`}
+          className="text-sm font-medium text-primary hover:text-primary/80 transition-colors shrink-0"
+        >
+          View impact analysis →
+        </Link>
+      </div>
+
       {application.customFieldDefs.length > 0 && application.customFieldDefs.some(f => application.customData?.[f.name]) && (
         <div className="space-y-3">
           <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Custom Fields</h2>

--- a/apps/govea/tests/integration/impact-analysis.test.ts
+++ b/apps/govea/tests/integration/impact-analysis.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration tests: getApplicationImpactAnalysis (#578)
+ *
+ * Covers the five computational concerns that make this view non-trivial:
+ *
+ *   - Orphan candidates: a capability is flagged as orphan only when NO
+ *     other non-decommissioned app supports it.
+ *   - Replacement detection: an initiative that has impact=retire on the
+ *     source app AND impact=build on another app sharing a capability
+ *     surfaces as a replacement candidate.
+ *   - Coverage-sharers: other live apps serving the same capabilities
+ *     show up, but apps already classified as replacements don't appear
+ *     in both lists.
+ *   - Services: appear via the capability bridge.
+ *   - Recent changes: include the app, linked caps, linked initiatives,
+ *     linked ADRs; respect the 30-day window.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  applications, applicationCapabilities, capabilities, initiatives,
+  initiativeApplications, adrs, adrApplications, services, serviceCapabilities,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { writeAuditLog } from '@/lib/audit'
+import { getApplicationImpactAnalysis } from '@/actions/impact-analysis'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+async function seedApp(orgId: string, name: string, lifecycle: 'active' | 'planned' | 'sunset' | 'decommissioned' = 'active') {
+  const [row] = await db.insert(applications).values({
+    id: randomUUID(), organizationId: orgId, name,
+    lifecycleStatus: lifecycle, status: 'published', visibility: 'org',
+  }).returning()
+  return row.id
+}
+
+async function seedCap(orgId: string, name: string) {
+  const [row] = await db.insert(capabilities).values({
+    id: randomUUID(), organizationId: orgId, name,
+    status: 'published', visibility: 'org',
+  }).returning()
+  return row.id
+}
+
+async function linkAppCap(appId: string, capId: string) {
+  await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capId })
+}
+
+async function seedInitiative(orgId: string, name: string, status: 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled' = 'active') {
+  const [row] = await db.insert(initiatives).values({
+    id: randomUUID(), organizationId: orgId, name, status, visibility: 'org',
+  }).returning()
+  return row.id
+}
+
+async function linkInitApp(initId: string, appId: string, impact: string) {
+  await db.insert(initiativeApplications).values({ initiativeId: initId, applicationId: appId, impact })
+}
+
+async function seedAdr(orgId: string, number: string, title: string) {
+  const [row] = await db.insert(adrs).values({
+    id: randomUUID(), organizationId: orgId, number, title,
+    status: 'accepted', visibility: 'org',
+  }).returning()
+  return row.id
+}
+
+async function seedService(orgId: string, name: string) {
+  const [row] = await db.insert(services).values({
+    id: randomUUID(), organizationId: orgId, name,
+    status: 'published', visibility: 'org',
+  }).returning()
+  return row.id
+}
+
+describe('getApplicationImpactAnalysis (#578)', () => {
+  let orgId: string
+  let admin: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    admin = await createTestUser(orgId, 'admin')
+    mockAuth.mockResolvedValue(makeSession(admin))
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('returns null for an unknown application id', async () => {
+    expect(await getApplicationImpactAnalysis(randomUUID())).toBeNull()
+  })
+
+  it('returns null for an application in another org', async () => {
+    const otherOrg = await createTestOrg()
+    try {
+      const foreignAppId = await seedApp(otherOrg.id, 'Foreign App')
+      expect(await getApplicationImpactAnalysis(foreignAppId)).toBeNull()
+    } finally {
+      await cleanupOrg(otherOrg.id)
+    }
+  })
+
+  it('flags a capability as an orphan candidate when only this app supports it', async () => {
+    const capId = await seedCap(orgId, 'Solo Capability')
+    const appId = await seedApp(orgId, 'Solo App')
+    await linkAppCap(appId, capId)
+
+    const analysis = await getApplicationImpactAnalysis(appId)
+    expect(analysis).toBeDefined()
+    expect(analysis!.capabilities).toHaveLength(1)
+    expect(analysis!.capabilities[0]).toMatchObject({
+      name: 'Solo Capability',
+      otherSupportingAppCount: 0,
+      isOrphanCandidate: true,
+    })
+    expect(analysis!.summary.orphanCount).toBe(1)
+  })
+
+  it('does NOT flag a capability when another live app also supports it', async () => {
+    const capId = await seedCap(orgId, 'Shared Capability')
+    const sourceApp = await seedApp(orgId, 'Shared App Source')
+    const otherApp = await seedApp(orgId, 'Shared App Other', 'active')
+    await linkAppCap(sourceApp, capId)
+    await linkAppCap(otherApp, capId)
+
+    const analysis = await getApplicationImpactAnalysis(sourceApp)
+    expect(analysis!.capabilities[0].otherSupportingAppCount).toBe(1)
+    expect(analysis!.capabilities[0].isOrphanCandidate).toBe(false)
+  })
+
+  it('ignores decommissioned other-apps when computing orphans', async () => {
+    const capId = await seedCap(orgId, 'Decom-Other Capability')
+    const sourceApp = await seedApp(orgId, 'Decom-Other Source')
+    const decomApp = await seedApp(orgId, 'Decom-Other Old', 'decommissioned')
+    await linkAppCap(sourceApp, capId)
+    await linkAppCap(decomApp, capId)
+
+    const analysis = await getApplicationImpactAnalysis(sourceApp)
+    // The decommissioned app doesn't count; this is an orphan candidate.
+    expect(analysis!.capabilities[0].otherSupportingAppCount).toBe(0)
+    expect(analysis!.capabilities[0].isOrphanCandidate).toBe(true)
+  })
+
+  it('detects a replacement when an initiative retires this app and builds another for a shared capability', async () => {
+    const capId = await seedCap(orgId, 'Replaced Capability')
+    const legacyApp = await seedApp(orgId, 'Legacy App')
+    const newApp = await seedApp(orgId, 'New App')
+    await linkAppCap(legacyApp, capId)
+    await linkAppCap(newApp, capId)
+
+    const initId = await seedInitiative(orgId, 'Migration Initiative', 'active')
+    await linkInitApp(initId, legacyApp, 'retire')
+    await linkInitApp(initId, newApp, 'build')
+
+    const analysis = await getApplicationImpactAnalysis(legacyApp)
+    expect(analysis!.replacements).toHaveLength(1)
+    expect(analysis!.replacements[0]).toMatchObject({
+      initiativeName: 'Migration Initiative',
+      replacementAppName: 'New App',
+      capabilityName: 'Replaced Capability',
+    })
+    expect(analysis!.summary.replacementInProgress).toBe(true)
+  })
+
+  it('does not double-list a replacement app under coverage-sharers', async () => {
+    // Continues from the previous test's fixture set — the New App that is a
+    // replacement should NOT also appear in coverage-sharers for legacyApp.
+    const legacyApp = (await db.query.applications.findFirst({
+      where: and(eq(applications.organizationId, orgId), eq(applications.name, 'Legacy App')),
+    }))!.id
+
+    const analysis = await getApplicationImpactAnalysis(legacyApp)
+    expect(analysis!.coverageSharers.find(s => s.name === 'New App')).toBeUndefined()
+  })
+
+  it('surfaces services routed through linked capabilities', async () => {
+    const capId = await seedCap(orgId, 'Service-Bearing Capability')
+    const appId = await seedApp(orgId, 'Service-Bearing App')
+    await linkAppCap(appId, capId)
+
+    const svcId = await seedService(orgId, 'Resident Permit Lookup')
+    await db.insert(serviceCapabilities).values({ serviceId: svcId, capabilityId: capId })
+
+    const analysis = await getApplicationImpactAnalysis(appId)
+    expect(analysis!.services).toHaveLength(1)
+    expect(analysis!.services[0]).toMatchObject({
+      name: 'Resident Permit Lookup',
+      viaCapabilities: [{ name: 'Service-Bearing Capability' }],
+    })
+    expect(analysis!.summary.serviceCount).toBe(1)
+  })
+
+  it('lists referencing ADRs', async () => {
+    const appId = await seedApp(orgId, 'ADR-Linked App')
+    const adrId = await seedAdr(orgId, 'TEST-ADR-001', 'Authentication for ADR-Linked App')
+    await db.insert(adrApplications).values({ adrId, applicationId: appId })
+
+    const analysis = await getApplicationImpactAnalysis(appId)
+    expect(analysis!.adrs).toHaveLength(1)
+    expect(analysis!.adrs[0].title).toBe('Authentication for ADR-Linked App')
+  })
+
+  it('returns initiatives touching this app with their impact label', async () => {
+    const appId = await seedApp(orgId, 'Initiative-Touched App')
+    const initId = await seedInitiative(orgId, 'Future Improvement', 'proposed')
+    await linkInitApp(initId, appId, 'improve')
+
+    const analysis = await getApplicationImpactAnalysis(appId)
+    expect(analysis!.initiatives).toHaveLength(1)
+    expect(analysis!.initiatives[0]).toMatchObject({
+      name: 'Future Improvement',
+      impact: 'improve',
+      status: 'proposed',
+    })
+  })
+
+  it('hides proposed initiatives from viewer-role callers (status gate parity)', async () => {
+    // Re-use the previous fixture by name (proposed initiative on Initiative-Touched App).
+    const viewer = await createTestUser(orgId, 'viewer')
+    const appId = (await db.query.applications.findFirst({
+      where: and(eq(applications.organizationId, orgId), eq(applications.name, 'Initiative-Touched App')),
+    }))!.id
+
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    try {
+      const analysis = await getApplicationImpactAnalysis(appId)
+      expect(analysis!.initiatives.find(i => i.name === 'Future Improvement')).toBeUndefined()
+    } finally {
+      mockAuth.mockResolvedValue(makeSession(admin))
+    }
+  })
+
+  it('includes recent audit events for this app and linked entities within the 30-day window', async () => {
+    const appId = await seedApp(orgId, 'Auditable App')
+    const capId = await seedCap(orgId, 'Auditable Capability')
+    await linkAppCap(appId, capId)
+
+    // Write one audit event on the app itself, and one on the linked capability.
+    await writeAuditLog(db, {
+      action: 'application.edit', entityType: 'application', entityId: appId,
+      userId: admin.id, organizationId: orgId, after: { name: 'Auditable App' },
+    })
+    await writeAuditLog(db, {
+      action: 'capability.edit', entityType: 'capability', entityId: capId,
+      userId: admin.id, organizationId: orgId, after: { name: 'Auditable Capability' },
+    })
+
+    const analysis = await getApplicationImpactAnalysis(appId)
+    const actions = analysis!.recentChanges.map(c => c.action).sort()
+    expect(actions).toContain('application.edit')
+    expect(actions).toContain('capability.edit')
+    expect(analysis!.summary.recentChangeCount).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary

The audit's headline gap — Programme Director persona's canonical question *"what breaks if I decommission Y?"* — answered in one screen.

This is the highest-leverage open finding from the 16-walk audit (5 personas served). The data was always in the model; the gap was that nobody had composed it for delivery decision-making.

## What ships

### \`/applications/[id]/impact\` — new dedicated route, three sections

1. **If you decommission this…**
   - Orphan candidates (only this app supports the capability — decommissioned apps don't count as "support")
   - Replacement work in flight (initiative retires this app + builds a replacement for the same capability)
   - Active initiatives touching this app, with impact labels
   - Coverage-sharers (other live apps serving these capabilities, could absorb load — not double-listed with replacements)
   - Downstream services routed through these capabilities

2. **What this depends on**
   - Capabilities served (with other-supporting-app count)
   - ADRs that govern this app

3. **Recent changes (last 30 days)**
   - Audit events on this app or any directly-linked capability/initiative/ADR

### \`/applications/[id]\` — \"View impact analysis →\" CTA

Discoverable from the page a stakeholder already lands on. Sits below the existing qualitative \`ApplicationImpactPanel\` (which stays — that's the at-a-glance summary; this PR adds the structured breakdown for sequencing decisions).

## Persona-foundational fit

| Persona | Need from persona file | This PR |
|---|---|---|
| Programme Director | *"what breaks if I decommission Y?"* | Section 1 ✓ |
| Business Stakeholder | *"see whether their programme's intended changes overlap"* | Replacement panel + initiatives ✓ |
| Department Director | What systems support this capability and what's retiring? | Coverage-sharers + lifecycle status ✓ |
| Domain Architect | *"what trusts this IdP?"* (inverted question) | Section 2 (Capabilities + ADRs) ✓ |
| Budget Analyst | Investment exposure before decommission | Section 3 (recent changes) + initiative end dates ✓ |

Viewer role can read the analysis — essential to the persona file's critical insight that *self-service* access without an EA-team interpreter is what unlocks adoption.

## Test plan

- [x] 12 new integration tests in \`tests/integration/impact-analysis.test.ts\`
  - null-on-unknown id; cross-org isolation
  - orphan flagging (live other-app present → not orphan; only decommissioned other-app → still orphan)
  - replacement-pair detection (retire + build on same initiative for shared capability)
  - no double-listing between replacements and coverage-sharers
  - downstream services via capability bridge
  - ADR linking; initiative impact labels
  - viewer status-gate parity (proposed initiative hidden)
  - recent audit events captured for app + linked capabilities within 30-day window
- [x] All 12 pass (459 ms)
- [x] \`tsc --noEmit\` clean
- [x] Browser-verified on Riverdale's **Legacy Permitting System** (canonical persona fixture):
  - Orphans: 0 · Active initiatives: 1 (replacement in flight) · Coverage-sharers: 1 · Downstream services: 2
  - Replacement panel correctly identifies Accela Implementation → Accela
  - Viewer-role (\`victor@govea.dev\`) can access the page

## Out of scope (follow-ups under same issue)

- **Change notifications / subscribe-to-changes** — persona pain point #4; depends on email transport (the actual nodemailer send is the #528 follow-up, not the configuration which already landed)
- **Programme-scope filtering** — persona pain point #5; needs a "programme" concept in the data model that doesn't exist today
- **App-to-app technology dependencies** — flagged in the issue body; would require new schema. Section 2 framing makes the absence explicit

## Capability traceability

Capability: candidate new \`fd-impact-analysis\` / \`po-dependency-impact\`
Persona: programme-director (primary); also serves business-stakeholder, department-director, domain-architect, budget-performance-analyst
Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)