### PR TITLE
docs+ui: ARB cleanup trio (closes #75, #133, #7)

### DIFF
--- a/apps/govea/src/app/(admin)/debt/page.tsx
+++ b/apps/govea/src/app/(admin)/debt/page.tsx
@@ -28,12 +28,14 @@ const STATUS_LABEL: Record<DebtStatus, string> = {
   archived: 'Archived',
 }
 
+// Plain-language labels per #133 — see debt-form.tsx for the long form.
+// Slugs stay as the DB enum; only user-visible labels change.
 const TYPE_LABEL: Record<DebtType, string> = {
   'lifecycle-risk': 'Lifecycle risk',
-  'capability-gap': 'Capability gap',
-  'decision-drift': 'Decision drift',
-  'known-shortcut': 'Known shortcut',
-  unreviewed: 'Unreviewed',
+  'capability-gap': 'Unsupported capability',
+  'decision-drift': 'Drift from decision',
+  'known-shortcut': 'Deliberate trade-off',
+  unreviewed: 'Stale / unreviewed',
 }
 
 export default async function DebtIndexPage({ searchParams }: { searchParams: Promise<SearchParams> }) {

--- a/apps/govea/src/components/debt-form.tsx
+++ b/apps/govea/src/components/debt-form.tsx
@@ -35,12 +35,18 @@ interface DebtFormProps {
   prefillInitiativeIds?: string[]
 }
 
-const DEBT_TYPES: { value: DebtType; label: string }[] = [
-  { value: 'lifecycle-risk',  label: 'Lifecycle risk' },
-  { value: 'capability-gap',  label: 'Capability gap' },
-  { value: 'decision-drift',  label: 'Decision drift' },
-  { value: 'known-shortcut',  label: 'Known shortcut' },
-  { value: 'unreviewed',      label: 'Unreviewed' },
+// Labels rewritten under #133 — the original taxonomy (decision-drift,
+// known-shortcut, capability-gap) assumed formal EA vocabulary that the
+// Agency EA Coordinator persona (an assumed persona often from IT operations
+// or project management, not formal EA practice) could not be expected to
+// recognise. Descriptions give the long form so the meaning is plain on hover
+// without losing the structured DB slug. Slugs are unchanged.
+const DEBT_TYPES: { value: DebtType; label: string; description: string }[] = [
+  { value: 'lifecycle-risk', label: 'Lifecycle risk',                description: 'An application is approaching or has passed vendor support end' },
+  { value: 'capability-gap', label: 'Unsupported capability',        description: 'A business capability has no application supporting it' },
+  { value: 'decision-drift', label: 'Drift from a recorded decision', description: 'An ADR is being superseded by practice without a formal revision' },
+  { value: 'known-shortcut', label: 'Deliberate trade-off',          description: 'A technical or architectural compromise was accepted on purpose; record it so it does not get forgotten' },
+  { value: 'unreviewed',     label: 'Stale / unreviewed',            description: 'An object has not been updated or reviewed within the configured window' },
 ]
 
 const SEVERITIES: { value: DebtSeverity; label: string }[] = [
@@ -152,6 +158,9 @@ export function DebtForm({
             className="w-full rounded-md border bg-background px-3 py-2 text-sm">
             {DEBT_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
           </select>
+          <p className="text-xs text-muted-foreground">
+            {DEBT_TYPES.find(t => t.value === debtType)?.description}
+          </p>
         </div>
         <div className="space-y-1.5">
           <label htmlFor="severity" className="text-sm font-medium">Severity</label>

--- a/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
+++ b/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
@@ -23,6 +23,27 @@ The system must allow users to sign in using their agency's identity provider vi
 - If an SSO user is deactivated in GovEA or is not pre-provisioned, sign-in must fail
 - Only one SSO provider is supported in v1
 
+## Identity Provider Failover
+
+GovEA's design choice when the configured identity provider is unavailable is **fail open to local authentication**, not fail closed:
+
+- The SSO sign-in path returns an error to the user when the IdP is unreachable or returns an OIDC error
+- The local-credentials sign-in form remains visible and functional regardless of IdP state — there is no code path that disables local auth based on SSO health
+- A user pre-provisioned with local credentials *and* an SSO identity can sign in either way; an SSO-only user without a local password cannot sign in during an IdP outage (a known v1 trade-off — see Rule above about pre-provisioning)
+- Operators are expected to retain at least one admin account with local credentials so administrative access is never gated solely on a single external dependency
+
+This is a deliberate availability choice: the cost of locking every user out of GovEA while their IdP is degraded is judged higher than the cost of permitting local sign-in for accounts that have it. Operators who require strict fail-closed behavior can remove the local-credentials provider at deploy time and accept the resulting availability profile.
+
+## Integration Boundary (v1)
+
+GovEA's integration boundary in v1 is intentionally narrow:
+
+- **In scope:** OIDC sign-in (one configured provider at a time) and outbound SMTP for system mail (when configured under `ac-email-configuration`)
+- **Out of scope:** SCIM provisioning sync, IdP group → role mapping, multiple simultaneous SSO providers, IdP-driven user deactivation, customer-side configuration of the SSO binding through the admin UI
+- All other inter-system integrations (CMDB, HR, finance, ERP, ITSM, BI) are out of scope for v1 — see the `ea/integration/` capability group for the planned-but-not-built surface
+
+This boundary is explicit so reviewers and operators are not surprised by gaps that are deliberate rather than accidental.
+
 ## Session Invalidation
 
 - Sessions expire after 24 hours and require re-authentication

--- a/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
@@ -4,9 +4,11 @@
 The system must allow contributors to maintain a structured inventory of the organization's applications, capturing lifecycle status, hosting model, vendor, version, and links to the business capabilities each application supports.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes application records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published application records through the front-end portfolio view
+- **Enterprise Architect (Central IT)** — owns the application inventory at the enterprise level; uses it as the source of truth for portfolio analysis
+- **Domain Architect** — maintains the slice of the inventory for their domain (e.g. finance, public works) and reviews lifecycle status
+- **Department Director** — reads the inventory to understand what their department depends on and where investment is going
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create an application record with: name, description, vendor, version, hosting model, lifecycle status, workflow status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
+++ b/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
@@ -4,10 +4,11 @@
 The system must allow contributors to record, track, and supersede architecture decisions so the organization has a durable, navigable log of why significant technical choices were made. ADRs use the standard lightweight format: context, decision, consequences.
 
 ## Personas
-- **CMS Contributor** — creates and maintains ADR records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads accepted ADRs through the front-end ADR list and detail views
+- **Domain Architect** — authors most ADRs for their domain; records the why behind each significant decision
+- **Enterprise Architect (Central IT)** — owns enterprise-wide ADRs and reviews domain ADRs for cross-cutting impact
 - **Department Director** — reads significant decisions to understand technical direction and constraints
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create an ADR with: number (e.g. ADR-001), title, context, decision, consequences, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-capability-map.md
+++ b/business-architecture/capabilities/cms/portfolio/po-capability-map.md
@@ -4,10 +4,12 @@
 The system must allow contributors to define and maintain the organization's business capabilities — the things the organization does, independent of how they are implemented. Capabilities are organized by domain and linked to the applications that support them and the personas that depend on them.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes capability records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published capabilities through the front-end capability map view
+- **Enterprise Architect (Central IT)** — owns the enterprise capability map and uses it as the anchor entity to which applications, personas, and decisions attach
+- **Agency EA Coordinator** — maintains their agency's branch of the capability map
 - **Department Director** — uses the capability map to understand what the organization does and where technology supports it
+- **Business Stakeholder** — references the published map to see what the organization is set up to do
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a capability with: name, description, domain, workflow status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-glossary.md
+++ b/business-architecture/capabilities/cms/portfolio/po-glossary.md
@@ -4,10 +4,11 @@
 The system must allow contributors to maintain a shared terminology reference for the organization's EA repository. The glossary gives architects, contributors, and non-technical stakeholders a common language — reducing ambiguity across capability maps, ADRs, principles, and planning content.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes glossary terms
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published terms to understand EA vocabulary
+- **Junior EA Analyst** — uses the glossary to learn the organization's specific EA vocabulary without specialist training
 - **Department Director** — references the glossary to interpret EA content without needing specialist training
+- **Business Stakeholder** — looks up unfamiliar EA jargon while reading a portfolio view or report
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a glossary term with: term, definition, domain, notes, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-principles.md
+++ b/business-architecture/capabilities/cms/portfolio/po-principles.md
@@ -4,10 +4,11 @@
 The system must allow contributors to capture and maintain the architecture principles that guide design decisions across the organization. Principles articulate the values and rules that constrain how the organization builds and changes its EA — giving decision-makers a stable reference point when evaluating options and trade-offs.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes principle records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published principles through the front-end view
+- **Enterprise Architect (Central IT)** — authors enterprise-level principles and applies them when reviewing portfolio changes
+- **Domain Architect** — authors domain-specific principles and reviews work against them
 - **Department Director** — references principles to understand the rules of the road before initiating change
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a principle with: name (short label), title (full principle statement), description (one-sentence summary), rationale, implications, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-value-streams.md
+++ b/business-architecture/capabilities/cms/portfolio/po-value-streams.md
@@ -18,11 +18,11 @@ Admin UI: list view, detail view with inline stage and persona management (`apps
 
 ## Personas
 
-- **CMS Contributor** — authors and maintains value stream records; adds stages and assigns capabilities
-- **CMS Administrator** — has all Contributor permissions; can delete value stream records
 - **Enterprise Architect (Central IT)** — uses value streams to communicate how the capability portfolio delivers outcomes to government service recipients; this is the EA practitioner's primary tool for making the mission-technology link legible
 - **Agency EA Coordinator** — maintains their agency's value stream records as a sub-set of the enterprise view
-- **Content Viewer** — reads published value streams and their stages through the frontend display
+- **Department Director** — reads value streams to see how their department's services map to enabling capabilities
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Record Fields
 

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -4,10 +4,12 @@
 The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, architecture decisions, and supporting reference content. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
 
 ## Personas
-- **CMS Contributor** — creates and maintains portfolio records
-- **CMS Administrator** — has all Contributor permissions; manages visibility and lifecycle
-- **Content Viewer** — reads published portfolio content through front-end views
+- **Enterprise Architect (Central IT)** — owns the portfolio at the enterprise level; uses it to model the organization-wide application, capability, and decision landscape
+- **Agency EA Coordinator** — maintains their agency's portfolio as a sub-set of the enterprise view
 - **Department Director** — reads portfolio views to inform investment and planning decisions
+- **Business Stakeholder** — references published portfolio content to understand what the organization can do and what's planned
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas — they describe access, not people. Role behavior is documented in [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md) and reflected in each sub-capability's `## Rules` block.
 
 ## Sub-Capabilities
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -26,7 +26,12 @@ Future work tracked separately:
 ## Behaviors
 
 - Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, optional target resolution date, and a `security_sensitive` boolean flag
-- Debt types: `lifecycle-risk` (application approaching or past vendor support end), `capability-gap` (capability with no supporting application), `decision-drift` (ADR superseded by practice without formal revision), `known-shortcut` (deliberate technical or architectural compromise), `unreviewed` (object not updated in more than N months)
+- Debt types — UI labels are plain-language per #133; DB slugs are stable for backwards compatibility:
+  - `lifecycle-risk` — **"Lifecycle risk"** — application approaching or past vendor support end
+  - `capability-gap` — **"Unsupported capability"** — capability with no supporting application
+  - `decision-drift` — **"Drift from a recorded decision"** — ADR superseded by practice without formal revision
+  - `known-shortcut` — **"Deliberate trade-off"** — technical or architectural compromise accepted on purpose
+  - `unreviewed` — **"Stale / unreviewed"** — object not updated within the configured window
 - Severity tiers (defined once here; used by this capability and referenced by `rm-end-to-end-traceability` and `rm-repository-completeness`):
   - `critical` — immediate operational or security risk: an application past end-of-life in active use with no remediation plan; a published capability with zero linked personas
   - `high` — significant constraint on future options: application approaching end-of-life, ADR that contradicts current practice without a formal revision

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-21 (no open PRs; reviewed recent merged PRs through #608)
+Last groomed: 2026-05-24 (rewritten end-to-end; the previous version had drifted — four of its five recommendations were either shipped, on hold, or decided won't-do).
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -8,36 +8,45 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-The latest persona-journey and follow-up work shifted the backlog from broad foundation building toward specific adoption blockers:
+The post-audit gap pipeline is roughly half-drained. The most recent merges closed out the doc-hygiene class of bugs (a recurring source of audit findings) and continued the per-entity CSV beachhead:
 
-- [#603](https://github.com/roballred/GovEA/pull/603) made the audit log readable by Contributors, scoped to architecture content.
-- [#604](https://github.com/roballred/GovEA/pull/604) shipped the first CSV import/export beachhead for Capabilities under [#596](https://github.com/roballred/GovEA/issues/596).
-- [#605](https://github.com/roballred/GovEA/pull/605) shipped EasyEA starter content and empty-state CTAs for new practices under [#587](https://github.com/roballred/GovEA/issues/587).
-- [#606](https://github.com/roballred/GovEA/pull/606) shipped the Email Configuration UI, encrypted SMTP settings, delivery log, and dashboard warning under [#528](https://github.com/roballred/GovEA/issues/528). Actual SMTP sending remains the follow-up.
-- [#607](https://github.com/roballred/GovEA/pull/607) closed a batch of small persona-audit quality issues: connection target filtering, traceability hub behavior, guided-answer prompt chips, detail-page freshness lines, and taxonomy deduplication.
-- [#608](https://github.com/roballred/GovEA/pull/608) shipped the self-service application dependency-impact view under [#578](https://github.com/roballred/GovEA/issues/578).
-- There are no open pull requests at this grooming point.
+- [#624](https://github.com/roballred/GovEA/pull/624) shipped STYLE.md compliance fixes across 58 capability/persona files **and** the CI `docs-lint` job that prevents future drift. Capability doc drift was the source of #530, #570, #573-rm-architecture-debt, and #575 — that class of bug is now structurally prevented.
+- [#625](https://github.com/roballred/GovEA/pull/625) shipped CSV import/export for Personas and ADRs (continuing the pattern from [#604](https://github.com/roballred/GovEA/pull/604)). Shared CSV utilities now live in `@/lib/csv`, so each remaining entity is a small per-entity PR.
+- [#623](https://github.com/roballred/GovEA/pull/623) reconciled the IAM/SSO capability doc with the env-var-only implementation reality ([#530](https://github.com/roballred/GovEA/issues/530)).
+- [#626](https://github.com/roballred/GovEA/pull/626) (open) gates cross-tenant user PII on active break-glass — re-scoped Option 1 promotion of [#436](https://github.com/roballred/GovEA/issues/436) after architectural audit confirmed the original "content-read" scope was moot (no read path exists; act-as already gates mutations).
+- [#392](https://github.com/roballred/GovEA/issues/392) closed as substantially shipped; instance-hardening tests cover the four acceptance criteria.
 
-The practical implication: several previously ranked items are now done or partially done. The next best work should build on those shipped surfaces instead of opening another broad exploratory stream.
+Persona-walk gap pipeline as of today: **13 open issues across 8 personas** (down from ~26 in mid-May).
 
-## Top 5 Next Things To Do
+## Top Five Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Finish email transport, then start the change-notification substrate | #606 made email configurable, but sends still return the stub failure. Real SMTP is the prerequisite for password reset, object/domain subscriptions, and the change-notification needs now repeated by Programme Director, Domain Architect, Consultant, and Agency EA Coordinator personas. | [#528](https://github.com/roballred/GovEA/issues/528), [#581](https://github.com/roballred/GovEA/issues/581), [#87](https://github.com/roballred/GovEA/issues/87) |
-| 2 | Continue CSV import/export across the next high-value entity types | #604 proved the pattern for Capabilities. The Consultant / SI and Early-Maturity Practice Lead personas still need reusable starter libraries and handoff exports beyond Applications and Capabilities. Prioritize Personas and ADRs next, then Initiatives, Objectives, Services, Value Streams, Principles, Glossary, and Data Architecture. | [#596](https://github.com/roballred/GovEA/issues/596), [#86](https://github.com/roballred/GovEA/issues/86) |
-| 3 | Add data-architecture quality cues and naming-standard hints | Data Architecture is now a shipped module, and the remaining gaps are reviewer/operator quality loops: Data Vault physical-name hints, per-row quality cues, and a roll-up scorecard summary. These are cheaper and safer than expanding conceptual/logical modeling. | [#570](https://github.com/roballred/GovEA/issues/570), [#573](https://github.com/roballred/GovEA/issues/573) |
-| 4 | Add authoring guardrails for duplicate names, unsaved changes, and publish-readiness guidance | Persona walks keep finding the same authoring failure mode across entities: easy duplicate creation, silent discard, and weak required-field guidance. A shared guardrail pattern would improve quality across the repository without inventing a new product area. | [#566](https://github.com/roballred/GovEA/issues/566), [#567](https://github.com/roballred/GovEA/issues/567) |
-| 5 | Build a traceable release pipeline for the Azure demo | The demo is now product-critical: starter content, impact analysis, email configuration, and persona-facing reports all depend on reviewers seeing the expected build. Manual deploys still make it too hard to prove which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
+| 1 | **Slice the viewer-experience cluster** — start with role-tailored landing | Largest open cluster (6+ issues) and the most consistently surfaced gap in the persona walks. [#548](https://github.com/roballred/GovEA/issues/548) is the cheapest first slice: a Viewer signed into the system lands on a stakeholder-friendly entry page, not the admin dashboard. Same persona payoff as the broader [#547](https://github.com/roballred/GovEA/issues/547) (public-read) at a fraction of the cost, and it surfaces *what content viewers actually want* — useful input into the eventual #547 design. | [#548](https://github.com/roballred/GovEA/issues/548), [#547](https://github.com/roballred/GovEA/issues/547), [#556](https://github.com/roballred/GovEA/issues/556), [#538](https://github.com/roballred/GovEA/issues/538), [#537](https://github.com/roballred/GovEA/issues/537) |
+| 2 | **ARB cleanup trio** — three small, well-defined items | Each is well-scoped and has been open since early April. Together they close roughly half the remaining `arb-finding` label. None requires design conversation. [#75](https://github.com/roballred/GovEA/issues/75): refactor portfolio capability docs to put roles in `Rules`/`Links` rather than `Personas` (lint now enforces the structural part). [#133](https://github.com/roballred/GovEA/issues/133): rename debt taxonomy labels (`decision-drift`, `known-shortcut`, `capability-gap`) to plain-language equivalents in the debt UI. [#7](https://github.com/roballred/GovEA/issues/7): add a Failover section to `iam-sso-authentication.md` plus the integration-boundary statement. | [#75](https://github.com/roballred/GovEA/issues/75), [#133](https://github.com/roballred/GovEA/issues/133), [#7](https://github.com/roballred/GovEA/issues/7) |
+| 3 | **Next CSV per-entity slice (Initiatives + Objectives)** | The pattern is now mechanical thanks to the shared `@/lib/csv` helpers. Initiatives + Objectives pair naturally in the Consultant / SI persona's handover bundle and follow the persona-validated order in the (now-closed) [#596](https://github.com/roballred/GovEA/issues/596). File a fresh issue first since #596 is closed. | (file a new issue) |
+| 4 | **Add data-architecture quality cues and naming-standard hints** | Data Architecture is now a shipped module, and the remaining gaps are reviewer/operator quality loops: Data Vault physical-name hints, per-row quality cues. [#570](https://github.com/roballred/GovEA/issues/570) is the cheaper, more persona-validated slice — pick it before [#573](https://github.com/roballred/GovEA/issues/573)'s scorecard, which warrants the @nicholerip conversation in [#363](https://github.com/roballred/GovEA/issues/363) first. | [#570](https://github.com/roballred/GovEA/issues/570), [#573](https://github.com/roballred/GovEA/issues/573) |
+| 5 | **Doc/capability backfill — #510 + #511** | Small documentation slices that close out the explicit triage-split parent [#10](https://github.com/roballred/GovEA/issues/10). [#510](https://github.com/roballred/GovEA/issues/510) adds Scope fields to capability files; [#511](https://github.com/roballred/GovEA/issues/511) creates the `cms/deployment-operations` capability group + README "what does it take to run this?" section. Both are now enforceable by the new docs-lint. | [#510](https://github.com/roballred/GovEA/issues/510), [#511](https://github.com/roballred/GovEA/issues/511) |
+
+## On Hold
+
+Items previously ranked that the product owner has paused:
+
+- **SMTP transport ([#528](https://github.com/roballred/GovEA/issues/528) follow-up + [#581](https://github.com/roballred/GovEA/issues/581) + [#87](https://github.com/roballred/GovEA/issues/87))** — held until an outbound mail account is available. The subscriptions / inbox substrate ([#610](https://github.com/roballred/GovEA/pull/610)) and domain-owner attribution ([#611](https://github.com/roballred/GovEA/pull/611)) shipped, but sends still hit the stub. Resume when the account lands.
+- **Release pipeline ([#504](https://github.com/roballred/GovEA/issues/504))** — held this session. Reason to revisit: every persona-facing feature now depends on the Azure demo being a known build, and manual deploys remain the largest operational risk. Promote back into the top five when ready to take it on.
+
+## Won't-Do (recorded for future grooming)
+
+- [#512](https://github.com/roballred/GovEA/issues/512) — **"Tools" stays as the user-facing term.** Do not propose Tools→Modules renames in future grooming. If "Modules" appears in capability docs, patch the drift toward "Tools," not the other way. Decision recorded 2026-05-22.
 
 ## Product Manager Notes
 
-- Treat #528 as unfinished until a real SMTP transport lands. The configuration UI unblocks downstream work, but notification features cannot ship on a stub sender.
-- #581 is too broad to build in one pass. Split it into an event/subscription foundation, domain-owner attribution, non-owner edit warning, and email digest delivery.
-- #596 should keep moving in small per-entity PRs. Preserve the export -> unchanged import -> zero-diff property from #604.
-- #573 Layer 1 and Layer 2 are the right near-term data-architecture scope. A full Hoberman-style scorecard should wait for persona validation.
-- #512 should be handled before expanding #499 glossary-backed menu definitions. "Modules" is now the settled term; cleanup and a CI guard are process hygiene, but they sit just outside the top five.
-- #510 and #511 remain worthwhile documentation/capability-definition work for operating GovEA, especially for non-technical decision-makers. They are good candidates when the team wants a docs-only or capability-only slice.
+- [#436](https://github.com/roballred/GovEA/issues/436) was re-scoped from its original "Option 1" framing once the architectural audit confirmed there is no cross-tenant content-read path to gate (act-as gates mutations; reads always use `session.user.organizationId`). The remaining gate is user PII, and that work is now in PR #626.
+- [#596](https://github.com/roballred/GovEA/issues/596) (parent CSV issue) was closed before the Personas + ADRs slice landed. Future per-entity CSV PRs should reference the persona-source rationale but file their own issue rather than reopening #596.
+- [#363](https://github.com/roballred/GovEA/issues/363) is the right umbrella issue to ping @nicholerip on before deciding whether the next data-arch slice is conceptual/logical-layer support, Chen visualization, or the scorecard ([#573](https://github.com/roballred/GovEA/issues/573)). The answer materially changes priority 4.
+- The **persona-walk audit** ([epic #515](https://github.com/roballred/GovEA/issues/515)) closed all 16 sub-issues. Remaining gap issues filed by the audit carry `journey:<persona>` labels — use those for any future "what's next for this persona" filtering.
+- **Doc drift** is no longer a recurring class of bug: the CI `docs-lint` enforces STYLE.md compliance, and the persona-journey reports document expected reality. Pick docs-only slices opportunistically (they're cheap), not strategically.
+- The **viewer cluster** (rank 1) is blocked on a design decision about what to expose publicly. Doing [#548](https://github.com/roballred/GovEA/issues/548) first generates the right design input for [#547](https://github.com/roballred/GovEA/issues/547) without forcing the decision up front.
 
 ## Security Remediation Status
 
@@ -55,4 +64,4 @@ The practical implication: several previously ranked items are now done or parti
 | #421 - test: unauthenticated server-action POSTs blocked | Enhancement | Fixed (PR #440) |
 | #422 - test: read actions ignore caller-supplied orgId/role | Enhancement | Fixed (PR #441) |
 | #437 - wire cross-tenant impersonation through break-glass | Medium | Fixed (PR #502) |
-| #436 - promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 / after act-as operating experience) |
+| #436 - cross-tenant **user-PII** read gate (re-scoped from original) | Medium | In review (PR #626) |


### PR DESCRIPTION
## Summary

Three small, well-defined ARB findings open since early April. Together they close ~half of the remaining \`arb-finding\` label. No design dependencies; bundled as one PR because each touch is small.

## #75 — Separate personas from RBAC roles in portfolio docs

All 7 files under \`capabilities/cms/portfolio/\` listed \`CMS Contributor\` / \`CMS Administrator\` / \`Content Viewer\` as Personas. Per STYLE.md these are **roles**, not personas (*"Personas describe people; roles describe access. Document roles in capabilities/cms/iam/"*).

Each \`## Personas\` block now lists only real personas — Enterprise Architect, Domain Architect, Department Director, Agency EA Coordinator, Business Stakeholder, Junior EA Analyst — and carries a footnote pointing to [\`iam-role-based-access-control.md\`](business-architecture/capabilities/cms/iam/iam-role-based-access-control.md) for the role behaviour. The \`## Rules\` blocks already expressed RBAC behaviour correctly; left untouched.

[\`po-application-portfolio.md\`](business-architecture/capabilities/cms/portfolio/po-application-portfolio.md) had no real personas at all; added Enterprise Architect, Domain Architect, and Department Director.

## #7 — Define integration boundary and SSO failover behaviour

[\`iam-sso-authentication.md\`](business-architecture/capabilities/cms/iam/iam-sso-authentication.md) gained two sections:

- **\"Identity Provider Failover\"** — documents the deliberate fail-open-to-local-auth choice when the IdP is unavailable, why the trade-off was made, and operator guidance (keep at least one local-credentials admin)
- **\"Integration Boundary (v1)\"** — explicit in-scope / out-of-scope list so reviewers and operators are not surprised by deliberate gaps. References \`ea/integration/\` for the planned-but-not-built surface.

No code change — the failover behaviour is what \`authConfig\` already does; this issue was about documenting it.

## #133 — Debt taxonomy labels are EA jargon

The Agency EA Coordinator persona (assumed; often from IT operations or project management, not formal EA practice) was cited as unable to map their experience to the original labels.

**DB slugs unchanged** (zero migration risk). UI labels and form helper text rewritten:

| DB slug (unchanged) | Old label | New label |
|---|---|---|
| \`capability-gap\` | \"Capability gap\" | **\"Unsupported capability\"** |
| \`decision-drift\` | \"Decision drift\" | **\"Drift from a recorded decision\"** (form), **\"Drift from decision\"** (chip) |
| \`known-shortcut\` | \"Known shortcut\" | **\"Deliberate trade-off\"** |
| \`unreviewed\` | \"Unreviewed\" | **\"Stale / unreviewed\"** |
| \`lifecycle-risk\` | \"Lifecycle risk\" | (unchanged — already plain) |

[\`/debt\` page](apps/govea/src/app/(admin)/debt/page.tsx) chip labels and [\`debt-form.tsx\`](apps/govea/src/components/debt-form.tsx) options use the new labels. The form now shows a one-line description below the type select so the meaning is plain at authoring time. The [\`rm-architecture-debt\`](business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md) capability doc lists both the slug and the new label for each type.

## Test plan

- [x] \`docs-lint\` passes (102 files checked)
- [x] \`tsc --noEmit\` clean
- [x] No DB migration needed — enum slugs unchanged

Capability: \`cms/portfolio\`, \`iam-sso-authentication\`, \`rm-architecture-debt\`
Persona: Agency EA Coordinator (#133), plus EA / Domain Architect / Department Director / Business Stakeholder / Junior EA Analyst (#75)
Closes #7, #75, #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)