### PR TITLE
feat(data-arch): Data Vault naming hints on physical-table fields (#570)

### DIFF
--- a/apps/govea/src/components/data-architecture-form.tsx
+++ b/apps/govea/src/components/data-architecture-form.tsx
@@ -5,6 +5,12 @@ import type {
   DataEntity, DataAttribute, DataLink, DataBusinessKey,
   PhysicalAttributeType, PhysicalLinkType,
 } from '@/db/schema'
+import {
+  type DataVaultPrefix,
+  DATA_VAULT_PREFIX_LABELS,
+  suggestDataVaultName,
+  matchesDataVaultPrefix,
+} from '@/lib/data-vault-naming'
 
 type Status = 'draft' | 'published' | 'archived'
 type Visibility = 'org' | 'connections' | 'instance'
@@ -55,6 +61,64 @@ function NameField({ value, onChange }: { value: string; onChange: (v: string) =
         onChange={e => onChange(e.target.value)}
         className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
+    </div>
+  )
+}
+
+/**
+ * #570 — Soft Data Vault naming hint for physical-table-name fields.
+ *
+ * Shows the convention as helper text, offers a one-click suggestion derived
+ * from the entity / link / attribute name, and gently flags values that
+ * don't match the expected prefix. Submit is never blocked — orgs that
+ * don't run Data Vault keep full control.
+ */
+function PhysicalTableNameField({
+  id, prefix, sourceName, value, onChange, placeholder,
+}: {
+  id: string
+  prefix: DataVaultPrefix
+  /** The "Customer Order" entity / link / attribute name suggestions are derived from. */
+  sourceName: string
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+}) {
+  const kindLabel = DATA_VAULT_PREFIX_LABELS[prefix]
+  const suggestion = suggestDataVaultName(prefix, sourceName)
+  const canSuggest = !!suggestion && value !== suggestion
+  const trimmed = value.trim()
+  const looksOff = trimmed.length > 0 && !matchesDataVaultPrefix(prefix, trimmed)
+
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="text-sm font-medium">
+        Physical {kindLabel} Table Name <span className="text-muted-foreground font-normal">(optional)</span>
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={id} name={id}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 rounded-md border bg-background px-3 py-2 text-sm font-mono"
+        />
+        {canSuggest && (
+          <button
+            type="button"
+            onClick={() => onChange(suggestion)}
+            className="shrink-0 rounded-md border bg-background px-2 py-1 text-xs hover:bg-muted whitespace-nowrap"
+            title={`Fill with "${suggestion}"`}
+          >
+            Suggest: <code className="font-mono">{suggestion}</code>
+          </button>
+        )}
+      </div>
+      <p className={`text-xs ${looksOff ? 'text-amber-700 dark:text-amber-400' : 'text-muted-foreground'}`}>
+        {looksOff
+          ? `This doesn't look like a Data Vault ${kindLabel} name (expected to start with "${prefix}_"). You can keep it as-is, or use the Suggest button.`
+          : `Data Vault convention: ${kindLabel}s are prefixed with "${prefix}_" (e.g. ${prefix}_${prefix === 's' ? 'customer_profile' : prefix === 'l' ? 'customer_order' : 'customer'}).`}
+      </p>
     </div>
   )
 }
@@ -229,18 +293,14 @@ export function DataEntityForm({
       <NameField value={name} onChange={setName} />
       <DescriptionField value={description ?? ''} onChange={setDescription} />
       <StatusVisibilityRow status={status} onStatus={setStatus} visibility={visibility} onVisibility={setVisibility} />
-      <div className="space-y-1.5">
-        <label htmlFor="physicalHubTableName" className="text-sm font-medium">
-          Physical Hub Table Name <span className="text-muted-foreground font-normal">(optional)</span>
-        </label>
-        <input
-          id="physicalHubTableName" name="physicalHubTableName"
-          value={physicalHubTableName ?? ''}
-          onChange={e => setHub(e.target.value)}
-          placeholder="e.g. hub_customer"
-          className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono"
-        />
-      </div>
+      <PhysicalTableNameField
+        id="physicalHubTableName"
+        prefix="h"
+        sourceName={name}
+        value={physicalHubTableName ?? ''}
+        onChange={setHub}
+        placeholder="e.g. h_customer"
+      />
       <PhysicalLocationFields
         server={serverName ?? ''} onServer={setServer}
         database={databaseName ?? ''} onDatabase={setDatabase}
@@ -298,18 +358,14 @@ export function DataAttributeForm({
       <DescriptionField value={description ?? ''} onChange={setDescription} />
       <StatusVisibilityRow status={status} onStatus={setStatus} visibility={visibility} onVisibility={setVisibility} />
       <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <label htmlFor="physicalSatelliteTableName" className="text-sm font-medium">
-            Physical Satellite Table Name <span className="text-muted-foreground font-normal">(optional)</span>
-          </label>
-          <input
-            id="physicalSatelliteTableName" name="physicalSatelliteTableName"
-            value={physicalSatelliteTableName ?? ''}
-            onChange={e => setSat(e.target.value)}
-            placeholder="e.g. sat_customer_address"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono"
-          />
-        </div>
+        <PhysicalTableNameField
+          id="physicalSatelliteTableName"
+          prefix="s"
+          sourceName={name}
+          value={physicalSatelliteTableName ?? ''}
+          onChange={setSat}
+          placeholder="e.g. s_customer_profile"
+        />
         <div className="space-y-1.5">
           <label htmlFor="physicalAttributeType" className="text-sm font-medium">
             Physical Attribute Type
@@ -384,18 +440,14 @@ export function DataLinkForm({
       <DescriptionField value={description ?? ''} onChange={setDescription} />
       <StatusVisibilityRow status={status} onStatus={setStatus} visibility={visibility} onVisibility={setVisibility} />
       <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <label htmlFor="physicalLinkTableName" className="text-sm font-medium">
-            Physical Link Table Name <span className="text-muted-foreground font-normal">(optional)</span>
-          </label>
-          <input
-            id="physicalLinkTableName" name="physicalLinkTableName"
-            value={physicalLinkTableName ?? ''}
-            onChange={e => setLink(e.target.value)}
-            placeholder="e.g. lnk_customer_address"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono"
-          />
-        </div>
+        <PhysicalTableNameField
+          id="physicalLinkTableName"
+          prefix="l"
+          sourceName={name}
+          value={physicalLinkTableName ?? ''}
+          onChange={setLink}
+          placeholder="e.g. l_customer_address"
+        />
         <div className="space-y-1.5">
           <label htmlFor="physicalLinkType" className="text-sm font-medium">
             Physical Relationship Type

--- a/apps/govea/src/lib/data-vault-naming.ts
+++ b/apps/govea/src/lib/data-vault-naming.ts
@@ -1,0 +1,48 @@
+/**
+ * Data Vault naming helpers (#570).
+ *
+ * The convention enforced (softly) on physical-table-name fields in the
+ * Data Architecture forms. Hubs prefix `h_`, Satellites `s_`, Links `l_`,
+ * matching the seed fixture data and the standard Data Vault 2.0
+ * methodology. The DB stores free-text; these helpers exist so the UI can
+ * suggest compliant names without blocking non-Data-Vault use.
+ */
+
+export type DataVaultPrefix = 'h' | 's' | 'l'
+
+export const DATA_VAULT_PREFIX_LABELS: Record<DataVaultPrefix, string> = {
+  h: 'Hub',
+  s: 'Satellite',
+  l: 'Link',
+}
+
+/**
+ * Slugify a human name into a Data-Vault-friendly identifier fragment.
+ * Lowercases, replaces non-alphanumerics with single underscores, trims
+ * leading/trailing underscores. Empty input yields empty string.
+ */
+export function slugifyForDataVault(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
+/**
+ * Compose a suggested Data Vault physical-table name from an entity / link /
+ * attribute name. Returns an empty string when the input slug is empty so
+ * the caller can suppress the suggestion when there's nothing to suggest.
+ */
+export function suggestDataVaultName(prefix: DataVaultPrefix, name: string): string {
+  const slug = slugifyForDataVault(name)
+  return slug ? `${prefix}_${slug}` : ''
+}
+
+/**
+ * True when a value already matches the expected Data Vault prefix.
+ * Used to suppress redundant "Suggest" affordance once the user has typed
+ * a compliant value.
+ */
+export function matchesDataVaultPrefix(prefix: DataVaultPrefix, value: string): boolean {
+  return new RegExp(`^${prefix}_[a-z0-9_]+$`).test(value)
+}

--- a/apps/govea/tests/unit/data-vault-naming.test.ts
+++ b/apps/govea/tests/unit/data-vault-naming.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests: Data Vault naming helpers (#570)
+ *
+ * The slug / suggestion / prefix-match helpers used by the soft Data Vault
+ * naming hints in the Data Architecture forms. UI behavior is exercised by
+ * inspection; this suite pins the slug and suggestion outputs.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  slugifyForDataVault,
+  suggestDataVaultName,
+  matchesDataVaultPrefix,
+} from '@/lib/data-vault-naming'
+
+describe('slugifyForDataVault', () => {
+  it('lowercases', () => {
+    expect(slugifyForDataVault('Customer')).toBe('customer')
+  })
+
+  it('joins spaced words with underscore', () => {
+    expect(slugifyForDataVault('Customer Order')).toBe('customer_order')
+  })
+
+  it('replaces multiple non-alphanumeric runs with a single underscore', () => {
+    expect(slugifyForDataVault('Customer  --  Order!')).toBe('customer_order')
+  })
+
+  it('trims leading and trailing underscores', () => {
+    expect(slugifyForDataVault('  Order ')).toBe('order')
+    expect(slugifyForDataVault('--Order--')).toBe('order')
+  })
+
+  it('returns empty string for empty / whitespace-only input', () => {
+    expect(slugifyForDataVault('')).toBe('')
+    expect(slugifyForDataVault('   ')).toBe('')
+  })
+
+  it('preserves digits', () => {
+    expect(slugifyForDataVault('FY2026 Plan')).toBe('fy2026_plan')
+  })
+
+  it('strips punctuation that occurs inside words', () => {
+    expect(slugifyForDataVault("Driver's Licence")).toBe('driver_s_licence')
+  })
+})
+
+describe('suggestDataVaultName', () => {
+  it('produces the seed convention for Hub', () => {
+    expect(suggestDataVaultName('h', 'Customer')).toBe('h_customer')
+    expect(suggestDataVaultName('h', 'Order')).toBe('h_order')
+    expect(suggestDataVaultName('h', 'Product')).toBe('h_product')
+  })
+
+  it('produces the seed convention for Satellite', () => {
+    expect(suggestDataVaultName('s', 'Customer Profile')).toBe('s_customer_profile')
+    expect(suggestDataVaultName('s', 'Order Status')).toBe('s_order_status')
+  })
+
+  it('produces the seed convention for Link', () => {
+    expect(suggestDataVaultName('l', 'Customer Order')).toBe('l_customer_order')
+  })
+
+  it('returns empty string when there is nothing to slugify', () => {
+    expect(suggestDataVaultName('h', '')).toBe('')
+    expect(suggestDataVaultName('h', '   ')).toBe('')
+    expect(suggestDataVaultName('h', '!!!')).toBe('')
+  })
+})
+
+describe('matchesDataVaultPrefix', () => {
+  it('matches values starting with the prefix and underscore', () => {
+    expect(matchesDataVaultPrefix('h', 'h_customer')).toBe(true)
+    expect(matchesDataVaultPrefix('s', 's_customer_profile')).toBe(true)
+    expect(matchesDataVaultPrefix('l', 'l_customer_order')).toBe(true)
+  })
+
+  it('rejects values with the wrong prefix', () => {
+    expect(matchesDataVaultPrefix('h', 's_customer')).toBe(false)
+    expect(matchesDataVaultPrefix('s', 'h_customer')).toBe(false)
+  })
+
+  it('rejects values missing the prefix', () => {
+    expect(matchesDataVaultPrefix('h', 'customer')).toBe(false)
+    expect(matchesDataVaultPrefix('h', 'hub_customer')).toBe(false)
+    expect(matchesDataVaultPrefix('h', 'h-customer')).toBe(false)
+  })
+
+  it('rejects empty / whitespace input', () => {
+    expect(matchesDataVaultPrefix('h', '')).toBe(false)
+    expect(matchesDataVaultPrefix('h', 'h_')).toBe(false)
+  })
+
+  it('rejects uppercase / mixed case (the slug is always lower)', () => {
+    expect(matchesDataVaultPrefix('h', 'h_Customer')).toBe(false)
+    expect(matchesDataVaultPrefix('h', 'H_customer')).toBe(false)
+  })
+})

--- a/business-architecture/capabilities/ea/data-architecture/data-architecture.md
+++ b/business-architecture/capabilities/ea/data-architecture/data-architecture.md
@@ -16,7 +16,7 @@ The system must support the practice of Data Architecture as defined by the DAMA
 | Capability | File | Status | Description |
 |---|---|---|---|
 | Physical Metamodel | [da-physical-metamodel.md](./da-physical-metamodel.md) | Shipped (v1) | Data Vault-aligned physical-layer metamodel: entities (Hubs), attributes (Satellites), links, and business keys, with four cross-object semantic relationship kinds |
-| Chen Notation Visualization | [da-chen-visualization.md](./da-chen-visualization.md) | Planned — not yet implemented | Read-only Chen Notation graph rendering of the metamodel so architects can see the full picture rather than navigating object by object |
+| Chen Notation Visualization | [da-chen-visualization.md](./da-chen-visualization.md) | Shipped (v1) | Read-only Chen Notation graph rendering of the metamodel so architects can see the full picture rather than navigating object by object |
 
 ## Success Criteria
 
@@ -54,9 +54,7 @@ The system must support the practice of Data Architecture as defined by the DAMA
 
 **Shipped (v1):**
 - `da-physical-metamodel` via PRs [#471](https://github.com/roballred/EasyEA/pull/471) (schema + CRUD, schema actually merged at roballred/GovEA#471) and [#472](https://github.com/roballred/GovEA/pull/472) (cross-object semantic relationships). Four CRUD-able object types with the Data Vault metadata fields the SME specified; three cross-object semantic relationship junctions (entity ↔ entity, entity ↔ attribute, attribute ↔ attribute) plus the structural FK for entity ↔ business-key "instantiates"
-
-**Planned:**
-- `da-chen-visualization` — tracked at [#470](https://github.com/roballred/GovEA/issues/470)
+- `da-chen-visualization` — `/data/diagram` ships the documented Chen Notation graph with all four filters, live counts, and read-only edit-back links. Confirmed during the Data Modeler persona journey audit ([#569](https://github.com/roballred/GovEA/issues/569))
 
 ## Links
 


### PR DESCRIPTION
## Summary

Soft **Tier-1** naming-standard surfacing on the three Data Architecture forms (entities, attributes, links). The Data Modeler persona audit ([#569](https://github.com/roballred/GovEA/issues/569)) named the gap directly: *"naming standards drift when there is no enforced linter or scorecard hook in the tool."* Today the physical-table fields accept any value with no nudge toward the Data Vault \`h_*\` / \`s_*\` / \`l_*\` convention the seed data uses.

This PR takes the lowest-friction tier from the issue's three-tier proposal. Submit is never blocked — orgs not running Data Vault keep full control.

## What ships

### New helper — \`@/lib/data-vault-naming\`
- \`slugifyForDataVault(name)\` — lowercases, collapses non-alnum runs to underscore, trims edges
- \`suggestDataVaultName('h' | 's' | 'l', name)\` — returns \`<prefix>_<slug>\` or empty
- \`matchesDataVaultPrefix(prefix, value)\` — true when value follows the convention

### New form sub-component — \`PhysicalTableNameField\`
Used by \`DataEntityForm\`, \`DataAttributeForm\`, and \`DataLinkForm\`:

| Affordance | Behavior |
|---|---|
| Helper text | *"Data Vault convention: Hubs are prefixed with \"h_\" (e.g. h_customer)."* |
| **Suggest** button | One click fills the field with \`<prefix>_<slug>\` derived from the entity / link / attribute Name. Hidden when the value already matches the suggestion. |
| Soft warning | When the typed value doesn't match the expected prefix, an amber inline note appears. Copy explicitly says *"you can keep it as-is, or use the Suggest button"* — no submit block. |
| Placeholders | Corrected from \`hub_*\` / \`sat_*\` / \`lnk_*\` to the seed convention \`h_*\` / \`s_*\` / \`l_*\`. The old placeholders were inconsistent with what the seed actually writes. |

### Tiers deferred (per issue recommendation)

- **Tier 2** — server-side validation block on blur
- **Tier 3** — admin enforcement toggle

Both depend on persona validation that hasn't happened. Lean toward the cheapest tier first.

## Doc-hygiene observation also addressed

The issue noted that \`da-chen-visualization.md\` had been updated to \"Shipped (v1)\" but the parent \`data-architecture.md\` sub-capabilities table still listed it as \"Planned — not yet implemented.\" That row and the \"Planned:\" section under Implementation Status are corrected here.

## Test plan

- [x] **16 unit tests** in \`tests/unit/data-vault-naming.test.ts\` covering slugify edge cases (multiple non-alnum runs, leading/trailing junk, digits, apostrophes, empty input), suggestion against the seed convention for all three prefixes, and prefix-match rules (right/wrong/missing/empty/case).
- [x] All 16 pass locally in 2 ms.
- [x] \`tsc --noEmit\` clean.
- [x] \`docs-lint\` clean (102 files).

## Capability traceability

Capability: \`da-physical-metamodel\`
Persona: data-modeler (primary); enterprise-data-architect (secondary — they review the modeler's work)
Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)