### PR TITLE
feat(authoring): duplicate-name soft-warn + unsaved-changes hook (#566, partial #567)

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -9,6 +9,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { notifySubscribers } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { autoFlagLifecycleDebt } from '@/lib/lifecycle-debt'
 import { redirect } from 'next/navigation'
@@ -130,6 +131,9 @@ export async function createApplication(formData: FormData) {
   if (domainOwnerUserId) {
     await assertUserInOrg(domainOwnerUserId, orgId)
   }
+
+  // #566 — soft-warn on duplicate names.
+  await ensureNoDuplicateName('application', orgId, name, formData.get('acknowledgeDuplicate') === 'on')
 
   const fieldDefs = await getCustomFieldSchema(orgId, 'application')
   const customData = extractCustomData(formData, fieldDefs.map(f => f.name))

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -10,6 +10,7 @@ import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { notifySubscribers } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
@@ -169,6 +170,10 @@ export async function createCapability(formData: FormData) {
   if (domainOwnerUserId) {
     await assertUserInOrg(domainOwnerUserId, orgId)
   }
+
+  // #566 — soft-warn on duplicate names. Throws unless the form sent
+  // `acknowledgeDuplicate=on`. Client form catches + re-submits with ack.
+  await ensureNoDuplicateName('capability', orgId, name, formData.get('acknowledgeDuplicate') === 'on')
 
   // Mutation + audit are wrapped in a single transaction so a DB-layer audit
   // failure rolls back the capability insert and its junction rows (#416).

--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -7,6 +7,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { redirect } from 'next/navigation'
 import { validateWebUrl } from '@/lib/url'
 
@@ -89,6 +90,9 @@ export async function createGlossaryTerm(formData: FormData) {
   const sourcesJson = formData.get('sources') as string | null
   const parsedSources: { name: string; url?: string; definition: string }[] | null =
     sourcesJson ? JSON.parse(sourcesJson) : null
+
+  // #566 — soft-warn on duplicate term names.
+  await ensureNoDuplicateName('glossary', orgId, term, formData.get('acknowledgeDuplicate') === 'on')
 
   await db.transaction(async (tx) => {
     const [entry] = await tx.insert(glossaryTerms).values({

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -11,6 +11,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 
 async function requireContributor() {
   const session = await auth()
@@ -87,6 +88,9 @@ export async function createInitiative(formData: FormData) {
 
   const orgId = session.user.organizationId as string
   const userId = session.user.id
+
+  // #566 — soft-warn on duplicate names.
+  await ensureNoDuplicateName('initiative', orgId, formData.get('name') as string, formData.get('acknowledgeDuplicate') === 'on')
 
   await db.transaction(async (tx) => {
     const [row] = await tx.insert(initiatives).values({

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -8,6 +8,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { redirect } from 'next/navigation'
 
 async function requireContributor() {
@@ -128,6 +129,9 @@ export async function createObjective(formData: FormData) {
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const capabilityIds = formData.getAll('capabilityIds') as string[]
   const valueStreamIds = formData.getAll('valueStreamIds') as string[]
+
+  // #566 — soft-warn on duplicate names.
+  await ensureNoDuplicateName('objective', orgId, name, formData.get('acknowledgeDuplicate') === 'on')
 
   await db.transaction(async (tx) => {
     const [obj] = await tx.insert(strategicObjectives).values({

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -7,6 +7,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
@@ -86,6 +87,9 @@ export async function createPersona(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const tagIds = formData.getAll('tagIds') as string[]
+
+  // #566 — soft-warn on duplicate names.
+  await ensureNoDuplicateName('persona', orgId, name, formData.get('acknowledgeDuplicate') === 'on')
 
   await db.transaction(async (tx) => {
     const [persona] = await tx.insert(personas).values({

--- a/apps/govea/src/actions/services.ts
+++ b/apps/govea/src/actions/services.ts
@@ -10,6 +10,7 @@ import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/l
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { redirect } from 'next/navigation'
 import { syncEntityTaxonomyValues, getEntityTaxonomyValues, getEntityTaxonomyDefinitions } from '@/lib/entity-taxonomy-helpers'
 
@@ -105,6 +106,9 @@ export async function createService(formData: FormData) {
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const personaIds = formData.getAll('personaIds') as string[]
   const taxonomyTermIds = formData.getAll('taxonomyTermIds') as string[]
+
+  // #566 — soft-warn on duplicate names.
+  await ensureNoDuplicateName('service', orgId, name, formData.get('acknowledgeDuplicate') === 'on')
 
   await db.transaction(async (tx) => {
     const [service] = await tx.insert(services).values({

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -15,6 +15,7 @@ import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
@@ -317,9 +318,15 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createApplication(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createApplication, formData)
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -21,6 +21,8 @@ import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { buildCapabilityTree, flattenTree, collectDescendantIds, resolveCapabilityDomain } from '@/lib/capability-tree'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { DomainOwnerFormSection } from '@/components/domain-owner-form-section'
 
 type CapabilityRow = Pick<Capability, 'id' | 'name' | 'description' | 'domain' | 'behaviors' | 'rules' | 'capabilityType' | 'status' | 'visibility' | 'createdAt' | 'organizationId' | 'domainOwnerUserId'> & {
@@ -89,6 +91,10 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<CapabilityRow | null>(null)
+  // #567 Part A — track unsaved changes on the create/edit forms so closing
+  // the dialog or hitting Cancel doesn't silently discard work.
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<CapabilityRow | null>(null)
 
   // CSV import dialog state (#596). Two-step flow: preview (dryRun) →
@@ -167,9 +173,16 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createCapability(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createCapability, formData)
+        createDirty.reset()
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 
@@ -178,6 +191,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
     startTransition(async () => {
       try {
         await editCapability(editTarget.id, formData)
+        editDirty.reset()
         setEditTarget(null)
         refresh()
       } catch (err) {
@@ -189,6 +203,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editCapability(editTarget.id, formData)
+            editDirty.reset()
             setEditTarget(null)
             refresh()
             return
@@ -438,12 +453,20 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog
+        open={createOpen}
+        onOpenChange={(o) => {
+          // #567 Part A — guard against accidental discard via backdrop / Esc / × button.
+          if (!o && !confirmDiscard(createDirty)) return
+          if (!o) createDirty.reset()
+          setCreateOpen(o)
+        }}
+      >
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New Capability</DialogTitle>
           </DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required />
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <DomainCombobox options={domainTerms.map(t => t.name)} defaultValue="" />
@@ -499,7 +522,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
               orgUsers={orgUsers}
             />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create capability'}</Button>
             </DialogFooter>
           </form>
@@ -507,12 +530,19 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={open => {
+          if (!open && !confirmDiscard(editDirty)) return
+          if (!open) editDirty.reset()
+          if (!open) setEditTarget(null)
+        }}
+      >
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Capability</DialogTitle>
           </DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <DomainCombobox options={domainTerms.map(t => t.name)} defaultValue={editTarget?.domain ?? ''} />
@@ -579,7 +609,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
               />
             )}
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -18,6 +18,7 @@ import {
 import { cn } from '@/lib/utils'
 import { isSafeUrl } from '@/lib/url'
 import type { Role } from '@/lib/rbac'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { MarkdownEditor } from '@/components/markdown-editor'
 
 type GlossaryRow = GlossaryTerm & {
@@ -73,9 +74,15 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createGlossaryTerm(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createGlossaryTerm, formData)
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import type { EntityTaxonomyValue } from '@/db/schema'
@@ -97,10 +98,16 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createInitiative(formData)
-      setCreateOpen(false)
-      setSelectedCaps([])
-      refresh()
+      try {
+        await submitWithDuplicateAck(createInitiative, formData)
+        setCreateOpen(false)
+        setSelectedCaps([])
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/objectives/objective-table.tsx
+++ b/apps/govea/src/app/(admin)/objectives/objective-table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import type { EntityTaxonomyValue } from '@/db/schema'
@@ -74,9 +75,15 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createObjective(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createObjective, formData)
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -15,6 +15,7 @@ import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
 
@@ -83,9 +84,15 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createPersona(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createPersona, formData)
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/app/(admin)/services/service-table.tsx
+++ b/apps/govea/src/app/(admin)/services/service-table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
+import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyInputs, TaxonomyFilters, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 
@@ -95,9 +96,15 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
 
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
-      await createService(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        await submitWithDuplicateAck(createService, formData)
+        setCreateOpen(false)
+        refresh()
+      } catch (err) {
+        if (typeof window !== 'undefined') {
+          window.alert(err instanceof Error ? err.message : 'Create failed')
+        }
+      }
     })
   }
 

--- a/apps/govea/src/lib/duplicate-name-client.ts
+++ b/apps/govea/src/lib/duplicate-name-client.ts
@@ -1,0 +1,36 @@
+/**
+ * Client-side wrapper for the duplicate-name soft-warn gate (#566).
+ *
+ * Each create form calls `submitWithDuplicateAck(createAction, formData)`.
+ * If the server throws DuplicateNameAcknowledgmentRequiredError, the
+ * wrapper shows a window.confirm dialog and re-submits with
+ * `acknowledgeDuplicate=on`. If the user dismisses the confirm, the
+ * original error is re-thrown so the calling form can decide what to do.
+ *
+ * Detection is by error-message substring rather than `instanceof` so
+ * this helper works on the client side without importing the server-only
+ * @/lib/duplicate-name-gate module (which pulls in db client + drizzle).
+ */
+'use client'
+
+/** Substring carried by every DuplicateNameAcknowledgmentRequiredError message. */
+const DUPLICATE_MESSAGE_MARKER = 'already exists in this organization'
+
+export async function submitWithDuplicateAck(
+  action: (fd: FormData) => Promise<unknown>,
+  formData: FormData,
+): Promise<void> {
+  try {
+    await action(formData)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes(DUPLICATE_MESSAGE_MARKER)) {
+      if (typeof window !== 'undefined' && window.confirm(msg + '\n\nCreate anyway?')) {
+        formData.set('acknowledgeDuplicate', 'on')
+        await action(formData)
+        return
+      }
+    }
+    throw err
+  }
+}

--- a/apps/govea/src/lib/duplicate-name-gate.ts
+++ b/apps/govea/src/lib/duplicate-name-gate.ts
@@ -1,0 +1,186 @@
+/**
+ * Duplicate-name soft-warn gate (#566).
+ *
+ * Surfaced by the Junior EA Analyst persona walk:
+ *   "Contributing to the wrong capability domain or duplicating an
+ *    existing record is a common error with no warning mechanism."
+ *
+ * Same shape as the publish-debt gate (#381) and the domain-owner
+ * overwrite gate (#581):
+ *   - typed error class the client form catches + re-submits with ack
+ *   - server-side helper that throws unless the form sent `acknowledgeDuplicate=on`
+ *
+ * Per the issue, this is soft-warn: we DO NOT block duplicates outright.
+ * A user who has reviewed the existing record and intends to create a
+ * second one with the same name (e.g. different scope) can proceed by
+ * confirming. The friction is the goal; the block is not.
+ *
+ * Name normalisation: case-insensitive + trimmed + collapsed whitespace.
+ * "Online Permitting", "online permitting", and "Online  Permitting"
+ * (double-space) all collide. Different normalisation than #538 across
+ * orgs — keep them separate so that policy change is easy.
+ */
+import { db } from '@/db/client'
+import {
+  applications, capabilities, glossaryTerms, initiatives,
+  personas, strategicObjectives, services,
+} from '@/db/schema'
+import { and, eq, sql } from 'drizzle-orm'
+import type { PgColumn } from 'drizzle-orm/pg-core'
+
+/**
+ * Normalise a column reference at the SQL layer:
+ *   lower(regexp_replace(trim(col), '[[:space:]]+', ' ', 'g'))
+ *
+ * Matches the JS-side `normaliseName` exactly so a row that's
+ * normalised-equal to the user's input is found regardless of casing
+ * differences or internal whitespace runs.
+ *
+ * Note: PostgreSQL POSIX regex does NOT recognise `\s` as a whitespace
+ * shorthand in its default (basic POSIX) mode — `\s` matches a literal
+ * `s` character. The POSIX character class `[[:space:]]` is the
+ * portable form. Easy footgun.
+ */
+function sqlNormalize(col: PgColumn) {
+  return sql`lower(regexp_replace(trim(${col}), '[[:space:]]+', ' ', 'g'))`
+}
+
+/**
+ * Entity types covered by the duplicate-name soft-warn. ADRs use
+ * `number` as the unique key (hard-blocked separately by schema in
+ * future work); the seven below all use `name` (or `term` for
+ * glossary).
+ */
+export type DuplicateNameEntityType =
+  | 'application'
+  | 'capability'
+  | 'glossary'
+  | 'initiative'
+  | 'persona'
+  | 'objective'
+  | 'service'
+
+export const DUPLICATE_NAME_ENTITY_LABELS: Record<DuplicateNameEntityType, string> = {
+  application: 'application',
+  capability: 'capability',
+  glossary: 'glossary term',
+  initiative: 'initiative',
+  persona: 'persona',
+  objective: 'objective',
+  service: 'service',
+}
+
+/**
+ * Thrown when a non-ack'd create finds a name collision in the same
+ * org. Carries the canonical existing name (with original casing) so
+ * the client can render "A capability named 'Online Permitting' already
+ * exists. Create anyway?" rather than echoing whatever the user typed.
+ */
+export class DuplicateNameAcknowledgmentRequiredError extends Error {
+  readonly code = 'DUPLICATE_NAME_ACK_REQUIRED'
+  readonly entityType: DuplicateNameEntityType
+  readonly existingName: string
+
+  constructor(entityType: DuplicateNameEntityType, existingName: string) {
+    const label = DUPLICATE_NAME_ENTITY_LABELS[entityType]
+    super(`A ${label} named "${existingName}" already exists in this organization. Submit again to create anyway.`)
+    this.entityType = entityType
+    this.existingName = existingName
+  }
+}
+
+/**
+ * Trim, collapse internal whitespace, lowercase. Used both at lookup
+ * and (conceptually) at compare time. Returns empty string for empty
+ * input so callers can short-circuit on missing names.
+ */
+export function normaliseName(name: string | null | undefined): string {
+  if (!name) return ''
+  return name.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/**
+ * Returns the canonical (original-cased) existing name when a row
+ * already exists in this org with a normalised-equal name. Returns
+ * null otherwise.
+ *
+ * Uses `ilike` for case-insensitive match at the SQL level, then
+ * normalises both sides in JS to honour the whitespace rule. The
+ * SQL prefilter keeps the candidate set small enough that JS-side
+ * normalisation is fine even at thousands of rows.
+ */
+export async function findDuplicateName(
+  entityType: DuplicateNameEntityType,
+  orgId: string,
+  name: string,
+): Promise<{ existingName: string } | null> {
+  const target = normaliseName(name)
+  if (!target) return null
+
+  switch (entityType) {
+    case 'application': {
+      const row = await db.select({ name: applications.name }).from(applications)
+        .where(and(eq(applications.organizationId, orgId), sql`${sqlNormalize(applications.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'capability': {
+      const row = await db.select({ name: capabilities.name }).from(capabilities)
+        .where(and(eq(capabilities.organizationId, orgId), sql`${sqlNormalize(capabilities.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'glossary': {
+      const row = await db.select({ name: glossaryTerms.term }).from(glossaryTerms)
+        .where(and(eq(glossaryTerms.organizationId, orgId), sql`${sqlNormalize(glossaryTerms.term)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'initiative': {
+      const row = await db.select({ name: initiatives.name }).from(initiatives)
+        .where(and(eq(initiatives.organizationId, orgId), sql`${sqlNormalize(initiatives.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'persona': {
+      const row = await db.select({ name: personas.name }).from(personas)
+        .where(and(eq(personas.organizationId, orgId), sql`${sqlNormalize(personas.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'objective': {
+      const row = await db.select({ name: strategicObjectives.name }).from(strategicObjectives)
+        .where(and(eq(strategicObjectives.organizationId, orgId), sql`${sqlNormalize(strategicObjectives.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+    case 'service': {
+      const row = await db.select({ name: services.name }).from(services)
+        .where(and(eq(services.organizationId, orgId), sql`${sqlNormalize(services.name)} = ${target}`))
+        .limit(1)
+      return row[0] ? { existingName: row[0].name } : null
+    }
+  }
+}
+
+/**
+ * The gate itself. Call from createX after reading the form's
+ * `acknowledgeDuplicate` flag:
+ *
+ *   const ack = formData.get('acknowledgeDuplicate') === 'on'
+ *   await ensureNoDuplicateName('capability', orgId, name, ack)
+ *
+ * Throws when a duplicate exists AND the ack is missing.
+ * Returns silently in every other case (no duplicate / duplicate but
+ * explicitly acknowledged).
+ */
+export async function ensureNoDuplicateName(
+  entityType: DuplicateNameEntityType,
+  orgId: string,
+  name: string,
+  acknowledged: boolean,
+): Promise<void> {
+  if (acknowledged) return
+  const dup = await findDuplicateName(entityType, orgId, name)
+  if (dup) throw new DuplicateNameAcknowledgmentRequiredError(entityType, dup.existingName)
+}

--- a/apps/govea/src/lib/use-dirty-dialog.ts
+++ b/apps/govea/src/lib/use-dirty-dialog.ts
@@ -1,0 +1,70 @@
+'use client'
+
+/**
+ * Hook + helper for unsaved-changes confirmation on dialog close (#567 Part A).
+ *
+ * Surfaced by the Junior EA Analyst persona walk:
+ *   "Clicking Cancel silently discards changes. No warning."
+ *
+ * Usage:
+ *
+ *   const dirty = useDirtyTracker()
+ *   <Dialog
+ *     open={open}
+ *     onOpenChange={(o) => { if (!o && !confirmDiscard(dirty)) return; setOpen(o) }}
+ *   >
+ *     <form onChange={dirty.markDirty} onSubmit={() => dirty.reset()}>
+ *       ...
+ *       <Button onClick={() => { if (confirmDiscard(dirty)) setOpen(false) }}>Cancel</Button>
+ *     </form>
+ *   </Dialog>
+ *
+ * The hook deliberately stays minimal — it does NOT auto-wire to a
+ * specific Dialog component, because the form structure varies across
+ * the codebase (some use Dialog, some inline forms, some controlled
+ * inputs). Each caller decides where to mark-dirty and where to
+ * confirm-discard.
+ */
+import { useCallback, useRef, useState } from 'react'
+
+export interface DirtyTracker {
+  isDirty: boolean
+  markDirty: () => void
+  reset: () => void
+}
+
+/**
+ * Returns a dirty-tracker. `markDirty` flips the flag on the first
+ * input change; `reset` clears it (call after a successful save).
+ *
+ * The internal ref is used so we can read the latest value from event
+ * handlers without re-rendering on every keystroke.
+ */
+export function useDirtyTracker(): DirtyTracker {
+  const [, setTick] = useState(0)
+  const ref = useRef(false)
+  const markDirty = useCallback(() => {
+    if (!ref.current) {
+      ref.current = true
+      setTick(t => t + 1)
+    }
+  }, [])
+  const reset = useCallback(() => {
+    if (ref.current) {
+      ref.current = false
+      setTick(t => t + 1)
+    }
+  }, [])
+  return { get isDirty() { return ref.current }, markDirty, reset }
+}
+
+/**
+ * Returns true when the user is okay to close (either nothing was
+ * changed, or they confirmed discarding). Returns false when the
+ * dialog should stay open.
+ */
+export function confirmDiscard(tracker: DirtyTracker): boolean {
+  if (!tracker.isDirty) return true
+  if (typeof window === 'undefined') return true
+  return window.confirm('You have unsaved changes. Discard them?')
+}

--- a/apps/govea/tests/integration/duplicate-name-gate.test.ts
+++ b/apps/govea/tests/integration/duplicate-name-gate.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration tests: duplicate-name soft-warn gate (#566)
+ *
+ * Covers:
+ *   - DuplicateNameAcknowledgmentRequiredError thrown on collision
+ *   - acknowledgeDuplicate=on bypasses the gate
+ *   - Case + whitespace normalisation: 'Online Permitting', 'online permitting',
+ *     and 'Online  Permitting' (double-space) all collide with each other
+ *   - Per-org scope: same name across different orgs is OK
+ *   - All 7 entity types use the gate (capability, application, persona,
+ *     initiative, objective, service, glossary)
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  capabilities, applications, personas, initiatives,
+  strategicObjectives, services, glossaryTerms,
+} from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { createCapability } from '@/actions/capabilities'
+import { createApplication } from '@/actions/applications'
+import { createPersona } from '@/actions/personas'
+import { createInitiative } from '@/actions/initiatives'
+import { createObjective } from '@/actions/objectives'
+import { createService } from '@/actions/services'
+import { createGlossaryTerm } from '@/actions/glossary'
+import {
+  findDuplicateName, normaliseName,
+  DuplicateNameAcknowledgmentRequiredError,
+} from '@/lib/duplicate-name-gate'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('duplicate-name soft-warn gate (#566)', () => {
+  let orgId: string
+  let otherOrgId: string
+  let contributor: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    const other = await createTestOrg()
+    orgId = org.id
+    otherOrgId = other.id
+    contributor = await createTestUser(orgId, 'contributor')
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgId)
+    await cleanupOrg(otherOrgId)
+  })
+
+  // ── normaliseName ────────────────────────────────────────────────────────
+
+  it('normaliseName lowercases + trims + collapses whitespace', () => {
+    expect(normaliseName('Online Permitting')).toBe('online permitting')
+    expect(normaliseName('  Online   Permitting  ')).toBe('online permitting')
+    expect(normaliseName('online\tpermitting')).toBe('online permitting')
+    expect(normaliseName('')).toBe('')
+    expect(normaliseName(null)).toBe('')
+  })
+
+  // ── findDuplicateName ────────────────────────────────────────────────────
+
+  it('findDuplicateName: returns existing row on case-insensitive match', async () => {
+    await db.insert(capabilities).values({
+      id: randomUUID(), organizationId: orgId,
+      name: 'Budget Reporting', status: 'draft', visibility: 'org',
+    })
+    const dup = await findDuplicateName('capability', orgId, 'budget reporting')
+    expect(dup?.existingName).toBe('Budget Reporting')
+  })
+
+  it('findDuplicateName: returns null when no match', async () => {
+    const dup = await findDuplicateName('capability', orgId, `Nonexistent-${randomUUID().slice(0, 6)}`)
+    expect(dup).toBeNull()
+  })
+
+  it('findDuplicateName: whitespace-normalises (double space collides)', async () => {
+    await db.insert(capabilities).values({
+      id: randomUUID(), organizationId: orgId,
+      name: 'Permits  Issuance', // intentional double space
+      status: 'draft', visibility: 'org',
+    })
+    const dup = await findDuplicateName('capability', orgId, 'Permits Issuance')
+    expect(dup?.existingName).toBe('Permits  Issuance')
+  })
+
+  it('findDuplicateName: scoped to org (same name in another org returns null)', async () => {
+    await db.insert(capabilities).values({
+      id: randomUUID(), organizationId: otherOrgId,
+      name: 'Different Org Cap', status: 'draft', visibility: 'org',
+    })
+    const dup = await findDuplicateName('capability', orgId, 'Different Org Cap')
+    expect(dup).toBeNull()
+  })
+
+  // ── Gate fires on createCapability ────────────────────────────────────────
+
+  it('createCapability without ack throws DuplicateNameAcknowledgmentRequiredError', async () => {
+    await db.insert(capabilities).values({
+      id: randomUUID(), organizationId: orgId,
+      name: 'Capability For Dup Test', status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'capability for dup test') // lowercase variation
+    fd.set('status', 'draft')
+    fd.set('visibility', 'org')
+    await expect(createCapability(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createCapability with acknowledgeDuplicate=on succeeds', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'Capability For Dup Test') // same name, ack'd
+    fd.set('status', 'draft')
+    fd.set('visibility', 'org')
+    fd.set('acknowledgeDuplicate', 'on')
+    await createCapability(fd)
+    const rows = await db.select().from(capabilities)
+      .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Capability For Dup Test')))
+    expect(rows.length).toBeGreaterThanOrEqual(2) // original + new ack'd duplicate
+  })
+
+  it('error message carries the canonical existing name', async () => {
+    await db.insert(capabilities).values({
+      id: randomUUID(), organizationId: orgId,
+      name: 'Online Permitting', status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'ONLINE PERMITTING')
+    fd.set('status', 'draft')
+    fd.set('visibility', 'org')
+    try {
+      await createCapability(fd)
+      expect.fail('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DuplicateNameAcknowledgmentRequiredError)
+      const e = err as DuplicateNameAcknowledgmentRequiredError
+      expect(e.code).toBe('DUPLICATE_NAME_ACK_REQUIRED')
+      expect(e.existingName).toBe('Online Permitting')
+      expect(e.message).toContain('Online Permitting')
+      expect(e.message).toContain('already exists in this organization')
+    }
+  })
+
+  // ── Each entity type uses the gate ────────────────────────────────────────
+
+  it('createApplication uses the gate', async () => {
+    await db.insert(applications).values({
+      id: randomUUID(), organizationId: orgId, name: 'Existing App',
+      status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'existing app')
+    fd.set('lifecycleStatus', 'active')
+    await expect(createApplication(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createPersona uses the gate', async () => {
+    await db.insert(personas).values({
+      id: randomUUID(), organizationId: orgId, name: 'Existing Persona',
+      status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'EXISTING PERSONA')
+    await expect(createPersona(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createInitiative uses the gate', async () => {
+    await db.insert(initiatives).values({
+      id: randomUUID(), organizationId: orgId, name: 'Existing Initiative',
+      status: 'proposed', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'Existing Initiative')
+    fd.set('status', 'proposed')
+    fd.set('visibility', 'org')
+    await expect(createInitiative(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createObjective uses the gate', async () => {
+    await db.insert(strategicObjectives).values({
+      id: randomUUID(), organizationId: orgId, name: 'Existing Objective',
+      status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'existing objective')
+    await expect(createObjective(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createService uses the gate', async () => {
+    await db.insert(services).values({
+      id: randomUUID(), organizationId: orgId, name: 'Existing Service',
+      channels: [], status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('name', 'existing service')
+    await expect(createService(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+
+  it('createGlossaryTerm uses the gate', async () => {
+    await db.insert(glossaryTerms).values({
+      id: randomUUID(), organizationId: orgId, term: 'Existing Term',
+      definition: 'a thing', status: 'draft', visibility: 'org',
+    })
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    fd.set('term', 'EXISTING TERM')
+    fd.set('definition', 'another thing')
+    await expect(createGlossaryTerm(fd)).rejects.toThrow(DuplicateNameAcknowledgmentRequiredError)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #566 fully. Lands #567 Part A's shared hook + the canonical wiring on the capability dialogs. The remaining 6 dialogs get the same wiring in a fast follow-up PR — the pattern is mechanical and a single form is enough to settle review on the shape.

Addresses two **Junior EA Analyst** persona pain points:

- **#6: "duplicating an existing record is a common error with no warning mechanism"** — every content-create action now soft-warns on a name collision in the same org. Same ack-and-retry pattern as the publish-debt gate (#381) and the domain-owner overwrite gate (#581). Consistency wins.
- **#1: "no guardrails — easy to overwrite or misclassify data"** — a shared dirty-tracker hook intercepts Cancel / Escape / backdrop close when the form has unsaved changes.

## What ships

- **`lib/duplicate-name-gate.ts`** — `DuplicateNameAcknowledgmentRequiredError` + `findDuplicateName()` + `ensureNoDuplicateName()`. Per-org scope; case + whitespace normalised at the SQL layer using `[[:space:]]+` (NOT `\s` — PostgreSQL POSIX regex doesn't recognise `\s` as whitespace; that footgun is documented in the helper).
- **`lib/duplicate-name-client.ts`** — `submitWithDuplicateAck(action, formData)` wraps a create action with catch-and-retry-with-ack. Client never imports the server-only module.
- **7 server create actions wired**: application, capability, glossary, initiative, objective, persona, service.
- **7 client tables wired** to use `submitWithDuplicateAck`.
- **`lib/use-dirty-dialog.ts`** — `useDirtyTracker()` + `confirmDiscard()`. Deliberately minimal — each caller decides where to mark-dirty and confirm-discard.
- **Capability table create + edit dialogs** wired with the dirty hook as the template.

## Scope decisions

- **#567 Part B (per-field validation + status-aware required fields) deferred.** Per the issue: *"A is mechanically cheaper; B is design-heavier — could ship as separate PRs once design is settled."*
- **6 of 7 dialogs not yet wired for the dirty-tracker** — follow-up PR. The shared hook is settled; the per-form wiring is repetitive.
- **ADR `number` field deliberately not in scope.** Hard-block-on-schema-uniqueness is a separate concern from the soft-warn-on-content-name pattern.

## Design notes

- **POSIX regex footgun documented in the helper**: PostgreSQL doesn't recognise `\s` in its default POSIX regex mode; `\s` matches a literal `s` character. Using `[[:space:]]+` instead.
- **Per-key normalisation lives in SQL** so an index on `lower(name)` can be added later without a code change.
- **Error-message substring detection** on the client (not `instanceof`) so the client doesn't pull in the server-only db module.

## Test plan

- [x] 14 integration tests in `duplicate-name-gate.test.ts`:
  - Normalise: lowercase, trim, whitespace collapse
  - findDuplicateName: case-insensitive, null on miss, double-space collides, per-org scope
  - createCapability without ack throws + error carries canonical name
  - createCapability with ack succeeds
  - All 7 entity types use the gate
- [x] `tsc --noEmit` clean
- [x] Full vitest sweep: 690 / 690 passing

Capability: candidate new `cm-content-authoring`
Closes #566
Refs #567 (Part A landed, Part B deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)