### PR TITLE
feat(viewer): print/export-ready output on executive, roadmap, traceability, answers (#559)

### DIFF
--- a/apps/govea/src/app/(admin)/answers/page.tsx
+++ b/apps/govea/src/app/(admin)/answers/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link'
 import { getAnswerContent, type AnswerItem, type AnswerSection } from '@/actions/answers'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
+import { PrintExportButton } from '@/components/print-export'
+import { PrintCoverSheet } from '@/components/print-cover-sheet'
 
 interface AnswerPageProps {
   searchParams: Promise<{ q?: string }>
@@ -70,19 +72,25 @@ export default async function AnswerPage({ searchParams }: AnswerPageProps) {
           ← Back to search results
         </Link>
 
-        <div className="space-y-1">
-          <h1 className="text-2xl font-bold tracking-tight">
-            {query ? `"${query}"` : 'Guided Answer'}
-          </h1>
-          {answer && (
-            <p className="text-sm text-muted-foreground">
-              {totalItems === 0
-                ? 'No published content found for this question.'
-                : `${totalItems} item${totalItems === 1 ? '' : 's'} across ${answer.sections.length} area${answer.sections.length === 1 ? '' : 's'}`}
-            </p>
-          )}
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-bold tracking-tight">
+              {query ? `"${query}"` : 'Guided Answer'}
+            </h1>
+            {answer && (
+              <p className="text-sm text-muted-foreground">
+                {totalItems === 0
+                  ? 'No published content found for this question.'
+                  : `${totalItems} item${totalItems === 1 ? '' : 's'} across ${answer.sections.length} area${answer.sections.length === 1 ? '' : 's'}`}
+              </p>
+            )}
+          </div>
+          {hasQuery && <PrintExportButton />}
         </div>
       </div>
+
+      {/* Print cover sheet (#559). */}
+      {hasQuery && <PrintCoverSheet orgName="" title={`Question: "${query}"`} />}
 
       <form action="/answers" method="get" className="flex gap-2">
         <input

--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -9,6 +9,8 @@ import { and, count, desc, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { ConfidenceSummary } from '@/components/confidence-summary'
+import { PrintExportButton } from '@/components/print-export'
+import { PrintCoverSheet } from '@/components/print-cover-sheet'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 
@@ -280,12 +282,18 @@ export default async function ExecutiveDashboardPage() {
   return (
     <div className="space-y-8 max-w-4xl">
 
+      {/* Print-only cover sheet (#559) — first page of the handout. */}
+      <PrintCoverSheet orgName={org?.name ?? 'Your organisation'} title="Executive Summary" />
+
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Executive Summary</h1>
-        <p className="text-muted-foreground mt-1">
-          {org?.name ?? 'Your organisation'} · {generatedDate}
-        </p>
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Executive Summary</h1>
+          <p className="text-muted-foreground mt-1">
+            {org?.name ?? 'Your organisation'} · {generatedDate}
+          </p>
+        </div>
+        <PrintExportButton />
       </div>
 
       {/* Repository confidence — shown when org has authenticated visibility on (#380 PR-4) */}

--- a/apps/govea/src/app/(admin)/roadmap/page.tsx
+++ b/apps/govea/src/app/(admin)/roadmap/page.tsx
@@ -2,6 +2,11 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getInitiatives } from '@/actions/initiatives'
 import { ConfidenceSummary } from '@/components/confidence-summary'
+import { PrintExportButton } from '@/components/print-export'
+import { PrintCoverSheet } from '@/components/print-cover-sheet'
+import { db } from '@/db/client'
+import { organizations } from '@/db/schema'
+import { eq } from 'drizzle-orm'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
@@ -253,7 +258,10 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
 
   const orgId = session.user.organizationId!
   const role = session.user.role
-  const allInitiatives = await getInitiatives()
+  const [allInitiatives, org] = await Promise.all([
+    getInitiatives(),
+    db.query.organizations.findFirst({ where: eq(organizations.id, orgId), columns: { name: true } }),
+  ])
   const hasInitiatives = allInitiatives.length > 0
 
   // Grid view: group by status in display order
@@ -268,6 +276,9 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
 
   return (
     <div className="space-y-6 max-w-3xl">
+      {/* Print-only cover sheet (#559). */}
+      <PrintCoverSheet orgName={org?.name ?? 'Your organisation'} title="Roadmap" />
+
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
@@ -279,8 +290,10 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
           </p>
         </div>
 
+        <div className="flex items-center gap-2 shrink-0">
+          <PrintExportButton />
         {/* View toggle */}
-        <div className="flex shrink-0 items-center rounded-lg border bg-muted/40 p-1 gap-0.5">
+        <div className="flex items-center rounded-lg border bg-muted/40 p-1 gap-0.5">
           <Link
             href="/roadmap"
             className={cn(
@@ -303,6 +316,7 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
           >
             Grid
           </Link>
+        </div>
         </div>
       </div>
 

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -8,6 +8,8 @@ import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getServices } from '@/actions/services'
 import { dedupeById } from '@/lib/dedup'
+import { PrintExportButton } from '@/components/print-export'
+import { PrintCoverSheet } from '@/components/print-cover-sheet'
 
 // ── Status colours ────────────────────────────────────────────────────────────
 
@@ -530,6 +532,9 @@ export default async function TraceabilityPage({
 
   return (
     <div className="space-y-8">
+      {/* Print cover sheet (#559). */}
+      <PrintCoverSheet orgName="" title={title} />
+
       <div className="space-y-1">
         <Link
           href={backHref}
@@ -537,9 +542,12 @@ export default async function TraceabilityPage({
         >
           {backLabel}
         </Link>
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p>
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p>
+          </div>
+          <PrintExportButton />
         </div>
       </div>
 

--- a/apps/govea/src/app/globals.css
+++ b/apps/govea/src/app/globals.css
@@ -73,4 +73,33 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Print stylesheet (#559).
+   *
+   * Government persona walks (department-director, elected-official,
+   * budget-performance-analyst) all need presentation-ready output for
+   * budget hearings, oversight sessions, and constituent briefings.
+   * The on-screen app shell (sidebar, header, role badge, sign-out)
+   * is noise on a printed handout — strip it for @media print.
+   *
+   * App shell uses data-print-hide="true" on the regions that should
+   * disappear when printing. The .print-only utility flips the inverse
+   * (visible only when printing) — used by the export cover sheet.
+   */
+  @media print {
+    [data-print-hide="true"] { display: none !important; }
+    /* App shell <main> is wrapped at 1 column when sidebar is hidden;
+     * undo the lg:pl-56 offset so content uses the full page width. */
+    main[data-print-main] { padding: 0 !important; margin: 0 !important; }
+    /* Common interactive controls that shouldn't appear on a handout. */
+    button[type="button"]:not([data-print-keep]),
+    .print-hide { display: none !important; }
+    /* Encourage page breaks before each major heading region. */
+    section { break-inside: avoid; }
+    /* Default monochrome — better for B&W printers, cheaper to ink. */
+    body { background: #fff !important; color: #000 !important; }
+    a { color: inherit !important; text-decoration: none !important; }
+  }
+  .print-only { display: none; }
+  @media print { .print-only { display: block !important; } }
 }

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -305,6 +305,7 @@ export function AppShell({
 
       {/* ── Desktop sidebar (fixed, always visible on lg+) ── */}
       <aside
+        data-print-hide="true"
         className="hidden lg:flex flex-col fixed inset-y-0 left-0 w-56 z-40 border-r"
         style={{ backgroundColor: sidebarBg, borderColor: sidebarBorder }}
       >
@@ -334,6 +335,7 @@ export function AppShell({
 
       {/* ── Mobile sidebar (slide-in drawer) ── */}
       <aside
+        data-print-hide="true"
         className={cn(
           'flex flex-col fixed inset-y-0 left-0 w-72 z-50 lg:hidden border-r transition-transform duration-200 ease-in-out',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
@@ -365,6 +367,7 @@ export function AppShell({
 
         {/* Top header */}
         <header
+          data-print-hide="true"
           className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-3 border-b px-4 lg:px-6"
           style={{
             backgroundColor: sidebarBg,
@@ -441,7 +444,7 @@ export function AppShell({
         </header>
 
         {/* Page content */}
-        <main className="flex-1 p-4 lg:p-6">
+        <main data-print-main className="flex-1 p-4 lg:p-6">
           {children}
         </main>
       </div>

--- a/apps/govea/src/components/print-cover-sheet.tsx
+++ b/apps/govea/src/components/print-cover-sheet.tsx
@@ -1,0 +1,38 @@
+/**
+ * Print cover sheet (#559).
+ *
+ * Renders only when printing (via the `.print-only` utility in globals.css).
+ * On screen it's invisible. On a handout it sits as the first thing
+ * stakeholders see — meeting the persona need for "as of <date>"
+ * attribution suitable for budget hearings or oversight sessions.
+ *
+ * Plain-language by design: no jargon, no internal-EA terminology.
+ * The Department Director / Elected Official personas read this, not
+ * the EA team.
+ */
+export function PrintCoverSheet({
+  orgName,
+  title,
+  asOf = new Date(),
+  confidenceLine,
+}: {
+  orgName: string
+  title: string
+  asOf?: Date
+  confidenceLine?: string | null
+}) {
+  return (
+    <div className="print-only" style={{ pageBreakAfter: 'always', padding: '2rem 0' }}>
+      <p style={{ fontSize: 13, color: '#666', margin: 0 }}>{orgName}</p>
+      <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0.5rem 0 0.25rem' }}>{title}</h1>
+      <p style={{ fontSize: 13, color: '#666', margin: 0 }}>
+        As of {asOf.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+      </p>
+      {confidenceLine && (
+        <p style={{ fontSize: 12, color: '#555', marginTop: '1rem', maxWidth: '60ch' }}>
+          {confidenceLine}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/components/print-export.tsx
+++ b/apps/govea/src/components/print-export.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+/**
+ * Print/export trigger (#559).
+ *
+ * Wraps the browser's native `window.print()` — combined with the
+ * `@media print` rules in globals.css and the `data-print-hide` markers
+ * on the app shell, the result is a clean handout that:
+ *
+ *   - Drops sidebar, header, role badge, sign-out, theme controls
+ *   - Surfaces the PrintCoverSheet (if present) as the first thing
+ *     on the printed page
+ *   - Keeps the page content
+ *
+ * V1 deliberately uses `window.print()` rather than headless-Chrome /
+ * server PDF rendering. The issue's "cheap wins first" cut: the
+ * browser print dialog already does the right thing with a print
+ * stylesheet, and any modern OS lets the user "Save as PDF" from
+ * there. Server-rendered PDF would be a follow-up if we ever need
+ * to schedule briefing emails (also called out in the issue).
+ *
+ * The button itself has `data-print-keep` so the print stylesheet
+ * doesn't hide it from the preview pane in browsers that render
+ * actionable elements during print preview.
+ */
+export function PrintExportButton({ label = 'Print / Export PDF' }: { label?: string }) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      data-print-keep
+      data-print-hide="true" // hide from the actual printed output, kept for preview
+      onClick={() => { if (typeof window !== 'undefined') window.print() }}
+      className="gap-1.5"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <polyline points="6 9 6 2 18 2 18 9" />
+        <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+        <rect x="6" y="14" width="12" height="8" />
+      </svg>
+      {label}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary

Closes the Department Director / Elected Official / Budget-Performance-Analyst persona pain: today Cmd-P or a screenshot produces a handout cluttered with sidebar, header, role badge, sign-out button — unsuitable for a budget hearing or oversight session.

The issue's "cheap wins first" cut, in three layers:

1. **Print stylesheet** (`globals.css`). `@media print` hides everything marked `data-print-hide="true"` (app shell sidebar, header, the export button itself), strips colour for B&W printer friendliness, encourages page breaks before each section.
2. **`PrintExportButton`** wrapping `window.print()`. V1 uses the browser's native print dialog — modern OSes let users "Save as PDF" from there. Server-rendered PDF deferred until scheduled briefing emails become a need.
3. **`PrintCoverSheet`** — render-only-when-printing component, first page of the output. Plain-language org name, title, "as of <date>". The personas reading this don't speak EA jargon.

## Pages wired

- `/executive` — Executive Summary
- `/roadmap` — Timeline + grid views
- `/traceability/*` — per-trace detail
- `/answers?q=<...>` — guided answer view

## Scope decisions

- **Server-side PDF rendering** (headless Chrome / Puppeteer) — out of scope. Deferred until scheduled briefing emails or pixel-perfect templates become a need.
- **Per-agency branded templates** — out of scope. Cover sheet uses agency-neutral plain text.
- **Confidence-summary line on the cover sheet** — wiring point exists (`confidenceLine` prop) but not threaded yet (refactor `getConfidenceSummary` for clean context-free call). Tracked.
- **Slide-deck export** — out of scope, called out in the issue.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full vitest sweep: 708 / 708 passing
- [ ] Manual: open each of the 4 pages, Cmd-P, verify cover sheet appears as page 1 + sidebar/header gone

Capability: fd-traceability-views; fd-guided-answer-views; fd-executive-roadmap-timeline
Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)