### PR TITLE
security(iam): gate cross-tenant user PII on break-glass (#436)

### DIFF
--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { organizations, users, breakGlassSessions } from '@/db/schema'
-import { eq, and, isNull, gt, ne, desc } from 'drizzle-orm'
+import { eq, and, isNull, gt, ne, desc, count } from 'drizzle-orm'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -45,12 +45,11 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
   const session = await requireInstanceAdmin()
 
   const now = new Date()
-  const [org, orgUsers, myActiveSession, pendingFromOthers, bgHistory, govHistory] = await Promise.all([
+  const [org, userCountRow, myActiveSession, pendingFromOthers, bgHistory, govHistory] = await Promise.all([
     db.query.organizations.findFirst({ where: eq(organizations.id, id) }),
-    db.query.users.findMany({
-      where: eq(users.organizationId, id),
-      orderBy: (u, { asc }) => [asc(u.name)],
-    }),
+    // #436 — only the COUNT is metadata. Full user rows are loaded below,
+    // and only when the caller has earned the right to see them.
+    db.select({ n: count(users.id) }).from(users).where(eq(users.organizationId, id)),
     db.query.breakGlassSessions.findFirst({
       where: and(
         eq(breakGlassSessions.instanceAdminId, session.user.id),
@@ -85,6 +84,20 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
   const myActiveIsPending = !!myActiveSession && myActiveSession.requiresApproval && !myActiveSession.approvedAt
 
   if (!org) notFound()
+
+  const userCount = userCountRow[0]?.n ?? 0
+
+  // #436 — gate user PII on active+approved break-glass. The caller can also
+  // see their own home org without break-glass (no cross-tenant boundary
+  // being crossed there).
+  const isHomeOrg = id === session.user.organizationId
+  const canSeeUserPii = isHomeOrg || (!!myActiveSession && !myActiveIsPending)
+  const orgUsers = canSeeUserPii
+    ? await db.query.users.findMany({
+        where: eq(users.organizationId, id),
+        orderBy: (u, { asc }) => [asc(u.name)],
+      })
+    : []
 
   const tierBadge = org.supportTier ? TIER_BADGE[org.supportTier] : null
 
@@ -161,7 +174,7 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
           <div><dt className="text-muted-foreground">Created</dt><dd className="mt-0.5 font-medium">{org.createdAt.toLocaleDateString()}</dd></div>
           <div><dt className="text-muted-foreground">Theme</dt><dd className="mt-0.5 font-medium">{org.theme}</dd></div>
           <div><dt className="text-muted-foreground">System org</dt><dd className="mt-0.5 font-medium">{org.isSystemOrg ? 'Yes' : 'No'}</dd></div>
-          <div><dt className="text-muted-foreground">Users</dt><dd className="mt-0.5 font-medium">{orgUsers.length}</dd></div>
+          <div><dt className="text-muted-foreground">Users</dt><dd className="mt-0.5 font-medium">{userCount}</dd></div>
         </dl>
       </section>
 
@@ -350,49 +363,67 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
         )}
       </section>
 
-      {/* Users */}
+      {/* Users — #436 gates PII behind active+approved break-glass. */}
       <section>
-        <h2 className="text-base font-semibold mb-3">Users <span className="text-muted-foreground font-normal text-sm">({orgUsers.length})</span></h2>
-        <div className="rounded-lg border bg-card">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Email</TableHead>
-                <TableHead>Role</TableHead>
-                <TableHead>Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {orgUsers.map(u => (
-                <TableRow key={u.id}>
-                  <TableCell className="font-medium">{u.name ?? '—'}</TableCell>
-                  <TableCell className="text-muted-foreground">{u.email}</TableCell>
-                  <TableCell>
-                    <span className="capitalize text-sm">{u.role}</span>
-                  </TableCell>
-                  <TableCell>
-                    <span className={cn(
-                      'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
-                      u.isActive === 'true'
-                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
-                        : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
-                    )}>
-                      {u.isActive === 'true' ? 'Active' : 'Inactive'}
-                    </span>
-                  </TableCell>
-                </TableRow>
-              ))}
-              {orgUsers.length === 0 && (
+        <h2 className="text-base font-semibold mb-3">Users <span className="text-muted-foreground font-normal text-sm">({userCount})</span></h2>
+        {canSeeUserPii ? (
+          <div className="rounded-lg border bg-card">
+            <Table>
+              <TableHeader>
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
-                    No users in this organisation
-                  </TableCell>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Status</TableHead>
                 </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
+              </TableHeader>
+              <TableBody>
+                {orgUsers.map(u => (
+                  <TableRow key={u.id}>
+                    <TableCell className="font-medium">{u.name ?? '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">{u.email}</TableCell>
+                    <TableCell>
+                      <span className="capitalize text-sm">{u.role}</span>
+                    </TableCell>
+                    <TableCell>
+                      <span className={cn(
+                        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                        u.isActive === 'true'
+                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
+                          : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                      )}>
+                        {u.isActive === 'true' ? 'Active' : 'Inactive'}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {orgUsers.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+                      No users in this organisation
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800 p-5 text-sm">
+            <p className="font-medium text-amber-900 dark:text-amber-200">
+              User PII hidden — break-glass required
+            </p>
+            <p className="text-amber-800 dark:text-amber-400 mt-1">
+              {userCount === 0
+                ? 'This organisation has no users to display.'
+                : `${userCount} user${userCount === 1 ? '' : 's'} on file. Grant break-glass access above to see names, emails, roles, and account status. Sessions over one hour require a second instance admin to approve.`}
+            </p>
+            {myActiveSession && myActiveIsPending && (
+              <p className="text-amber-700 dark:text-amber-500 mt-2 text-xs">
+                Your break-glass request is pending approval from another instance admin.
+              </p>
+            )}
+          </div>
+        )}
       </section>
     </div>
   )

--- a/apps/govea/src/app/(instance)/instance/users/instance-user-table.tsx
+++ b/apps/govea/src/app/(instance)/instance/users/instance-user-table.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -34,9 +35,13 @@ interface Props {
   users: InstanceUserRow[]
   organizations: OrgOption[]
   currentUserId: string
+  /** #436 — count of tenant users filtered out because no active break-glass for their org. */
+  hiddenUserCount: number
+  /** #436 — count of distinct tenant orgs whose users were filtered out. */
+  hiddenOrgCount: number
 }
 
-export function InstanceUserTable({ users, organizations, currentUserId }: Props) {
+export function InstanceUserTable({ users, organizations, currentUserId, hiddenUserCount, hiddenOrgCount }: Props) {
   const router = useRouter()
   const [createOpen, setCreateOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
@@ -58,12 +63,29 @@ export function InstanceUserTable({ users, organizations, currentUserId }: Props
       <div className="flex items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Users</h1>
-          <p className="text-muted-foreground mt-1">All users across all tenant organisations.</p>
+          <p className="text-muted-foreground mt-1">Platform admins are always visible. Tenant users are only visible for organisations you currently hold break-glass access to.</p>
         </div>
         <Button size="sm" onClick={() => setCreateOpen(true)}>
           + Create account
         </Button>
       </div>
+
+      {/* #436 — honest disclosure when tenant users are filtered out. */}
+      {hiddenUserCount > 0 && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800 p-3 text-sm flex items-start justify-between gap-4">
+          <div>
+            <p className="font-medium text-amber-900 dark:text-amber-200">
+              {hiddenUserCount} tenant user{hiddenUserCount === 1 ? '' : 's'} hidden across {hiddenOrgCount} organisation{hiddenOrgCount === 1 ? '' : 's'}.
+            </p>
+            <p className="text-amber-800 dark:text-amber-400 mt-0.5">
+              Tenant-user PII is gated behind active, approved break-glass sessions. Grant break-glass from the organisation&apos;s detail page to view its users here.
+            </p>
+          </div>
+          <Link href="/instance/orgs" className="shrink-0">
+            <Button variant="outline" size="sm">Go to Organisations</Button>
+          </Link>
+        </div>
+      )}
 
       <div className="rounded-lg border bg-card">
         <Table>

--- a/apps/govea/src/app/(instance)/instance/users/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/users/page.tsx
@@ -2,10 +2,25 @@ import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
 import { users, organizations } from '@/db/schema'
 import { eq, desc } from 'drizzle-orm'
+import { getUnlockedOrgIds } from '@/lib/break-glass'
 import { InstanceUserTable } from './instance-user-table'
 
+/**
+ * Cross-tenant user-PII gating (#436). Instance admins see:
+ *   - All platform admins (instanceRole = 'instance_admin'), regardless of
+ *     org. Visible so platform-role management is possible without first
+ *     elevating against every tenant.
+ *   - Tenant users only for orgs the caller currently has an active,
+ *     approved, non-expired break-glass session for.
+ *
+ * The `hiddenOrgCount` and `hiddenUserCount` props let the table render an
+ * honest banner explaining what's been filtered, with a link to the orgs
+ * list where break-glass is granted.
+ */
 export default async function InstanceUsersPage() {
   const session = await requireInstanceAdmin()
+
+  const unlocked = await getUnlockedOrgIds(session.user.id)
 
   const [rows, orgRows] = await Promise.all([
     db
@@ -20,11 +35,30 @@ export default async function InstanceUsersPage() {
     }),
   ])
 
+  // Split visible vs hidden. Platform admins are always visible; tenant users
+  // are visible only when their org is in the unlocked set.
+  const visible: typeof rows = []
+  const hiddenOrgIds = new Set<string>()
+  let hiddenUserCount = 0
+  for (const r of rows) {
+    if (r.user.instanceRole === 'instance_admin') {
+      visible.push(r)
+      continue
+    }
+    const orgId = r.user.organizationId
+    if (orgId && unlocked.has(orgId)) {
+      visible.push(r)
+    } else {
+      hiddenUserCount++
+      if (orgId) hiddenOrgIds.add(orgId)
+    }
+  }
+
   return (
     <InstanceUserTable
       currentUserId={session.user.id}
       organizations={orgRows}
-      users={rows.map(({ user, org }) => ({
+      users={visible.map(({ user, org }) => ({
         id: user.id,
         name: user.name,
         email: user.email,
@@ -33,6 +67,8 @@ export default async function InstanceUsersPage() {
         isActive: user.isActive,
         organizationName: org?.name ?? null,
       }))}
+      hiddenUserCount={hiddenUserCount}
+      hiddenOrgCount={hiddenOrgIds.size}
     />
   )
 }

--- a/apps/govea/src/lib/break-glass.ts
+++ b/apps/govea/src/lib/break-glass.ts
@@ -17,10 +17,10 @@ export function isValidBreakGlassTtl(value: number): value is BreakGlassTtlMinut
  * admin + org, or null if no such session exists. A pending-approval session
  * does NOT satisfy `requireBreakGlass` — it must be approved first.
  *
- * Under Option 2 (see #418 design note), this helper has no caller in the
- * read path. It will be consulted by the cross-tenant impersonation feature
- * (#437) once that lands, and by gated cross-tenant reads when #436 promotes
- * to Option 1.
+ * Consulted by:
+ *  - Cross-tenant impersonation flow (#437/#502)
+ *  - Cross-tenant user-PII gating (#436): see `getUnlockedOrgIds` for the
+ *    multi-org variant used by `/instance/users` and `/instance/orgs/[id]`
  */
 export async function requireBreakGlass(
   adminId: string,
@@ -40,4 +40,32 @@ export async function requireBreakGlass(
     ),
   })
   return session ?? null
+}
+
+/**
+ * Returns the set of org IDs the given instance admin currently has active,
+ * approved, non-expired break-glass sessions for. Empty set if none.
+ *
+ * Multi-org variant of `requireBreakGlass` for surfaces that need to filter
+ * a list (e.g., the cross-tenant user list) without N round-trips. Mirrors
+ * the same gating rules: pending-approval sessions do NOT count; expired
+ * and revoked sessions do NOT count.
+ *
+ * Added for #436 (gate cross-tenant user-PII reads on break-glass).
+ */
+export async function getUnlockedOrgIds(adminId: string): Promise<Set<string>> {
+  const now = new Date()
+  const rows = await db.query.breakGlassSessions.findMany({
+    where: and(
+      eq(breakGlassSessions.instanceAdminId, adminId),
+      isNull(breakGlassSessions.revokedAt),
+      gt(breakGlassSessions.expiresAt, now),
+      or(
+        eq(breakGlassSessions.requiresApproval, false),
+        isNotNull(breakGlassSessions.approvedAt),
+      ),
+    ),
+    columns: { targetOrgId: true },
+  })
+  return new Set(rows.map(r => r.targetOrgId))
 }

--- a/apps/govea/tests/integration/break-glass-unlocked-orgs.test.ts
+++ b/apps/govea/tests/integration/break-glass-unlocked-orgs.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Integration tests: getUnlockedOrgIds (#436)
+ *
+ * The multi-org break-glass query used by `/instance/users` and
+ * `/instance/orgs/[id]` to gate cross-tenant user-PII reads. Same gating
+ * rules as `requireBreakGlass`, exercised against rows directly so each
+ * scenario can pin the exact state under test (approved vs pending vs
+ * expired vs revoked) without timer mocks.
+ *
+ * Capability: iam-instance-administration, iam-role-based-access-control
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { db } from '@/db/client'
+import { breakGlassSessions } from '@/db/schema'
+import { eq, or } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { getUnlockedOrgIds } from '@/lib/break-glass'
+import {
+  createTestOrg,
+  createTestUser,
+  cleanupOrg,
+  type TestUser,
+} from './helpers/db'
+
+let homeOrgId: string
+let orgA: string
+let orgB: string
+let orgC: string
+let adminMe: TestUser
+let adminOther: TestUser
+
+beforeAll(async () => {
+  const [home, a, b, c] = await Promise.all([
+    createTestOrg(),
+    createTestOrg(),
+    createTestOrg(),
+    createTestOrg(),
+  ])
+  homeOrgId = home.id
+  orgA = a.id
+  orgB = b.id
+  orgC = c.id
+  ;[adminMe, adminOther] = await Promise.all([
+    createTestUser(homeOrgId, 'admin'),
+    createTestUser(homeOrgId, 'admin'),
+  ])
+})
+
+afterAll(async () => {
+  await db.delete(breakGlassSessions).where(
+    or(
+      eq(breakGlassSessions.targetOrgId, orgA),
+      eq(breakGlassSessions.targetOrgId, orgB),
+      eq(breakGlassSessions.targetOrgId, orgC),
+      eq(breakGlassSessions.targetOrgId, homeOrgId),
+    ),
+  )
+  await Promise.all([
+    cleanupOrg(homeOrgId),
+    cleanupOrg(orgA),
+    cleanupOrg(orgB),
+    cleanupOrg(orgC),
+  ])
+})
+
+beforeEach(async () => {
+  await db.delete(breakGlassSessions).where(
+    or(
+      eq(breakGlassSessions.targetOrgId, orgA),
+      eq(breakGlassSessions.targetOrgId, orgB),
+      eq(breakGlassSessions.targetOrgId, orgC),
+    ),
+  )
+})
+
+// Helper: insert a row with explicit state. Mirrors the shape grantBreakGlass
+// would produce, but skips the action layer so each test can pin expiresAt
+// and approvedAt independently of the action's TTL logic.
+async function insertSession(opts: {
+  adminId: string
+  orgId: string
+  expiresAt: Date
+  approved: boolean
+  revoked?: boolean
+  requiresApproval?: boolean
+}) {
+  await db.insert(breakGlassSessions).values({
+    id: randomUUID(),
+    instanceAdminId: opts.adminId,
+    targetOrgId: opts.orgId,
+    reason: 'test',
+    grantedAt: new Date(),
+    expiresAt: opts.expiresAt,
+    requiresApproval: opts.requiresApproval ?? false,
+    approvedAt: opts.approved ? new Date() : null,
+    approvedBy: opts.approved ? opts.adminId : null,
+    revokedAt: opts.revoked ? new Date() : null,
+  })
+}
+
+const future = () => new Date(Date.now() + 60 * 60 * 1000) // +1 hour
+const past = () => new Date(Date.now() - 60 * 1000)        // -1 minute
+
+describe('getUnlockedOrgIds (#436)', () => {
+  it('returns an empty set when the admin has no sessions', async () => {
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns orgs for active, no-approval-needed sessions', async () => {
+    await insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: false, requiresApproval: false })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(Array.from(result)).toEqual([orgA])
+  })
+
+  it('returns orgs for active, approved sessions', async () => {
+    await insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: true, requiresApproval: true })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(Array.from(result)).toEqual([orgA])
+  })
+
+  it('does NOT return orgs for pending-approval sessions', async () => {
+    await insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: false, requiresApproval: true })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(result.size).toBe(0)
+  })
+
+  it('does NOT return orgs for expired sessions', async () => {
+    await insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: past(), approved: true, requiresApproval: false })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(result.size).toBe(0)
+  })
+
+  it('does NOT return orgs for revoked sessions', async () => {
+    await insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: true, revoked: true, requiresApproval: false })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns multiple orgs when the admin has sessions for several at once', async () => {
+    await Promise.all([
+      insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: true, requiresApproval: false }),
+      insertSession({ adminId: adminMe.id, orgId: orgB, expiresAt: future(), approved: true, requiresApproval: true }),
+    ])
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(Array.from(result).sort()).toEqual([orgA, orgB].sort())
+  })
+
+  it('does NOT return orgs that another admin has elevated against', async () => {
+    // adminOther holds break-glass for orgA. adminMe must not inherit it.
+    await insertSession({ adminId: adminOther.id, orgId: orgA, expiresAt: future(), approved: true, requiresApproval: false })
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(result.size).toBe(0)
+  })
+
+  it('partitions correctly when both admins have overlapping but distinct sessions', async () => {
+    await Promise.all([
+      insertSession({ adminId: adminMe.id,    orgId: orgA, expiresAt: future(), approved: true, requiresApproval: false }),
+      insertSession({ adminId: adminMe.id,    orgId: orgB, expiresAt: future(), approved: true, requiresApproval: false }),
+      insertSession({ adminId: adminOther.id, orgId: orgB, expiresAt: future(), approved: true, requiresApproval: false }),
+      insertSession({ adminId: adminOther.id, orgId: orgC, expiresAt: future(), approved: true, requiresApproval: false }),
+    ])
+    const me = await getUnlockedOrgIds(adminMe.id)
+    const other = await getUnlockedOrgIds(adminOther.id)
+    expect(Array.from(me).sort()).toEqual([orgA, orgB].sort())
+    expect(Array.from(other).sort()).toEqual([orgB, orgC].sort())
+  })
+
+  it('mixed-state sessions for one admin produce only the active+approved ones', async () => {
+    await Promise.all([
+      insertSession({ adminId: adminMe.id, orgId: orgA, expiresAt: future(), approved: true,  requiresApproval: false }),
+      insertSession({ adminId: adminMe.id, orgId: orgB, expiresAt: future(), approved: false, requiresApproval: true  }), // pending
+      insertSession({ adminId: adminMe.id, orgId: orgC, expiresAt: past(),   approved: true,  requiresApproval: false }), // expired
+    ])
+    const result = await getUnlockedOrgIds(adminMe.id)
+    expect(Array.from(result)).toEqual([orgA])
+  })
+})


### PR DESCRIPTION
## Summary

Closes the longest-standing security follow-up. Re-scoped per the architectural audit posted on the issue ([comment](https://github.com/roballred/GovEA/issues/436#issuecomment-4527491405), 2026-05-23): the original \"Option 1\" spec called out content reads, but those never had a cross-tenant path — every read action uses \`session.user.organizationId\`, which always resolves to the admin's home org. Act-As (#502) gates mutations. The only cross-tenant read surface left to gate is **user PII** on \`/instance/users\` and the user-list block on \`/instance/orgs/[id]\`.

## What ships

### New helper — \`getUnlockedOrgIds(adminId)\`
Multi-org variant of \`requireBreakGlass\`. Returns the set of org IDs an instance admin currently has active+approved+non-expired break-glass for. Same gating rules: pending-approval sessions don't count; expired or revoked sessions don't count.

### \`/instance/users\`
- **Platform admins** (\`instanceRole = 'instance_admin'\`) are always visible regardless of org. Necessary so platform-role management works without first elevating against every tenant.
- **Tenant users** are visible only for orgs the caller holds active+approved break-glass for.
- An amber banner discloses the hidden count and routes the admin to Organisations where break-glass is granted.
- The page header was updated to reflect the new policy honestly.

### \`/instance/orgs/[id]\`
- User **count** stays visible (metadata per the issue spec — needed so the admin knows whether to elevate).
- User-PII block (names, emails, roles, status) renders only when the caller holds active+approved break-glass for that org **or** is viewing their own home org.
- Otherwise, an amber panel explains the gate and surfaces pending-approval state when applicable.
- **Defense in depth:** when not authorised, the full user query is skipped — only the COUNT runs — so even a future JSX edit can't accidentally leak PII.

## Test plan

- [x] 10 new integration tests in \`tests/integration/break-glass-unlocked-orgs.test.ts\`:
  - Empty set when admin has no sessions
  - Returns org for no-approval-needed session
  - Returns org for approved session
  - Excludes pending-approval sessions
  - Excludes expired sessions
  - Excludes revoked sessions
  - Multiple sessions return multiple orgs
  - Does not return another admin's sessions
  - Partition between admins is correct
  - Mixed-state for one admin returns only active+approved
- [x] All 76 existing break-glass / instance / hardening tests still pass — the helper is purely additive.
- [x] \`tsc --noEmit\` clean.

## Out of scope

- **Tenant business content** (capabilities, applications, ADRs, etc.). No instance-admin read path for these exists; act-as already gates the mutation path. See the comment on #436 for the architectural reasoning.

## Capability traceability

Capability: \`iam-instance-administration\`, \`iam-role-based-access-control\`
Persona: Instance Administrator
Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)