### PR TITLE
feat(import-export): CSV import/export for Initiatives + Objectives (#629)

### DIFF
--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -3,8 +3,11 @@
 import { db } from '@/db/client'
 import {
   initiatives, initiativeCapabilities, initiativeObjectives, initiativeApplications, entityTaxonomyValues,
+  capabilities, strategicObjectives,
 } from '@/db/schema'
 import { eq, and, inArray, ne } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+import { parseCsv, splitSemicolonList } from '@/lib/csv'
 import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
@@ -399,4 +402,174 @@ function buildCapabilityEntries(formData: FormData, initiativeId: string) {
     capabilityId,
     impact: (formData.get(`impact_${capabilityId}`) as string) || null,
   }))
+}
+
+// ── CSV Import (#629) ────────────────────────────────────────────────────────
+
+export type InitiativeImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_INITIATIVE_STATUS = new Set(['proposed', 'active', 'on-hold', 'complete', 'cancelled'])
+const VALID_INITIATIVE_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+/**
+ * Initiative CSV import — #629. Same pattern as importCapabilities /
+ * importPersonas / importADRs:
+ *   - Two-step flow via dryRun (preview → confirm)
+ *   - Case-insensitive upsert by name
+ *   - Capability + Objective names resolve against the org's own records;
+ *     unknown names report as row warnings, not row failures
+ *   - On upsert, the two junctions (capabilities, objectives) are replaced
+ *     wholesale; the application junction is left alone because the
+ *     CSV does not carry impact labels — see export route for context
+ */
+export async function importInitiatives(formData: FormData, dryRun = false): Promise<InitiativeImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const text = await file.text()
+  const rows = parseCsv(text)
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  const [existing, orgCaps, orgObjs] = await Promise.all([
+    db.query.initiatives.findMany({
+      where: eq(initiatives.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.strategicObjectives.findMany({
+      where: eq(strategicObjectives.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+  ])
+  const existingByName = new Map(existing.map(r => [r.name.toLowerCase(), r.id]))
+  const capByName = new Map(orgCaps.map(c => [c.name.toLowerCase(), c.id]))
+  const objByName = new Map(orgObjs.map(o => [o.name.toLowerCase(), o.id]))
+
+  type ValidRow = {
+    name: string
+    description: string | null
+    status: 'proposed' | 'active' | 'on-hold' | 'complete' | 'cancelled'
+    startDate: string | null
+    endDate: string | null
+    visibility: 'org' | 'connections' | 'instance'
+    capabilityIds: string[]
+    objectiveIds: string[]
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+  let created = 0, updated = 0, skipped = 0
+  const errors: string[] = []
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2
+    const name = row['name']?.trim()
+    if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
+
+    const status = (row['status'] || 'proposed').trim()
+    const visibility = (row['visibility'] || 'org').trim()
+    if (!VALID_INITIATIVE_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`)
+      skipped++; continue
+    }
+    if (!VALID_INITIATIVE_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`)
+      skipped++; continue
+    }
+
+    const resolveList = (values: string[], lookup: Map<string, string>, label: string): string[] => {
+      const ids: string[] = []
+      for (const v of values) {
+        const id = lookup.get(v.toLowerCase())
+        if (id) ids.push(id)
+        else errors.push(`Row ${rowNum}: ${label} "${v}" not found in this org — skipped`)
+      }
+      return ids
+    }
+
+    const capabilityIds = resolveList(splitSemicolonList(row['capabilities']), capByName, 'capability')
+    const objectiveIds = resolveList(splitSemicolonList(row['objectives']), objByName, 'objective')
+
+    const existingId = existingByName.get(name.toLowerCase())
+    if (existingId) updated++; else created++
+
+    validRows.push({
+      name,
+      description: row['description'] || null,
+      status: status as ValidRow['status'],
+      startDate: row['start_date'] || null,
+      endDate: row['end_date'] || null,
+      visibility: visibility as ValidRow['visibility'],
+      capabilityIds,
+      objectiveIds,
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await db.transaction(async (tx) => {
+      for (const r of validRows) {
+        let initiativeId = r.existingId
+        if (initiativeId) {
+          await tx.update(initiatives).set({
+            description: r.description,
+            status: r.status,
+            startDate: r.startDate,
+            endDate: r.endDate,
+            visibility: r.visibility,
+            updatedBy: session.user.id,
+            updatedAt: new Date(),
+          }).where(and(eq(initiatives.id, initiativeId), eq(initiatives.organizationId, orgId)))
+          await tx.delete(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, initiativeId))
+          await tx.delete(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, initiativeId))
+        } else {
+          const [inserted] = await tx.insert(initiatives).values({
+            name: r.name,
+            description: r.description,
+            status: r.status,
+            startDate: r.startDate,
+            endDate: r.endDate,
+            visibility: r.visibility,
+            organizationId: orgId,
+            createdBy: session.user.id,
+            updatedBy: session.user.id,
+          }).returning({ id: initiatives.id })
+          initiativeId = inserted.id
+        }
+        if (r.capabilityIds.length > 0) {
+          await tx.insert(initiativeCapabilities).values(
+            r.capabilityIds.map(capabilityId => ({ initiativeId: initiativeId!, capabilityId, impact: null }))
+          )
+        }
+        if (r.objectiveIds.length > 0) {
+          await tx.insert(initiativeObjectives).values(
+            r.objectiveIds.map(objectiveId => ({ initiativeId: initiativeId!, objectiveId }))
+          )
+        }
+      }
+
+      await writeAuditLog(tx, {
+        action: 'initiative.import',
+        entityType: 'initiative',
+        entityId: orgId,
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, errorCount: errors.length },
+      })
+    })
+
+    revalidatePath('/initiatives')
+  }
+
+  return { created, updated, skipped, errors }
 }

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -1,8 +1,13 @@
 'use server'
 
 import { db } from '@/db/client'
-import { strategicObjectives, objectiveCapabilities, objectiveValueStreams, entityTaxonomyValues } from '@/db/schema'
+import {
+  strategicObjectives, objectiveCapabilities, objectiveValueStreams, entityTaxonomyValues,
+  capabilities, valueStreams,
+} from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+import { parseCsv, splitSemicolonList } from '@/lib/csv'
 import { syncEntityTaxonomyValues, getEntityTaxonomyDefinitions, getEntityTaxonomyValues } from '@/lib/entity-taxonomy-helpers'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
@@ -256,4 +261,172 @@ export async function deleteObjective(objectiveId: string) {
       userId: session.user.id, organizationId: orgId, before: { name: before?.name },
     })
   })
+}
+
+// ── CSV Import (#629) ────────────────────────────────────────────────────────
+
+export type ObjectiveImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_OBJECTIVE_STATUS = new Set(['draft', 'published', 'archived'])
+const VALID_OBJECTIVE_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+/**
+ * Strategic Objective CSV import — #629. Mirrors the established pattern:
+ *   - Two-step preview/confirm via dryRun
+ *   - Case-insensitive upsert by name
+ *   - Capability + Value Stream names resolve against the org's records;
+ *     unknown names report as row warnings, not row failures
+ *   - On upsert, both junctions (capabilities, value_streams) replaced
+ *     wholesale. Goal junctions are out of this slice.
+ */
+export async function importObjectives(formData: FormData, dryRun = false): Promise<ObjectiveImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const text = await file.text()
+  const rows = parseCsv(text)
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  const [existing, orgCaps, orgVs] = await Promise.all([
+    db.query.strategicObjectives.findMany({
+      where: eq(strategicObjectives.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.valueStreams.findMany({
+      where: eq(valueStreams.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+  ])
+  const existingByName = new Map(existing.map(r => [r.name.toLowerCase(), r.id]))
+  const capByName = new Map(orgCaps.map(c => [c.name.toLowerCase(), c.id]))
+  const vsByName = new Map(orgVs.map(v => [v.name.toLowerCase(), v.id]))
+
+  type ValidRow = {
+    name: string
+    description: string | null
+    successMetric: string | null
+    timeHorizon: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    capabilityIds: string[]
+    valueStreamIds: string[]
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+  let created = 0, updated = 0, skipped = 0
+  const errors: string[] = []
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2
+    const name = row['name']?.trim()
+    if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
+
+    const status = (row['status'] || 'draft').trim()
+    const visibility = (row['visibility'] || 'org').trim()
+    if (!VALID_OBJECTIVE_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`)
+      skipped++; continue
+    }
+    if (!VALID_OBJECTIVE_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`)
+      skipped++; continue
+    }
+
+    const resolveList = (values: string[], lookup: Map<string, string>, label: string): string[] => {
+      const ids: string[] = []
+      for (const v of values) {
+        const id = lookup.get(v.toLowerCase())
+        if (id) ids.push(id)
+        else errors.push(`Row ${rowNum}: ${label} "${v}" not found in this org — skipped`)
+      }
+      return ids
+    }
+
+    const capabilityIds = resolveList(splitSemicolonList(row['capabilities']), capByName, 'capability')
+    const valueStreamIds = resolveList(splitSemicolonList(row['value_streams']), vsByName, 'value stream')
+
+    const existingId = existingByName.get(name.toLowerCase())
+    if (existingId) updated++; else created++
+
+    validRows.push({
+      name,
+      description: row['description'] || null,
+      successMetric: row['success_metric'] || null,
+      timeHorizon: row['time_horizon'] || null,
+      status: status as ValidRow['status'],
+      visibility: visibility as ValidRow['visibility'],
+      capabilityIds,
+      valueStreamIds,
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await db.transaction(async (tx) => {
+      for (const r of validRows) {
+        let objectiveId = r.existingId
+        if (objectiveId) {
+          await tx.update(strategicObjectives).set({
+            description: r.description,
+            successMetric: r.successMetric,
+            timeHorizon: r.timeHorizon,
+            status: r.status,
+            visibility: r.visibility,
+            updatedBy: session.user.id,
+            updatedAt: new Date(),
+          }).where(and(eq(strategicObjectives.id, objectiveId), eq(strategicObjectives.organizationId, orgId)))
+          await tx.delete(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, objectiveId))
+          await tx.delete(objectiveValueStreams).where(eq(objectiveValueStreams.objectiveId, objectiveId))
+        } else {
+          const [inserted] = await tx.insert(strategicObjectives).values({
+            name: r.name,
+            description: r.description,
+            successMetric: r.successMetric,
+            timeHorizon: r.timeHorizon,
+            status: r.status,
+            visibility: r.visibility,
+            organizationId: orgId,
+            createdBy: session.user.id,
+            updatedBy: session.user.id,
+          }).returning({ id: strategicObjectives.id })
+          objectiveId = inserted.id
+        }
+        if (r.capabilityIds.length > 0) {
+          await tx.insert(objectiveCapabilities).values(
+            r.capabilityIds.map(capabilityId => ({ objectiveId: objectiveId!, capabilityId }))
+          )
+        }
+        if (r.valueStreamIds.length > 0) {
+          await tx.insert(objectiveValueStreams).values(
+            r.valueStreamIds.map(valueStreamId => ({ objectiveId: objectiveId!, valueStreamId }))
+          )
+        }
+      }
+
+      await writeAuditLog(tx, {
+        action: 'objective.import',
+        entityType: 'objective',
+        entityId: orgId,
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, errorCount: errors.length },
+      })
+    })
+
+    revalidatePath('/objectives')
+  }
+
+  return { created, updated, skipped, errors }
 }

--- a/apps/govea/src/app/(admin)/debt/page.tsx
+++ b/apps/govea/src/app/(admin)/debt/page.tsx
@@ -28,12 +28,14 @@ const STATUS_LABEL: Record<DebtStatus, string> = {
   archived: 'Archived',
 }
 
+// Plain-language labels per #133 — see debt-form.tsx for the long form.
+// Slugs stay as the DB enum; only user-visible labels change.
 const TYPE_LABEL: Record<DebtType, string> = {
   'lifecycle-risk': 'Lifecycle risk',
-  'capability-gap': 'Capability gap',
-  'decision-drift': 'Decision drift',
-  'known-shortcut': 'Known shortcut',
-  unreviewed: 'Unreviewed',
+  'capability-gap': 'Unsupported capability',
+  'decision-drift': 'Drift from decision',
+  'known-shortcut': 'Deliberate trade-off',
+  unreviewed: 'Stale / unreviewed',
 }
 
 export default async function DebtIndexPage({ searchParams }: { searchParams: Promise<SearchParams> }) {

--- a/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/initiative-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createInitiative, editInitiative, deleteInitiative } from '@/actions/initiatives'
+import { createInitiative, editInitiative, deleteInitiative, importInitiatives, type InitiativeImportResult } from '@/actions/initiatives'
 import type { Initiative, Capability, StrategicObjective } from '@/db/schema'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -68,6 +68,40 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
     initiatives.map(i => [i.organizationId, i.organization?.name ?? 'Unknown'])
   ).entries())
   const [createOpen, setCreateOpen] = useState(false)
+
+  // CSV import dialog state (#629)
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<InitiativeImportResult | null>(null)
+  const [importResult, setImportResult] = useState<InitiativeImportResult | null>(null)
+
+  async function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      setImportPreview(await importInitiatives(fd, true))
+    })
+  }
+
+  async function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      setImportResult(await importInitiatives(fd, false))
+      setImportPreview(null)
+      setImportFile(null)
+      router.refresh()
+    })
+  }
+
+  function openImport() {
+    setImportOpen(true)
+    setImportResult(null)
+    setImportPreview(null)
+    setImportFile(null)
+  }
   const [editTarget, setEditTarget] = useState<InitiativeRow | null>(null)
   const createDirty = useDirtyTracker()
   const editDirty = useDirtyTracker()
@@ -169,11 +203,19 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
           filters={taxonomyFilters}
           onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
         />
-        {canEdit && (
-          <Button onClick={openCreate} size="sm" className="ml-auto">
-            + New Initiative
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          <a href="/api/initiatives/export">
+            <Button variant="outline" size="sm">Export CSV</Button>
+          </a>
+          {canEdit && (
+            <>
+              <Button variant="outline" size="sm" onClick={openImport}>Import CSV</Button>
+              <Button onClick={openCreate} size="sm">
+                + New Initiative
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Empty state — when the org has no initiatives at all (#587 follow-up). */}
@@ -381,6 +423,62 @@ export function InitiativeTable({ initiatives, capabilities, objectives, role, c
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* CSV Import dialog (#629) */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import Initiatives</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">name</code>, <code className="bg-muted px-1 rounded">description</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">start_date</code>, <code className="bg-muted px-1 rounded">end_date</code>, <code className="bg-muted px-1 rounded">visibility</code>, <code className="bg-muted px-1 rounded">capabilities</code> (semicolon-separated names), <code className="bg-muted px-1 rounded">objectives</code> (semicolon-separated names).
+              Existing initiatives are matched by name (case-insensitive) and updated. Unknown capability or objective names are reported as warnings without failing the row.
+            </p>
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input type="file" accept=".csv,text/csv" onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }} />
+              </div>
+            )}
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} records`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/src/app/(admin)/objectives/objective-table.tsx
+++ b/apps/govea/src/app/(admin)/objectives/objective-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createObjective, editObjective, deleteObjective } from '@/actions/objectives'
+import { createObjective, editObjective, deleteObjective, importObjectives, type ObjectiveImportResult } from '@/actions/objectives'
 import type { StrategicObjective, Capability, ValueStream, Goal } from '@/db/schema'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -61,6 +61,40 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
   const createDirty = useDirtyTracker()
   const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<ObjectiveRow | null>(null)
+
+  // CSV import dialog state (#629)
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<ObjectiveImportResult | null>(null)
+  const [importResult, setImportResult] = useState<ObjectiveImportResult | null>(null)
+
+  async function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      setImportPreview(await importObjectives(fd, true))
+    })
+  }
+
+  async function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      setImportResult(await importObjectives(fd, false))
+      setImportPreview(null)
+      setImportFile(null)
+      router.refresh()
+    })
+  }
+
+  function openImport() {
+    setImportOpen(true)
+    setImportResult(null)
+    setImportPreview(null)
+    setImportFile(null)
+  }
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -139,11 +173,19 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
           filters={taxonomyFilters}
           onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
         />
-        {canEdit && (
-          <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
-            + New objective
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          <a href="/api/objectives/export">
+            <Button variant="outline" size="sm">Export CSV</Button>
+          </a>
+          {canEdit && (
+            <>
+              <Button variant="outline" size="sm" onClick={openImport}>Import CSV</Button>
+              <Button onClick={() => setCreateOpen(true)} size="sm">
+                + New objective
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Empty state — when the org has no objectives at all (#587 follow-up). */}
@@ -395,6 +437,62 @@ export function ObjectiveTable({ objectives, capabilities, valueStreams, role, c
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* CSV Import dialog (#629) */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import Strategic Objectives</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">name</code>, <code className="bg-muted px-1 rounded">description</code>, <code className="bg-muted px-1 rounded">success_metric</code>, <code className="bg-muted px-1 rounded">time_horizon</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">visibility</code>, <code className="bg-muted px-1 rounded">capabilities</code> (semicolon-separated names), <code className="bg-muted px-1 rounded">value_streams</code> (semicolon-separated names).
+              Existing objectives are matched by name (case-insensitive) and updated. Unknown linked names are reported as warnings without failing the row.
+            </p>
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input type="file" accept=".csv,text/csv" onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }} />
+              </div>
+            )}
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} records`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/src/app/api/initiatives/export/route.ts
+++ b/apps/govea/src/app/api/initiatives/export/route.ts
@@ -1,0 +1,91 @@
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { getInitiatives } from '@/actions/initiatives'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import { escapeCsv } from '@/lib/csv'
+
+type InitiativeForExport = Awaited<ReturnType<typeof getInitiatives>>[number]
+
+function buildCsv(
+  rows: InitiativeForExport[],
+  taxDefs: EnrichedTaxonomyDefinition[],
+  taxValueMap: Record<string, { taxonomyTermId: string }[]>,
+): string {
+  const termNames = new Map<string, string>()
+  for (const def of taxDefs) {
+    for (const term of def.values) {
+      termNames.set(term.id, term.name)
+    }
+  }
+
+  const fixedHeaders = [
+    'name', 'description', 'status', 'start_date', 'end_date', 'visibility',
+    'capabilities', 'objectives',
+  ]
+  const taxHeaders = taxDefs.map(d => d.typeName)
+  const headers = [...fixedHeaders, ...taxHeaders]
+
+  const lines = rows.map(i => {
+    const join = (xs: { name?: string | null }[]) =>
+      xs.map(x => x.name).filter((n): n is string => Boolean(n)).join('; ')
+
+    const fixed = [
+      i.name,
+      i.description ?? '',
+      i.status,
+      i.startDate ?? '',
+      i.endDate ?? '',
+      i.visibility,
+      join(i.initiativeCapabilities.map(x => x.capability)),
+      join(i.initiativeObjectives.map(x => x.objective)),
+    ]
+
+    const termIds = (taxValueMap[i.id] ?? []).map(v => v.taxonomyTermId)
+    const tax = taxDefs.map(def => {
+      const defTermIds = new Set(def.values.map(v => v.id))
+      return termIds
+        .filter(id => defTermIds.has(id))
+        .map(id => termNames.get(id) ?? id)
+        .join(', ')
+    })
+
+    return [...fixed, ...tax].map(escapeCsv).join(',')
+  })
+
+  return [headers.map(escapeCsv).join(','), ...lines].join('\n')
+}
+
+/**
+ * Initiative CSV export — #629 continuation of the per-entity pattern.
+ * Capabilities + Objectives appear as semicolon-joined name columns.
+ * The application junction is intentionally not exported — it carries an
+ * `impact` label that needs richer CSV semantics; pair it with a future
+ * slice when there's persona pull.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!canEdit(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const orgId = session.user.organizationId!
+
+  const [all, taxDefs] = await Promise.all([
+    getInitiatives(),
+    getEntityTaxonomyDefinitions(orgId, 'initiative'),
+  ])
+
+  const own = all.filter(i => i.organizationId === orgId)
+  const ids = own.map(i => i.id)
+  const taxValueMap = await getEntityTaxonomyValuesForMany(orgId, 'initiative', ids)
+
+  const csv = buildCsv(own, taxDefs, taxValueMap)
+  const date = new Date().toISOString().slice(0, 10)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="initiatives-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/app/api/objectives/export/route.ts
+++ b/apps/govea/src/app/api/objectives/export/route.ts
@@ -1,0 +1,90 @@
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { getObjectives } from '@/actions/objectives'
+import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
+import { escapeCsv } from '@/lib/csv'
+
+type ObjectiveForExport = Awaited<ReturnType<typeof getObjectives>>[number]
+
+function buildCsv(
+  rows: ObjectiveForExport[],
+  taxDefs: EnrichedTaxonomyDefinition[],
+  taxValueMap: Record<string, { taxonomyTermId: string }[]>,
+): string {
+  const termNames = new Map<string, string>()
+  for (const def of taxDefs) {
+    for (const term of def.values) {
+      termNames.set(term.id, term.name)
+    }
+  }
+
+  const fixedHeaders = [
+    'name', 'description', 'success_metric', 'time_horizon',
+    'status', 'visibility', 'capabilities', 'value_streams',
+  ]
+  const taxHeaders = taxDefs.map(d => d.typeName)
+  const headers = [...fixedHeaders, ...taxHeaders]
+
+  const lines = rows.map(o => {
+    const join = (xs: { name?: string | null }[]) =>
+      xs.map(x => x.name).filter((n): n is string => Boolean(n)).join('; ')
+
+    const fixed = [
+      o.name,
+      o.description ?? '',
+      o.successMetric ?? '',
+      o.timeHorizon ?? '',
+      o.status,
+      o.visibility,
+      join(o.objectiveCapabilities.map(x => x.capability)),
+      join(o.objectiveValueStreams.map(x => x.valueStream)),
+    ]
+
+    const termIds = (taxValueMap[o.id] ?? []).map(v => v.taxonomyTermId)
+    const tax = taxDefs.map(def => {
+      const defTermIds = new Set(def.values.map(v => v.id))
+      return termIds
+        .filter(id => defTermIds.has(id))
+        .map(id => termNames.get(id) ?? id)
+        .join(', ')
+    })
+
+    return [...fixed, ...tax].map(escapeCsv).join(',')
+  })
+
+  return [headers.map(escapeCsv).join(','), ...lines].join('\n')
+}
+
+/**
+ * Strategic Objective CSV export — #629. Same per-entity shape used by
+ * Capabilities, Personas, ADRs, and Initiatives. Capabilities and Value
+ * Streams appear as semicolon-joined name columns. Goal junctions (an
+ * orthogonal hierarchy) are out of this slice.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!canEdit(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const orgId = session.user.organizationId!
+
+  const [all, taxDefs] = await Promise.all([
+    getObjectives(),
+    getEntityTaxonomyDefinitions(orgId, 'objective'),
+  ])
+
+  const own = all.filter(o => o.organizationId === orgId)
+  const ids = own.map(o => o.id)
+  const taxValueMap = await getEntityTaxonomyValuesForMany(orgId, 'objective', ids)
+
+  const csv = buildCsv(own, taxDefs, taxValueMap)
+  const date = new Date().toISOString().slice(0, 10)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="objectives-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/components/debt-form.tsx
+++ b/apps/govea/src/components/debt-form.tsx
@@ -35,12 +35,18 @@ interface DebtFormProps {
   prefillInitiativeIds?: string[]
 }
 
-const DEBT_TYPES: { value: DebtType; label: string }[] = [
-  { value: 'lifecycle-risk',  label: 'Lifecycle risk' },
-  { value: 'capability-gap',  label: 'Capability gap' },
-  { value: 'decision-drift',  label: 'Decision drift' },
-  { value: 'known-shortcut',  label: 'Known shortcut' },
-  { value: 'unreviewed',      label: 'Unreviewed' },
+// Labels rewritten under #133 — the original taxonomy (decision-drift,
+// known-shortcut, capability-gap) assumed formal EA vocabulary that the
+// Agency EA Coordinator persona (an assumed persona often from IT operations
+// or project management, not formal EA practice) could not be expected to
+// recognise. Descriptions give the long form so the meaning is plain on hover
+// without losing the structured DB slug. Slugs are unchanged.
+const DEBT_TYPES: { value: DebtType; label: string; description: string }[] = [
+  { value: 'lifecycle-risk', label: 'Lifecycle risk',                description: 'An application is approaching or has passed vendor support end' },
+  { value: 'capability-gap', label: 'Unsupported capability',        description: 'A business capability has no application supporting it' },
+  { value: 'decision-drift', label: 'Drift from a recorded decision', description: 'An ADR is being superseded by practice without a formal revision' },
+  { value: 'known-shortcut', label: 'Deliberate trade-off',          description: 'A technical or architectural compromise was accepted on purpose; record it so it does not get forgotten' },
+  { value: 'unreviewed',     label: 'Stale / unreviewed',            description: 'An object has not been updated or reviewed within the configured window' },
 ]
 
 const SEVERITIES: { value: DebtSeverity; label: string }[] = [
@@ -152,6 +158,9 @@ export function DebtForm({
             className="w-full rounded-md border bg-background px-3 py-2 text-sm">
             {DEBT_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
           </select>
+          <p className="text-xs text-muted-foreground">
+            {DEBT_TYPES.find(t => t.value === debtType)?.description}
+          </p>
         </div>
         <div className="space-y-1.5">
           <label htmlFor="severity" className="text-sm font-medium">Severity</label>

--- a/apps/govea/tests/integration/initiatives-import.test.ts
+++ b/apps/govea/tests/integration/initiatives-import.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests: importInitiatives server action (#629)
+ *
+ * Covers:
+ *  - Role enforcement (viewer rejected)
+ *  - Basic create with all fixed columns
+ *  - Case-insensitive upsert by name
+ *  - Junction resolution (capabilities + objectives); unknown names → warnings
+ *  - Junction replacement on upsert
+ *  - Status / visibility validation
+ *  - dryRun does not write rows
+ *  - Multi-line description round-trip via shared @/lib/csv parser
+ *  - Round-trip property: re-importing an existing row reports updated=1
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  initiatives, initiativeCapabilities, initiativeObjectives,
+  capabilities, strategicObjectives,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { importInitiatives } from '@/actions/initiatives'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function csvForm(content: string): FormData {
+  const fd = new FormData()
+  const blob = new Blob([content], { type: 'text/csv' })
+  fd.append('csvFile', new File([blob], 'initiatives.csv', { type: 'text/csv' }))
+  return fd
+}
+
+async function seedCapability(orgId: string, name: string) {
+  const [row] = await db.insert(capabilities).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+async function seedObjective(orgId: string, name: string) {
+  const [row] = await db.insert(strategicObjectives).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+describe('importInitiatives (#629)', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects viewer role', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(importInitiatives(csvForm('name\nTest\n'))).rejects.toThrow('Forbidden')
+  })
+
+  it('creates new initiatives from CSV (contributor)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Auth Modernization,Move all apps to OIDC,active,Q1 FY2026,Q4 FY2026,org,,',
+      'Permitting Refresh,Replace legacy permit system,proposed,Q3 FY2026,,org,,',
+    ].join('\n')
+
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.created).toBe(2)
+    expect(result.updated).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toEqual([])
+
+    const rows = await db.select().from(initiatives).where(eq(initiatives.organizationId, orgId))
+    expect(rows.some(r => r.name === 'Auth Modernization' && r.status === 'active')).toBe(true)
+    expect(rows.some(r => r.name === 'Permitting Refresh' && r.startDate === 'Q3 FY2026')).toBe(true)
+  })
+
+  it('upserts existing initiatives by name (case-insensitive)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'auth modernization,Updated description,active,Q1 FY2026,Q4 FY2026,org,,',
+    ].join('\n')
+
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.updated).toBe(1)
+
+    const row = await db.query.initiatives.findFirst({
+      where: and(eq(initiatives.organizationId, orgId), eq(initiatives.name, 'Auth Modernization')),
+    })
+    expect(row?.description).toBe('Updated description')
+  })
+
+  it('resolves capability + objective names; unknown names become warnings', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const capId = await seedCapability(orgId, 'Identity')
+    const objId = await seedObjective(orgId, 'Improve Security Posture')
+
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Wire OIDC,Reduce password sprawl,active,Q2 FY2026,,org,Identity; Unknown Cap,Improve Security Posture; Unknown Obj',
+    ].join('\n')
+
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.errors.some(e => e.includes('Unknown Cap'))).toBe(true)
+    expect(result.errors.some(e => e.includes('Unknown Obj'))).toBe(true)
+
+    const init = await db.query.initiatives.findFirst({
+      where: and(eq(initiatives.organizationId, orgId), eq(initiatives.name, 'Wire OIDC')),
+    })
+    expect(init).toBeDefined()
+    const [caps, objs] = await Promise.all([
+      db.select().from(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, init!.id)),
+      db.select().from(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, init!.id)),
+    ])
+    expect(caps.map(c => c.capabilityId)).toEqual([capId])
+    expect(objs.map(o => o.objectiveId)).toEqual([objId])
+  })
+
+  it('replaces both junctions on upsert', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const init = await db.query.initiatives.findFirst({
+      where: and(eq(initiatives.organizationId, orgId), eq(initiatives.name, 'Wire OIDC')),
+    })
+    expect(init).toBeDefined()
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Wire OIDC,Reduce password sprawl,active,Q2 FY2026,,org,,',
+    ].join('\n')
+    await importInitiatives(csvForm(csv), false)
+    const [caps, objs] = await Promise.all([
+      db.select().from(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, init!.id)),
+      db.select().from(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, init!.id)),
+    ])
+    expect(caps).toHaveLength(0)
+    expect(objs).toHaveLength(0)
+  })
+
+  it('skips rows with invalid status / visibility', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Bad Status,desc,not-a-status,,,org,,',
+      'Bad Vis,desc,proposed,,,not-a-visibility,,',
+    ].join('\n')
+
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.skipped).toBe(2)
+    expect(result.errors.some(e => e.includes('invalid status'))).toBe(true)
+    expect(result.errors.some(e => e.includes('invalid visibility'))).toBe(true)
+  })
+
+  it('dryRun does not write rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Dry Run Init,never created,proposed,,,org,,',
+    ].join('\n')
+
+    const before = await db.select().from(initiatives).where(eq(initiatives.organizationId, orgId))
+    const result = await importInitiatives(csvForm(csv), true)
+    expect(result.created).toBe(1)
+    const after = await db.select().from(initiatives).where(eq(initiatives.organizationId, orgId))
+    expect(after).toHaveLength(before.length)
+    expect(after.some(r => r.name === 'Dry Run Init')).toBe(false)
+  })
+
+  it('handles multi-line description through quote-aware parser', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv =
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives\n' +
+      'MultiLine Init,"Phase 1: scope\nPhase 2: pilot\nPhase 3: rollout",active,Q1 FY2026,Q4 FY2026,org,,\n'
+
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(0)
+
+    const row = await db.query.initiatives.findFirst({
+      where: and(eq(initiatives.organizationId, orgId), eq(initiatives.name, 'MultiLine Init')),
+    })
+    expect(row?.description).toBe('Phase 1: scope\nPhase 2: pilot\nPhase 3: rollout')
+  })
+
+  it('round-trip: re-importing an existing row reports updated=1 with no field changes', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,status,start_date,end_date,visibility,capabilities,objectives',
+      'Permitting Refresh,Replace legacy permit system,proposed,Q3 FY2026,,org,,',
+    ].join('\n')
+    const result = await importInitiatives(csvForm(csv), false)
+    expect(result.updated).toBe(1)
+    expect(result.created).toBe(0)
+
+    const row = await db.query.initiatives.findFirst({
+      where: and(eq(initiatives.organizationId, orgId), eq(initiatives.name, 'Permitting Refresh')),
+    })
+    expect(row).toMatchObject({
+      description: 'Replace legacy permit system',
+      status: 'proposed',
+      startDate: 'Q3 FY2026',
+    })
+  })
+
+  it('reports CSV with no data rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const result = await importInitiatives(csvForm('name,description\n'), false)
+    expect(result.errors).toContain('CSV has no data rows')
+  })
+
+  it('reports missing file', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    const result = await importInitiatives(fd, false)
+    expect(result.errors).toContain('No file provided')
+  })
+})

--- a/apps/govea/tests/integration/objectives-import.test.ts
+++ b/apps/govea/tests/integration/objectives-import.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration tests: importObjectives server action (#629)
+ *
+ * Same coverage shape as initiatives-import.test.ts. Objective-specific
+ * fields exercised: success_metric, time_horizon. Junctions: capabilities,
+ * value_streams.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  strategicObjectives, objectiveCapabilities, objectiveValueStreams,
+  capabilities, valueStreams,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { importObjectives } from '@/actions/objectives'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function csvForm(content: string): FormData {
+  const fd = new FormData()
+  const blob = new Blob([content], { type: 'text/csv' })
+  fd.append('csvFile', new File([blob], 'objectives.csv', { type: 'text/csv' }))
+  return fd
+}
+
+async function seedCapability(orgId: string, name: string) {
+  const [row] = await db.insert(capabilities).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+async function seedValueStream(orgId: string, name: string) {
+  const [row] = await db.insert(valueStreams).values({
+    id: randomUUID(), organizationId: orgId, name,
+  }).returning()
+  return row.id
+}
+
+describe('importObjectives (#629)', () => {
+  let orgId: string
+  let admin: TestUser
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects viewer role', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(importObjectives(csvForm('name\nTest\n'))).rejects.toThrow('Forbidden')
+  })
+
+  it('creates new objectives from CSV (contributor)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Improve Security Posture,Reduce attack surface,Critical CVEs at zero,FY2026,published,org,,',
+      'Customer Self-Service,Shift volume from call centre,30% of permits online,3-year,draft,org,,',
+    ].join('\n')
+
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.created).toBe(2)
+    expect(result.updated).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(result.errors).toEqual([])
+
+    const rows = await db.select().from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId))
+    expect(rows.some(r => r.name === 'Improve Security Posture' && r.successMetric === 'Critical CVEs at zero')).toBe(true)
+    expect(rows.some(r => r.name === 'Customer Self-Service' && r.timeHorizon === '3-year')).toBe(true)
+  })
+
+  it('upserts existing objectives by name (case-insensitive)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'improve security posture,Updated desc,Critical CVEs at zero,FY2026,published,org,,',
+    ].join('\n')
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.updated).toBe(1)
+
+    const row = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'Improve Security Posture')),
+    })
+    expect(row?.description).toBe('Updated desc')
+  })
+
+  it('resolves capability + value_stream names; unknown names become warnings', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const capId = await seedCapability(orgId, 'Identity')
+    const vsId = await seedValueStream(orgId, 'Permit Issuance')
+
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Secure Permits,Tighten the permit chain,100% audit pass,FY2026,published,org,Identity; Unknown Cap,Permit Issuance; Unknown VS',
+    ].join('\n')
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.errors.some(e => e.includes('Unknown Cap'))).toBe(true)
+    expect(result.errors.some(e => e.includes('Unknown VS'))).toBe(true)
+
+    const obj = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'Secure Permits')),
+    })
+    expect(obj).toBeDefined()
+    const [caps, vs] = await Promise.all([
+      db.select().from(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, obj!.id)),
+      db.select().from(objectiveValueStreams).where(eq(objectiveValueStreams.objectiveId, obj!.id)),
+    ])
+    expect(caps.map(c => c.capabilityId)).toEqual([capId])
+    expect(vs.map(v => v.valueStreamId)).toEqual([vsId])
+  })
+
+  it('replaces both junctions on upsert', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const obj = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'Secure Permits')),
+    })
+    expect(obj).toBeDefined()
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Secure Permits,Tighten the permit chain,100% audit pass,FY2026,published,org,,',
+    ].join('\n')
+    await importObjectives(csvForm(csv), false)
+    const [caps, vs] = await Promise.all([
+      db.select().from(objectiveCapabilities).where(eq(objectiveCapabilities.objectiveId, obj!.id)),
+      db.select().from(objectiveValueStreams).where(eq(objectiveValueStreams.objectiveId, obj!.id)),
+    ])
+    expect(caps).toHaveLength(0)
+    expect(vs).toHaveLength(0)
+  })
+
+  it('skips rows with invalid status / visibility', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Bad Status,desc,,,not-a-status,org,,',
+      'Bad Vis,desc,,,draft,not-a-visibility,,',
+    ].join('\n')
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.created).toBe(0)
+    expect(result.skipped).toBe(2)
+    expect(result.errors.some(e => e.includes('invalid status'))).toBe(true)
+    expect(result.errors.some(e => e.includes('invalid visibility'))).toBe(true)
+  })
+
+  it('dryRun does not write rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Dry Run Obj,never created,,,,org,,',
+    ].join('\n')
+    const before = await db.select().from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId))
+    const result = await importObjectives(csvForm(csv), true)
+    expect(result.created).toBe(1)
+    const after = await db.select().from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId))
+    expect(after).toHaveLength(before.length)
+    expect(after.some(r => r.name === 'Dry Run Obj')).toBe(false)
+  })
+
+  it('handles multi-line description through quote-aware parser', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv =
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams\n' +
+      'MultiLine Obj,"Reduce risk.\nIncrease trust.\nLower TCO.",,,draft,org,,\n'
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(0)
+
+    const row = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'MultiLine Obj')),
+    })
+    expect(row?.description).toBe('Reduce risk.\nIncrease trust.\nLower TCO.')
+  })
+
+  it('round-trip: re-importing an existing row reports updated=1 with no field changes', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,success_metric,time_horizon,status,visibility,capabilities,value_streams',
+      'Customer Self-Service,Shift volume from call centre,30% of permits online,3-year,draft,org,,',
+    ].join('\n')
+    const result = await importObjectives(csvForm(csv), false)
+    expect(result.updated).toBe(1)
+    expect(result.created).toBe(0)
+
+    const row = await db.query.strategicObjectives.findFirst({
+      where: and(eq(strategicObjectives.organizationId, orgId), eq(strategicObjectives.name, 'Customer Self-Service')),
+    })
+    expect(row).toMatchObject({
+      description: 'Shift volume from call centre',
+      successMetric: '30% of permits online',
+      timeHorizon: '3-year',
+      status: 'draft',
+    })
+  })
+
+  it('reports CSV with no data rows', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const result = await importObjectives(csvForm('name,description\n'), false)
+    expect(result.errors).toContain('CSV has no data rows')
+  })
+
+  it('reports missing file', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const fd = new FormData()
+    const result = await importObjectives(fd, false)
+    expect(result.errors).toContain('No file provided')
+  })
+})

--- a/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
+++ b/business-architecture/capabilities/cms/iam/iam-sso-authentication.md
@@ -23,6 +23,27 @@ The system must allow users to sign in using their agency's identity provider vi
 - If an SSO user is deactivated in GovEA or is not pre-provisioned, sign-in must fail
 - Only one SSO provider is supported in v1
 
+## Identity Provider Failover
+
+GovEA's design choice when the configured identity provider is unavailable is **fail open to local authentication**, not fail closed:
+
+- The SSO sign-in path returns an error to the user when the IdP is unreachable or returns an OIDC error
+- The local-credentials sign-in form remains visible and functional regardless of IdP state — there is no code path that disables local auth based on SSO health
+- A user pre-provisioned with local credentials *and* an SSO identity can sign in either way; an SSO-only user without a local password cannot sign in during an IdP outage (a known v1 trade-off — see Rule above about pre-provisioning)
+- Operators are expected to retain at least one admin account with local credentials so administrative access is never gated solely on a single external dependency
+
+This is a deliberate availability choice: the cost of locking every user out of GovEA while their IdP is degraded is judged higher than the cost of permitting local sign-in for accounts that have it. Operators who require strict fail-closed behavior can remove the local-credentials provider at deploy time and accept the resulting availability profile.
+
+## Integration Boundary (v1)
+
+GovEA's integration boundary in v1 is intentionally narrow:
+
+- **In scope:** OIDC sign-in (one configured provider at a time) and outbound SMTP for system mail (when configured under `ac-email-configuration`)
+- **Out of scope:** SCIM provisioning sync, IdP group → role mapping, multiple simultaneous SSO providers, IdP-driven user deactivation, customer-side configuration of the SSO binding through the admin UI
+- All other inter-system integrations (CMDB, HR, finance, ERP, ITSM, BI) are out of scope for v1 — see the `ea/integration/` capability group for the planned-but-not-built surface
+
+This boundary is explicit so reviewers and operators are not surprised by gaps that are deliberate rather than accidental.
+
 ## Session Invalidation
 
 - Sessions expire after 24 hours and require re-authentication

--- a/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/po-application-portfolio.md
@@ -4,9 +4,11 @@
 The system must allow contributors to maintain a structured inventory of the organization's applications, capturing lifecycle status, hosting model, vendor, version, and links to the business capabilities each application supports.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes application records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published application records through the front-end portfolio view
+- **Enterprise Architect (Central IT)** — owns the application inventory at the enterprise level; uses it as the source of truth for portfolio analysis
+- **Domain Architect** — maintains the slice of the inventory for their domain (e.g. finance, public works) and reviews lifecycle status
+- **Department Director** — reads the inventory to understand what their department depends on and where investment is going
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create an application record with: name, description, vendor, version, hosting model, lifecycle status, workflow status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
+++ b/business-architecture/capabilities/cms/portfolio/po-architecture-decisions.md
@@ -4,10 +4,11 @@
 The system must allow contributors to record, track, and supersede architecture decisions so the organization has a durable, navigable log of why significant technical choices were made. ADRs use the standard lightweight format: context, decision, consequences.
 
 ## Personas
-- **CMS Contributor** — creates and maintains ADR records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads accepted ADRs through the front-end ADR list and detail views
+- **Domain Architect** — authors most ADRs for their domain; records the why behind each significant decision
+- **Enterprise Architect (Central IT)** — owns enterprise-wide ADRs and reviews domain ADRs for cross-cutting impact
 - **Department Director** — reads significant decisions to understand technical direction and constraints
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create an ADR with: number (e.g. ADR-001), title, context, decision, consequences, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-capability-map.md
+++ b/business-architecture/capabilities/cms/portfolio/po-capability-map.md
@@ -4,10 +4,12 @@
 The system must allow contributors to define and maintain the organization's business capabilities — the things the organization does, independent of how they are implemented. Capabilities are organized by domain and linked to the applications that support them and the personas that depend on them.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes capability records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published capabilities through the front-end capability map view
+- **Enterprise Architect (Central IT)** — owns the enterprise capability map and uses it as the anchor entity to which applications, personas, and decisions attach
+- **Agency EA Coordinator** — maintains their agency's branch of the capability map
 - **Department Director** — uses the capability map to understand what the organization does and where technology supports it
+- **Business Stakeholder** — references the published map to see what the organization is set up to do
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a capability with: name, description, domain, workflow status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-glossary.md
+++ b/business-architecture/capabilities/cms/portfolio/po-glossary.md
@@ -4,10 +4,11 @@
 The system must allow contributors to maintain a shared terminology reference for the organization's EA repository. The glossary gives architects, contributors, and non-technical stakeholders a common language — reducing ambiguity across capability maps, ADRs, principles, and planning content.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes glossary terms
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published terms to understand EA vocabulary
+- **Junior EA Analyst** — uses the glossary to learn the organization's specific EA vocabulary without specialist training
 - **Department Director** — references the glossary to interpret EA content without needing specialist training
+- **Business Stakeholder** — looks up unfamiliar EA jargon while reading a portfolio view or report
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a glossary term with: term, definition, domain, notes, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-principles.md
+++ b/business-architecture/capabilities/cms/portfolio/po-principles.md
@@ -4,10 +4,11 @@
 The system must allow contributors to capture and maintain the architecture principles that guide design decisions across the organization. Principles articulate the values and rules that constrain how the organization builds and changes its EA — giving decision-makers a stable reference point when evaluating options and trade-offs.
 
 ## Personas
-- **CMS Contributor** — creates, edits, and publishes principle records
-- **CMS Administrator** — has all Contributor permissions; can delete records
-- **Content Viewer** — reads published principles through the front-end view
+- **Enterprise Architect (Central IT)** — authors enterprise-level principles and applies them when reviewing portfolio changes
+- **Domain Architect** — authors domain-specific principles and reviews work against them
 - **Department Director** — references principles to understand the rules of the road before initiating change
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Behaviors
 - Create a principle with: name (short label), title (full principle statement), description (one-sentence summary), rationale, implications, status, and visibility

--- a/business-architecture/capabilities/cms/portfolio/po-value-streams.md
+++ b/business-architecture/capabilities/cms/portfolio/po-value-streams.md
@@ -18,11 +18,11 @@ Admin UI: list view, detail view with inline stage and persona management (`apps
 
 ## Personas
 
-- **CMS Contributor** — authors and maintains value stream records; adds stages and assigns capabilities
-- **CMS Administrator** — has all Contributor permissions; can delete value stream records
 - **Enterprise Architect (Central IT)** — uses value streams to communicate how the capability portfolio delivers outcomes to government service recipients; this is the EA practitioner's primary tool for making the mission-technology link legible
 - **Agency EA Coordinator** — maintains their agency's value stream records as a sub-set of the enterprise view
-- **Content Viewer** — reads published value streams and their stages through the frontend display
+- **Department Director** — reads value streams to see how their department's services map to enabling capabilities
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas. See [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md); role behavior is reflected in `## Rules` below.
 
 ## Record Fields
 

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -4,10 +4,12 @@
 The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, architecture decisions, and supporting reference content. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
 
 ## Personas
-- **CMS Contributor** — creates and maintains portfolio records
-- **CMS Administrator** — has all Contributor permissions; manages visibility and lifecycle
-- **Content Viewer** — reads published portfolio content through front-end views
+- **Enterprise Architect (Central IT)** — owns the portfolio at the enterprise level; uses it to model the organization-wide application, capability, and decision landscape
+- **Agency EA Coordinator** — maintains their agency's portfolio as a sub-set of the enterprise view
 - **Department Director** — reads portfolio views to inform investment and planning decisions
+- **Business Stakeholder** — references published portfolio content to understand what the organization can do and what's planned
+
+> RBAC roles (Admin / Contributor / Viewer) are not personas — they describe access, not people. Role behavior is documented in [`iam-role-based-access-control.md`](../iam/iam-role-based-access-control.md) and reflected in each sub-capability's `## Rules` block.
 
 ## Sub-Capabilities
 

--- a/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
+++ b/business-architecture/capabilities/ea/repository-modelling/rm-architecture-debt.md
@@ -26,7 +26,12 @@ Future work tracked separately:
 ## Behaviors
 
 - Create a debt item linked to one or more applications, capabilities, ADRs, or technology records, with a description, debt type, severity, optional target resolution date, and a `security_sensitive` boolean flag
-- Debt types: `lifecycle-risk` (application approaching or past vendor support end), `capability-gap` (capability with no supporting application), `decision-drift` (ADR superseded by practice without formal revision), `known-shortcut` (deliberate technical or architectural compromise), `unreviewed` (object not updated in more than N months)
+- Debt types — UI labels are plain-language per #133; DB slugs are stable for backwards compatibility:
+  - `lifecycle-risk` — **"Lifecycle risk"** — application approaching or past vendor support end
+  - `capability-gap` — **"Unsupported capability"** — capability with no supporting application
+  - `decision-drift` — **"Drift from a recorded decision"** — ADR superseded by practice without formal revision
+  - `known-shortcut` — **"Deliberate trade-off"** — technical or architectural compromise accepted on purpose
+  - `unreviewed` — **"Stale / unreviewed"** — object not updated within the configured window
 - Severity tiers (defined once here; used by this capability and referenced by `rm-end-to-end-traceability` and `rm-repository-completeness`):
   - `critical` — immediate operational or security risk: an application past end-of-life in active use with no remediation plan; a published capability with zero linked personas
   - `high` — significant constraint on future options: application approaching end-of-life, ADR that contradicts current practice without a formal revision

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-21 (no open PRs; reviewed recent merged PRs through #608)
+Last groomed: 2026-05-24 (rewritten end-to-end; the previous version had drifted — four of its five recommendations were either shipped, on hold, or decided won't-do).
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -8,36 +8,45 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-The latest persona-journey and follow-up work shifted the backlog from broad foundation building toward specific adoption blockers:
+The post-audit gap pipeline is roughly half-drained. The most recent merges closed out the doc-hygiene class of bugs (a recurring source of audit findings) and continued the per-entity CSV beachhead:
 
-- [#603](https://github.com/roballred/GovEA/pull/603) made the audit log readable by Contributors, scoped to architecture content.
-- [#604](https://github.com/roballred/GovEA/pull/604) shipped the first CSV import/export beachhead for Capabilities under [#596](https://github.com/roballred/GovEA/issues/596).
-- [#605](https://github.com/roballred/GovEA/pull/605) shipped EasyEA starter content and empty-state CTAs for new practices under [#587](https://github.com/roballred/GovEA/issues/587).
-- [#606](https://github.com/roballred/GovEA/pull/606) shipped the Email Configuration UI, encrypted SMTP settings, delivery log, and dashboard warning under [#528](https://github.com/roballred/GovEA/issues/528). Actual SMTP sending remains the follow-up.
-- [#607](https://github.com/roballred/GovEA/pull/607) closed a batch of small persona-audit quality issues: connection target filtering, traceability hub behavior, guided-answer prompt chips, detail-page freshness lines, and taxonomy deduplication.
-- [#608](https://github.com/roballred/GovEA/pull/608) shipped the self-service application dependency-impact view under [#578](https://github.com/roballred/GovEA/issues/578).
-- There are no open pull requests at this grooming point.
+- [#624](https://github.com/roballred/GovEA/pull/624) shipped STYLE.md compliance fixes across 58 capability/persona files **and** the CI `docs-lint` job that prevents future drift. Capability doc drift was the source of #530, #570, #573-rm-architecture-debt, and #575 — that class of bug is now structurally prevented.
+- [#625](https://github.com/roballred/GovEA/pull/625) shipped CSV import/export for Personas and ADRs (continuing the pattern from [#604](https://github.com/roballred/GovEA/pull/604)). Shared CSV utilities now live in `@/lib/csv`, so each remaining entity is a small per-entity PR.
+- [#623](https://github.com/roballred/GovEA/pull/623) reconciled the IAM/SSO capability doc with the env-var-only implementation reality ([#530](https://github.com/roballred/GovEA/issues/530)).
+- [#626](https://github.com/roballred/GovEA/pull/626) (open) gates cross-tenant user PII on active break-glass — re-scoped Option 1 promotion of [#436](https://github.com/roballred/GovEA/issues/436) after architectural audit confirmed the original "content-read" scope was moot (no read path exists; act-as already gates mutations).
+- [#392](https://github.com/roballred/GovEA/issues/392) closed as substantially shipped; instance-hardening tests cover the four acceptance criteria.
 
-The practical implication: several previously ranked items are now done or partially done. The next best work should build on those shipped surfaces instead of opening another broad exploratory stream.
+Persona-walk gap pipeline as of today: **13 open issues across 8 personas** (down from ~26 in mid-May).
 
-## Top 5 Next Things To Do
+## Top Five Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | Finish email transport, then start the change-notification substrate | #606 made email configurable, but sends still return the stub failure. Real SMTP is the prerequisite for password reset, object/domain subscriptions, and the change-notification needs now repeated by Programme Director, Domain Architect, Consultant, and Agency EA Coordinator personas. | [#528](https://github.com/roballred/GovEA/issues/528), [#581](https://github.com/roballred/GovEA/issues/581), [#87](https://github.com/roballred/GovEA/issues/87) |
-| 2 | Continue CSV import/export across the next high-value entity types | #604 proved the pattern for Capabilities. The Consultant / SI and Early-Maturity Practice Lead personas still need reusable starter libraries and handoff exports beyond Applications and Capabilities. Prioritize Personas and ADRs next, then Initiatives, Objectives, Services, Value Streams, Principles, Glossary, and Data Architecture. | [#596](https://github.com/roballred/GovEA/issues/596), [#86](https://github.com/roballred/GovEA/issues/86) |
-| 3 | Add data-architecture quality cues and naming-standard hints | Data Architecture is now a shipped module, and the remaining gaps are reviewer/operator quality loops: Data Vault physical-name hints, per-row quality cues, and a roll-up scorecard summary. These are cheaper and safer than expanding conceptual/logical modeling. | [#570](https://github.com/roballred/GovEA/issues/570), [#573](https://github.com/roballred/GovEA/issues/573) |
-| 4 | Add authoring guardrails for duplicate names, unsaved changes, and publish-readiness guidance | Persona walks keep finding the same authoring failure mode across entities: easy duplicate creation, silent discard, and weak required-field guidance. A shared guardrail pattern would improve quality across the repository without inventing a new product area. | [#566](https://github.com/roballred/GovEA/issues/566), [#567](https://github.com/roballred/GovEA/issues/567) |
-| 5 | Build a traceable release pipeline for the Azure demo | The demo is now product-critical: starter content, impact analysis, email configuration, and persona-facing reports all depend on reviewers seeing the expected build. Manual deploys still make it too hard to prove which commit, image digest, and runtime configuration are live. | [#504](https://github.com/roballred/GovEA/issues/504) |
+| 1 | **Slice the viewer-experience cluster** — start with role-tailored landing | Largest open cluster (6+ issues) and the most consistently surfaced gap in the persona walks. [#548](https://github.com/roballred/GovEA/issues/548) is the cheapest first slice: a Viewer signed into the system lands on a stakeholder-friendly entry page, not the admin dashboard. Same persona payoff as the broader [#547](https://github.com/roballred/GovEA/issues/547) (public-read) at a fraction of the cost, and it surfaces *what content viewers actually want* — useful input into the eventual #547 design. | [#548](https://github.com/roballred/GovEA/issues/548), [#547](https://github.com/roballred/GovEA/issues/547), [#556](https://github.com/roballred/GovEA/issues/556), [#538](https://github.com/roballred/GovEA/issues/538), [#537](https://github.com/roballred/GovEA/issues/537) |
+| 2 | **ARB cleanup trio** — three small, well-defined items | Each is well-scoped and has been open since early April. Together they close roughly half the remaining `arb-finding` label. None requires design conversation. [#75](https://github.com/roballred/GovEA/issues/75): refactor portfolio capability docs to put roles in `Rules`/`Links` rather than `Personas` (lint now enforces the structural part). [#133](https://github.com/roballred/GovEA/issues/133): rename debt taxonomy labels (`decision-drift`, `known-shortcut`, `capability-gap`) to plain-language equivalents in the debt UI. [#7](https://github.com/roballred/GovEA/issues/7): add a Failover section to `iam-sso-authentication.md` plus the integration-boundary statement. | [#75](https://github.com/roballred/GovEA/issues/75), [#133](https://github.com/roballred/GovEA/issues/133), [#7](https://github.com/roballred/GovEA/issues/7) |
+| 3 | **Next CSV per-entity slice (Initiatives + Objectives)** | The pattern is now mechanical thanks to the shared `@/lib/csv` helpers. Initiatives + Objectives pair naturally in the Consultant / SI persona's handover bundle and follow the persona-validated order in the (now-closed) [#596](https://github.com/roballred/GovEA/issues/596). File a fresh issue first since #596 is closed. | (file a new issue) |
+| 4 | **Add data-architecture quality cues and naming-standard hints** | Data Architecture is now a shipped module, and the remaining gaps are reviewer/operator quality loops: Data Vault physical-name hints, per-row quality cues. [#570](https://github.com/roballred/GovEA/issues/570) is the cheaper, more persona-validated slice — pick it before [#573](https://github.com/roballred/GovEA/issues/573)'s scorecard, which warrants the @nicholerip conversation in [#363](https://github.com/roballred/GovEA/issues/363) first. | [#570](https://github.com/roballred/GovEA/issues/570), [#573](https://github.com/roballred/GovEA/issues/573) |
+| 5 | **Doc/capability backfill — #510 + #511** | Small documentation slices that close out the explicit triage-split parent [#10](https://github.com/roballred/GovEA/issues/10). [#510](https://github.com/roballred/GovEA/issues/510) adds Scope fields to capability files; [#511](https://github.com/roballred/GovEA/issues/511) creates the `cms/deployment-operations` capability group + README "what does it take to run this?" section. Both are now enforceable by the new docs-lint. | [#510](https://github.com/roballred/GovEA/issues/510), [#511](https://github.com/roballred/GovEA/issues/511) |
+
+## On Hold
+
+Items previously ranked that the product owner has paused:
+
+- **SMTP transport ([#528](https://github.com/roballred/GovEA/issues/528) follow-up + [#581](https://github.com/roballred/GovEA/issues/581) + [#87](https://github.com/roballred/GovEA/issues/87))** — held until an outbound mail account is available. The subscriptions / inbox substrate ([#610](https://github.com/roballred/GovEA/pull/610)) and domain-owner attribution ([#611](https://github.com/roballred/GovEA/pull/611)) shipped, but sends still hit the stub. Resume when the account lands.
+- **Release pipeline ([#504](https://github.com/roballred/GovEA/issues/504))** — held this session. Reason to revisit: every persona-facing feature now depends on the Azure demo being a known build, and manual deploys remain the largest operational risk. Promote back into the top five when ready to take it on.
+
+## Won't-Do (recorded for future grooming)
+
+- [#512](https://github.com/roballred/GovEA/issues/512) — **"Tools" stays as the user-facing term.** Do not propose Tools→Modules renames in future grooming. If "Modules" appears in capability docs, patch the drift toward "Tools," not the other way. Decision recorded 2026-05-22.
 
 ## Product Manager Notes
 
-- Treat #528 as unfinished until a real SMTP transport lands. The configuration UI unblocks downstream work, but notification features cannot ship on a stub sender.
-- #581 is too broad to build in one pass. Split it into an event/subscription foundation, domain-owner attribution, non-owner edit warning, and email digest delivery.
-- #596 should keep moving in small per-entity PRs. Preserve the export -> unchanged import -> zero-diff property from #604.
-- #573 Layer 1 and Layer 2 are the right near-term data-architecture scope. A full Hoberman-style scorecard should wait for persona validation.
-- #512 should be handled before expanding #499 glossary-backed menu definitions. "Modules" is now the settled term; cleanup and a CI guard are process hygiene, but they sit just outside the top five.
-- #510 and #511 remain worthwhile documentation/capability-definition work for operating GovEA, especially for non-technical decision-makers. They are good candidates when the team wants a docs-only or capability-only slice.
+- [#436](https://github.com/roballred/GovEA/issues/436) was re-scoped from its original "Option 1" framing once the architectural audit confirmed there is no cross-tenant content-read path to gate (act-as gates mutations; reads always use `session.user.organizationId`). The remaining gate is user PII, and that work is now in PR #626.
+- [#596](https://github.com/roballred/GovEA/issues/596) (parent CSV issue) was closed before the Personas + ADRs slice landed. Future per-entity CSV PRs should reference the persona-source rationale but file their own issue rather than reopening #596.
+- [#363](https://github.com/roballred/GovEA/issues/363) is the right umbrella issue to ping @nicholerip on before deciding whether the next data-arch slice is conceptual/logical-layer support, Chen visualization, or the scorecard ([#573](https://github.com/roballred/GovEA/issues/573)). The answer materially changes priority 4.
+- The **persona-walk audit** ([epic #515](https://github.com/roballred/GovEA/issues/515)) closed all 16 sub-issues. Remaining gap issues filed by the audit carry `journey:<persona>` labels — use those for any future "what's next for this persona" filtering.
+- **Doc drift** is no longer a recurring class of bug: the CI `docs-lint` enforces STYLE.md compliance, and the persona-journey reports document expected reality. Pick docs-only slices opportunistically (they're cheap), not strategically.
+- The **viewer cluster** (rank 1) is blocked on a design decision about what to expose publicly. Doing [#548](https://github.com/roballred/GovEA/issues/548) first generates the right design input for [#547](https://github.com/roballred/GovEA/issues/547) without forcing the decision up front.
 
 ## Security Remediation Status
 
@@ -55,4 +64,4 @@ The practical implication: several previously ranked items are now done or parti
 | #421 - test: unauthenticated server-action POSTs blocked | Enhancement | Fixed (PR #440) |
 | #422 - test: read actions ignore caller-supplied orgId/role | Enhancement | Fixed (PR #441) |
 | #437 - wire cross-tenant impersonation through break-glass | Medium | Fixed (PR #502) |
-| #436 - promote break-glass to gate cross-tenant reads | Medium | Open (post-v1 / after act-as operating experience) |
+| #436 - cross-tenant **user-PII** read gate (re-scoped from original) | Medium | In review (PR #626) |


### PR DESCRIPTION
## Summary

Fourth slice of the per-entity CSV pattern. Capabilities ([#604](https://github.com/roballred/GovEA/pull/604)), Personas + ADRs ([#625](https://github.com/roballred/GovEA/pull/625)), and now Initiatives + Objectives — the pair that rounds out the Consultant / SI persona's handover bundle.

## What ships

| Surface | Initiatives | Objectives |
|---|---|---|
| \`GET /api/<entity>/export\` | name, description, status, start_date, end_date, visibility + per-entity taxonomy + semicolon-joined \`capabilities\` and \`objectives\` | name, description, success_metric, time_horizon, status, visibility + per-entity taxonomy + semicolon-joined \`capabilities\` and \`value_streams\` |
| \`import<Entity>\` server action | Two-step preview/confirm; case-insensitive upsert by name | Same |
| Junction resolution | Capabilities + Objectives against the org's own records; unknown names → row warnings | Capabilities + Value Streams; same warning behavior |
| Junction replacement on upsert | Both wiped + re-inserted, matching the established pattern | Same |
| Multi-line cell support | ✅ via shared \`@/lib/csv\` quote-aware parser | ✅ |
| \`<entity>-table.tsx\` | Export + Import buttons + dialog in the toolbar | Same |

## Intentionally out of scope

- **Initiative ↔ Application junction.** Carries an \`impact\` label (\`build\` / \`improve\` / \`retire\` / \`migrate\`) which needs richer CSV semantics than a name list. Pair with a future slice when persona pull surfaces.
- **Objective ↔ Goal junction.** Orthogonal hierarchy; not in this slice.
- **Cross-org import.** Out of scope on every per-entity slice for the same reasons #596 originally specified.

## Test plan

- [x] **22 new integration tests** (11 per entity), all passing locally in 1.66s:
  - Role enforcement (viewer rejected)
  - Basic create with all fixed columns
  - Case-insensitive upsert by name
  - Junction resolution + unknown-name warnings (not row failures)
  - Junction replacement on upsert (both junctions emptied when re-imported with empty values)
  - Status / visibility validation
  - dryRun does not write rows
  - Multi-line cells round-trip via shared \`@/lib/csv\` parser
  - Round-trip property: re-import reports \`updated=1\` with no field changes
  - Empty CSV + missing file error paths
- [x] **35 existing CSV tests** (Capabilities, Personas, ADRs) still pass — shared \`@/lib/csv\` layer is unchanged
- [x] \`tsc --noEmit\` clean

Net: 57 CSV integration tests, all green.

## Pattern is now mechanical

The shared \`@/lib/csv\` helpers and the established server-action shape have made each new entity a 1-PR slice. Of the remaining entities listed in (the now-closed) #596 — Services, Value Streams, Principles, Glossary, Data Architecture — each follows the same template. Recommend filing them individually when persona pull surfaces rather than batching.

## Capability traceability

Capability: \`ac-backup-export\` (per-entity CSV subset)
Persona: consultant-si (primary); also serves early-maturity-practice-lead, agency-ea-coordinator, enterprise-architect
Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)