### PR TITLE
docs: refresh backlog grooming priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - Clear product boundary: org admins manage their own workspace settings; instance admins govern the shared platform and tenant lifecycle
 - User management and first-run setup flow
 - Live admin dashboard with coverage, recent activity, domain summaries, and operational review-health signals
+- Email configuration surface with encrypted SMTP settings, delivery log, and an admin dashboard warning when email is not configured
+- EasyEA starter content and empty-state prompts for new practices that need a credible first repository quickly
+- CSV import/export for Applications and Capabilities, with broader entity coverage planned
 - Prototype multi-org federation: connection requests, visibility levels, approval-based cross-org links, read-only remote detail pages, and write-protection enforcement
 - Demo seed data and dev login roster for Riverdale, GovEA Project dogfooding, Office of Digital Services, Hartfield TOGAF overlay, and dev-only instance-admin scenarios
 - Reusable `@govea/core` package: RBAC, audit, taxonomy, workflow, content type, and recipe primitives
@@ -243,25 +246,26 @@ Capabilities are defined one at a time through the EasyEA workflow: persona vali
 - ADRs: basic CRUD, detail pages, and linkage exist, but the authoring experience is still maturing relative to the core portfolio records
 - Planning semantics: useful for demos and early v1, with objectives using content workflow while initiatives use planning lifecycle states
 - Long-form authoring: markdown now renders on detail pages, but editing still uses plain textareas rather than a richer toolbar/preview workflow
-- Admin configuration beyond core settings
+- Admin configuration beyond core settings, including the real SMTP send path behind the shipped Email Configuration UI
+- Repository portability beyond Application and Capability CSV round-trips
 - Risk tracking is defined as a proposed Repository & Modelling capability, but the first-class product surface has not been implemented yet
-- Deeper end-to-end traceability analysis and conceptual/logical Data Architecture expansion
+- Data Architecture quality signals, naming-standard hints, and any later conceptual/logical expansion
 
 **Active work:**
+- Finishing actual SMTP email transport so configured email can support notifications and password reset
+- Continuing CSV import/export across the next high-value entity types
+- Adding Data Architecture quality cues and Data Vault naming-standard hints
+- Adding authoring guardrails for duplicate names, unsaved changes, and publish-readiness guidance
 - Building a traceable release pipeline for the Azure demo so deployments are tied to a known commit, image digest, and post-deploy smoke result
-- Implementing the inherited system glossary and menu definitions so glossary, tour, onboarding, and contextual help use the same language
-- Deciding the Data Architecture v1 boundary before expanding conceptual/logical modeling
-- Validating assumed stakeholder personas and starting a lightweight feedback loop for analysis surfaces
-- Deciding whether user-facing product language should remain "module" or shift to "tool"
-- Expanding automated test coverage
 - Keeping documentation aligned with rapid product-shape changes
 
 **Near-term:**
+- Ship the #528 SMTP transport follow-up, then split the #581 change-notification substrate into small slices
+- Continue #596 after Capabilities with Personas and ADRs as the next likely import/export targets
+- Ship #570 and the Layer 1 / Layer 2 portions of #573 before broadening Data Architecture scope
+- Ship #566 / #567 authoring guardrails as shared patterns across content forms
 - Ship #504 for traceable demo releases and rollback
-- Implement #499 for inherited glossary/menu definitions
-- Split or close #363 based on the Data Architecture v1 boundary decision
-- Run #384 and #103 Phase 1 feedback capture for stakeholder-facing analysis surfaces
-- Resolve #446 before broader onboarding, glossary, or tour copy work
+- Complete #512 before broader #499 onboarding, glossary, or tour copy work
 
 **Longer-term:**
 - End-to-end traceability expansion and risk-informed decision support

--- a/capabilities.md
+++ b/capabilities.md
@@ -155,8 +155,8 @@ Organization-level settings and administrative tools.
 | Persona Tags | Implemented | Manage persona tag values as taxonomy terms under the `Persona Tag` branch |
 | Admin Dashboard | Implemented | Live practitioner dashboard with repository activity, coverage signals, and navigation shortcuts |
 | Feature Management | Partially implemented | Org-level module toggles and instance-wide module availability controls are shipped; richer dependency and feature-flag behavior remains future work |
-| Email Configuration | Not implemented | SMTP setup for notifications and password reset |
-| Backup & Export | Not implemented | Data export and backup tooling |
+| Email Configuration | Partially implemented | Admin UI, encrypted SMTP settings, delivery log, and dashboard warning are shipped; actual SMTP transport remains the next slice |
+| Backup & Export | Partially implemented | Application and Capability CSV import/export are shipped; full repository export, backup, and broader entity coverage remain future work |
 | Security Settings | Not implemented | Session timeouts, password policy, IP restrictions |
 
 ---

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-16 (no open PRs; #507 and #508 merged after the prior grooming pass)
+Last groomed: 2026-05-21 (no open PRs; reviewed recent merged PRs through #608)
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -8,43 +8,36 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-The security hardening wave remains closed end-to-end. The remaining security-adjacent backlog is productized control work, not emergency remediation.
+The latest persona-journey and follow-up work shifted the backlog from broad foundation building toward specific adoption blockers:
 
-The repository-completeness, repository-confidence, and architecture-debt streams are now shipped baselines rather than active build streams:
-
-- [#380](https://github.com/roballred/GovEA/issues/380) shipped snapshot foundations, settings, drill-downs, ranked cleanup actions, RAG indicators, trend history, stakeholder surfaces, and auto-suppression through PRs [#448](https://github.com/roballred/GovEA/pull/448), [#450](https://github.com/roballred/GovEA/pull/450), [#454](https://github.com/roballred/GovEA/pull/454), and [#457](https://github.com/roballred/GovEA/pull/457).
-- [#381](https://github.com/roballred/GovEA/issues/381) shipped architecture debt CRUD, linked-debt panels, dashboard priority signals, publish-time acknowledgement, and lifecycle-based system-detected debt through PRs [#459](https://github.com/roballred/GovEA/pull/459), [#466](https://github.com/roballred/GovEA/pull/466), [#467](https://github.com/roballred/GovEA/pull/467), and [#486](https://github.com/roballred/GovEA/pull/486).
-- [#437](https://github.com/roballred/GovEA/issues/437) is complete through [#502](https://github.com/roballred/GovEA/pull/502), which added scoped act-as sessions gated by break-glass and a first cross-tenant support action.
-
-The Data Architecture stream from [#363](https://github.com/roballred/GovEA/issues/363) is also a real shipped module: schema and CRUD foundation, relationship editing, business-architecture docs, Chen notation visualization, dedicated sidebar group, and representative demo fixtures have all landed. What remains is a product boundary decision: close the issue as v1-complete, or split conceptual/logical model expansion into explicit follow-up issues.
-
-Recent merged PRs changed the next-work queue:
-
-- [#503](https://github.com/roballred/GovEA/pull/503) recovered the seed cleanup and GovEA Project value-chain enrichment from [#496](https://github.com/roballred/GovEA/pull/496) and [#497](https://github.com/roballred/GovEA/pull/497) onto `main`, closing [#492](https://github.com/roballred/GovEA/issues/492) and adding a PR base-check workflow.
-- [#501](https://github.com/roballred/GovEA/pull/501) documented first-class risk tracking and closed [#500](https://github.com/roballred/GovEA/issues/500) as a design/capability-definition slice.
-- [#505](https://github.com/roballred/GovEA/pull/505) merged the 2026-05-15 backlog-grooming refresh into `main`.
-- [#507](https://github.com/roballred/GovEA/pull/507) aligned module group controls with the sidebar group model and closed [#506](https://github.com/roballred/GovEA/issues/506).
-- [#508](https://github.com/roballred/GovEA/pull/508) shipped the org-scoped half of admin notices from [#456](https://github.com/roballred/GovEA/issues/456). Instance-wide notices remain the planned second slice.
+- [#603](https://github.com/roballred/GovEA/pull/603) made the audit log readable by Contributors, scoped to architecture content.
+- [#604](https://github.com/roballred/GovEA/pull/604) shipped the first CSV import/export beachhead for Capabilities under [#596](https://github.com/roballred/GovEA/issues/596).
+- [#605](https://github.com/roballred/GovEA/pull/605) shipped EasyEA starter content and empty-state CTAs for new practices under [#587](https://github.com/roballred/GovEA/issues/587).
+- [#606](https://github.com/roballred/GovEA/pull/606) shipped the Email Configuration UI, encrypted SMTP settings, delivery log, and dashboard warning under [#528](https://github.com/roballred/GovEA/issues/528). Actual SMTP sending remains the follow-up.
+- [#607](https://github.com/roballred/GovEA/pull/607) closed a batch of small persona-audit quality issues: connection target filtering, traceability hub behavior, guided-answer prompt chips, detail-page freshness lines, and taxonomy deduplication.
+- [#608](https://github.com/roballred/GovEA/pull/608) shipped the self-service application dependency-impact view under [#578](https://github.com/roballred/GovEA/issues/578).
 - There are no open pull requests at this grooming point.
+
+The practical implication: several previously ranked items are now done or partially done. The next best work should build on those shipped surfaces instead of opening another broad exploratory stream.
 
 ## Top 5 Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Finish admin notices with the instance-wide slice | #508 shipped org-scoped notices, but #456 is only complete when instance admins can post distinct instance-wide notices and the UI handles both scopes clearly. | [#456](https://github.com/roballred/GovEA/issues/456) |
-| 2 | Build a traceable release pipeline for the Azure demo | Demo stability is now good enough to protect. Manual deploys still make it too hard to know which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
-| 3 | Decide module/tool terminology, then implement inherited glossary/menu definitions | Glossary-backed menu definitions and product tours will spread language across the app. Make the #446 wording decision first, then use #499 to seed shared definitions. | [#446](https://github.com/roballred/GovEA/issues/446), [#499](https://github.com/roballred/GovEA/issues/499) |
-| 4 | Decide the Data Architecture v1 boundary and split #363 if needed | Data Architecture is no longer speculative. With the v1 metamodel, relationships, diagram, nav, fixtures, and settings alignment shipped, the remaining conceptual/logical scope needs a deliberate follow-up shape. | [#363](https://github.com/roballred/GovEA/issues/363) |
-| 5 | Run the persona-validation and feedback-capture slice | GovEA is shipping stakeholder-facing confidence, roadmap, reporting, Data Architecture, risk, and architecture-debt concepts based on assumed personas. Validate before adding more analysis workflows. | [#384](https://github.com/roballred/GovEA/issues/384), [#103](https://github.com/roballred/GovEA/issues/103) |
+| 1 | Finish email transport, then start the change-notification substrate | #606 made email configurable, but sends still return the stub failure. Real SMTP is the prerequisite for password reset, object/domain subscriptions, and the change-notification needs now repeated by Programme Director, Domain Architect, Consultant, and Agency EA Coordinator personas. | [#528](https://github.com/roballred/GovEA/issues/528), [#581](https://github.com/roballred/GovEA/issues/581), [#87](https://github.com/roballred/GovEA/issues/87) |
+| 2 | Continue CSV import/export across the next high-value entity types | #604 proved the pattern for Capabilities. The Consultant / SI and Early-Maturity Practice Lead personas still need reusable starter libraries and handoff exports beyond Applications and Capabilities. Prioritize Personas and ADRs next, then Initiatives, Objectives, Services, Value Streams, Principles, Glossary, and Data Architecture. | [#596](https://github.com/roballred/GovEA/issues/596), [#86](https://github.com/roballred/GovEA/issues/86) |
+| 3 | Add data-architecture quality cues and naming-standard hints | Data Architecture is now a shipped module, and the remaining gaps are reviewer/operator quality loops: Data Vault physical-name hints, per-row quality cues, and a roll-up scorecard summary. These are cheaper and safer than expanding conceptual/logical modeling. | [#570](https://github.com/roballred/GovEA/issues/570), [#573](https://github.com/roballred/GovEA/issues/573) |
+| 4 | Add authoring guardrails for duplicate names, unsaved changes, and publish-readiness guidance | Persona walks keep finding the same authoring failure mode across entities: easy duplicate creation, silent discard, and weak required-field guidance. A shared guardrail pattern would improve quality across the repository without inventing a new product area. | [#566](https://github.com/roballred/GovEA/issues/566), [#567](https://github.com/roballred/GovEA/issues/567) |
+| 5 | Build a traceable release pipeline for the Azure demo | The demo is now product-critical: starter content, impact analysis, email configuration, and persona-facing reports all depend on reviewers seeing the expected build. Manual deploys still make it too hard to prove which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
 
 ## Product Manager Notes
 
-- #456 should now be split into an instance-notice PR rather than reopened as another broad design pass. #508 already settled most of the shared notice semantics.
-- #504 should be treated as operational product work, not infrastructure polish. The demo is how many users will first understand GovEA.
-- #507 reduces the settings/navigation mismatch, so #479 can move when the team wants a usability-focused navigation-density slice. It sits just outside the top five because the current top items reduce broader product and operating risk.
-- #500/#501 created the risk-tracking capability definition. Do not jump straight to implementation until persona validation clarifies which risk summaries leadership and practitioners actually trust.
-- #482 is important process work, but it has an explicit maintainer-review-first workflow. Do not bypass that by bundling an AI-session-start document into ordinary grooming PRs.
-- #436 remains a future security hardening option after enough operational experience with #502's act-as flow. It is not the next security item unless read-surface risk becomes urgent.
+- Treat #528 as unfinished until a real SMTP transport lands. The configuration UI unblocks downstream work, but notification features cannot ship on a stub sender.
+- #581 is too broad to build in one pass. Split it into an event/subscription foundation, domain-owner attribution, non-owner edit warning, and email digest delivery.
+- #596 should keep moving in small per-entity PRs. Preserve the export -> unchanged import -> zero-diff property from #604.
+- #573 Layer 1 and Layer 2 are the right near-term data-architecture scope. A full Hoberman-style scorecard should wait for persona validation.
+- #512 should be handled before expanding #499 glossary-backed menu definitions. "Modules" is now the settled term; cleanup and a CI guard are process hygiene, but they sit just outside the top five.
+- #510 and #511 remain worthwhile documentation/capability-definition work for operating GovEA, especially for non-technical decision-makers. They are good candidates when the team wants a docs-only or capability-only slice.
 
 ## Security Remediation Status
 

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -24,28 +24,29 @@ This register is intentionally lightweight:
 
 | ID | Risk | Category | Impact | Likelihood | Mitigation | Owner | Status | Last reviewed |
 |---|---|---|---|---|---|---|---|---|
-| R-001 | Admin notices can remain half-shipped if the instance-wide scope does not follow #508 | Product / Operations | Medium | Medium | Treat #508 as PR 1 of #456 and ship the instance-admin notice management and rendering slice next | Product / Engineering | Open | 2026-05-16 |
-| R-002 | Manual demo deployment can obscure which commit, image, and runtime configuration are live | Operational / Release | High | Medium | Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear | Product / Engineering | Open | 2026-05-16 |
-| R-003 | Data Architecture can keep expanding without a deliberate v1 boundary | Scope | Medium | Medium | Decide whether #363 is v1-complete or split conceptual/logical model expansion into focused follow-ups | Product | Open | 2026-05-16 |
-| R-004 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-16 |
-| R-005 | Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately | Product / UX | Medium | Medium | Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499 | Product | Open | 2026-05-16 |
-| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-16 |
+| R-001 | Email-dependent features can appear ready while the SMTP transport is still stubbed | Product / Operations | High | Medium | Finish the real SMTP send path under #528 before starting notification, password-reset, or digest features | Product / Engineering | Open | 2026-05-21 |
+| R-002 | Manual demo deployment can obscure which commit, image, and runtime configuration are live | Operational / Release | High | Medium | Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear | Product / Engineering | Open | 2026-05-21 |
+| R-003 | Data Architecture can keep expanding without quality loops or a deliberate v1 boundary | Scope | Medium | Medium | Prioritize #570 and #573 quality cues before expanding conceptual/logical modeling under #363 | Product | Open | 2026-05-21 |
+| R-004 | Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals | Product Fit | High | High | Run #384 and activate #103 Phase 1 manual feedback logging before building more analysis surfaces | Product | Open | 2026-05-21 |
+| R-005 | Glossary, tour, and navigation help can drift if the settled "Modules" language is not enforced | Product / UX | Medium | Medium | Complete #512 before expanding inherited glossary/menu definitions in #499 | Product | Open | 2026-05-21 |
+| R-006 | Documentation can drift behind shipped repo state during fast-moving backlog turns | Process | Medium | Medium | Refresh `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this register during backlog grooming when status materially changes | Product | Watching | 2026-05-21 |
+| R-007 | Import/export can create a false portability story if only two entities round-trip cleanly | Product / Trust | Medium | Medium | Continue #596 as small per-entity PRs and preserve export -> unchanged import -> zero-diff behavior | Product / Engineering | Open | 2026-05-21 |
 
 ## Risk Details
 
-### R-001 - Admin notices can remain half-shipped if the instance-wide scope does not follow #508
+### R-001 - Email-dependent features can appear ready while the SMTP transport is still stubbed
 
 - **Category:** Product / Operations
-- **Impact:** Medium
+- **Impact:** High
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-16
-- **Mitigation:** Treat #508 as PR 1 of #456 and ship the instance-admin notice management and rendering slice next.
+- **Last reviewed:** 2026-05-21
+- **Mitigation:** Finish the real SMTP send path under #528 before starting notification, password-reset, or digest features.
 
 #### Details
 
-PR #508 shipped org-scoped admin notices and settled much of the shared behavior: severity, single active notice per scope, audit trail, authenticated-page rendering, and optional learn-more URLs. Issue #456 remains broader. If the instance-wide slice does not follow, GovEA will have agency-level operational messaging but still lack a shared-instance operator channel for maintenance windows, migrations, and platform-level warnings.
+PR #606 shipped the Email Configuration UI, encrypted SMTP settings, delivery log, and dashboard warning. That is a useful foundation, but the send path still returns an explicit stub failure until nodemailer or equivalent transport work lands. Change notifications (#581 and #87), password reset flows, and email digests should not be treated as implementation-ready until the transport is real and tested.
 
 ### R-002 - Manual demo deployment can obscure which commit, image, and runtime configuration are live
 
@@ -54,26 +55,26 @@ PR #508 shipped org-scoped admin notices and settled much of the shared behavior
 - **Likelihood:** Medium
 - **Owner:** Product / Engineering
 - **Status:** Open
-- **Last reviewed:** 2026-05-16
+- **Last reviewed:** 2026-05-21
 - **Mitigation:** Ship #504 so main-branch releases build immutable images, record deployment metadata, smoke test after deploy, and keep rollback clear.
 
 #### Details
 
 PRs #493 and #498 stabilized the Azure demo runtime and separated demo-mode shortcuts from `NODE_ENV`. That fixed the immediate runtime mismatch, but the process is still too manual for a demo environment that users and reviewers depend on. Without a traceable release pipeline, maintainers can lose time reconstructing which commit, image digest, and Container Apps revision are actually live.
 
-### R-003 - Data Architecture can keep expanding without a deliberate v1 boundary
+### R-003 - Data Architecture can keep expanding without quality loops or a deliberate v1 boundary
 
 - **Category:** Scope
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-16
-- **Mitigation:** Decide whether #363 is v1-complete after the shipped schema, CRUD, relationships, docs, visualization, nav, fixtures, and settings alignment; if not, split conceptual/logical expansion into focused follow-up issues.
+- **Last reviewed:** 2026-05-21
+- **Mitigation:** Prioritize #570 and #573 quality cues before expanding conceptual/logical modeling under #363.
 
 #### Details
 
-The Data Architecture Metamodel is now a shipped module, not only a request. That increases the need for a product boundary. Leaving #363 open as a broad umbrella risks sliding from an enterprise-architecture support surface into a much larger data-modelling product without a deliberate sequence.
+The Data Architecture Metamodel is now a shipped module, not only a request. The next risk is not lack of modeling breadth; it is lack of quality feedback for the people who author and review the model. Data Vault naming hints (#570), per-row quality cues, and a `/data` scorecard roll-up (#573) should come before expanding #363 into broader conceptual/logical modeling.
 
 ### R-004 - Stakeholder-facing analytics are still driven by assumed personas and unvalidated trust signals
 
@@ -82,26 +83,26 @@ The Data Architecture Metamodel is now a shipped module, not only a request. Tha
 - **Likelihood:** High
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-16
+- **Last reviewed:** 2026-05-21
 - **Mitigation:** Execute #384 and start #103 Phase 1 with a manual feedback log tied to recently shipped stakeholder-facing surfaces.
 
 #### Details
 
 The research artifacts already identify high-risk assumptions about who uses roadmap, confidence-summary, guided-answer, Data Architecture, risk, and architecture-debt surfaces; what formats they trust; and whether they act on freshness or confidence labels at all. If those assumptions are wrong, GovEA can continue shipping polished features that do not improve adoption or decision quality.
 
-### R-005 - Glossary, tour, and navigation help can spread inconsistent product language if #446 and #499 are handled separately
+### R-005 - Glossary, tour, and navigation help can drift if the settled "Modules" language is not enforced
 
 - **Category:** Product / UX
 - **Impact:** Medium
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Open
-- **Last reviewed:** 2026-05-16
-- **Mitigation:** Decide module/tool terminology in #446 before implementing inherited system glossary and menu definitions in #499.
+- **Last reviewed:** 2026-05-21
+- **Mitigation:** Complete #512 before expanding inherited glossary/menu definitions in #499.
 
 #### Details
 
-Issue #499 proposes glossary-backed menu definitions and reusable tour/contextual-help language. If #499 moves before #446, the product may encode terminology that #446 later changes, creating avoidable copy churn across onboarding, glossary, settings, and navigation surfaces. The #507 module-settings work makes this decision more visible, not less.
+The terminology decision is now made: "Modules" is canonical and "Tools" is rejected for the product-area concept. Issue #512 covers the cleanup and CI guard. If #499 moves before #512, glossary-backed menu definitions and reusable tour/contextual-help language can re-spread terms the project has already rejected.
 
 ### R-006 - Documentation can drift behind shipped repo state during fast-moving backlog turns
 
@@ -110,9 +111,23 @@ Issue #499 proposes glossary-backed menu definitions and reusable tour/contextua
 - **Likelihood:** Medium
 - **Owner:** Product
 - **Status:** Watching
-- **Last reviewed:** 2026-05-16
+- **Last reviewed:** 2026-05-21
 - **Mitigation:** Treat backlog grooming as the required checkpoint for refreshing `README.md`, `capabilities.md`, `docs/product-priorities.md`, and this file when the live repo state changes materially.
 
 #### Details
 
-The current grooming pass found that the 2026-05-15 docs were correct when opened, but #505, #507, and #508 all merged before the next run completed. The consequence is not just cosmetic; stale docs distort prioritization and make automation repeat work that should already be closed.
+The current grooming pass found that the local checkout lagged behind the live GitHub mainline, where PRs #603 through #608 had already merged. The consequence is not just cosmetic; stale docs distort prioritization and make automation repeat work that should already be closed.
+
+### R-007 - Import/export can create a false portability story if only two entities round-trip cleanly
+
+- **Category:** Product / Trust
+- **Impact:** Medium
+- **Likelihood:** Medium
+- **Owner:** Product / Engineering
+- **Status:** Open
+- **Last reviewed:** 2026-05-21
+- **Mitigation:** Continue #596 as small per-entity PRs and preserve export -> unchanged import -> zero-diff behavior.
+
+#### Details
+
+PR #604 proved the CSV round-trip pattern for Capabilities, adding quote-aware parsing and org-scoped export. Applications and Capabilities now have useful tactical portability, but the broader Consultant / SI and Early-Maturity Practice Lead promise requires Personas, ADRs, Initiatives, Objectives, Services, Value Streams, Principles, Glossary, and Data Architecture to follow. Until that happens, GovEA should describe export/import as partial, not as a full repository portability story.


### PR DESCRIPTION
## Summary

- Refreshes `docs/product-priorities.md` after recent merged PRs through #608.
- Re-ranks the top five next items around email transport/notifications, import/export expansion, data-architecture quality, authoring guardrails, and the demo release pipeline.
- Updates `docs/risk-register.md` for the current operating risks.
- Aligns `README.md` and `capabilities.md` with shipped Email Configuration and Application/Capability CSV import/export status.

## Validation

- `git diff --check`
- Docs-only update.

Capability: governance/standards
Persona: enterprise-architect

Automation: Backlog Grooming for GovEA