### PR TITLE
feat(admin): URL-backed filters on /audit (#531)

### DIFF
--- a/apps/govea/src/app/(admin)/audit/page.tsx
+++ b/apps/govea/src/app/(admin)/audit/page.tsx
@@ -1,12 +1,22 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canEdit, isAdmin } from '@/lib/rbac'
-import { getAuditEntries } from '@/lib/audit-view'
+import {
+  getAuditEntries, getAuditActorOptions, getAuditActionNamespaces,
+  timeWindowToDate, type AuditTimeWindow,
+} from '@/lib/audit-view'
+import { AuditLogFilters } from '@/components/audit-log-filters'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
 
-export default async function AuditPage() {
+const VALID_WINDOWS: AuditTimeWindow[] = ['24h', '7d', '30d', '90d', 'all']
+
+export default async function AuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ actor?: string; action?: string; since?: string }>
+}) {
   const session = await auth()
   if (!session?.user) redirect('/login')
   if (!canEdit(session.user)) redirect('/dashboard')
@@ -15,7 +25,21 @@ export default async function AuditPage() {
   const role: 'admin' | 'contributor' = isUserAdmin ? 'admin' : 'contributor'
   const orgId = session.user.organizationId!
 
-  const entries = await getAuditEntries(orgId, role)
+  const params = await searchParams
+  const actorUserId = params.actor || null
+  const actionNamespaces = params.action ? params.action.split(',').filter(Boolean) : []
+  const windowKey = (VALID_WINDOWS.includes((params.since ?? '30d') as AuditTimeWindow)
+    ? (params.since ?? '30d')
+    : '30d') as AuditTimeWindow
+  const since = timeWindowToDate(windowKey)
+
+  const [entries, actorOptions, namespaceOptions] = await Promise.all([
+    getAuditEntries(orgId, role, { actorUserId, actionNamespaces, since }),
+    getAuditActorOptions(orgId, role),
+    getAuditActionNamespaces(orgId, role),
+  ])
+
+  const filteredOut = actorUserId || actionNamespaces.length > 0 || windowKey !== '30d'
 
   return (
     <div className="space-y-6">
@@ -27,6 +51,9 @@ export default async function AuditPage() {
             : 'Changes to architecture content in this organization. Authentication, user management, and organization settings stay admin-only.'}
         </p>
       </div>
+
+      <AuditLogFilters actors={actorOptions} actionNamespaces={namespaceOptions} />
+
       <div className="rounded-lg border bg-card">
         <Table>
           <TableHeader>
@@ -49,7 +76,9 @@ export default async function AuditPage() {
             {entries.length === 0 && (
               <TableRow>
                 <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
-                  No audit entries yet
+                  {filteredOut
+                    ? 'No audit entries match the current filters.'
+                    : 'No audit entries yet'}
                 </TableCell>
               </TableRow>
             )}

--- a/apps/govea/src/components/audit-log-filters.tsx
+++ b/apps/govea/src/components/audit-log-filters.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useRouter, usePathname, useSearchParams } from 'next/navigation'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+/**
+ * URL-backed audit-log filter controls (#531).
+ *
+ * Three filters:
+ *   - Actor (single-select dropdown of users with audit entries in scope)
+ *   - Action namespace (multi-select chips over distinct namespaces)
+ *   - Time window (24h / 7d / 30d / 90d / all)
+ *
+ * State lives in the URL (`?actor=`, `?action=`, `?since=`) so a filtered
+ * view is shareable + bookmarkable, and reloading the page keeps the
+ * current cut. URL is the source of truth; this component is a thin
+ * driver around `router.replace`.
+ *
+ * Designed to be drop-in shareable between the org-scoped /audit and the
+ * instance-scoped /instance/audit (per #523 — same pattern, different
+ * scope) — the parent passes in the actor + action options and the
+ * component just renders + writes the URL.
+ */
+export function AuditLogFilters({
+  actors,
+  actionNamespaces,
+}: {
+  actors: { id: string; name: string | null; email: string | null }[]
+  actionNamespaces: string[]
+}) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const sp = useSearchParams()
+
+  const currentActor = sp.get('actor') ?? ''
+  const currentActionsRaw = sp.get('action') ?? ''
+  const currentActions = currentActionsRaw ? currentActionsRaw.split(',').filter(Boolean) : []
+  const currentSince = sp.get('since') ?? '30d'
+
+  function navigate(updates: { actor?: string | null; action?: string[]; since?: string }) {
+    const next = new URLSearchParams(sp.toString())
+    if (updates.actor !== undefined) {
+      if (!updates.actor) next.delete('actor')
+      else next.set('actor', updates.actor)
+    }
+    if (updates.action !== undefined) {
+      if (updates.action.length === 0) next.delete('action')
+      else next.set('action', updates.action.join(','))
+    }
+    if (updates.since !== undefined) {
+      if (updates.since === '30d') next.delete('since') // default = no param
+      else next.set('since', updates.since)
+    }
+    router.replace(`${pathname}${next.size > 0 ? `?${next.toString()}` : ''}`)
+  }
+
+  function toggleAction(ns: string) {
+    const set = new Set(currentActions)
+    if (set.has(ns)) set.delete(ns)
+    else set.add(ns)
+    navigate({ action: Array.from(set) })
+  }
+
+  const anyFilter = currentActor || currentActions.length > 0 || (currentSince && currentSince !== '30d')
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Filters</h2>
+        {anyFilter && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => router.replace(pathname)}
+            className="text-xs h-7"
+          >
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="audit-actor">Actor</Label>
+          <select
+            id="audit-actor"
+            value={currentActor}
+            onChange={(e) => navigate({ actor: e.target.value || null })}
+            className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="">All actors</option>
+            {actors.map(a => (
+              <option key={a.id} value={a.id}>
+                {a.name ?? a.email ?? a.id.slice(0, 8)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="audit-since">Time window</Label>
+          <select
+            id="audit-since"
+            value={currentSince}
+            onChange={(e) => navigate({ since: e.target.value })}
+            className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days (default)</option>
+            <option value="90d">Last 90 days</option>
+            <option value="all">All time</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>Action types</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {actionNamespaces.length === 0 && (
+            <p className="text-xs text-muted-foreground">No actions recorded yet.</p>
+          )}
+          {actionNamespaces.map(ns => {
+            const active = currentActions.includes(ns)
+            return (
+              <button
+                type="button"
+                key={ns}
+                onClick={() => toggleAction(ns)}
+                className={
+                  'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono transition-colors ' +
+                  (active
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-input bg-background hover:bg-muted')
+                }
+              >
+                {ns}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/govea/src/lib/audit-view.ts
+++ b/apps/govea/src/lib/audit-view.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/client'
 import { auditLog, users } from '@/db/schema'
-import { and, eq, desc, inArray } from 'drizzle-orm'
+import { and, eq, desc, gte, inArray, like, sql, type SQL } from 'drizzle-orm'
 
 /**
  * Entity types whose audit events are visible to Contributors (#597).
@@ -58,19 +58,100 @@ export type AuditViewRole = 'admin' | 'contributor'
  * helper. The page-level gate is `canEdit(session.user)`; this helper
  * assumes the caller already enforced that.
  */
-export async function getAuditEntries(orgId: string, role: AuditViewRole, limit = 200) {
-  const where = role === 'admin'
-    ? eq(auditLog.organizationId, orgId)
-    : and(
-        eq(auditLog.organizationId, orgId),
-        inArray(auditLog.entityType, [...CONTRIBUTOR_VISIBLE_ENTITY_TYPES]),
-      )
+/** Filters surfaced by the /audit URL (#531). */
+export type AuditFilters = {
+  /** Caller chose a specific actor; null = all actors. */
+  actorUserId?: string | null
+  /**
+   * One or more action namespaces (the part before the first `.`).
+   * Empty = all actions. Matched with `action LIKE 'ns.%'` so a single
+   * URL param can carry multiple comma-separated namespaces.
+   */
+  actionNamespaces?: string[]
+  /** Cutoff for `createdAt >= since`. null = no time window. */
+  since?: Date | null
+}
+
+/** Time-window presets exposed by the filter UI. */
+export type AuditTimeWindow = '24h' | '7d' | '30d' | '90d' | 'all'
+
+export function timeWindowToDate(window: AuditTimeWindow): Date | null {
+  const now = Date.now()
+  switch (window) {
+    case '24h': return new Date(now - 24 * 60 * 60 * 1000)
+    case '7d':  return new Date(now - 7 * 24 * 60 * 60 * 1000)
+    case '30d': return new Date(now - 30 * 24 * 60 * 60 * 1000)
+    case '90d': return new Date(now - 90 * 24 * 60 * 60 * 1000)
+    case 'all': return null
+  }
+}
+
+export async function getAuditEntries(
+  orgId: string,
+  role: AuditViewRole,
+  filters: AuditFilters = {},
+  limit = 200,
+) {
+  const clauses: SQL[] = [eq(auditLog.organizationId, orgId)]
+  if (role === 'contributor') {
+    clauses.push(inArray(auditLog.entityType, [...CONTRIBUTOR_VISIBLE_ENTITY_TYPES]))
+  }
+  if (filters.actorUserId) {
+    clauses.push(eq(auditLog.userId, filters.actorUserId))
+  }
+  if (filters.actionNamespaces && filters.actionNamespaces.length > 0) {
+    // OR across namespaces — match action LIKE 'ns.%' for each.
+    const orClauses = filters.actionNamespaces.map(ns => like(auditLog.action, `${ns}.%`))
+    clauses.push(sql`(${sql.join(orClauses, sql` OR `)})`)
+  }
+  if (filters.since) {
+    clauses.push(gte(auditLog.createdAt, filters.since))
+  }
 
   return db
     .select({ log: auditLog, user: users })
     .from(auditLog)
     .leftJoin(users, eq(auditLog.userId, users.id))
-    .where(where)
+    .where(and(...clauses))
     .orderBy(desc(auditLog.createdAt))
     .limit(limit)
+}
+
+/**
+ * Returns distinct actors (id, name, email) who have audit-log entries
+ * in this org. Drives the actor-filter dropdown. Scoped to the role's
+ * visible entity-types so a Contributor doesn't see admin-only actors
+ * leak through the filter list.
+ */
+export async function getAuditActorOptions(orgId: string, role: AuditViewRole) {
+  const clauses: SQL[] = [eq(auditLog.organizationId, orgId)]
+  if (role === 'contributor') {
+    clauses.push(inArray(auditLog.entityType, [...CONTRIBUTOR_VISIBLE_ENTITY_TYPES]))
+  }
+  const rows = await db
+    .selectDistinct({ id: users.id, name: users.name, email: users.email })
+    .from(auditLog)
+    .innerJoin(users, eq(auditLog.userId, users.id))
+    .where(and(...clauses))
+    .orderBy(users.name)
+  return rows
+}
+
+/**
+ * Returns distinct action namespaces (`split_part(action, '.', 1)`) that
+ * have at least one row in this org's audit log. Drives the action-filter
+ * multi-select. Role-scoped same as the actor lookup above.
+ */
+export async function getAuditActionNamespaces(orgId: string, role: AuditViewRole) {
+  const clauses: SQL[] = [eq(auditLog.organizationId, orgId)]
+  if (role === 'contributor') {
+    clauses.push(inArray(auditLog.entityType, [...CONTRIBUTOR_VISIBLE_ENTITY_TYPES]))
+  }
+  const rows = await db
+    .select({ ns: sql<string>`split_part(${auditLog.action}, '.', 1)` })
+    .from(auditLog)
+    .where(and(...clauses))
+    .groupBy(sql`split_part(${auditLog.action}, '.', 1)`)
+    .orderBy(sql`split_part(${auditLog.action}, '.', 1)`)
+  return rows.map(r => r.ns).filter(Boolean)
 }

--- a/apps/govea/tests/integration/audit-filters.test.ts
+++ b/apps/govea/tests/integration/audit-filters.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration tests: audit-log filters (#531)
+ *
+ * Covers the three filter axes the UI exposes:
+ *   - actor (actorUserId)
+ *   - action namespace (actionNamespaces — match `action LIKE 'ns.%'`)
+ *   - time window (since)
+ *
+ * Plus the option-lookup helpers (actor dropdown + namespace chip list)
+ * that the page uses to drive the filter UI.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { auditLog } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import {
+  getAuditEntries, getAuditActorOptions, getAuditActionNamespaces,
+  timeWindowToDate,
+} from '@/lib/audit-view'
+import {
+  createTestOrg, createTestUser, cleanupOrg, type TestUser,
+} from './helpers/db'
+
+describe('audit-log filters (#531)', () => {
+  let orgId: string
+  let alice: TestUser
+  let bob: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[alice, bob] = await Promise.all([
+      createTestUser(orgId, 'admin', { name: 'Alice Admin' }),
+      createTestUser(orgId, 'contributor', { name: 'Bob Contributor' }),
+    ])
+
+    // Seed audit events across actors / namespaces / time.
+    const now = new Date()
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)
+    const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000)
+    const sixtyDaysAgo = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000)
+
+    await db.insert(auditLog).values([
+      { id: randomUUID(), organizationId: orgId, userId: alice.id, action: 'capability.edit', entityType: 'capability', createdAt: now },
+      { id: randomUUID(), organizationId: orgId, userId: alice.id, action: 'capability.create', entityType: 'capability', createdAt: twoDaysAgo },
+      { id: randomUUID(), organizationId: orgId, userId: bob.id,   action: 'capability.edit', entityType: 'capability', createdAt: tenDaysAgo },
+      { id: randomUUID(), organizationId: orgId, userId: bob.id,   action: 'application.edit', entityType: 'application', createdAt: tenDaysAgo },
+      { id: randomUUID(), organizationId: orgId, userId: alice.id, action: 'auth.login', entityType: 'user', createdAt: sixtyDaysAgo },
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('no filter: admin sees all events; contributor only sees architecture-content', async () => {
+    const adminRows = await getAuditEntries(orgId, 'admin', {})
+    expect(adminRows.length).toBe(5)
+    const contribRows = await getAuditEntries(orgId, 'contributor', {})
+    expect(contribRows.length).toBe(4) // excludes auth.login (entityType=user)
+  })
+
+  it('actor filter narrows to a single user', async () => {
+    const rows = await getAuditEntries(orgId, 'admin', { actorUserId: alice.id })
+    expect(rows.length).toBe(3)
+    expect(rows.every(r => r.log.userId === alice.id)).toBe(true)
+  })
+
+  it('action namespace filter matches LIKE prefix (single namespace)', async () => {
+    const rows = await getAuditEntries(orgId, 'admin', { actionNamespaces: ['application'] })
+    expect(rows.length).toBe(1)
+    expect(rows[0].log.action).toBe('application.edit')
+  })
+
+  it('action namespace filter ORs multiple namespaces', async () => {
+    const rows = await getAuditEntries(orgId, 'admin', { actionNamespaces: ['application', 'auth'] })
+    expect(rows.length).toBe(2)
+    const actions = rows.map(r => r.log.action).sort()
+    expect(actions).toEqual(['application.edit', 'auth.login'])
+  })
+
+  it('time window filter respects the cutoff (7d)', async () => {
+    const since = timeWindowToDate('7d')!
+    const rows = await getAuditEntries(orgId, 'admin', { since })
+    expect(rows.length).toBe(2) // only today + 2-days-ago survive
+  })
+
+  it('filters combine: actor + namespace + time', async () => {
+    const since = timeWindowToDate('30d')! // 30d cutoff drops the 60-day-old auth row
+    const rows = await getAuditEntries(orgId, 'admin', {
+      actorUserId: alice.id,
+      actionNamespaces: ['capability'],
+      since,
+    })
+    expect(rows.length).toBe(2) // alice's two capability events within 30d
+  })
+
+  it('getAuditActorOptions returns distinct actors in role scope', async () => {
+    const admin = await getAuditActorOptions(orgId, 'admin')
+    expect(admin.length).toBe(2)
+    const contrib = await getAuditActorOptions(orgId, 'contributor')
+    // alice only has architecture-content events visible to contributors via
+    // capability.edit + capability.create; bob has capability + application
+    // events. Both still appear because both have content events.
+    expect(contrib.length).toBe(2)
+  })
+
+  it('getAuditActionNamespaces returns distinct, sorted namespaces', async () => {
+    const admin = await getAuditActionNamespaces(orgId, 'admin')
+    expect(admin).toEqual(['application', 'auth', 'capability'])
+    const contrib = await getAuditActionNamespaces(orgId, 'contributor')
+    expect(contrib).toEqual(['application', 'capability']) // auth hidden from contributor
+  })
+})


### PR DESCRIPTION
## Summary

Closes the CMS-Administrator persona pain: */audit* had the data but no slicing. With history accumulating, scrolling 200 rows for a specific change degraded fast.

## What ships

- **`AuditLogFilters`** client component — actor dropdown, action-namespace multi-select chips, time-window picker.
- **URL-backed** (`?actor=`, `?action=`, `?since=`) — filtered views are shareable, bookmarkable, reload-stable.
- **`getAuditEntries`** extended with three filter axes; role-scoped option lookups for the dropdown.
- **Time windows**: 24h / 7d / 30d (default) / 90d / all.
- **Empty-state copy** differentiates "no matches for filters" vs. "audit log is empty".

## Design notes

- URL is the source of truth — `router.replace` writes, `useSearchParams` reads. No client state out of sync.
- Namespaces derived via `split_part(action, '.', 1)` — cleaner than a hardcoded enum and naturally extends as new prefixes appear.
- Filter component takes options as props so it's **drop-in shareable** with `/instance/audit` when #523 lands.
- Contributors can't see admin-only namespaces (`auth.*`, `user.*`, etc.) in the filter dropdown — role-scoped at the option-lookup helper.

## Test plan

- [x] 8 integration tests covering: no-filter (role scope), actor filter, single + multi-namespace OR, time-window cutoff, all three combined, actor + namespace option lookups
- [x] `tsc --noEmit` clean
- [x] Full vitest sweep: 716 / 716 passing

Capability: iam-audit-trail
Closes #531
Refs #523 (instance-scope counterpart — same pattern, filter component reusable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)