### PR TITLE
docs(iam-sso): reconcile persona line with env-var-only implementation (#530)

### DIFF
--- a/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
+++ b/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
@@ -4,7 +4,7 @@
 The system must allow users to sign in using their agency's identity provider via OpenID Connect (OIDC). Microsoft Entra ID is the current configured provider target, but the capability should remain provider-neutral so Okta, Auth0, or other OIDC providers can be supported through the same sign-in and pre-provisioning model. SSO is optional — the system works without it.
 
 ## Personas
-- **CMS Administrator** — configures SSO via the admin UI; no code changes required
+- **CMS Administrator** — has SSO enabled for their organization at deploy time via environment variables; no code changes required. (v1 limitation: tenant SSO binding is not yet self-serve through the admin UI.)
 - **Content Viewer** — signs in transparently with their existing agency credentials
 
 ## Behaviors


### PR DESCRIPTION
## Summary
- The `iam-sso-authentication` capability doc contained a direct internal contradiction: the persona row said the CMS Administrator "configures SSO via the admin UI", while the Behaviors section (and the actual code) describes env-var-only configuration.
- This PR takes **Option A** from #530 — fix the doc to match reality, and explicitly flag the missing self-serve admin UI as a known v1 limitation rather than implying it already exists.
- No code change. The contradiction was unblocking the CMS Administrator persona journey audit (epic #515).

## Why Option A
The issue itself recommends starting with the documentation-only fix and only building the admin UI (Option B) if and when the persona is validated against real government IT admins. Shipping a tenant SSO config UI on an unvalidated assumed persona would be premature.

A follow-up issue for Option B (self-serve admin UI for tenant SSO binding) can be filed once the persona need is validated — see the persona file's "assumed persona" caveat.

## Test plan
- [x] `grep -n "Microsoft\|admin UI\|environment variable" business-architecture/capabilities/cms/iam/iam-sso-authentication.md` no longer surfaces the contradiction
- [x] Persona row and Behaviors section now agree: SSO is configured via environment variables at deploy time
- [x] v1 limitation is called out in-line so the persona need isn't lost

Capability: iam-sso-authentication
Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)