### PR TITLE
feat(onboarding): first-sign-in modal (#587 follow-up)

### DIFF
--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
   type RagBucket,
 } from '@/lib/completeness-signals'
 import Link from 'next/link'
+import { FirstSignInModal } from '@/components/first-sign-in-modal'
 
 const RAG_TEXT_CLASS: Record<RagBucket, string> = {
   green:   'text-green-700 dark:text-green-400',
@@ -224,6 +225,10 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-6">
+      {/* First-sign-in modal (#587 follow-up). Self-managed via localStorage;
+          renders nothing on subsequent visits. Admin-only. */}
+      <FirstSignInModal role={session.user.role} />
+
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
         <p className="text-muted-foreground mt-1">

--- a/apps/govea/src/components/first-sign-in-modal.tsx
+++ b/apps/govea/src/components/first-sign-in-modal.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { driver } from 'driver.js'
+import 'driver.js/dist/driver.css'
+
+/**
+ * First-sign-in onboarding modal (#587 follow-up).
+ *
+ * Surfaced by the Early-Maturity EA Practice Lead persona walk:
+ *   "Today, an admin who completes /setup lands in an empty org with
+ *    no first-time framing, no starter content option, no inline
+ *    empty-state CTAs on the catalog pages."
+ *
+ * Shows once per browser to admins, offering three anchored choices:
+ *   - Take the tour (existing driver.js tour)
+ *   - Apply a starter pack (navigates to /settings#starter-content)
+ *   - Start from scratch (just dismisses)
+ *
+ * Persistence is via localStorage rather than a server-side flag so that:
+ *   - No schema change is required (smallest reviewable PR for v1)
+ *   - Switching devices re-shows the modal once — acceptable for an
+ *     onboarding affordance; if a director-of-IT installs GovEA on a
+ *     laptop one day and an iPad the next, seeing the welcome once
+ *     more is fine
+ *
+ * If we ever need cross-device persistence, the upgrade path is a
+ * `firstSignInOnboardingDismissedAt` timestamp on users + a tiny
+ * server action — same pattern as `markCapabilityReviewed`. Tracked
+ * here so the option is visible.
+ */
+const STORAGE_KEY = 'govea-first-sign-in-dismissed'
+
+// Minimal tour definition — keep in sync with the main TourButton's tour.
+// Shared via a re-exported `buildTour()` would be cleaner; deferred to
+// avoid expanding scope of #587 follow-up.
+function buildBasicTour() {
+  return driver({
+    showProgress: true,
+    popoverClass: 'govea-tour-popover',
+    steps: [
+      { element: '[data-tour="dashboard-link"]', popover: { title: 'Dashboard', description: 'Coverage and health signals across all of your EA content live here.' } },
+      { element: '[data-tour="capabilities-link"]', popover: { title: 'Capabilities', description: 'What your organization must be able to do.' } },
+      { element: '[data-tour="applications-link"]', popover: { title: 'Applications', description: 'The technology platforms that deliver capabilities.' } },
+      { element: '[data-tour="settings-link"]', popover: { title: 'Settings', description: 'Apply starter content, adjust security, and configure your org here.' } },
+    ],
+  })
+}
+
+export function FirstSignInModal({ role }: { role: 'admin' | 'contributor' | 'viewer' }) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (role !== 'admin') return
+    try {
+      if (typeof window === 'undefined') return
+      const dismissed = window.localStorage.getItem(STORAGE_KEY)
+      if (!dismissed) setOpen(true)
+    } catch {
+      // localStorage can be unavailable (Safari private mode, etc.) —
+      // gracefully skip in that case rather than crashing the dashboard.
+    }
+  }, [role])
+
+  function dismiss() {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, new Date().toISOString())
+      }
+    } catch {}
+    setOpen(false)
+  }
+
+  function handleTakeTour() {
+    dismiss()
+    // Small delay so the modal animates closed before the tour overlay opens.
+    setTimeout(() => buildBasicTour().drive(), 200)
+  }
+
+  function handleApplyStarterPack() {
+    dismiss()
+    router.push('/settings#starter-content')
+  }
+
+  function handleStartScratch() {
+    dismiss()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) dismiss() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Welcome to GovEA</DialogTitle>
+          <DialogDescription>
+            Pick the path that fits how you want to start. You can change your mind any time — none of these are one-way doors.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 pt-2">
+          <button
+            type="button"
+            onClick={handleTakeTour}
+            className="w-full rounded-md border bg-card p-4 text-left hover:border-primary/50 hover:bg-muted/40 transition-colors"
+          >
+            <p className="font-medium">Take the tour</p>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              A short guided walk through the main surfaces — dashboard, capabilities, applications, settings.
+            </p>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleApplyStarterPack}
+            className="w-full rounded-md border bg-card p-4 text-left hover:border-primary/50 hover:bg-muted/40 transition-colors"
+          >
+            <p className="font-medium">Apply a starter pack</p>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Seed your org with a small, credible example map you can use to demo or replace as you build your own. Tagged so it never gets confused with your authored content.
+            </p>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleStartScratch}
+            className="w-full rounded-md border bg-card p-4 text-left hover:border-primary/50 hover:bg-muted/40 transition-colors"
+          >
+            <p className="font-medium">Start from scratch</p>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Skip both. You&rsquo;ll see empty-state prompts on each catalog page as you go.
+            </p>
+          </button>
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <Button variant="ghost" size="sm" onClick={dismiss}>
+            Don&rsquo;t show this again
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

Closes the Early-Maturity EA Practice Lead persona walk pain point #587 left unaddressed: today an admin completing /setup lands in an empty org with no first-time framing — no auto-fired tour, no starter-pack prompt, no inline guidance about where to start. They have to know the product well enough to click the unobtrusive Tour button to find any of that.

## What ships

- **`FirstSignInModal`** client component, rendered once on /dashboard for admins. Three anchored choices:
  - **Take the tour** — fires a small driver.js tour
  - **Apply a starter pack** — routes to `/settings#starter-content` (where #605 ships the picker)
  - **Start from scratch** — dismiss without action
- **`localStorage` persistence** (no schema change for v1). Cross-device re-shows the modal once — acceptable for onboarding.
- **Admin-only** per #587 ("Out of scope: auto-firing for non-admin users — admin-only initially").
- **Graceful localStorage failure handling** so a flaky storage layer (Safari private mode etc.) never crashes the dashboard.

## Scope decisions

- **Empty-state CTAs on catalog pages** (also listed in #587 acceptance) — out of scope. Each of /capabilities, /applications, /personas, etc. would need an empty-state component + copy. Mechanical but multi-file; belongs in a follow-up.
- **Shared tour definition** — the modal's tour is a four-step subset, not the full tour from `TourButton`. Sharing one definition is the right cleanup but expands scope; deferred.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: sign in as a brand-new admin → modal appears → each choice works → dismiss persists across page navigations
- [ ] Manual: sign in as a Contributor or Viewer → modal does NOT appear

Capability: candidate new `ac-starter-content`
Refs #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)