### PR TITLE
feat(import-export): CSV import/export for Personas + ADRs (#596)

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -3,6 +3,7 @@
 import { db } from '@/db/client'
 import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives, entityTaxonomyValues,
+  capabilities, applications, initiatives, strategicObjectives,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
@@ -14,6 +15,8 @@ import { notifySubscribers, notifyDomainOwner } from './notifications'
 import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { parseCsv, splitSemicolonList } from '@/lib/csv'
 
 async function requireContributor() {
   const session = await auth()
@@ -306,6 +309,221 @@ export async function deleteADR(id: string) {
 }
 
 type DBOrTx = Pick<typeof db, 'insert'>
+
+// ── CSV Import (#596) ────────────────────────────────────────────────────────
+
+export type ADRImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_ADR_STATUS = new Set(['proposed', 'accepted', 'deprecated', 'superseded'])
+const VALID_ADR_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+/**
+ * ADR CSV import — #596. Mirrors importCapabilities / importPersonas with two
+ * ADR-specific wrinkles:
+ *   - Upsert key is `number` (e.g. "ADR-001"), not `name`.
+ *   - `superseded_by` references another ADR by its number; the reference is
+ *     resolved against the org's ADR set (including newly-created rows in the
+ *     same import), so round-trip exports import cleanly even when one ADR
+ *     supersedes another within the same batch.
+ *   - Four junction tables (capabilities / applications / initiatives /
+ *     objectives) — unknown names report as warnings, not row failures.
+ */
+export async function importADRs(formData: FormData, dryRun = false): Promise<ADRImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const text = await file.text()
+  const rows = parseCsv(text)
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  // Pre-fetch existing ADRs and all four junction targets, org-scoped.
+  const [existing, orgCaps, orgApps, orgInits, orgObjs] = await Promise.all([
+    db.query.adrs.findMany({
+      where: eq(adrs.organizationId, orgId),
+      columns: { id: true, number: true },
+    }),
+    db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.applications.findMany({
+      where: eq(applications.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.initiatives.findMany({
+      where: eq(initiatives.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.strategicObjectives.findMany({
+      where: eq(strategicObjectives.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+  ])
+  const existingByNumber = new Map(existing.map(a => [a.number.toLowerCase(), a.id]))
+  const capByName = new Map(orgCaps.map(c => [c.name.toLowerCase(), c.id]))
+  const appByName = new Map(orgApps.map(a => [a.name.toLowerCase(), a.id]))
+  const initByName = new Map(orgInits.map(i => [i.name.toLowerCase(), i.id]))
+  const objByName = new Map(orgObjs.map(o => [o.name.toLowerCase(), o.id]))
+
+  type ValidRow = {
+    number: string
+    title: string
+    context: string | null
+    decision: string | null
+    consequences: string | null
+    status: 'proposed' | 'accepted' | 'deprecated' | 'superseded'
+    visibility: 'org' | 'connections' | 'instance'
+    supersededByNumber: string | null
+    capabilityIds: string[]
+    applicationIds: string[]
+    initiativeIds: string[]
+    objectiveIds: string[]
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+  let created = 0, updated = 0, skipped = 0
+  const errors: string[] = []
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2
+    const number = row['number']?.trim()
+    const title = row['title']?.trim()
+    if (!number) { errors.push(`Row ${rowNum}: missing required field "number"`); skipped++; continue }
+    if (!title) { errors.push(`Row ${rowNum}: missing required field "title"`); skipped++; continue }
+
+    const status = (row['status'] || 'proposed').trim()
+    const visibility = (row['visibility'] || 'org').trim()
+    if (!VALID_ADR_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`)
+      skipped++; continue
+    }
+    if (!VALID_ADR_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`)
+      skipped++; continue
+    }
+
+    const resolveList = (
+      values: string[],
+      lookup: Map<string, string>,
+      label: string,
+    ): string[] => {
+      const ids: string[] = []
+      for (const v of values) {
+        const id = lookup.get(v.toLowerCase())
+        if (id) ids.push(id)
+        else errors.push(`Row ${rowNum}: ${label} "${v}" not found in this org — skipped`)
+      }
+      return ids
+    }
+
+    const capabilityIds = resolveList(splitSemicolonList(row['capabilities']), capByName, 'capability')
+    const applicationIds = resolveList(splitSemicolonList(row['applications']), appByName, 'application')
+    const initiativeIds = resolveList(splitSemicolonList(row['initiatives']), initByName, 'initiative')
+    const objectiveIds = resolveList(splitSemicolonList(row['objectives']), objByName, 'objective')
+
+    const existingId = existingByNumber.get(number.toLowerCase())
+    if (existingId) updated++; else created++
+
+    validRows.push({
+      number,
+      title,
+      context: row['context'] || null,
+      decision: row['decision'] || null,
+      consequences: row['consequences'] || null,
+      status: status as 'proposed' | 'accepted' | 'deprecated' | 'superseded',
+      visibility: visibility as 'org' | 'connections' | 'instance',
+      supersededByNumber: row['superseded_by']?.trim() || null,
+      capabilityIds,
+      applicationIds,
+      initiativeIds,
+      objectiveIds,
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await db.transaction(async (tx) => {
+      // First pass: upsert ADR rows and remember the resolved id by number so
+      // a later supersedes_by reference can resolve even if the target was
+      // created in the same import.
+      const idByNumber = new Map<string, string>(existingByNumber)
+      for (const r of validRows) {
+        let adrId = r.existingId
+        if (adrId) {
+          await tx.update(adrs).set({
+            title: r.title,
+            context: r.context,
+            decision: r.decision,
+            consequences: r.consequences,
+            status: r.status,
+            visibility: r.visibility,
+            updatedBy: session.user.id,
+            updatedAt: new Date(),
+          }).where(and(eq(adrs.id, adrId), eq(adrs.organizationId, orgId)))
+          // Replace all four junctions wholesale — same semantics as editADR.
+          await tx.delete(adrCapabilities).where(eq(adrCapabilities.adrId, adrId))
+          await tx.delete(adrApplications).where(eq(adrApplications.adrId, adrId))
+          await tx.delete(adrInitiatives).where(eq(adrInitiatives.adrId, adrId))
+          await tx.delete(adrObjectives).where(eq(adrObjectives.adrId, adrId))
+        } else {
+          const [inserted] = await tx.insert(adrs).values({
+            number: r.number,
+            title: r.title,
+            context: r.context,
+            decision: r.decision,
+            consequences: r.consequences,
+            status: r.status,
+            visibility: r.visibility,
+            organizationId: orgId,
+            createdBy: session.user.id,
+            updatedBy: session.user.id,
+          }).returning({ id: adrs.id })
+          adrId = inserted.id
+        }
+        idByNumber.set(r.number.toLowerCase(), adrId)
+
+        await insertJunctions(tx, adrId!, r.capabilityIds, r.applicationIds, r.initiativeIds, r.objectiveIds)
+      }
+
+      // Second pass: resolve `supersededBy` references now that every row in
+      // this batch has an id. Unresolved references report as warnings.
+      for (const r of validRows) {
+        if (!r.supersededByNumber) continue
+        const targetId = idByNumber.get(r.supersededByNumber.toLowerCase())
+        const sourceId = idByNumber.get(r.number.toLowerCase())
+        if (!sourceId) continue
+        if (!targetId) {
+          errors.push(`Row for "${r.number}": superseded_by "${r.supersededByNumber}" not found in this org — left unlinked`)
+          continue
+        }
+        await tx.update(adrs)
+          .set({ supersededBy: targetId, updatedAt: new Date() })
+          .where(and(eq(adrs.id, sourceId), eq(adrs.organizationId, orgId)))
+      }
+
+      await writeAuditLog(tx, {
+        action: 'adr.import',
+        entityType: 'adr',
+        entityId: orgId,
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, errorCount: errors.length },
+      })
+    })
+
+    revalidatePath('/adrs')
+  }
+
+  return { created, updated, skipped, errors }
+}
 
 async function insertJunctions(
   tx: DBOrTx,

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -13,6 +13,7 @@ import { ensurePublishOpenDebtAck } from '@/lib/debt-publish-gate'
 import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { ensurePublishReady } from '@/lib/publish-readiness-gate'
+import { parseCsv, splitSemicolonList } from '@/lib/csv'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
@@ -474,49 +475,7 @@ const VALID_CAPABILITY_TYPE = new Set(['', 'business', 'technical'])
 const VALID_CAPABILITY_STATUS = new Set(['draft', 'published', 'archived'])
 const VALID_CAPABILITY_VISIBILITY = new Set(['org', 'connections', 'instance'])
 
-/**
- * Quote-aware CSV row splitter. Walks the full text character-by-character
- * tracking quote state so that embedded newlines inside quoted fields stay
- * with their row. Capabilities exports include multi-line `behaviors` and
- * `rules` cells, so a naive `text.split('\n')` would split a single row into
- * many malformed ones (#596 regression test fixture).
- */
-function splitCsvRows(text: string): string[][] {
-  const rows: string[][] = []
-  let row: string[] = []
-  let field = ''
-  let inQuotes = false
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i]
-    if (ch === '"') {
-      if (inQuotes && text[i + 1] === '"') { field += '"'; i++ }
-      else inQuotes = !inQuotes
-    } else if (ch === ',' && !inQuotes) {
-      row.push(field); field = ''
-    } else if ((ch === '\n' || ch === '\r') && !inQuotes) {
-      if (ch === '\r' && text[i + 1] === '\n') i++
-      row.push(field); field = ''
-      if (row.some(c => c.length > 0)) rows.push(row)
-      row = []
-    } else {
-      field += ch
-    }
-  }
-  if (field.length > 0 || row.length > 0) {
-    row.push(field)
-    if (row.some(c => c.length > 0)) rows.push(row)
-  }
-  return rows
-}
-
-function parseCapabilityCsv(text: string): Record<string, string>[] {
-  const rows = splitCsvRows(text)
-  if (rows.length < 2) return []
-  const headers = rows[0].map(h => h.trim())
-  return rows.slice(1).map(values =>
-    Object.fromEntries(headers.map((h, i) => [h, (values[i] ?? '').trim()]))
-  )
-}
+// CSV parser lives in `@/lib/csv` — shared with personas + ADRs per #596.
 
 export async function importCapabilities(formData: FormData, dryRun = false): Promise<CapabilityImportResult> {
   const session = await requireContributor()
@@ -526,7 +485,7 @@ export async function importCapabilities(formData: FormData, dryRun = false): Pr
   if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
 
   const text = await file.text()
-  const rows = parseCapabilityCsv(text)
+  const rows = parseCsv(text)
   if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
 
   // Pre-fetch existing capabilities for upsert + persona name → id lookup.
@@ -586,7 +545,7 @@ export async function importCapabilities(formData: FormData, dryRun = false): Pr
     // Resolve personas — unknown names report as warnings, not row failures.
     // The capability still imports; just without the unresolvable links.
     const personaIds: string[] = []
-    const personaNames = (row['personas'] || '').split(/;|\n/).map(s => s.trim()).filter(Boolean)
+    const personaNames = splitSemicolonList(row['personas'])
     for (const personaName of personaNames) {
       const id = personaIdByName.get(personaName.toLowerCase())
       if (id) personaIds.push(id)

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -12,6 +12,8 @@ import { ensurePublishReady } from '@/lib/publish-readiness-gate'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
+import { parseCsv, splitSemicolonList } from '@/lib/csv'
+import { taxonomyTerms } from '@/db/schema'
 
 async function requireContributor() {
   const session = await auth()
@@ -241,4 +243,163 @@ export async function markPersonaReviewed(personaId: string, _formData: FormData
   })
 
   revalidatePath(`/personas/${personaId}`)
+}
+
+// ── CSV Import (#596) ────────────────────────────────────────────────────────
+
+export type PersonaImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_PERSONA_STATUS = new Set(['draft', 'published', 'archived'])
+const VALID_PERSONA_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+/**
+ * Persona CSV import — #596. Same shape as importCapabilities:
+ *   - Two-step flow via `dryRun` flag (preview → confirm)
+ *   - Name match is case-insensitive (matches the export's upsert convention)
+ *   - Tags resolve from semicolon-joined names against the "Persona Tag"
+ *     taxonomy branch; unknown names report as row warnings, not row failures
+ *   - On update, existing tag links are replaced wholesale (matches editPersona)
+ */
+export async function importPersonas(formData: FormData, dryRun = false): Promise<PersonaImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const text = await file.text()
+  const rows = parseCsv(text)
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  // Pre-fetch existing personas (for upsert) and the "Persona Tag" branch
+  // (children of the top-level taxonomy term whose slug is `persona-tag`).
+  const existing = await db.query.personas.findMany({
+    where: eq(personas.organizationId, orgId),
+    columns: { id: true, name: true },
+  })
+  const existingByName = new Map(existing.map(p => [p.name.toLowerCase(), p.id]))
+
+  const tagRoot = await db.query.taxonomyTerms.findFirst({
+    where: and(
+      eq(taxonomyTerms.organizationId, orgId),
+      eq(taxonomyTerms.slug, 'persona-tag'),
+    ),
+    columns: { id: true },
+  })
+  const tagByName = new Map<string, string>()
+  if (tagRoot) {
+    const tags = await db.query.taxonomyTerms.findMany({
+      where: and(
+        eq(taxonomyTerms.organizationId, orgId),
+        eq(taxonomyTerms.parentId, tagRoot.id),
+      ),
+      columns: { id: true, name: true },
+    })
+    for (const t of tags) tagByName.set(t.name.toLowerCase(), t.id)
+  }
+
+  type ValidRow = {
+    name: string
+    description: string | null
+    type: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    tagIds: string[]
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+  let created = 0, updated = 0, skipped = 0
+  const errors: string[] = []
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2
+    const name = row['name']?.trim()
+    if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
+
+    const status = (row['status'] || 'draft').trim()
+    const visibility = (row['visibility'] || 'org').trim()
+
+    if (!VALID_PERSONA_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`)
+      skipped++; continue
+    }
+    if (!VALID_PERSONA_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`)
+      skipped++; continue
+    }
+
+    const tagIds: string[] = []
+    for (const tagName of splitSemicolonList(row['tags'])) {
+      const id = tagByName.get(tagName.toLowerCase())
+      if (id) tagIds.push(id)
+      else errors.push(`Row ${rowNum}: tag "${tagName}" not found in this org — skipped`)
+    }
+
+    const existingId = existingByName.get(name.toLowerCase())
+    if (existingId) updated++; else created++
+
+    validRows.push({
+      name,
+      description: row['description'] || null,
+      type: row['type'] || null,
+      status: status as 'draft' | 'published' | 'archived',
+      visibility: visibility as 'org' | 'connections' | 'instance',
+      tagIds,
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await db.transaction(async (tx) => {
+      for (const r of validRows) {
+        let personaId = r.existingId
+        if (personaId) {
+          await tx.update(personas).set({
+            description: r.description,
+            type: r.type,
+            status: r.status,
+            visibility: r.visibility,
+            updatedBy: session.user.id,
+            updatedAt: new Date(),
+          }).where(and(eq(personas.id, personaId), eq(personas.organizationId, orgId)))
+          await tx.delete(personaTags).where(eq(personaTags.personaId, personaId))
+        } else {
+          const [inserted] = await tx.insert(personas).values({
+            name: r.name,
+            description: r.description,
+            type: r.type,
+            status: r.status,
+            visibility: r.visibility,
+            organizationId: orgId,
+            createdBy: session.user.id,
+            updatedBy: session.user.id,
+          }).returning({ id: personas.id })
+          personaId = inserted.id
+        }
+        if (r.tagIds.length > 0) {
+          await tx.insert(personaTags).values(
+            r.tagIds.map(tagId => ({ personaId: personaId!, tagId }))
+          )
+        }
+      }
+
+      await writeAuditLog(tx, {
+        action: 'persona.import',
+        entityType: 'persona',
+        entityId: orgId,
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, errorCount: errors.length },
+      })
+    })
+
+    revalidatePath('/personas')
+  }
+
+  return { created, updated, skipped, errors }
 }

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createADR, editADR, deleteADR } from '@/actions/adrs'
+import { createADR, editADR, deleteADR, importADRs, type ADRImportResult } from '@/actions/adrs'
 import type { ADR, Capability, Application, Initiative, StrategicObjective } from '@/db/schema'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -82,6 +82,42 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
   const createDirty = useDirtyTracker()
   const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ADRRow | null>(null)
+
+  // CSV import dialog state (#596) — same shape as Capabilities / Personas.
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<ADRImportResult | null>(null)
+  const [importResult, setImportResult] = useState<ADRImportResult | null>(null)
+
+  async function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importADRs(fd, true)
+      setImportPreview(result)
+    })
+  }
+
+  async function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importADRs(fd, false)
+      setImportResult(result)
+      setImportPreview(null)
+      setImportFile(null)
+      router.refresh()
+    })
+  }
+
+  function openImport() {
+    setImportOpen(true)
+    setImportResult(null)
+    setImportPreview(null)
+    setImportFile(null)
+  }
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -164,11 +200,19 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
           filters={taxonomyFilters}
           onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
         />
-        {canEdit && (
-          <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
-            + New Architecture Decision Record
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          <a href="/api/adrs/export">
+            <Button variant="outline" size="sm">Export CSV</Button>
+          </a>
+          {canEdit && (
+            <>
+              <Button variant="outline" size="sm" onClick={openImport}>Import CSV</Button>
+              <Button onClick={() => setCreateOpen(true)} size="sm">
+                + New Architecture Decision Record
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Empty state — when the org has no ADRs at all (#587 follow-up). */}
@@ -389,6 +433,70 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* CSV Import dialog (#596) */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import ADRs</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">number</code>, <code className="bg-muted px-1 rounded">title</code>, <code className="bg-muted px-1 rounded">context</code>, <code className="bg-muted px-1 rounded">decision</code>, <code className="bg-muted px-1 rounded">consequences</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">visibility</code>, <code className="bg-muted px-1 rounded">superseded_by</code>, and semicolon-joined name lists for <code className="bg-muted px-1 rounded">capabilities</code>, <code className="bg-muted px-1 rounded">applications</code>, <code className="bg-muted px-1 rounded">initiatives</code>, and <code className="bg-muted px-1 rounded">objectives</code>.
+              Existing ADRs are matched by number (case-insensitive) and updated. Unknown linked-entity names are reported as warnings without failing the row.
+            </p>
+
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }}
+                />
+              </div>
+            )}
+
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} records`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import type { Persona, TaxonomyTerm } from '@/db/schema'
-import { createPersona, editPersona, deletePersona } from '@/actions/personas'
+import { createPersona, editPersona, deletePersona, importPersonas, type PersonaImportResult } from '@/actions/personas'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
@@ -71,6 +71,42 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
   const createDirty = useDirtyTracker()
   const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<PersonaRow | null>(null)
+
+  // CSV import dialog state (#596) — same shape as Capabilities import.
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<PersonaImportResult | null>(null)
+  const [importResult, setImportResult] = useState<PersonaImportResult | null>(null)
+
+  async function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importPersonas(fd, true)
+      setImportPreview(result)
+    })
+  }
+
+  async function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importPersonas(fd, false)
+      setImportResult(result)
+      setImportPreview(null)
+      setImportFile(null)
+      router.refresh()
+    })
+  }
+
+  function openImport() {
+    setImportOpen(true)
+    setImportResult(null)
+    setImportPreview(null)
+    setImportFile(null)
+  }
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -171,10 +207,16 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           </select>
         )}
         <div className="ml-auto flex items-center gap-2">
+          <a href="/api/personas/export">
+            <Button variant="outline" size="sm">Export CSV</Button>
+          </a>
           {canEdit && (
-            <Button onClick={() => setCreateOpen(true)} size="sm">
-              + New Persona
-            </Button>
+            <>
+              <Button variant="outline" size="sm" onClick={openImport}>Import CSV</Button>
+              <Button onClick={() => setCreateOpen(true)} size="sm">
+                + New Persona
+              </Button>
+            </>
           )}
         </div>
       </div>
@@ -433,6 +475,70 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* CSV Import dialog (#596) */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import Personas</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">name</code>, <code className="bg-muted px-1 rounded">description</code>, <code className="bg-muted px-1 rounded">type</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">visibility</code>, <code className="bg-muted px-1 rounded">tags</code> (semicolon-separated names from the Persona Tag taxonomy).
+              Existing personas are matched by name (case-insensitive) and updated. Unknown tag names are reported as warnings without failing the row.
+            </p>
+
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }}
+                />
+              </div>
+            )}
+
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} records`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/src/app/api/adrs/export/route.ts
+++ b/apps/govea/src/app/api/adrs/export/route.ts
@@ -1,0 +1,102 @@
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { getADRs } from '@/actions/adrs'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import { escapeCsv } from '@/lib/csv'
+
+type ADRForExport = Awaited<ReturnType<typeof getADRs>>[number]
+
+function buildCsv(
+  rows: ADRForExport[],
+  numberById: Map<string, string>,
+  taxDefs: EnrichedTaxonomyDefinition[],
+  taxValueMap: Record<string, { taxonomyTermId: string }[]>,
+): string {
+  const termNames = new Map<string, string>()
+  for (const def of taxDefs) {
+    for (const term of def.values) {
+      termNames.set(term.id, term.name)
+    }
+  }
+
+  const fixedHeaders = [
+    'number', 'title', 'context', 'decision', 'consequences',
+    'status', 'visibility', 'superseded_by',
+    'capabilities', 'applications', 'initiatives', 'objectives',
+  ]
+  const taxHeaders = taxDefs.map(d => d.typeName)
+  const headers = [...fixedHeaders, ...taxHeaders]
+
+  const lines = rows.map(a => {
+    const join = (xs: { name?: string | null }[]) =>
+      xs.map(x => x.name).filter((n): n is string => Boolean(n)).join('; ')
+
+    const fixed = [
+      a.number,
+      a.title,
+      a.context ?? '',
+      a.decision ?? '',
+      a.consequences ?? '',
+      a.status,
+      a.visibility,
+      a.supersededBy ? (numberById.get(a.supersededBy) ?? '') : '',
+      join(a.adrCapabilities.map(x => x.capability)),
+      join(a.adrApplications.map(x => x.application)),
+      join(a.adrInitiatives.map(x => x.initiative)),
+      join(a.adrObjectives.map(x => x.objective)),
+    ]
+
+    const termIds = (taxValueMap[a.id] ?? []).map(v => v.taxonomyTermId)
+    const tax = taxDefs.map(def => {
+      const defTermIds = new Set(def.values.map(v => v.id))
+      return termIds
+        .filter(id => defTermIds.has(id))
+        .map(id => termNames.get(id) ?? id)
+        .join(', ')
+    })
+
+    return [...fixed, ...tax].map(escapeCsv).join(',')
+  })
+
+  return [headers.map(escapeCsv).join(','), ...lines].join('\n')
+}
+
+/**
+ * ADR CSV export — #596 continuation. ADRs have four junction tables
+ * (capabilities, applications, initiatives, objectives) which all appear as
+ * semicolon-joined name columns. `superseded_by` is exported as the
+ * referenced ADR's number (not its UUID) so the CSV is portable.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!canEdit(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const orgId = session.user.organizationId!
+
+  const [allADRs, taxDefs] = await Promise.all([
+    getADRs(),
+    getEntityTaxonomyDefinitions(orgId, 'adr'),
+  ])
+
+  const own = allADRs.filter(a => a.organizationId === orgId)
+  // Map ADR.id → ADR.number so `superseded_by` exports as a portable number.
+  // Includes federated rows in case an own-org ADR references a remote one
+  // (still safe — number-by-number resolution only happens at import time).
+  const numberById = new Map<string, string>()
+  for (const a of allADRs) numberById.set(a.id, a.number)
+
+  const ids = own.map(a => a.id)
+  const taxValueMap = await getEntityTaxonomyValuesForMany(orgId, 'adr', ids)
+
+  const csv = buildCsv(own, numberById, taxDefs, taxValueMap)
+  const date = new Date().toISOString().slice(0, 10)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="adrs-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/app/api/capabilities/export/route.ts
+++ b/apps/govea/src/app/api/capabilities/export/route.ts
@@ -3,13 +3,7 @@ import { canEdit } from '@/lib/rbac'
 import { getCapabilities } from '@/actions/capabilities'
 import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
-
-function escapeCsv(val: string): string {
-  if (val.includes(',') || val.includes('"') || val.includes('\n')) {
-    return `"${val.replace(/"/g, '""')}"`
-  }
-  return val
-}
+import { escapeCsv } from '@/lib/csv'
 
 type CapabilityForExport = Awaited<ReturnType<typeof getCapabilities>>[number]
 

--- a/apps/govea/src/app/api/personas/export/route.ts
+++ b/apps/govea/src/app/api/personas/export/route.ts
@@ -1,0 +1,90 @@
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { getPersonas } from '@/actions/personas'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import { escapeCsv } from '@/lib/csv'
+
+type PersonaForExport = Awaited<ReturnType<typeof getPersonas>>[number]
+
+function buildCsv(
+  rows: PersonaForExport[],
+  taxDefs: EnrichedTaxonomyDefinition[],
+  taxValueMap: Record<string, { taxonomyTermId: string }[]>,
+): string {
+  const termNames = new Map<string, string>()
+  for (const def of taxDefs) {
+    for (const term of def.values) {
+      termNames.set(term.id, term.name)
+    }
+  }
+
+  // `tags` mirrors capabilities' `personas` convention: semicolon-joined names
+  // pulled from the persona_tags junction (which points to taxonomy terms).
+  const fixedHeaders = [
+    'name', 'description', 'type', 'status', 'visibility', 'tags',
+  ]
+  const taxHeaders = taxDefs.map(d => d.typeName)
+  const headers = [...fixedHeaders, ...taxHeaders]
+
+  const lines = rows.map(p => {
+    const tagNames = p.personaTags
+      .map(pt => pt.tag?.name)
+      .filter((n): n is string => Boolean(n))
+      .join('; ')
+
+    const fixed = [
+      p.name,
+      p.description ?? '',
+      p.type ?? '',
+      p.status,
+      p.visibility,
+      tagNames,
+    ]
+
+    const termIds = (taxValueMap[p.id] ?? []).map(v => v.taxonomyTermId)
+    const tax = taxDefs.map(def => {
+      const defTermIds = new Set(def.values.map(v => v.id))
+      return termIds
+        .filter(id => defTermIds.has(id))
+        .map(id => termNames.get(id) ?? id)
+        .join(', ')
+    })
+
+    return [...fixed, ...tax].map(escapeCsv).join(',')
+  })
+
+  return [headers.map(escapeCsv).join(','), ...lines].join('\n')
+}
+
+/**
+ * Persona CSV export — #596 continuation. Mirrors the capabilities pattern:
+ * fixed columns + per-entity taxonomy columns, org-scoped to keep round-trip
+ * import safe (re-importing won't silently duplicate federated rows).
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!canEdit(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const orgId = session.user.organizationId!
+
+  const [allPersonas, taxDefs] = await Promise.all([
+    getPersonas(),
+    getEntityTaxonomyDefinitions(orgId, 'persona'),
+  ])
+
+  const own = allPersonas.filter(p => p.organizationId === orgId)
+  const ids = own.map(p => p.id)
+  const taxValueMap = await getEntityTaxonomyValuesForMany(orgId, 'persona', ids)
+
+  const csv = buildCsv(own, taxDefs, taxValueMap)
+  const date = new Date().toISOString().slice(0, 10)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="personas-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/lib/csv.ts
+++ b/apps/govea/src/lib/csv.ts
@@ -1,0 +1,53 @@
+// Shared CSV helpers for per-entity import/export under #596.
+//
+// `splitCsvRows` is the quote-aware row splitter introduced in #604 to survive
+// multi-line cells (capability `behaviors` / `rules`, ADR `context` / `decision`
+// / `consequences`, etc.) through an Export → Import round-trip.
+
+export function escapeCsv(val: string): string {
+  if (val.includes(',') || val.includes('"') || val.includes('\n')) {
+    return `"${val.replace(/"/g, '""')}"`
+  }
+  return val
+}
+
+export function splitCsvRows(text: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') { field += '"'; i++ }
+      else inQuotes = !inQuotes
+    } else if (ch === ',' && !inQuotes) {
+      row.push(field); field = ''
+    } else if ((ch === '\n' || ch === '\r') && !inQuotes) {
+      if (ch === '\r' && text[i + 1] === '\n') i++
+      row.push(field); field = ''
+      if (row.some(c => c.length > 0)) rows.push(row)
+      row = []
+    } else {
+      field += ch
+    }
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field)
+    if (row.some(c => c.length > 0)) rows.push(row)
+  }
+  return rows
+}
+
+export function parseCsv(text: string): Record<string, string>[] {
+  const rows = splitCsvRows(text)
+  if (rows.length < 2) return []
+  const headers = rows[0].map(h => h.trim())
+  return rows.slice(1).map(values =>
+    Object.fromEntries(headers.map((h, i) => [h, (values[i] ?? '').trim()]))
+  )
+}
+
+export function splitSemicolonList(value: string | undefined): string[] {
+  return (value || '').split(/;|\n/).map(s => s.trim()).filter(Boolean)
+}

--- a/apps/govea/tests/integration/adrs-import.test.ts
+++ b/apps/govea/tests/integration/adrs-import.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests: importADRs server action (#596)
+ *
+ * Covers:
+ *  - Role enforcement (viewer rejected; contributor accepted)
+ *  - Basic create from CSV with all fixed columns
+ *  - Upsert: existing ADR matched case-insensitively by number and updated
+ *  - Junction resolution: semicolon-joined names for all four targets
+ *    (capabilities, applications, initiatives, objectives) — unknown names
+ *    report as warnings without failing the row
+ *  - Junction replacement on upsert (no leftover stale links)
+ *  - superseded_by reference resolves both pre-existing and same-batch ADRs
+ *  - Validation: invalid status / visibility skip the row
+ *  - dryRun: returns counters and errors WITHOUT writing any rows
+ *  - Round-trip property: re-import reports updated with no field loss
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
+  capabilities, applications, initiatives, strategicObjectives,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { importADRs } from '@/actions/adrs'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function csvForm(content: string): FormData {
+  const fd = new FormData()
+  const blob = new Blob([content], { type: 'text/csv' })
+  fd.append('csvFile', new File([blob], 'adrs.csv', { type: 'text/csv' }))
+  return fd
+}
+
+async function seedCapability(orgId: string, name: string) {
+  const [row] = await db.insert(capabilities).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+async function seedApplication(orgId: string, name: string) {
+  const [row] = await db.insert(applications).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+async function seedInitiative(orgId: string, name: string) {
+  const [row] = await db.insert(initiatives).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+async function seedObjective(orgId: string, name: string) {
+  const [row] = await db.insert(strategicObjectives).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+describe('importADRs (#596)', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects viewer role', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(importADRs(csvForm('number,title\nADR-001,Test\n'))).rejects.toThrow('Forbidden')
+  })
+
+  it('creates new ADRs from CSV (contributor)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-001,Use Postgres,Need a relational store,Adopt Postgres,Pin to Postgres 16,accepted,org,,,,,',
+      'ADR-002,Server-rendered React,Need SEO and accessibility,Use Next.js App Router with RSC,Layered on top of Postgres,proposed,org,,,,,',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(2)
+    expect(result.updated).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toEqual([])
+
+    const rows = await db.select().from(adrs).where(eq(adrs.organizationId, orgId))
+    expect(rows.some(r => r.number === 'ADR-001' && r.status === 'accepted')).toBe(true)
+    expect(rows.some(r => r.number === 'ADR-002' && r.status === 'proposed')).toBe(true)
+  })
+
+  it('upserts existing ADRs by number (case-insensitive)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'adr-001,Use Postgres,Updated context,Adopt Postgres,Pin to Postgres 16,accepted,org,,,,,',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.updated).toBe(1)
+
+    const row = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-001')),
+    })
+    expect(row?.context).toBe('Updated context')
+  })
+
+  it('resolves capability/application/initiative/objective names to ids; unknown names are warnings', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const capId = await seedCapability(orgId, 'Identity')
+    const appId = await seedApplication(orgId, 'Auth Service')
+    const initId = await seedInitiative(orgId, 'Auth Modernization')
+    const objId = await seedObjective(orgId, 'Improve Security Posture')
+
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-003,Adopt OIDC,Need SSO,Use OIDC via Entra,Local accounts remain,accepted,org,,Identity; Unknown Cap,Auth Service,Auth Modernization,Improve Security Posture',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.errors.some(e => e.includes('Unknown Cap'))).toBe(true)
+
+    const adr = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-003')),
+    })
+    expect(adr).toBeDefined()
+    const [caps, apps, inits, objs] = await Promise.all([
+      db.select().from(adrCapabilities).where(eq(adrCapabilities.adrId, adr!.id)),
+      db.select().from(adrApplications).where(eq(adrApplications.adrId, adr!.id)),
+      db.select().from(adrInitiatives).where(eq(adrInitiatives.adrId, adr!.id)),
+      db.select().from(adrObjectives).where(eq(adrObjectives.adrId, adr!.id)),
+    ])
+    expect(caps.map(c => c.capabilityId)).toEqual([capId])
+    expect(apps.map(a => a.applicationId)).toEqual([appId])
+    expect(inits.map(i => i.initiativeId)).toEqual([initId])
+    expect(objs.map(o => o.objectiveId)).toEqual([objId])
+  })
+
+  it('replaces all four junctions on upsert', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const adr = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-003')),
+    })
+    expect(adr).toBeDefined()
+    // Re-import with no junctions — all existing links should drop.
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-003,Adopt OIDC,Need SSO,Use OIDC via Entra,Local accounts remain,accepted,org,,,,,',
+    ].join('\n')
+    await importADRs(csvForm(csv), false)
+    const [caps, apps, inits, objs] = await Promise.all([
+      db.select().from(adrCapabilities).where(eq(adrCapabilities.adrId, adr!.id)),
+      db.select().from(adrApplications).where(eq(adrApplications.adrId, adr!.id)),
+      db.select().from(adrInitiatives).where(eq(adrInitiatives.adrId, adr!.id)),
+      db.select().from(adrObjectives).where(eq(adrObjectives.adrId, adr!.id)),
+    ])
+    expect(caps).toHaveLength(0)
+    expect(apps).toHaveLength(0)
+    expect(inits).toHaveLength(0)
+    expect(objs).toHaveLength(0)
+  })
+
+  it('resolves superseded_by within the same batch', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    // ADR-101 supersedes ADR-100. Both are new in this batch.
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-100,Initial decision,context,decision,consequences,deprecated,org,ADR-101,,,,',
+      'ADR-101,Revised decision,context,decision,consequences,accepted,org,,,,,',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(2)
+    expect(result.errors).toEqual([])
+
+    const [oldAdr, newAdr] = await Promise.all([
+      db.query.adrs.findFirst({ where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-100')) }),
+      db.query.adrs.findFirst({ where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-101')) }),
+    ])
+    expect(oldAdr?.supersededBy).toBe(newAdr?.id)
+  })
+
+  it('reports unresolved superseded_by as a warning, not a failure', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-200,Some decision,context,decision,consequences,accepted,org,ADR-NEVER,,,,',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.errors.some(e => e.includes('ADR-NEVER'))).toBe(true)
+
+    const adr = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-200')),
+    })
+    expect(adr?.supersededBy).toBeNull()
+  })
+
+  it('skips rows missing required fields and invalid status/visibility', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      ',Missing number,context,decision,consequences,accepted,org,,,,,',
+      'ADR-300,,context,decision,consequences,accepted,org,,,,,',
+      'ADR-301,OK,context,decision,consequences,not-a-status,org,,,,,',
+      'ADR-302,OK,context,decision,consequences,accepted,not-a-visibility,,,,,',
+    ].join('\n')
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.skipped).toBe(4)
+    expect(result.errors.some(e => e.includes('missing required field "number"'))).toBe(true)
+    expect(result.errors.some(e => e.includes('missing required field "title"'))).toBe(true)
+    expect(result.errors.some(e => e.includes('invalid status'))).toBe(true)
+    expect(result.errors.some(e => e.includes('invalid visibility'))).toBe(true)
+  })
+
+  it('dryRun does not write rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-DRY,Dry Run,c,d,k,accepted,org,,,,,',
+    ].join('\n')
+
+    const before = await db.select().from(adrs).where(eq(adrs.organizationId, orgId))
+    const result = await importADRs(csvForm(csv), true)
+    expect(result.created).toBe(1)
+    const after = await db.select().from(adrs).where(eq(adrs.organizationId, orgId))
+    expect(after).toHaveLength(before.length)
+    expect(after.some(r => r.number === 'ADR-DRY')).toBe(false)
+  })
+
+  it('handles multi-line context/decision/consequences through quote-aware parser', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv =
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives\n' +
+      'ADR-MULTI,Multi-line,"Reason 1\nReason 2","Decide A\nDecide B","Outcome 1\nOutcome 2",accepted,org,,,,,\n'
+
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(0)
+
+    const row = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-MULTI')),
+    })
+    expect(row?.context).toBe('Reason 1\nReason 2')
+    expect(row?.decision).toBe('Decide A\nDecide B')
+    expect(row?.consequences).toBe('Outcome 1\nOutcome 2')
+  })
+
+  it('round-trip: re-importing an existing row reports updated=1 with no field changes', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'number,title,context,decision,consequences,status,visibility,superseded_by,capabilities,applications,initiatives,objectives',
+      'ADR-002,Server-rendered React,Need SEO and accessibility,Use Next.js App Router with RSC,Layered on top of Postgres,proposed,org,,,,,',
+    ].join('\n')
+    const result = await importADRs(csvForm(csv), false)
+    expect(result.updated).toBe(1)
+    expect(result.created).toBe(0)
+
+    const row = await db.query.adrs.findFirst({
+      where: and(eq(adrs.organizationId, orgId), eq(adrs.number, 'ADR-002')),
+    })
+    expect(row).toMatchObject({
+      title: 'Server-rendered React',
+      context: 'Need SEO and accessibility',
+      status: 'proposed',
+    })
+  })
+
+  it('reports CSV with no data rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const result = await importADRs(csvForm('number,title\n'), false)
+    expect(result.errors).toContain('CSV has no data rows')
+  })
+
+  it('reports missing file', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    const result = await importADRs(fd, false)
+    expect(result.errors).toContain('No file provided')
+  })
+})

--- a/apps/govea/tests/integration/personas-import.test.ts
+++ b/apps/govea/tests/integration/personas-import.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Integration tests: importPersonas server action (#596)
+ *
+ * Covers:
+ *  - Role enforcement (viewer rejected; contributor accepted)
+ *  - Basic create from CSV with all fixed columns
+ *  - Upsert: existing persona matched case-insensitively by name and updated
+ *  - Tag resolution: semicolon-joined names → ids from the "Persona Tag"
+ *    taxonomy branch; unknown names reported as row warnings
+ *  - Validation: invalid status / visibility skip the row
+ *  - dryRun: returns counters and errors WITHOUT writing any rows
+ *  - Multi-line description regression (#596) — exercises the quote-aware
+ *    parser shared from `@/lib/csv`
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { personas, personaTags, taxonomyTerms } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { importPersonas } from '@/actions/personas'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function csvForm(content: string): FormData {
+  const fd = new FormData()
+  const blob = new Blob([content], { type: 'text/csv' })
+  fd.append('csvFile', new File([blob], 'personas.csv', { type: 'text/csv' }))
+  return fd
+}
+
+async function seedTagRoot(orgId: string) {
+  const [root] = await db.insert(taxonomyTerms).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    name: 'Persona Tag',
+    slug: 'persona-tag',
+    parentId: null,
+  }).returning()
+  return root.id
+}
+
+async function seedTag(orgId: string, rootId: string, name: string) {
+  const [tag] = await db.insert(taxonomyTerms).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, '-'),
+    parentId: rootId,
+  }).returning()
+  return tag.id
+}
+
+describe('importPersonas (#596)', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects viewer role', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(importPersonas(csvForm('name\nTest Persona\n'))).rejects.toThrow('Forbidden')
+  })
+
+  it('creates new personas from CSV (contributor)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Resident,Lives in the city,External,published,org,',
+      'Permitting Clerk,Reviews permit applications,Staff,draft,org,',
+    ].join('\n')
+
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.created).toBe(2)
+    expect(result.updated).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toEqual([])
+
+    const rows = await db.select().from(personas).where(eq(personas.organizationId, orgId))
+    expect(rows.some(r => r.name === 'Resident' && r.status === 'published')).toBe(true)
+    expect(rows.some(r => r.name === 'Permitting Clerk' && r.type === 'Staff')).toBe(true)
+  })
+
+  it('upserts existing personas by name (case-insensitive)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'resident,Updated description,External,published,org,',
+    ].join('\n')
+
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.updated).toBe(1)
+
+    const row = await db.query.personas.findFirst({
+      where: and(eq(personas.organizationId, orgId), eq(personas.name, 'Resident')),
+    })
+    expect(row?.description).toBe('Updated description')
+  })
+
+  it('resolves tag names to ids from the Persona Tag taxonomy', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const rootId = await seedTagRoot(orgId)
+    const mobileId = await seedTag(orgId, rootId, 'mobile-first')
+    const a11yId = await seedTag(orgId, rootId, 'accessibility')
+
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Field Inspector,On-the-go inspections,Staff,published,org,mobile-first; accessibility; unknown-tag',
+    ].join('\n')
+
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.errors.some(e => e.includes('unknown-tag'))).toBe(true)
+
+    const persona = await db.query.personas.findFirst({
+      where: and(eq(personas.organizationId, orgId), eq(personas.name, 'Field Inspector')),
+    })
+    expect(persona).toBeDefined()
+    const links = await db.select().from(personaTags).where(eq(personaTags.personaId, persona!.id))
+    expect(links.map(l => l.tagId).sort()).toEqual([mobileId, a11yId].sort())
+  })
+
+  it('replaces tag links on upsert (no leftover from earlier import)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const persona = await db.query.personas.findFirst({
+      where: and(eq(personas.organizationId, orgId), eq(personas.name, 'Field Inspector')),
+    })
+    expect(persona).toBeDefined()
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Field Inspector,On-the-go inspections,Staff,published,org,mobile-first',
+    ].join('\n')
+    await importPersonas(csvForm(csv), false)
+    const links = await db.select().from(personaTags).where(eq(personaTags.personaId, persona!.id))
+    expect(links).toHaveLength(1)
+  })
+
+  it('skips rows with invalid status / visibility', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Bad Status,desc,External,not-a-status,org,',
+      'Bad Vis,desc,External,draft,not-a-visibility,',
+    ].join('\n')
+
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.skipped).toBe(2)
+    expect(result.errors.some(e => e.includes('invalid status'))).toBe(true)
+    expect(result.errors.some(e => e.includes('invalid visibility'))).toBe(true)
+  })
+
+  it('dryRun does not write rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Dry Run Persona,never created,External,published,org,',
+    ].join('\n')
+
+    const before = await db.select().from(personas).where(eq(personas.organizationId, orgId))
+    const result = await importPersonas(csvForm(csv), true)
+    expect(result.created).toBe(1)
+    const after = await db.select().from(personas).where(eq(personas.organizationId, orgId))
+    expect(after).toHaveLength(before.length)
+    expect(after.some(r => r.name === 'Dry Run Persona')).toBe(false)
+  })
+
+  it('handles multi-line description through quote-aware parser', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv =
+      'name,description,type,status,visibility,tags\n' +
+      'MultiLine Persona,"Lives in the city.\nUses mobile first.\nNeeds accessibility.",External,published,org,\n'
+
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(0)
+
+    const row = await db.query.personas.findFirst({
+      where: and(eq(personas.organizationId, orgId), eq(personas.name, 'MultiLine Persona')),
+    })
+    expect(row?.description).toBe('Lives in the city.\nUses mobile first.\nNeeds accessibility.')
+  })
+
+  it('round-trip: re-importing an existing row reports updated=1 with no field changes', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,type,status,visibility,tags',
+      'Permitting Clerk,Reviews permit applications,Staff,draft,org,',
+    ].join('\n')
+    const result = await importPersonas(csvForm(csv), false)
+    expect(result.updated).toBe(1)
+    expect(result.created).toBe(0)
+
+    const row = await db.query.personas.findFirst({
+      where: and(eq(personas.organizationId, orgId), eq(personas.name, 'Permitting Clerk')),
+    })
+    expect(row).toMatchObject({
+      description: 'Reviews permit applications',
+      type: 'Staff',
+      status: 'draft',
+    })
+  })
+
+  it('reports CSV with no data rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const result = await importPersonas(csvForm('name,description\n'), false)
+    expect(result.errors).toContain('CSV has no data rows')
+  })
+
+  it('reports missing file', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    const result = await importPersonas(fd, false)
+    expect(result.errors).toContain('No file provided')
+  })
+})


### PR DESCRIPTION
## Summary

Next slice of the per-entity CSV beachhead opened by #604. Personas and ADRs were the persona file's top remaining priorities for the Consultant / SI persona ([#595](https://github.com/roballred/GovEA/issues/595)) — *"persona libraries reused across engagements"* and *"ADRs as a self-contained handover artefact"*. The pattern mirrors #604 exactly so future per-entity slices stay mechanical.

## What ships

| Surface | Personas | ADRs |
|---|---|---|
| `GET /api/<entity>/export` | ✅ (name, description, type, status, visibility, tags + per-entity taxonomy columns) | ✅ (number, title, context, decision, consequences, status, visibility, superseded_by + 4 junctions: capabilities/applications/initiatives/objectives + taxonomy) |
| `import<Entity>` server action | ✅ Two-step preview/confirm. Upsert by name (case-insensitive). | ✅ Two-step preview/confirm. Upsert by **number** (ADRs are number-keyed, not name-keyed). |
| Junction name resolution | Tags resolve against the `Persona Tag` taxonomy branch | Capabilities / applications / initiatives / objectives resolve against the org's own records |
| Junction replacement on upsert | ✅ Tags replaced wholesale | ✅ All four junctions replaced wholesale |
| Multi-line cell support | ✅ via shared `splitCsvRows` | ✅ via shared `splitCsvRows` |
| Unknown junction names | Reported as row warnings, not row failures | Reported as row warnings, not row failures |
| `superseded_by` | n/a | Resolved in a second pass — two ADRs in the same batch can reference each other |
| `<entity>-table.tsx` | ✅ Export + Import buttons + dialog | ✅ Export + Import buttons + dialog |

## Refactor

Extracted shared CSV utilities to `@/lib/csv`:
- `escapeCsv(val)`
- `splitCsvRows(text)` — quote-aware (the #604 multi-line fix)
- `parseCsv(text)` — returns header-keyed rows
- `splitSemicolonList(value)` — junction list parser

The capability action and its export route now import from the shared module. Behavior is unchanged.

## Test plan

- [x] 11 new integration tests in `tests/integration/personas-import.test.ts` — role enforcement, create, upsert, tag resolution + warnings, link replacement, validation, dryRun, multi-line, round-trip
- [x] 13 new integration tests in `tests/integration/adrs-import.test.ts` — same coverage plus four-junction round-trip, in-batch `superseded_by` resolution, unresolved `superseded_by` reported as warning (not failure), multi-line context/decision/consequences
- [x] Existing 11 capability tests still pass after the refactor
- [x] All 35 tests pass locally (`vitest run`, 1.94s)
- [x] `tsc --noEmit` clean

## What this PR does NOT do

Still queued under #596: Initiatives, Objectives, Services, Value Streams, Principles, Glossary, and Data Architecture. Each is a small per-entity PR following the same pattern.

## Capability traceability

Capability: `ac-backup-export` (per-entity CSV subset)
Persona: consultant-si (primary); also serves early-maturity-practice-lead, agency-ea-coordinator, enterprise-architect
Refs #596 (Capabilities done in #604; Personas + ADRs here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)