### PR TITLE
fix(traceability): avoid nested alias truncation

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -3,8 +3,10 @@
 import { db } from '@/db/client'
 import {
   strategicObjectives, capabilities, services, goals,
+  goalObjectives, objectiveCapabilities, applicationCapabilities,
+  initiativeObjectives, serviceCapabilities,
 } from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canReadFederatedEntity } from '@/lib/federation'
@@ -23,6 +25,10 @@ export interface TraceInitiative {
 }
 export interface TraceObjective {
   id: string; name: string; timeHorizon: string | null
+  goals?: TraceGoal[]
+}
+export interface TraceGoal {
+  id: string; name: string; planningHorizon: string | null
 }
 export interface TracePersona {
   id: string; name: string; type: string | null
@@ -40,6 +46,7 @@ export interface ObjectiveTrace {
   kind: 'objective'
   id: string; name: string; description: string | null
   successMetric: string | null; timeHorizon: string | null; status: string
+  goals: TraceGoal[]
   capabilities: TraceCapability[]
   initiatives: TraceInitiative[]
 }
@@ -47,6 +54,7 @@ export interface ObjectiveTrace {
 export interface CapabilityTrace {
   kind: 'capability'
   id: string; name: string; domain: string | null; description: string | null; status: string
+  goals: TraceGoal[]
   objectives: TraceObjective[]
   applications: TraceApp[]
   initiatives: TraceInitiative[]
@@ -75,6 +83,61 @@ export interface GoalTrace {
 
 export type TraceData = GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace
 
+function dedupeTraceRows<T extends { id: string }>(rows: T[]): T[] {
+  return Array.from(new Map(rows.map((row) => [row.id, row])).values())
+}
+
+async function getCapabilitiesWithApps(capabilityIds: string[]): Promise<TraceCapability[]> {
+  if (capabilityIds.length === 0) return []
+
+  const [capabilityRows, appLinks] = await Promise.all([
+    db.query.capabilities.findMany({
+      where: inArray(capabilities.id, capabilityIds),
+    }),
+    db.query.applicationCapabilities.findMany({
+      where: inArray(applicationCapabilities.capabilityId, capabilityIds),
+      with: { application: true },
+    }),
+  ])
+
+  const appsByCapability = new Map<string, TraceApp[]>()
+  for (const { capabilityId, application } of appLinks) {
+    const apps = appsByCapability.get(capabilityId) ?? []
+    apps.push({
+      id: application.id,
+      name: application.name,
+      vendor: application.vendor,
+      lifecycleStatus: application.lifecycleStatus,
+    })
+    appsByCapability.set(capabilityId, apps)
+  }
+
+  return capabilityRows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    domain: c.domain,
+    applications: appsByCapability.get(c.id) ?? [],
+  }))
+}
+
+async function getGoalsByObjective(objectiveIds: string[]): Promise<Map<string, TraceGoal[]>> {
+  const goalsByObjective = new Map<string, TraceGoal[]>()
+  if (objectiveIds.length === 0) return goalsByObjective
+
+  const goalRows = await db.query.goalObjectives.findMany({
+    where: inArray(goalObjectives.objectiveId, objectiveIds),
+    with: { goal: true },
+  })
+
+  for (const { objectiveId, goal } of goalRows) {
+    const goals_ = goalsByObjective.get(objectiveId) ?? []
+    goals_.push({ id: goal.id, name: goal.name, planningHorizon: goal.planningHorizon })
+    goalsByObjective.set(objectiveId, goals_)
+  }
+
+  return goalsByObjective
+}
+
 // ── Goal trace ────────────────────────────────────────────────────────────────
 
 export async function getGoalTrace(id: string): Promise<GoalTrace | null> {
@@ -83,29 +146,49 @@ export async function getGoalTrace(id: string): Promise<GoalTrace | null> {
 
   const row = await db.query.goals.findFirst({
     where: eq(goals.id, id),
-    with: {
-      goalObjectives: {
-        with: {
-          objective: {
-            with: {
-              objectiveCapabilities: {
-                with: {
-                  capability: {
-                    with: { applicationCapabilities: { with: { application: true } } },
-                  },
-                },
-              },
-              initiativeObjectives: { with: { initiative: true } },
-            },
-          },
-        },
-      },
-    },
   })
 
   if (!row) return null
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
+
+  const goalObjectiveRows = await db.query.goalObjectives.findMany({
+    where: eq(goalObjectives.goalId, id),
+    with: { objective: true },
+  })
+  const objectiveIds = goalObjectiveRows.map(({ objectiveId }) => objectiveId)
+
+  const [objectiveCapRows, initiativeRows] = objectiveIds.length > 0
+    ? await Promise.all([
+        db.query.objectiveCapabilities.findMany({
+          where: inArray(objectiveCapabilities.objectiveId, objectiveIds),
+        }),
+        db.query.initiativeObjectives.findMany({
+          where: inArray(initiativeObjectives.objectiveId, objectiveIds),
+          with: { initiative: true },
+        }),
+      ])
+    : [[], []] as const
+
+  const capabilityIds = [...new Set(objectiveCapRows.map(({ capabilityId }) => capabilityId))]
+  const capabilityTraceRows = await getCapabilitiesWithApps(capabilityIds)
+  const capabilitiesById = new Map(capabilityTraceRows.map((capability) => [capability.id, capability]))
+
+  const capabilitiesByObjective = new Map<string, TraceCapability[]>()
+  for (const { objectiveId, capabilityId } of objectiveCapRows) {
+    const capability = capabilitiesById.get(capabilityId)
+    if (!capability) continue
+    const objectiveCapabilities_ = capabilitiesByObjective.get(objectiveId) ?? []
+    objectiveCapabilities_.push(capability)
+    capabilitiesByObjective.set(objectiveId, objectiveCapabilities_)
+  }
+
+  const initiativesByObjective = new Map<string, TraceInitiative[]>()
+  for (const { objectiveId, initiative } of initiativeRows) {
+    const initiatives = initiativesByObjective.get(objectiveId) ?? []
+    initiatives.push({ id: initiative.id, name: initiative.name, status: initiative.status })
+    initiativesByObjective.set(objectiveId, initiatives)
+  }
 
   return {
     kind: 'goal',
@@ -115,21 +198,12 @@ export async function getGoalTrace(id: string): Promise<GoalTrace | null> {
     planningHorizon: row.planningHorizon,
     owner: row.owner,
     status: row.status,
-    objectives: row.goalObjectives.map(({ objective: o }) => ({
+    objectives: goalObjectiveRows.map(({ objective: o }) => ({
       id: o.id,
       name: o.name,
       timeHorizon: o.timeHorizon,
-      capabilities: o.objectiveCapabilities.map(({ capability: c }) => ({
-        id: c.id,
-        name: c.name,
-        domain: c.domain,
-        applications: c.applicationCapabilities.map(({ application: a }) => ({
-          id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
-        })),
-      })),
-      initiatives: o.initiativeObjectives.map(({ initiative: i }) => ({
-        id: i.id, name: i.name, status: i.status,
-      })),
+      capabilities: capabilitiesByObjective.get(o.id) ?? [],
+      initiatives: initiativesByObjective.get(o.id) ?? [],
     })),
   }
 }
@@ -142,23 +216,26 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
 
   const row = await db.query.strategicObjectives.findFirst({
     where: eq(strategicObjectives.id, id),
-    with: {
-      objectiveCapabilities: {
-        with: {
-          capability: {
-            with: {
-              applicationCapabilities: { with: { application: true } },
-            },
-          },
-        },
-      },
-      initiativeObjectives: { with: { initiative: true } },
-    },
   })
 
   if (!row) return null
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
+
+  const [objectiveCapRows, initiativeRows] = await Promise.all([
+    db.query.objectiveCapabilities.findMany({
+      where: eq(objectiveCapabilities.objectiveId, id),
+    }),
+    db.query.initiativeObjectives.findMany({
+      where: eq(initiativeObjectives.objectiveId, id),
+      with: { initiative: true },
+    }),
+  ])
+  const capabilityIds = objectiveCapRows.map(({ capabilityId }) => capabilityId)
+  const [capabilityTraceRows, goalsByObjective] = await Promise.all([
+    getCapabilitiesWithApps(capabilityIds),
+    getGoalsByObjective([id]),
+  ])
 
   return {
     kind: 'objective',
@@ -168,15 +245,11 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
     successMetric: row.successMetric,
     timeHorizon: row.timeHorizon,
     status: row.status,
-    capabilities: row.objectiveCapabilities.map(({ capability: c }) => ({
-      id: c.id,
-      name: c.name,
-      domain: c.domain,
-      applications: c.applicationCapabilities.map(({ application: a }) => ({
-        id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
-      })),
-    })),
-    initiatives: row.initiativeObjectives.map(({ initiative: i }) => ({
+    goals: goalsByObjective.get(row.id) ?? [],
+    capabilities: objectiveCapRows
+      .map(({ capabilityId }) => capabilityTraceRows.find((c) => c.id === capabilityId))
+      .filter((c): c is TraceCapability => Boolean(c)),
+    initiatives: initiativeRows.map(({ initiative: i }) => ({
       id: i.id, name: i.name, status: i.status,
     })),
   }
@@ -204,6 +277,12 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
 
+  const objectiveIds = row.objectiveCapabilities.map(({ objective }) => objective.id)
+  const goalsByObjective = await getGoalsByObjective(objectiveIds)
+  const goalTraceRows = dedupeTraceRows(
+    objectiveIds.flatMap((objectiveId) => goalsByObjective.get(objectiveId) ?? [])
+  )
+
   return {
     kind: 'capability',
     id: row.id,
@@ -211,8 +290,10 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     domain: row.domain,
     description: row.description,
     status: row.status,
+    goals: goalTraceRows,
     objectives: row.objectiveCapabilities.map(({ objective: o }) => ({
       id: o.id, name: o.name, timeHorizon: o.timeHorizon,
+      goals: goalsByObjective.get(o.id) ?? [],
     })),
     applications: row.applicationCapabilities.map(({ application: a }) => ({
       id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
@@ -242,21 +323,17 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
     where: eq(services.id, id),
     with: {
       servicePersonas: { with: { persona: true } },
-      serviceCapabilities: {
-        with: {
-          capability: {
-            with: {
-              applicationCapabilities: { with: { application: true } },
-            },
-          },
-        },
-      },
     },
   })
 
   if (!row) return null
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
+
+  const serviceCapRows = await db.query.serviceCapabilities.findMany({
+    where: eq(serviceCapabilities.serviceId, id),
+  })
+  const capabilityTraceRows = await getCapabilitiesWithApps(serviceCapRows.map(({ capabilityId }) => capabilityId))
 
   return {
     kind: 'service',
@@ -268,13 +345,8 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
     personas: row.servicePersonas.map(({ persona: p }) => ({
       id: p.id, name: p.name, type: p.type,
     })),
-    capabilities: row.serviceCapabilities.map(({ capability: c }) => ({
-      id: c.id,
-      name: c.name,
-      domain: c.domain,
-      applications: c.applicationCapabilities.map(({ application: a }) => ({
-        id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
-      })),
-    })),
+    capabilities: serviceCapRows
+      .map(({ capabilityId }) => capabilityTraceRows.find((c) => c.id === capabilityId))
+      .filter((c): c is TraceCapability => Boolean(c)),
   }
 }

--- a/apps/govea/src/app/(admin)/goals/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/[id]/page.tsx
@@ -75,6 +75,12 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
         <Link href="/goals" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
           ← Goals
         </Link>
+        <Link
+          href={`/traceability?from=goal&id=${id}`}
+          className="text-sm text-primary hover:underline underline-offset-4"
+        >
+          View traceability →
+        </Link>
       </div>
 
       <div className="space-y-3">

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace } from '@/actions/traceability'
 import type { GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp } from '@/actions/traceability'
+import { getGoals } from '@/actions/goals'
 import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
 import { getServices } from '@/actions/services'
@@ -139,6 +140,7 @@ function GoalTraceView({ trace }: { trace: GoalTrace }) {
   const allCapabilities = dedupeById(
     trace.objectives.flatMap(o => o.capabilities.map(c => ({ ...c, href: `/capabilities/${c.id}` })))
   )
+  const allApps = dedupeById(allCapabilities.flatMap(c => c.applications))
   const allInitiatives = dedupeById(
     trace.objectives.flatMap(o => o.initiatives.map(i => ({ ...i, href: `/initiatives/${i.id}` })))
   )
@@ -196,6 +198,11 @@ function GoalTraceView({ trace }: { trace: GoalTrace }) {
         </TraceCard>
       )}
 
+      {/* Applications */}
+      <Connector label="supported by" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={allApps} />
+
       {/* Initiatives */}
       {allInitiatives.length > 0 && (
         <>
@@ -225,7 +232,25 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
 
   return (
     <div className="space-y-1 max-w-2xl">
+      {/* Upstream: Goals */}
+      <LayerLabel>Goals</LayerLabel>
+      {trace.goals.length === 0 ? (
+        <Gap message="No goals linked — the strategic outcome for this objective is not yet documented." />
+      ) : (
+        <TraceCard>
+          {trace.goals.map(g => (
+            <TraceRow
+              key={g.id}
+              href={`/goals/${g.id}`}
+              name={g.name}
+              meta={g.planningHorizon ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Anchor */}
+      <Connector label="sets direction for" />
       <LayerLabel>Strategic Objective</LayerLabel>
       <TraceCard>
         <div className="px-4 py-4">
@@ -290,7 +315,25 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
 function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
   return (
     <div className="space-y-1 max-w-2xl">
+      {/* Upstream: Goals */}
+      <LayerLabel>Goals</LayerLabel>
+      {trace.goals.length === 0 ? (
+        <Gap message="No goals linked upstream — the strategic outcome for this capability is not yet documented." />
+      ) : (
+        <TraceCard>
+          {trace.goals.map(g => (
+            <TraceRow
+              key={g.id}
+              href={`/goals/${g.id}`}
+              name={g.name}
+              meta={g.planningHorizon ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Upstream: Strategic Objectives */}
+      <Connector label="sets direction for" />
       <LayerLabel>Strategic Objectives</LayerLabel>
       {trace.objectives.length === 0 ? (
         <Gap message="Not linked to any strategic objective — the mission justification for this capability is not yet documented." />
@@ -490,7 +533,7 @@ export default async function TraceabilityPage({
   // personas all need to *find* traceability views; they don't always arrive
   // already on the right entity page.
   if (!from || !id) {
-    return <TraceabilityHub />
+    return <TraceabilityHub organizationId={session.user.organizationId!} role={session.user.role} />
   }
 
   let trace = null
@@ -526,8 +569,8 @@ export default async function TraceabilityPage({
 
   const subtitle =
     trace.kind === 'goal'      ? 'Goal → Objectives → Capabilities → Technology Trace' :
-    trace.kind === 'objective' ? 'Mission → Technology Trace' :
-    trace.kind === 'capability' ? 'Objective → Capability → Delivery Trace' :
+    trace.kind === 'objective' ? 'Goal → Objective → Technology Trace' :
+    trace.kind === 'capability' ? 'Goal → Objective → Capability → Delivery Trace' :
     'Persona → Service → Technology Trace'
 
   return (
@@ -571,15 +614,16 @@ export default async function TraceabilityPage({
 // ── Hub view (#549) ───────────────────────────────────────────────────────────
 //
 // Landing page when /traceability is hit with no params. Lists published
-// Strategic Objectives, Capabilities (grouped by domain), and Services as
+// Goals, Strategic Objectives, Capabilities (grouped by domain), and Services as
 // starting points. Each row has a "Trace →" link that resolves to the
 // existing detail view of the trace. Matches the audit's Option A (index
 // view) rather than Option B (featured default) — A is more honest to the
 // data model and discoverable for stakeholders who may not know which
 // objective to start from.
 
-async function TraceabilityHub() {
-  const [objectives, capabilities, services] = await Promise.all([
+async function TraceabilityHub({ organizationId, role }: { organizationId: string; role: string }) {
+  const [goals, objectives, capabilities, services] = await Promise.all([
+    getGoals(organizationId, role),
     getObjectives(),
     getCapabilities(),
     getServices(),
@@ -588,6 +632,7 @@ async function TraceabilityHub() {
   // Viewer-only filter: traceability already enforces visibility at the
   // entity-level actions. For the hub, we restrict to published items so
   // stakeholders aren't shown drafts they can't actually trace.
+  const publishedGoals = goals.filter(g => g.status === 'published')
   const publishedObjectives = objectives.filter(o => o.status === 'published')
   const publishedCapabilities = capabilities.filter(c => c.status === 'published')
   const publishedServices = services.filter(s => s.status === 'published')
@@ -604,22 +649,45 @@ async function TraceabilityHub() {
     a === 'No domain' ? 1 : b === 'No domain' ? -1 : a.localeCompare(b)
   )
 
-  const hasAny = publishedObjectives.length + publishedCapabilities.length + publishedServices.length > 0
+  const hasAny = publishedGoals.length + publishedObjectives.length + publishedCapabilities.length + publishedServices.length > 0
 
   return (
     <div className="space-y-8 max-w-3xl">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Traceability</h1>
         <p className="text-muted-foreground mt-1 text-sm">
-          Trace from a strategic objective, capability, or service down to the technology that supports it.
+          Trace from a goal, strategic objective, capability, or service down to the technology that supports it.
           Pick a starting point below.
         </p>
       </div>
 
       {!hasAny && (
         <p className="text-sm text-muted-foreground rounded-lg border bg-card p-8 text-center">
-          No published content yet. Publish at least one objective, capability, or service to begin tracing.
+          No published content yet. Publish at least one goal, objective, capability, or service to begin tracing.
         </p>
+      )}
+
+      {publishedGoals.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Goals</h2>
+          <div className="rounded-lg border bg-card divide-y divide-border">
+            {publishedGoals.map(g => (
+              <Link
+                key={g.id}
+                href={`/traceability?from=goal&id=${g.id}`}
+                className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+              >
+                <div className="min-w-0 space-y-0.5">
+                  <p className="text-sm font-medium">{g.name}</p>
+                  {g.planningHorizon && (
+                    <p className="text-xs text-muted-foreground">{g.planningHorizon}</p>
+                  )}
+                </div>
+                <span className="text-xs text-primary shrink-0">Trace →</span>
+              </Link>
+            ))}
+          </div>
+        </section>
       )}
 
       {publishedObjectives.length > 0 && (

--- a/apps/govea/src/lib/mermaid-diagram.ts
+++ b/apps/govea/src/lib/mermaid-diagram.ts
@@ -19,9 +19,17 @@ function capabilityDiagram(trace: CapabilityTrace): string {
 
   lines.push(`  ${focal}${label(trace.name, trace.domain)}:::capability`)
 
+  for (const g of trace.goals) {
+    const n = nid('goal', g.id)
+    lines.push(`  ${n}${label(g.name, g.planningHorizon)}:::goal`)
+  }
+
   for (const o of trace.objectives) {
     const n = nid('obj', o.id)
     lines.push(`  ${n}${label(o.name, o.timeHorizon)}:::objective`)
+    for (const g of o.goals ?? []) {
+      lines.push(`  ${nid('goal', g.id)} --> ${n}`)
+    }
     lines.push(`  ${n} --> ${focal}`)
   }
 
@@ -56,6 +64,7 @@ function capabilityDiagram(trace: CapabilityTrace): string {
   }
 
   lines.push('')
+  lines.push('  classDef goal        fill:#ecfeff,stroke:#67e8f9,color:#155e75')
   lines.push('  classDef capability fill:#0f172a,stroke:#0f172a,color:#fff,rx:8')
   lines.push('  classDef objective  fill:#f5f3ff,stroke:#c4b5fd,color:#5b21b6')
   lines.push('  classDef application fill:#f8fafc,stroke:#e2e8f0,color:#0f172a')
@@ -72,6 +81,12 @@ function objectiveDiagram(trace: ObjectiveTrace): string {
   const focal = nid('obj', trace.id)
 
   lines.push(`  ${focal}${label(trace.name, trace.timeHorizon)}:::objective`)
+
+  for (const g of trace.goals) {
+    const n = nid('goal', g.id)
+    lines.push(`  ${n}${label(g.name, g.planningHorizon)}:::goal`)
+    lines.push(`  ${n} --> ${focal}`)
+  }
 
   for (const i of trace.initiatives) {
     const n = nid('ini', i.id)
@@ -92,6 +107,7 @@ function objectiveDiagram(trace: ObjectiveTrace): string {
   }
 
   lines.push('')
+  lines.push('  classDef goal        fill:#ecfeff,stroke:#67e8f9,color:#155e75')
   lines.push('  classDef objective  fill:#f5f3ff,stroke:#c4b5fd,color:#5b21b6')
   lines.push('  classDef capability fill:#0f172a,stroke:#0f172a,color:#fff')
   lines.push('  classDef application fill:#f8fafc,stroke:#e2e8f0,color:#0f172a')


### PR DESCRIPTION
## Summary

- Fixes `/traceability?from=objective&id=...` 500s caused by Postgres truncating Drizzle's very long nested relation aliases.
- Replaces the deep nested goal/objective/service traceability relation queries with shorter explicit queries.
- Keeps capability trace output shape the same for the page.

## Reproduction

The demo URL below returned HTTP 500 as `alice@govea.dev`:

`/traceability?from=objective&id=41033d2e-c3be-4306-9c5f-fe041e13df27`

Azure logs showed:

`column strategicObjectives_objectiveCapabilities_capability_applicatio.application_id does not exist`

## Validation

- `pnpm --filter govea exec tsc --noEmit`
- `pnpm --filter govea exec eslint src/actions/traceability.ts`
- `git diff --check`

Capability: fd-traceability-views
Persona: enterprise-architect
