### PR TITLE
feat(authoring): roll dirty-tracker out to remaining 7 dialogs (#567 Part A finish)

### DIFF
--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -20,6 +20,7 @@ import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import type { EntityTaxonomyValue } from '@/db/schema'
 import { DomainOwnerFormSection } from '@/components/domain-owner-form-section'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 
 type ADRRow = ADR & {
   organization: { id: string; name: string } | null
@@ -77,6 +78,8 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
   const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ADRRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ADRRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
@@ -96,6 +99,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
   async function handleCreate(formData: FormData) {
     startTransition(async () => {
       await createADR(formData)
+      createDirty.reset()
       setCreateOpen(false)
       refresh()
     })
@@ -106,6 +110,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
     startTransition(async () => {
       try {
         await editADR(editTarget.id, formData)
+        editDirty.reset()
         setEditTarget(null)
         refresh()
       } catch (err) {
@@ -115,6 +120,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
           if (typeof window !== 'undefined' && window.confirm(msg + '\n\nAccept anyway? Your acknowledgment will be logged in the audit trail.')) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editADR(editTarget.id, formData)
+            editDirty.reset()
             setEditTarget(null)
             refresh()
             return
@@ -260,12 +266,12 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={open => { if (!open) setCreateOpen(false) }}>
+      <Dialog open={createOpen} onOpenChange={open => { if (!open && !confirmDiscard(createDirty)) return; if (!open) { createDirty.reset(); setCreateOpen(false) } }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New Architecture Decision Record</DialogTitle>
           </DialogHeader>
-          <form action={handleCreate} className="space-y-4">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-4">
             <div className="grid grid-cols-3 gap-3">
               <FormField label="Number" name="number" required placeholder="ADR-001" />
               <div className="col-span-2">
@@ -299,7 +305,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
               orgUsers={orgUsers}
             />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create ADR'}</Button>
             </DialogFooter>
           </form>
@@ -307,12 +313,12 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null) } }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Architecture Decision Record</DialogTitle>
           </DialogHeader>
-          <form action={handleEdit} className="space-y-4">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-4">
             <div className="grid grid-cols-3 gap-3">
               <FormField label="Number" name="number" required defaultValue={editTarget?.number} />
               <div className="col-span-2">
@@ -351,7 +357,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
               />
             )}
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
@@ -282,6 +283,9 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ApplicationRow | null>(null)
+  // #567 Part A — unsaved-changes guard.
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ApplicationRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
@@ -320,6 +324,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createApplication, formData)
+        createDirty.reset()
         setCreateOpen(false)
         refresh()
       } catch (err) {
@@ -335,6 +340,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
     startTransition(async () => {
       try {
         await editApplication(editTarget.id, formData)
+        editDirty.reset()
         setEditTarget(null)
         refresh()
       } catch (err) {
@@ -344,6 +350,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editApplication(editTarget.id, formData)
+            editDirty.reset()
             setEditTarget(null)
             refresh()
             return
@@ -692,10 +699,17 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       )}
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog
+        open={createOpen}
+        onOpenChange={(o) => {
+          if (!o && !confirmDiscard(createDirty)) return
+          if (!o) createDirty.reset()
+          setCreateOpen(o)
+        }}
+      >
         <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
           <DialogHeader><DialogTitle>New Application</DialogTitle></DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required />
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <div className="grid grid-cols-2 gap-3">
@@ -760,7 +774,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
               orgUsers={orgUsers}
             />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create application'}</Button>
             </DialogFooter>
           </form>
@@ -768,10 +782,16 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={open => {
+          if (!open && !confirmDiscard(editDirty)) return
+          if (!open) { editDirty.reset(); setEditTarget(null) }
+        }}
+      >
         <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
           <DialogHeader><DialogTitle>Edit Application</DialogTitle></DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <div className="grid grid-cols-2 gap-3">
@@ -847,7 +867,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
               />
             )}
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils'
 import { isSafeUrl } from '@/lib/url'
 import type { Role } from '@/lib/rbac'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { MarkdownEditor } from '@/components/markdown-editor'
 
 type GlossaryRow = GlossaryTerm & {
@@ -58,6 +59,8 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
   const [domainFilter, setDomainFilter] = useState('all')
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<GlossaryRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<GlossaryRow | null>(null)
 
   const canEditRole = role === 'admin' || role === 'contributor'
@@ -76,6 +79,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createGlossaryTerm, formData)
+        createDirty.reset()
         setCreateOpen(false)
         refresh()
       } catch (err) {
@@ -90,6 +94,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
     if (!editTarget) return
     startTransition(async () => {
       await editGlossaryTerm(editTarget.id, formData)
+      editDirty.reset()
       setEditTarget(null)
       refresh()
     })
@@ -218,7 +223,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={open => { if (!open) setCreateOpen(false) }}>
+      <Dialog open={createOpen} onOpenChange={open => { if (!open && !confirmDiscard(createDirty)) return; if (!open) { createDirty.reset(); setCreateOpen(false) } }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New Glossary Term</DialogTitle>
@@ -227,7 +232,8 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
             domainTerms={domainTerms}
             isPending={isPending}
             onSubmit={handleCreate}
-            onCancel={() => setCreateOpen(false)}
+            onCancel={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}
+            onDirty={createDirty.markDirty}
             submitLabel="Create Term"
             pendingLabel="Creating…"
           />
@@ -235,7 +241,7 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null) } }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Glossary Term</DialogTitle>
@@ -246,7 +252,8 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
             domainTerms={domainTerms}
             isPending={isPending}
             onSubmit={handleEdit}
-            onCancel={() => setEditTarget(null)}
+            onCancel={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}
+            onDirty={editDirty.markDirty}
             submitLabel="Save changes"
             pendingLabel="Saving…"
           />
@@ -282,6 +289,7 @@ function TermForm({
   isPending,
   onSubmit,
   onCancel,
+  onDirty,
   submitLabel,
   pendingLabel,
 }: {
@@ -290,6 +298,7 @@ function TermForm({
   isPending: boolean
   onSubmit: (fd: FormData) => void
   onCancel: () => void
+  onDirty?: () => void
   submitLabel: string
   pendingLabel: string
 }) {
@@ -334,7 +343,7 @@ function TermForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} onChange={onDirty} className="space-y-4">
       <FormField label="Term" name="term" required defaultValue={term?.term} placeholder="e.g. Capability" />
 
       {/* Definition with attribution */}

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import type { EntityTaxonomyValue } from '@/db/schema'
@@ -67,6 +68,8 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
   ).entries())
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<InitiativeRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<InitiativeRow | null>(null)
   // Track selected capability IDs for the create/edit form impact fields
   const [selectedCaps, setSelectedCaps] = useState<string[]>([])
@@ -100,6 +103,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createInitiative, formData)
+        createDirty.reset()
         setCreateOpen(false)
         setSelectedCaps([])
         refresh()
@@ -115,6 +119,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
     if (!editTarget) return
     startTransition(async () => {
       await editInitiative(editTarget.id, formData)
+      editDirty.reset()
       setEditTarget(null)
       setSelectedCaps([])
       refresh()
@@ -266,10 +271,10 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={open => { if (!open) { setCreateOpen(false); setSelectedCaps([]) } }}>
+      <Dialog open={createOpen} onOpenChange={open => { if (!open && !confirmDiscard(createDirty)) return; if (!open) { createDirty.reset(); setCreateOpen(false); setSelectedCaps([]) } }}>
         <DialogContent className="max-w-lg">
           <DialogHeader><DialogTitle>New Initiative</DialogTitle></DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required placeholder="e.g. Replace OpenText Livelink" />
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <div className="grid grid-cols-2 gap-3">
@@ -298,7 +303,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
             <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <StatusAndVisibilityFields defaultStatus="proposed" />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => { setCreateOpen(false); setSelectedCaps([]) }}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false); setSelectedCaps([]) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create'}</Button>
             </DialogFooter>
           </form>
@@ -306,10 +311,10 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) { setEditTarget(null); setSelectedCaps([]) } }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null); setSelectedCaps([]) } }}>
         <DialogContent className="max-w-lg">
           <DialogHeader><DialogTitle>Edit Initiative</DialogTitle></DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <div className="grid grid-cols-2 gap-3">
@@ -344,7 +349,7 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
             />
             <StatusAndVisibilityFields defaultStatus={editTarget?.status ?? 'proposed'} defaultVisibility={editTarget?.visibility ?? 'org'} />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => { setEditTarget(null); setSelectedCaps([]) }}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null); setSelectedCaps([]) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/objectives/objective-table.tsx
+++ b/apps/govea/src/app/(admin)/objectives/objective-table.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyFilters, TaxonomyInputs, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 import type { EntityTaxonomyValue } from '@/db/schema'
@@ -56,6 +57,8 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
   ).entries())
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ObjectiveRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ObjectiveRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
@@ -77,6 +80,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createObjective, formData)
+        createDirty.reset()
         setCreateOpen(false)
         refresh()
       } catch (err) {
@@ -91,6 +95,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
     if (!editTarget) return
     startTransition(async () => {
       await editObjective(editTarget.id, formData)
+      editDirty.reset()
       setEditTarget(null)
       refresh()
     })
@@ -235,10 +240,10 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={createOpen} onOpenChange={(o) => { if (!o && !confirmDiscard(createDirty)) return; if (!o) createDirty.reset(); setCreateOpen(o) }}>
         <DialogContent className="max-w-lg">
           <DialogHeader><DialogTitle>New Objective</DialogTitle></DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required placeholder="e.g. Reduce permit processing time by 40%" />
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <FormField label="Success metric" name="successMetric" placeholder="How will achievement be measured?" />
@@ -290,7 +295,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
               </select>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create'}</Button>
             </DialogFooter>
           </form>
@@ -298,10 +303,10 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null) } }}>
         <DialogContent className="max-w-lg">
           <DialogHeader><DialogTitle>Edit Objective</DialogTitle></DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <FormField label="Success metric" name="successMetric" defaultValue={editTarget?.successMetric ?? ''} />
@@ -358,7 +363,7 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
               </select>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
 
@@ -66,6 +67,8 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<PersonaRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<PersonaRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
@@ -86,6 +89,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createPersona, formData)
+        createDirty.reset()
         setCreateOpen(false)
         refresh()
       } catch (err) {
@@ -100,6 +104,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
     if (!editTarget) return
     startTransition(async () => {
       await editPersona(editTarget.id, formData)
+      editDirty.reset()
       setEditTarget(null)
       refresh()
     })
@@ -289,12 +294,12 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={createOpen} onOpenChange={(o) => { if (!o && !confirmDiscard(createDirty)) return; if (!o) createDirty.reset(); setCreateOpen(o) }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Persona</DialogTitle>
           </DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required />
             <MarkdownEditor label="Description" name="description" rows={3} placeholder="Markdown supported" />
             <div className="space-y-1.5">
@@ -336,7 +341,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
               </select>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create persona'}</Button>
             </DialogFooter>
           </form>
@@ -344,12 +349,12 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Persona</DialogTitle>
           </DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={3} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <div className="space-y-1.5">
@@ -394,7 +399,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
               </select>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>

--- a/apps/govea/src/app/(admin)/services/service-table.tsx
+++ b/apps/govea/src/app/(admin)/services/service-table.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
+import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { TaxonomyInputs, TaxonomyFilters, type EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
 
@@ -76,6 +77,8 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
 
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ServiceRow | null>(null)
+  const createDirty = useDirtyTracker()
+  const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ServiceRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
@@ -98,6 +101,7 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
     startTransition(async () => {
       try {
         await submitWithDuplicateAck(createService, formData)
+        createDirty.reset()
         setCreateOpen(false)
         refresh()
       } catch (err) {
@@ -112,6 +116,7 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
     if (!editTarget) return
     startTransition(async () => {
       await editService(editTarget.id, formData)
+      editDirty.reset()
       setEditTarget(null)
       refresh()
     })
@@ -254,12 +259,12 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
       </div>
 
       {/* Create Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog open={createOpen} onOpenChange={(o) => { if (!o && !confirmDiscard(createDirty)) return; if (!o) createDirty.reset(); setCreateOpen(o) }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New Service</DialogTitle>
           </DialogHeader>
-          <form action={handleCreate} className="space-y-3">
+          <form action={handleCreate} onChange={createDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required />
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <FormField label="Service owner" name="serviceOwner" placeholder="Team or individual responsible" />
@@ -268,7 +273,7 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
             <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <StatusVisibilityFields />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(createDirty)) { createDirty.reset(); setCreateOpen(false) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create service'}</Button>
             </DialogFooter>
           </form>
@@ -276,12 +281,12 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open && !confirmDiscard(editDirty)) return; if (!open) { editDirty.reset(); setEditTarget(null) } }}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Service</DialogTitle>
           </DialogHeader>
-          <form action={handleEdit} className="space-y-3">
+          <form action={handleEdit} onChange={editDirty.markDirty} className="space-y-3">
             <FormField label="Name" name="name" required defaultValue={editTarget?.name} />
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <FormField label="Service owner" name="serviceOwner" placeholder="Team or individual responsible" defaultValue={editTarget?.serviceOwner ?? ''} />
@@ -293,7 +298,7 @@ export function ServiceTable({ services, personas, role, taxonomyDefinitions, ta
             />
             <StatusVisibilityFields status={editTarget?.status} visibility={editTarget?.visibility} />
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="button" variant="outline" onClick={() => { if (confirmDiscard(editDirty)) { editDirty.reset(); setEditTarget(null) } }}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
             </DialogFooter>
           </form>


### PR DESCRIPTION
## Summary

Completes the dirty-tracker rollout. #615 shipped the shared hook + canonical wiring on the capability dialogs; this PR mechanically applies the same pattern across application, persona, initiative, objective, service, glossary, and ADR — every create/edit dialog now warns before discarding unsaved changes.

## Per-dialog changes (uniform)

- `useDirtyTracker()` for create + edit
- `onChange={dirty.markDirty}` on the form element
- `onOpenChange` checks `confirmDiscard(dirty)` before closing
- Cancel button calls `confirmDiscard(dirty)` before closing
- `dirty.reset()` after successful save

## Notes

- **Glossary** needed a small extension to its in-file `TermForm` wrapping component — added an `onDirty?: () => void` prop that the parent threads through. Same shape as the others from the parent's perspective.
- **ADRs** included even though they didn't get the #566 duplicate-name treatment (ADRs use `number` not `name`). The unsaved-changes guard is independent of that and is the same persona need.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full vitest sweep: 708 / 708 passing
- [ ] Manual: open any dialog, change a field, click Cancel / Esc / backdrop → see "Discard?" prompt. Click Cancel-with-no-changes → no prompt.

Capability: candidate new `cm-content-authoring`
Refs #567 (Part A — dialog rollout completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)