### PR TITLE
feat(notifications): notify domain owner on non-owner overwrite (#581 bridge)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -10,7 +10,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
-import { notifySubscribers } from './notifications'
+import { notifySubscribers, notifyDomainOwner } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { redirect } from 'next/navigation'
@@ -251,6 +251,15 @@ export async function editADR(id: string, formData: FormData) {
           ownerName: ownerAck.ownerName,
           ownerEmail: ownerAck.ownerEmail,
         },
+      })
+      await notifyDomainOwner(tx, {
+        organizationId: orgId,
+        entityType: 'adr',
+        entityId: id,
+        action: 'adr.edit_by_non_owner',
+        actorUserId: session.user.id,
+        ownerUserId: ownerAck.ownerUserId,
+        summary: `${session.user.name ?? session.user.email ?? 'Someone'} edited your ADR "${title}"`,
       })
     }
 

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -7,7 +7,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
-import { notifySubscribers } from './notifications'
+import { notifySubscribers, notifyDomainOwner } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { autoFlagLifecycleDebt } from '@/lib/lifecycle-debt'
@@ -284,6 +284,15 @@ export async function editApplication(applicationId: string, formData: FormData)
           ownerName: ownerAck.ownerName,
           ownerEmail: ownerAck.ownerEmail,
         },
+      })
+      await notifyDomainOwner(tx, {
+        organizationId: orgId,
+        entityType: 'application',
+        entityId: applicationId,
+        action: 'application.edit_by_non_owner',
+        actorUserId: session.user.id,
+        ownerUserId: ownerAck.ownerUserId,
+        summary: `${session.user.name ?? session.user.email ?? 'Someone'} edited your application "${name}"`,
       })
     }
 

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -8,7 +8,7 @@ import { assertEntityInOrg, assertOwnership, canReadFederatedEntity, getConnecte
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
-import { notifySubscribers } from './notifications'
+import { notifySubscribers, notifyDomainOwner } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { redirect } from 'next/navigation'
@@ -336,6 +336,17 @@ export async function editCapability(capabilityId: string, formData: FormData) {
           ownerName: ownerAck.ownerName,
           ownerEmail: ownerAck.ownerEmail,
         },
+      })
+      // Bridge: notify the owner via the in-app inbox. Owners shouldn't
+      // have to subscribe to their own records to hear about overwrites.
+      await notifyDomainOwner(tx, {
+        organizationId: orgId,
+        entityType: 'capability',
+        entityId: capabilityId,
+        action: 'capability.edit_by_non_owner',
+        actorUserId: session.user.id,
+        ownerUserId: ownerAck.ownerUserId,
+        summary: `${session.user.name ?? session.user.email ?? 'Someone'} edited your capability "${name}"`,
       })
     }
 

--- a/apps/govea/src/actions/notifications.ts
+++ b/apps/govea/src/actions/notifications.ts
@@ -84,6 +84,52 @@ export async function isSubscribed(entityType: NotifiableEntityType, entityId: s
 }
 
 /**
+ * Owner-overwrite notification (#581 follow-up bridge).
+ *
+ * Sibling to `notifySubscribers`, called from inside an edit action's
+ * transaction. When a non-owner edits an architecture object that has
+ * a `domainOwnerUserId`, this writes a notification row for the owner
+ * with a distinct `*.edit_by_non_owner` action label.
+ *
+ * Distinct from `notifySubscribers` for two reasons:
+ *   - Owner notifications fire regardless of whether the owner subscribed.
+ *     The persona walk's pain ("changes happen with no signal to the
+ *     domain owner") is specifically about the owner not having to
+ *     opt-in to be told their record was touched.
+ *   - The action label is different so the inbox UI / future email
+ *     digest could weight owner-overwrite differently from a generic
+ *     subscriber-fan-out — an owner-overwrite is structurally more
+ *     attention-worthy.
+ *
+ * No-ops when the owner field is null or the owner is the actor.
+ */
+export async function notifyDomainOwner(
+  tx: Pick<typeof db, 'insert'>,
+  params: {
+    organizationId: string
+    entityType: NotifiableEntityType
+    entityId: string
+    action: string // e.g. 'capability.edit_by_non_owner'
+    actorUserId: string
+    ownerUserId: string | null | undefined
+    summary: string
+  },
+): Promise<number> {
+  if (!params.ownerUserId || params.ownerUserId === params.actorUserId) return 0
+  await tx.insert(notifications).values({
+    organizationId: params.organizationId,
+    userId: params.ownerUserId,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    action: params.action,
+    actorUserId: params.actorUserId,
+    summary: params.summary,
+  })
+  revalidatePath('/notifications')
+  return 1
+}
+
+/**
  * Fan-out helper called from inside an edit action's transaction.
  *
  * The caller passes the tx so this insert participates in the same

--- a/apps/govea/tests/integration/domain-owner-overwrite.test.ts
+++ b/apps/govea/tests/integration/domain-owner-overwrite.test.ts
@@ -14,7 +14,7 @@
 import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { db } from '@/db/client'
 import {
-  capabilities, applications, adrs, auditLog,
+  capabilities, applications, adrs, auditLog, notifications,
 } from '@/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
@@ -175,6 +175,75 @@ describe('domain-owner overwrite gate (#581)', () => {
     const meta = auditRows[0].metadata as { ownerUserId: string; ownerName: string }
     expect(meta.ownerUserId).toBe(owner.id)
     expect(meta.ownerName).toBe('Carlos Carter')
+
+    // Bridge: the owner should also have an inbox notification with the
+    // distinct edit_by_non_owner action label, regardless of subscription.
+    const ownerNotes = await db.select().from(notifications).where(and(
+      eq(notifications.entityId, cap.id),
+      eq(notifications.userId, owner.id),
+      eq(notifications.action, 'capability.edit_by_non_owner'),
+    ))
+    expect(ownerNotes).toHaveLength(1)
+    expect(ownerNotes[0].summary).toMatch(/edited your capability/i)
+  })
+
+  // ── Bridge: applications + ADRs also notify the owner ────────────────────
+
+  it('applications: a non-owner ack edit sends an edit_by_non_owner notification', async () => {
+    const app = await seedApp(orgId, 'Owner App Bridge', owner.id)
+    mockAuth.mockResolvedValue(makeSession(intruder))
+    const fd = new FormData()
+    fd.set('name', 'Owner App Bridge renamed')
+    fd.set('lifecycleStatus', 'active')
+    fd.set('status', 'draft')
+    fd.set('visibility', 'org')
+    fd.set('domainOwnerUserId', owner.id)
+    fd.set('acknowledgeOverwrite', 'on')
+    await editApplication(app.id, fd)
+    const ownerNotes = await db.select().from(notifications).where(and(
+      eq(notifications.entityId, app.id),
+      eq(notifications.userId, owner.id),
+      eq(notifications.action, 'application.edit_by_non_owner'),
+    ))
+    expect(ownerNotes).toHaveLength(1)
+  })
+
+  it('adrs: a non-owner ack edit sends an edit_by_non_owner notification', async () => {
+    const adr = await seedAdr(orgId, 'Owner ADR Bridge', owner.id)
+    mockAuth.mockResolvedValue(makeSession(intruder))
+    const fd = new FormData()
+    fd.set('number', adr.number)
+    fd.set('title', 'Owner ADR Bridge renamed')
+    fd.set('status', 'proposed')
+    fd.set('visibility', 'org')
+    fd.set('domainOwnerUserId', owner.id)
+    fd.set('acknowledgeOverwrite', 'on')
+    await editADR(adr.id, fd)
+    const ownerNotes = await db.select().from(notifications).where(and(
+      eq(notifications.entityId, adr.id),
+      eq(notifications.userId, owner.id),
+      eq(notifications.action, 'adr.edit_by_non_owner'),
+    ))
+    expect(ownerNotes).toHaveLength(1)
+  })
+
+  // ── Bridge: owner editing their own record does NOT self-notify ──────────
+
+  it('owner self-edit does not fire the edit_by_non_owner notification', async () => {
+    const cap = await seedCap(orgId, 'Owner Self Bridge', owner.id)
+    mockAuth.mockResolvedValue(makeSession(owner))
+    const fd = new FormData()
+    fd.set('name', 'Owner Self Bridge renamed')
+    fd.set('status', 'draft')
+    fd.set('visibility', 'org')
+    fd.set('domainOwnerUserId', owner.id)
+    await editCapability(cap.id, fd)
+    const selfNotes = await db.select().from(notifications).where(and(
+      eq(notifications.entityId, cap.id),
+      eq(notifications.userId, owner.id),
+      eq(notifications.action, 'capability.edit_by_non_owner'),
+    ))
+    expect(selfNotes).toHaveLength(0)
   })
 
   // ── Cross-org owner pick rejected ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the loop between #610 (subscriptions + in-app inbox) and #611 (domain-owner attribution + overwrite gate). When a non-owner edits an owned object and acknowledges the overwrite, the owner now receives an in-app notification — **without having to subscribe to their own record**.

The persona walk's pain (\"changes happen with no signal to the domain owner\") was about owners not having to opt-in to be told their record was touched. Subscription-based fan-out was the wrong mechanism for that case; this PR adds the right one.

## What ships

- **`notifyDomainOwner(tx, params)`** — sibling helper to `notifySubscribers` in `actions/notifications.ts`. No-ops when owner is null or owner is the actor.
- **Wired into all three edit actions** (capability, application, ADR) inside the existing transaction, right next to the `domain_owner.overwrite_acknowledged` audit row.
- **Distinct action label**: `${entity}.edit_by_non_owner` so the inbox UI / future email digest can weight owner-overwrites more prominently than generic subscriber-fan-out.
- **Owners notified regardless of subscription state.** A subscribed owner gets two notifications on a non-owner edit — intentional. Different meanings (\"FYI\" vs. \"someone touched MY record\").

## Design notes

- Owner notification fires from inside the same transaction as the edit + the overwrite audit row, so all three commit / roll back together. No half-state where the edit landed but the owner never heard.
- `notifyDomainOwner` is intentionally narrower than `notifySubscribers` (no subscriber lookup, just a single insert). Each helper does one thing.

## Test plan

- [x] 3 new integration tests in `domain-owner-overwrite.test.ts`:
  - Capability bridge: owner-notification row exists, summary mentions \"edited your capability\"
  - Application bridge: same shape
  - ADR bridge: same shape
  - Regression: owner self-edit does NOT self-notify
- [x] `tsc --noEmit` clean
- [x] Full vitest sweep: 679 / 679 passing

Capability: ac-change-notifications
Refs: #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)