### PR TITLE
feat(viewer): role-tailored landing + simplified sidebar (#548)

### DIFF
--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/lib/completeness-signals'
 import Link from 'next/link'
 import { FirstSignInModal } from '@/components/first-sign-in-modal'
+import { ViewerDashboard } from './viewer-dashboard'
 
 const RAG_TEXT_CLASS: Record<RagBucket, string> = {
   green:   'text-green-700 dark:text-green-400',
@@ -74,6 +75,14 @@ export default async function DashboardPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
   const orgId = session.user.organizationId!
+
+  // #548 — Viewer-mode dashboard. Auth-redirect routes Viewers to /executive
+  // by default; this branch covers the case where they navigate to /dashboard
+  // directly. The admin metrics surface is technically and behaviorally wrong
+  // for non-authoring stakeholders.
+  if (session.user.role === 'viewer') {
+    return <ViewerDashboard orgId={orgId} userName={session.user.name ?? null} />
+  }
 
   const orgRow = await db.query.organizations.findFirst({
     where: eq(organizations.id, orgId),

--- a/apps/govea/src/app/(admin)/dashboard/viewer-dashboard.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/viewer-dashboard.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link'
+import { ConfidenceSummary } from '@/components/confidence-summary'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Viewer-mode dashboard (#548).
+ *
+ * The Elected Official, CMS Viewer, and Business Stakeholder personas all
+ * surfaced the same gap during the audit: the admin dashboard is too dense
+ * and too technical to function as a stakeholder reader entry. Rather than
+ * try to make one dashboard serve both, this component is the Viewer-specific
+ * variant — confidence summary, plain-language entry tiles to the four
+ * pages a non-authoring reader actually uses, and no admin metrics.
+ *
+ * The auth-redirect bouncer routes Viewers to `/executive` after sign-in, so
+ * a Viewer should only reach this page by clicking "Dashboard" in the nav —
+ * but it still has to be honest when they do.
+ */
+export function ViewerDashboard({ orgId, userName }: { orgId: string; userName: string | null }) {
+  const greeting = userName ? `Welcome, ${userName.split(' ')[0]}` : 'Welcome'
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{greeting}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          GovEA describes what the organization does and the technology that supports it.
+          Use the views below to explore — no editing is required.
+        </p>
+      </div>
+
+      <ConfidenceSummary orgId={orgId} />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link href="/executive" className="block">
+          <Card className="hover:shadow-md transition-shadow h-full">
+            <CardHeader>
+              <CardTitle className="text-base">Executive Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              A one-page view of the most-significant capabilities, applications, initiatives, and decisions. Designed for non-technical readers.
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/roadmap" className="block">
+          <Card className="hover:shadow-md transition-shadow h-full">
+            <CardHeader>
+              <CardTitle className="text-base">Roadmap</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Initiatives plotted across fiscal quarters. See what's planned, in progress, and recently complete.
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/answers" className="block">
+          <Card className="hover:shadow-md transition-shadow h-full">
+            <CardHeader>
+              <CardTitle className="text-base">Guided Answers</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Plain-language questions that resolve to the right content — *"What does the city do?"*, *"Which applications support permitting?"*, *"Why did we choose Postgres?"*
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/reports" className="block">
+          <Card className="hover:shadow-md transition-shadow h-full">
+            <CardHeader>
+              <CardTitle className="text-base">Reports</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Architecture Vision, capability heatmap, and TOGAF rollups. Generated views — no setup required.
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      <p className="text-xs text-muted-foreground pt-2">
+        Need to author or edit? Ask an administrator to upgrade your role to Contributor.
+      </p>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/dashboard/viewer-dashboard.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/viewer-dashboard.tsx
@@ -48,7 +48,7 @@ export function ViewerDashboard({ orgId, userName }: { orgId: string; userName: 
               <CardTitle className="text-base">Roadmap</CardTitle>
             </CardHeader>
             <CardContent className="text-sm text-muted-foreground">
-              Initiatives plotted across fiscal quarters. See what's planned, in progress, and recently complete.
+              {`Initiatives plotted across fiscal quarters. See what's planned, in progress, and recently complete.`}
             </CardContent>
           </Card>
         </Link>
@@ -59,7 +59,7 @@ export function ViewerDashboard({ orgId, userName }: { orgId: string; userName: 
               <CardTitle className="text-base">Guided Answers</CardTitle>
             </CardHeader>
             <CardContent className="text-sm text-muted-foreground">
-              Plain-language questions that resolve to the right content — *"What does the city do?"*, *"Which applications support permitting?"*, *"Why did we choose Postgres?"*
+              {`Plain-language questions that resolve to the right content — "What does the city do?", "Which applications support permitting?", "Why did we choose Postgres?"`}
             </CardContent>
           </Card>
         </Link>

--- a/apps/govea/src/app/(auth)/auth-redirect/page.tsx
+++ b/apps/govea/src/app/(auth)/auth-redirect/page.tsx
@@ -1,11 +1,16 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { isInstanceAdmin } from '@/lib/rbac'
-import { safeCallbackUrl } from '@/lib/auth-redirect'
+import { safeCallbackUrl, defaultLandingPath } from '@/lib/auth-redirect'
 
-// Role-aware post-signin bouncer (#520). Instance admins land on /instance;
-// everyone else lands on /dashboard. An explicit, safe `callbackUrl` always
-// wins over the role-based default.
+/**
+ * Role-aware post-signin bouncer.
+ *
+ * Routing order:
+ *   1. An explicit, safe `callbackUrl` always wins (preserves deep-links).
+ *   2. Otherwise, fall back to `defaultLandingPath(role, isInstanceAdmin)`
+ *      — see that helper for the role-based routing rule.
+ */
 export default async function AuthRedirectPage({
   searchParams,
 }: {
@@ -20,6 +25,8 @@ export default async function AuthRedirectPage({
     if (explicit) redirect(explicit)
   }
 
-  if (isInstanceAdmin(session.user)) redirect('/instance')
-  redirect('/dashboard')
+  redirect(defaultLandingPath({
+    role: session.user.role,
+    isInstanceAdmin: isInstanceAdmin(session.user),
+  }))
 }

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -11,8 +11,13 @@ import { isModuleEnabled, moduleForPath } from '@/lib/modules'
 
 // ── Nav structure ─────────────────────────────────────────────────────────────
 
-type NavItem = { href: string; label: string; moduleKey?: string; contributorOnly?: boolean }
-type NavGroup = { label: string; items: NavItem[]; adminOnly?: boolean }
+// #548 — `viewerHidden` removes the item / group from Viewer-role sidebars.
+// Data Architecture, Architecture Debt, and the EA-jargon-heavy Goals page
+// are author/architect surfaces with no Elected-Official-equivalent reader
+// benefit. The persona-walk audit explicitly flagged the dense default nav
+// as a Viewer adoption blocker.
+type NavItem = { href: string; label: string; moduleKey?: string; contributorOnly?: boolean; viewerHidden?: boolean }
+type NavGroup = { label: string; items: NavItem[]; adminOnly?: boolean; viewerHidden?: boolean }
 
 const NAV_GROUPS: NavGroup[] = [
   {
@@ -22,7 +27,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: '/value-streams', label: 'Value Streams',  moduleKey: 'value-streams' },
       { href: '/capabilities',  label: 'Capabilities',   moduleKey: 'capabilities' },
       { href: '/services',      label: 'Services',       moduleKey: 'services' },
-      { href: '/principles',    label: 'Principles',     moduleKey: 'principles' },
+      { href: '/principles',    label: 'Principles',     moduleKey: 'principles', viewerHidden: true },
       { href: '/glossary',      label: 'Glossary',       moduleKey: 'glossary' },
     ],
   },
@@ -31,10 +36,9 @@ const NAV_GROUPS: NavGroup[] = [
     // link / business-key + the Chen Notation diagram) the same way
     // Business Architecture surfaces its object types. Every entry is
     // gated on the `data-architecture` module key so toggling the module
-    // hides the whole group. Diagram lives behind PR-3 (#470/#477) — the
-    // link is included here so the nav is complete once that PR lands;
-    // if this PR ships first the link 404s until #477 lands.
+    // hides the whole group. Hidden from Viewer-role sidebars per #548.
     label: 'Data Architecture',
+    viewerHidden: true,
     items: [
       { href: '/data',                label: 'Overview',      moduleKey: 'data-architecture' },
       { href: '/data/entities',       label: 'Entities',      moduleKey: 'data-architecture' },
@@ -49,13 +53,13 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { href: '/applications', label: 'Applications', moduleKey: 'applications' },
       { href: '/adrs',         label: 'Decisions',    moduleKey: 'adrs' },
-      { href: '/debt',         label: 'Debt',         moduleKey: 'debt' },
+      { href: '/debt',         label: 'Debt',         moduleKey: 'debt', viewerHidden: true },
     ],
   },
   {
     label: 'Strategy',
     items: [
-      { href: '/goals',       label: 'Goals',       moduleKey: 'objectives' },
+      { href: '/goals',       label: 'Goals',       moduleKey: 'objectives', viewerHidden: true },
       { href: '/objectives',  label: 'Objectives',  moduleKey: 'objectives' },
       { href: '/initiatives', label: 'Initiatives', moduleKey: 'initiatives' },
       { href: '/roadmap',     label: 'Roadmap',     moduleKey: 'roadmap' },
@@ -104,6 +108,7 @@ function SidebarContent({
 }) {
   const isAdmin = role === 'admin'
   const isContributor = role === 'admin' || role === 'contributor'
+  const isViewer = role === 'viewer'
 
   return (
     <nav className="flex flex-col h-full overflow-y-auto py-4 px-3 gap-1">
@@ -156,11 +161,15 @@ function SidebarContent({
       </Link>
 
       <div className="mt-2 space-y-4">
-        {NAV_GROUPS.filter(g => !g.adminOnly || isAdmin).map(group => {
+        {NAV_GROUPS
+          .filter(g => !g.adminOnly || isAdmin)
+          .filter(g => !(g.viewerHidden && isViewer))
+          .map(group => {
           const visibleItems = group.items.filter(
             item =>
               (!item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])) &&
-              (!item.contributorOnly || isContributor)
+              (!item.contributorOnly || isContributor) &&
+              !(item.viewerHidden && isViewer)
           )
           if (visibleItems.length === 0) return null
           return (

--- a/apps/govea/src/lib/auth-redirect.ts
+++ b/apps/govea/src/lib/auth-redirect.ts
@@ -1,12 +1,30 @@
 /**
- * Auth redirect utilities (#386)
+ * Auth redirect utilities (#386, #520, #548)
  *
  * callbackUrl values arrive from query params and are controlled by NextAuth
  * or the browser — they should never send users back into auth/error routes
  * after a successful login.
  */
 
+import type { Role } from './rbac'
+
 const AUTH_DEAD_ENDS = ['/login', '/error', '/api/auth']
+
+/**
+ * Default landing path for a freshly-signed-in user when no explicit
+ * `callbackUrl` was provided.
+ *
+ * Routing rule:
+ *   1. Instance admins → `/instance` (platform-admin console; #520)
+ *   2. Viewers → `/executive` (stakeholder-friendly entry; #548). The admin
+ *      `/dashboard` is too dense to function as a non-authoring reader landing.
+ *   3. Everyone else → `/dashboard`
+ */
+export function defaultLandingPath(opts: { role: Role; isInstanceAdmin: boolean }): string {
+  if (opts.isInstanceAdmin) return '/instance'
+  if (opts.role === 'viewer') return '/executive'
+  return '/dashboard'
+}
 
 /**
  * Returns a safe post-login destination, falling back to `fallback` if the

--- a/apps/govea/tests/e2e/global-setup.ts
+++ b/apps/govea/tests/e2e/global-setup.ts
@@ -50,7 +50,13 @@ export default async function globalSetup() {
       await page.getByLabel('Password').fill(role.password)
       await page.getByRole('button', { name: 'Sign in', exact: true }).click()
     }
-    await page.waitForURL(`${baseURL}/dashboard`)
+    // Role-aware landing per defaultLandingPath() in @/lib/auth-redirect:
+    //   instance admin → /instance
+    //   viewer         → /executive (#548)
+    //   everyone else  → /dashboard
+    // Wait for any of the three so the seed-step works regardless of which
+    // role this iteration is signing in as.
+    await page.waitForURL(/\/(dashboard|executive|instance)(\?|$)/)
 
     await context.storageState({ path: path.join(AUTH_DIR, role.file) })
     await context.close()

--- a/apps/govea/tests/unit/auth-redirect.test.ts
+++ b/apps/govea/tests/unit/auth-redirect.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { safeCallbackUrl } from '@/lib/auth-redirect'
+import { safeCallbackUrl, defaultLandingPath } from '@/lib/auth-redirect'
 
 describe('safeCallbackUrl', () => {
   describe('valid destinations — returned as-is', () => {
@@ -83,5 +83,24 @@ describe('safeCallbackUrl', () => {
     it('uses the supplied fallback for dead-end routes', () => {
       expect(safeCallbackUrl('/login', '/home')).toBe('/home')
     })
+  })
+})
+
+// #548 — role-aware landing rule pinned as a pure function so the routing
+// surface is testable without spinning up React Server Components.
+describe('defaultLandingPath', () => {
+  it('sends instance admins to /instance regardless of their role', () => {
+    expect(defaultLandingPath({ role: 'admin',       isInstanceAdmin: true })).toBe('/instance')
+    expect(defaultLandingPath({ role: 'contributor', isInstanceAdmin: true })).toBe('/instance')
+    expect(defaultLandingPath({ role: 'viewer',      isInstanceAdmin: true })).toBe('/instance')
+  })
+
+  it('sends Viewer-role users to /executive', () => {
+    expect(defaultLandingPath({ role: 'viewer', isInstanceAdmin: false })).toBe('/executive')
+  })
+
+  it('sends Admin and Contributor users to /dashboard', () => {
+    expect(defaultLandingPath({ role: 'admin',       isInstanceAdmin: false })).toBe('/dashboard')
+    expect(defaultLandingPath({ role: 'contributor', isInstanceAdmin: false })).toBe('/dashboard')
   })
 })


### PR DESCRIPTION
## Summary

Closes the most-cited Viewer-experience gap from the persona audit (#546). The Elected Official, CMS Viewer, and Business Stakeholder personas all surfaced the same gap: a Viewer signs in and lands on the admin dashboard — completeness trends, federation activity, review health, plus a sidebar full of EA-jargon surfaces (Data Architecture, Debt, Goals). The persona's stated insight is *"a small number of plain-language, obviously current, high-confidence visuals."* The current landing fails that on every count.

This PR implements **Option C** from the issue — both halves.

## 1. Role-aware default landing (Option A — cheap, ships fast)

- New pure helper `defaultLandingPath({ role, isInstanceAdmin })` in `@/lib/auth-redirect`. Routing rule:
  1. Instance admin → `/instance` (#520)
  2. Viewer → `/executive` (#548)
  3. Everyone else → `/dashboard`
- `auth-redirect/page.tsx` uses the helper. Explicit, safe `callbackUrl` values still win (preserves deep-links into specific entities).

## 2. Viewer-mode `/dashboard` variant (Option B — for Viewers who navigate directly)

New `viewer-dashboard.tsx` component, mounted via an early-return guard at the top of `dashboard/page.tsx`. Admin code path is untouched.

The Viewer dashboard shows:
- Confidence summary at the top
- Four plain-language entry tiles: **Executive Summary**, **Roadmap**, **Guided Answers**, **Reports**
- No admin metrics, no coverage tiles, no federation panel, no review-health table

## 3. Sidebar simplification

`NavItem` and `NavGroup` types gained a `viewerHidden` flag. Hidden from Viewer-role sidebars:

| Hidden | Why |
|---|---|
| Entire **Data Architecture** group (Overview / Entities / Attributes / Links / Business keys / Diagram) | Modeler surface; no non-author reader benefit |
| Portfolio › **Debt** | Architecture-debt is an architect surface |
| Business Architecture › **Principles** | Author-side guardrails |
| Strategy › **Goals** | EA-vocabulary parent of Objectives; Viewers keep Objectives, Initiatives, Roadmap |

## Test plan

- [x] **5 new unit tests** in \`tests/unit/auth-redirect.test.ts\` for \`defaultLandingPath\`:
  - Instance admin → \`/instance\` regardless of role (3 cases)
  - Viewer → \`/executive\`
  - Admin / Contributor → \`/dashboard\`
- [x] **14 existing \`safeCallbackUrl\` tests** still pass (19 total in the suite, all green)
- [x] \`tsc --noEmit\` clean
- [x] Admin / Contributor behavior is identical pre/post — the Viewer guard falls through to the existing admin code path for any non-Viewer caller.

## Out of scope

- **Public-read access** (#547) — separate, larger slice; needs an explicit decision about what's exposed without auth. Lands later.
- **Sidebar reorder** for Viewer (putting Executive Summary above Dashboard). The auth-redirect default handles primary use; if persona feedback surfaces the in-sidebar order as a remaining concern, do that as a follow-up.

## Capability traceability

Capability: \`fd-content-display\`, \`fd-navigation\`, \`fd-portfolio-views\`
Persona: elected-official; cms-viewer; business-stakeholder
Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)