### PR TITLE
docs(capabilities): add Scope field + deployment-operations group (closes #510, #511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,18 @@ GovEA is free and open source. There is no licensing fee. The real cost is staff
 - **Ongoing maintenance:** periodic updates, user provisioning, and backup verification; no dedicated admin role required
 - **Hosting:** runs on any server or container platform; no proprietary cloud dependency
 
+### What does it take to run this?
+
+| Concern | Today | Where it's documented |
+|---|---|---|
+| **Deployment** | Single container against a Postgres database. Three documented workflows: host app + containerized DB, DB-only, full container stack. ~1 hour from clean environment to working demo instance. | [Local Containers](#local-containers) above; capability: [`do-deployment`](business-architecture/capabilities/cms/deployment-operations/do-deployment.md) |
+| **Configuration** | Environment variables only — `DATABASE_URL`, `AUTH_SECRET`, `NEXT_PUBLIC_APP_URL` required; SSO and SMTP optional. No source-code edit required to deploy. | [`apps/govea/.env.local`](./apps/govea/.env.local) shape; capability: [`do-deployment`](business-architecture/capabilities/cms/deployment-operations/do-deployment.md) |
+| **Health & monitoring** | Drop into a generic uptime + log-aggregation tool. Operator-relevant events go to the platform audit log (`/instance/audit`). A dedicated `/api/healthz` endpoint and a documented log shape are planned. | Capability: [`do-health-monitoring`](business-architecture/capabilities/cms/deployment-operations/do-health-monitoring.md) |
+| **Upgrades** | Pre-production: `pnpm --filter govea db:push` syncs schema. Once a real tenant exists, the workflow shifts to migration files — procedure documented in advance. | Capability: [`do-upgrade-migration`](business-architecture/capabilities/cms/deployment-operations/do-upgrade-migration.md); [#4](https://github.com/roballred/GovEA/issues/4) |
+| **Admin time/month** | Estimated 1–4 hours for an active small-to-mid-tenant install, dominated by user provisioning and content review nudges — not platform operations. | Capability group: [`cms/deployment-operations`](business-architecture/capabilities/cms/deployment-operations/deployment-operations.md) |
+
+The full operator-facing capability surface is documented under [`business-architecture/capabilities/cms/deployment-operations/`](business-architecture/capabilities/cms/deployment-operations/).
+
 
 
 ## Contributing

--- a/business-architecture/STYLE.md
+++ b/business-architecture/STYLE.md
@@ -107,6 +107,26 @@ Capability group files are the parent file at the root of each group folder. Fil
 
 The canonical heading for current state is `## Implementation Status`. Do not use `Current Scope`, `Current State`, `Current Maturity`, or other variants. Single name keeps lint and search reliable.
 
+### Scope field
+
+Group parent files declare a release-scope signal so non-technical readers (Department Director, Elected Official) can tell what is in v1 vs deferred without parsing every capability doc. The field lives immediately under the H1, before `## What It Does`:
+
+```markdown
+# Capability: <Group Name>
+
+**Scope:** v1
+```
+
+Allowed values:
+
+- **v1** — included in the v1 release.
+- **v2** — planned for a later release. Use sparingly; "future work" is also documented in `## Deferred to v2` when it earns more detail.
+- **out of scope** — intentionally excluded. **Required:** add a rationale on the same line, e.g. *"out of scope — replaced by external IdP; see ADR-007."* No silent out-of-scope declarations.
+
+Sub-capability (leaf) files may carry a `Scope:` field when they meaningfully deviate from their parent group's scope (e.g. parent is v1 but one leaf is v2). When the leaf's scope matches its parent, the field is optional.
+
+The lint does not enforce Scope today — backfill is an explicit content decision. If enforcement is added later it will apply to group parents first.
+
 ---
 
 ## Sub-Capability Files

--- a/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
+++ b/business-architecture/capabilities/cms/admin-configuration/admin-configuration.md
@@ -1,5 +1,7 @@
 # Capability: Admin & Configuration
 
+**Scope:** v1
+
 ## What It Does
 The system must provide administrators with the tools needed to configure, monitor, and maintain the site without requiring code changes or server access. In the current product this is an early admin toolkit rather than a complete operations surface.
 

--- a/business-architecture/capabilities/cms/content-management/content-management.md
+++ b/business-architecture/capabilities/cms/content-management/content-management.md
@@ -1,5 +1,7 @@
 # Capability: Content Management
 
+**Scope:** v1
+
 ## What It Does
 The system must provide a complete content management foundation — defining content structure, authoring content items, managing their lifecycle, organizing them with taxonomy, linking them together, and enabling users to find what they need. In the current product, core authoring and relationships are strong, while repository-wide search and fully consistent workflow behavior are still maturing.
 

--- a/business-architecture/capabilities/cms/deployment-operations/deployment-operations.md
+++ b/business-architecture/capabilities/cms/deployment-operations/deployment-operations.md
@@ -1,0 +1,60 @@
+# Capability: Deployment & Operations
+
+**Scope:** v1
+
+## What It Does
+
+The system must be deployable, runnable, observable, and upgradable by a small Central IT team without specialist EA tooling expertise. Day-1 deployment, day-2 health checks, and day-N upgrades are the three operator-facing surfaces this group describes. The objective is to make the cost of ownership of running GovEA visible and reasonable for a state or local government IT director — not to ship a sophisticated operations platform.
+
+This group was added to close [ARB Finding #10](https://github.com/roballred/goveaapp/issues/10) (Central IT Director, Thomas Reed): "the real cost of ownership is invisible." With this group, an evaluator can read what running GovEA actually costs in operator effort before committing to it.
+
+## Personas
+
+- **Instance Administrator** — owns the deploy / monitor / upgrade workflow across the GovEA instance(s) they operate; needs the docs and surfaces here to be reliable enough that running the product is not a daily ad-hoc puzzle
+- **Department Director (Central IT)** — does not operate the instance directly but is responsible for the operating-cost decision; reads this group to understand the resource commitment before approving deployment
+
+## Sub-Capabilities
+
+| Capability | File | Status | Description |
+|---|---|---|---|
+| Deployment | [do-deployment.md](./do-deployment.md) | Shipped (v1) | Container-based deployment with documented environment variables and database initialization |
+| Health & Monitoring | [do-health-monitoring.md](./do-health-monitoring.md) | Planned — partial | Health-check endpoints, uptime monitoring, structured error logging |
+| Upgrade & Migration | [do-upgrade-migration.md](./do-upgrade-migration.md) | Planned | Safe upgrade procedure across released versions; cross-links to [#4](https://github.com/roballred/GovEA/issues/4) |
+
+## Success Criteria
+
+- A Central IT operator can deploy GovEA from a clean environment to a working dev or demo instance in under an hour by following the documented runbook — no source-code reading required
+- A running instance can be reliably monitored from a generic uptime / log-aggregation tool (no GovEA-specific operational stack required)
+- An operator can move from one supported GovEA version to the next without destructive schema changes; pre-flight checks identify when an upgrade is unsafe
+- A reader of `README.md` can answer "what does it take to run this in production?" without reaching out to a developer
+
+## Rules
+
+- All runtime configuration lives in environment variables, not hard-coded values — operators never edit source to deploy
+- The runtime never depends on a paid service to start; SMTP, identity provider, and metrics endpoints are all optional and the system functions in a degraded but explicit mode without them
+- Schema changes are forward-compatible during a transition window: a new GovEA version starts cleanly against the previous version's schema, runs migrations on boot or on demand, and only then assumes the new shape
+- Operator-facing audit events (`instance.*`) record deploy-relevant actions distinct from tenant audit; see `iam-audit-trail`
+
+## Implementation Status
+
+**Shipped (v1):**
+- Container-based deployment via the runtime-agnostic `scripts/container-compose.sh` helper, with Podman as the preferred default and Docker as the fallback. Documented in `README.md` under "Local Containers". `pnpm demo:start`, `pnpm demo:db`, and `pnpm demo:container` cover the three common workflows.
+
+**Planned (v1, partial):**
+- A documented production runbook beyond local-container quickstart. The current README is good for evaluators; a dedicated production-deployment doc is still missing.
+- Health-check endpoint convention. Next.js's default `/api/healthz` style hook is not yet implemented.
+
+**Planned (post-v1):**
+- Structured upgrade procedure across released versions (#4). Today's pre-production `db:push` workflow means upgrades are not a concern; once the first real tenant lands, this story becomes urgent.
+- Operator-facing observability dashboard.
+
+## Out of Scope (v1)
+
+- A GovEA-specific monitoring stack. The product is expected to drop into a generic operator's existing log + uptime tooling
+- High-availability multi-instance orchestration. v1 is a single-instance product
+- Automated rollback. Manual operator intervention is the v1 model
+
+## Links
+
+- Depends on: `cms/admin-configuration` (the in-app admin surface that complements operator-side configuration)
+- Related: `cms/iam` (instance-admin role + break-glass audit trail), `cms/content-management` (DB schema lifecycle ultimately drives the upgrade story)

--- a/business-architecture/capabilities/cms/deployment-operations/do-deployment.md
+++ b/business-architecture/capabilities/cms/deployment-operations/do-deployment.md
@@ -1,0 +1,37 @@
+# Capability: Deployment
+
+**Scope:** v1
+
+## What It Does
+
+The system must be installable and runnable from a clean operator environment without requiring source-code understanding. Operators provide a small set of environment variables and a database connection; everything else — schema, seed content, runtime configuration — is bootstrapped from documented commands. The supported deployment shape in v1 is a single-instance container running against a Postgres database; multi-instance horizontal scaling is post-v1.
+
+## Personas
+
+- **Instance Administrator** — performs the initial deployment and any redeploys; needs the procedure to be reliable and self-documenting
+
+## Behaviors
+
+- Provide a runtime-agnostic compose helper (`scripts/container-compose.sh`) that auto-detects Podman or Docker and exposes the same set of commands either way
+- Document the environment-variable surface (`DATABASE_URL`, `AUTH_SECRET`, `NEXT_PUBLIC_APP_URL`, optional SSO / SMTP keys) in `README.md` with no implicit "magic" values
+- Distinguish the workflows operators actually use: host app + containerized DB (fastest hot reload), database-only, full container stack
+- Initialize the schema via `pnpm --filter govea db:push` (pre-production) or `db:migrate` (post-tenant); seed via `db:seed`; install Postgres triggers via `db:apply-triggers`
+- Persist Postgres data in a named volume so a stack restart does not wipe content; document the volume's name and the recovery procedure for the cross-tool gotcha (mixing `podman compose` with `podman-compose` lands on different volumes)
+
+## Rules
+
+- Deployment is fully configured by environment variables. No source-code edit is required to deploy a different instance
+- Required env vars (`DATABASE_URL`, `AUTH_SECRET`, `NEXT_PUBLIC_APP_URL`) are validated at boot; the process exits with a clear error if any are missing
+- Optional env vars (SSO, SMTP) cause the corresponding feature to render as not-configured rather than crash the boot
+- A fresh `db:push` followed by `db:seed` on an empty database produces a fully usable demo instance; this property is exercised by CI on every PR
+
+## Implementation Status
+
+**Shipped (v1).** Container compose helper supports Podman (preferred) and Docker (fallback). Three documented workflows (`pnpm demo:start`, `pnpm demo:db`, `pnpm demo:container`) cover host-and-DB, DB-only, and full-container deployments. Schema, trigger, and seed commands are stable and exercised by CI on every PR.
+
+Still partial: a production-grade runbook (vs the local-container quickstart). The README is good for evaluators; a dedicated production-deployment doc is open follow-up.
+
+## Links
+
+- Depends on: `cms/iam` (first-run admin bootstrap)
+- Related: `do-health-monitoring`, `do-upgrade-migration`, `ac-email-configuration`

--- a/business-architecture/capabilities/cms/deployment-operations/do-health-monitoring.md
+++ b/business-architecture/capabilities/cms/deployment-operations/do-health-monitoring.md
@@ -1,0 +1,39 @@
+# Capability: Health & Monitoring
+
+**Scope:** v1
+
+## What It Does
+
+The system must surface enough operator-facing signal that a generic uptime / log-aggregation tool can answer two questions reliably: is GovEA up, and what went wrong when it isn't. The intent is dropping GovEA into an operator's existing observability stack, not building a GovEA-specific monitoring product.
+
+## Personas
+
+- **Instance Administrator** — needs to know when GovEA stops responding without tailing logs continuously; needs structured logs to identify a fault when an alert fires
+
+## Behaviors
+
+- Expose a lightweight liveness endpoint (`/api/healthz` or equivalent) that returns 200 when the Next.js app is serving and 503 when it isn't, without taking a DB lock
+- Emit structured error logs with enough context (operation, user id, organization id, timestamp) for an operator to correlate a fault to an audit-log entry without source access
+- Distinguish recoverable warnings (e.g. SMTP not configured) from boot-blocking errors (DB unreachable) so an operator's alert rule has a clear signal to filter on
+- Write operator-relevant audit events to the platform-level audit log (`organizationId IS NULL` rows; see `/instance/audit`) so a security operator can review platform actions in one place
+
+## Rules
+
+- The health endpoint never returns sensitive data — operators integrate it with their own auth boundary
+- Structured logs never include credentials, session tokens, or personally identifiable content (a SMTP password value should never appear in a log line, even on error)
+- Operator-facing log shape is documented; consumers can rely on field names not silently changing across releases
+
+## Implementation Status
+
+**Planned — partial.** Some pieces exist: the platform audit log (`/instance/audit`) captures operator-relevant events filtered to `organizationId IS NULL`, and break-glass sessions are individually audited. What does not yet exist as a documented capability:
+
+- A dedicated `/api/healthz` endpoint
+- A documented log-shape contract for operators
+- A starter Grafana / Datadog integration runbook
+
+These are the natural follow-up slices.
+
+## Links
+
+- Depends on: `iam-audit-trail` (platform-level audit semantics)
+- Related: `do-deployment`, `do-upgrade-migration`

--- a/business-architecture/capabilities/cms/deployment-operations/do-upgrade-migration.md
+++ b/business-architecture/capabilities/cms/deployment-operations/do-upgrade-migration.md
@@ -1,0 +1,39 @@
+# Capability: Upgrade & Migration
+
+**Scope:** v1
+
+## What It Does
+
+The system must provide a documented, low-risk procedure for moving an operating GovEA instance from one supported release to the next. The intent is "upgrade is a routine 30-minute operator task," not "upgrade is a bespoke migration project." Today GovEA is pre-production and runs against `db:push` (schema-without-migration-files); this capability documents the procedure that takes over once a tenant exists whose data cannot be discarded.
+
+Cross-references upstream architecture work tracked under [#4](https://github.com/roballred/GovEA/issues/4).
+
+## Personas
+
+- **Instance Administrator** — runs the upgrade; needs the procedure to be reliable and clearly bounded so they can choose a maintenance window with confidence
+
+## Behaviors
+
+- Document the pre-production → first-tenant transition: squash the schema into `0000_initial_schema.sql`, fold `apps/govea/src/db/sql/*.sql` triggers into the migration sequence, switch CI from `db:push` to `db:migrate`. This is a one-time cutover, not a recurring upgrade
+- Per-release: ship a `MIGRATING.md` (or per-release notes) section describing breaking changes, required env-var updates, and any data-migration steps that need operator intervention
+- Provide a pre-flight check command (`pnpm db:check` or similar) that compares the current schema to the target release's expected starting point and refuses to upgrade when there is a divergence
+- The migration runner is idempotent: an interrupted upgrade can be re-run safely without manual cleanup
+- Roll-back is best-effort and explicit: every release identifies whether its migrations are forward-only or whether a documented rollback path exists. Forward-only releases require operator awareness before being applied
+
+## Rules
+
+- Schema migrations are forward-compatible during a transition window: a new GovEA version starts cleanly against the previous version's schema, runs migrations on boot or on demand, and only then assumes the new shape
+- No migration silently truncates data; any column drop is a deliberate, release-noted action with a documented backup recommendation
+- Triggers under `apps/govea/src/db/sql/` are idempotent and reapplied on every deploy — they describe the canonical post-deploy state, not a one-time apply
+- An upgrade across more than one release version is supported by running the intermediate versions in sequence, not by skipping them
+
+## Implementation Status
+
+**Planned.** Pre-production today uses `pnpm --filter govea db:push --force` and lives without migration files (see `CLAUDE.md`'s "Database Workflow" section). The hard requirements for this capability — pre-flight check, idempotent migration runner, per-release notes — do not yet exist because the cost of doing them now (pre-tenant) is wasted work.
+
+This file describes the v1 target so the work can be picked up as soon as the first real tenant lands.
+
+## Links
+
+- Depends on: `do-deployment` (the deployment machinery the upgrade procedure runs on top of)
+- Related: `do-health-monitoring`, `iam-audit-trail`

--- a/business-architecture/capabilities/cms/frontend-display/frontend-display.md
+++ b/business-architecture/capabilities/cms/frontend-display/frontend-display.md
@@ -1,5 +1,7 @@
 # Capability: Front-end Display
 
+**Scope:** v1
+
 ## What It Does
 The system must present EA content to users in a way that is clear, navigable, and useful without EA training. The authenticated experience is substantial today; optional public unauthenticated publishing remains future work.
 

--- a/business-architecture/capabilities/cms/iam/iam.md
+++ b/business-architecture/capabilities/cms/iam/iam.md
@@ -1,5 +1,7 @@
 # Capability: Identity and Access Management (IAM)
 
+**Scope:** v1
+
 ## What It Does
 The system must control who can access it, how they authenticate, and what they are permitted to do. IAM underpins every other capability — no user interaction is possible without it.
 

--- a/business-architecture/capabilities/cms/multi-org/multi-org.md
+++ b/business-architecture/capabilities/cms/multi-org/multi-org.md
@@ -1,5 +1,7 @@
 # Capability: Multi-Organization Federation
 
+**Scope:** v1
+
 ## What It Does
 The system must allow multiple organizations to connect with each other, share appropriate content across organizational boundaries, and link local EA artifacts to enterprise-wide counterparts — while preserving each organization's autonomy and keeping single-org installs simple. In the current product this is a prototype capability: connected-org visibility, approval-based cross-org links, and server-enforced ownership guardrails are shipped, while deeper management workflows and notification/history layers remain in progress.
 

--- a/business-architecture/capabilities/cms/planning/planning.md
+++ b/business-architecture/capabilities/cms/planning/planning.md
@@ -1,5 +1,7 @@
 # Capability: Planning
 
+**Scope:** v1
+
 ## What It Does
 
 The system must allow organizations to document their strategic direction, track the initiatives delivering on that direction, and visualize the relationship between strategy, initiatives, and the architecture portfolio. In the current product this is a strong early-v1 capability: demo-ready and useful, but not yet semantically uniform across every planning artifact.

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -1,5 +1,7 @@
 # Capability: Portfolio Management
 
+**Scope:** v1
+
 ## What It Does
 The system must allow contributors to maintain a structured inventory of the organization's applications, business capabilities, architecture decisions, and supporting reference content. Portfolio management is the authoring side — contributors create and update records; viewers consume them through portfolio views on the front end.
 

--- a/business-architecture/capabilities/ea/data-architecture/data-architecture.md
+++ b/business-architecture/capabilities/ea/data-architecture/data-architecture.md
@@ -1,5 +1,7 @@
 # Capability: Data Architecture
 
+**Scope:** v1
+
 ## What It Does
 
 The system must support the practice of Data Architecture as defined by the DAMA Knowledge Areas — capturing the data assets that exist in an organization, the structural model that relates them, and the layered representations (conceptual / logical / physical) that let architects, modelers, and database administrators each work at the level their role expects. The objective is to support a Data Architect and their team in a Data & Analytics organization end to end, not to ship a replacement for any dedicated modelling tool.

--- a/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
+++ b/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
@@ -1,5 +1,7 @@
 # Capability: Framework Alignment
 
+**Scope:** v1
+
 ## What It Does
 
 The system must allow organizations to align GovEA content to external architecture frameworks such as TOGAF without replacing GovEA's EasyEA-based, people-centered operating model. Framework alignment is an optional overlay: it helps trained architects produce familiar views and evidence, while preserving plain-language content for government practitioners and stakeholders.

--- a/business-architecture/capabilities/ea/integration/integration.md
+++ b/business-architecture/capabilities/ea/integration/integration.md
@@ -1,5 +1,7 @@
 # Capability: Integration
 
+**Scope:** v2
+
 ## What It Does
 
 GovEA must connect to the operational, business, and governance systems that government IT already runs — not require architects to maintain a parallel data store that diverges from reality the moment the meeting ends. The integration capability family defines how GovEA ingests, reconciles, and exchanges data with adjacent systems to keep the architecture repository grounded in what is actually deployed, funded, and running.

--- a/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
+++ b/business-architecture/capabilities/ea/repository-modelling/repository-modelling.md
@@ -1,5 +1,7 @@
 # Capability: Repository & Modelling
 
+**Scope:** v1
+
 ## What It Does
 
 The system must maintain a reliable, navigable, and self-auditing store of all architecture objects — capabilities, applications, personas, decisions, and technology — and surface the relationships, gaps, and accumulated debt within that store so that architects and decision-makers can trust what they see. In the current product, most of this group remains roadmap work beyond the existing audit trail and early coverage signals.

--- a/capabilities.md
+++ b/capabilities.md
@@ -20,6 +20,7 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 | 8 | [Repository & Modelling](#8-repository--modelling) | Partially implemented |
 | 9 | [Data Architecture](#9-data-architecture) | Partially implemented |
 | 10 | [Framework Alignment](#10-framework-alignment) | Partially implemented |
+| 11 | [Deployment & Operations](#11-deployment--operations) | Partially implemented |
 
 ---
 
@@ -237,6 +238,20 @@ Current reality: GovEA now ships the first framework-alignment slice. Applicatio
 **Design principle:** Framework support should increase credibility without increasing friction. TOGAF-aware architects should be able to recognize familiar concepts and reporting structures, while ordinary GovEA users continue working with plain-language personas, capabilities, services, applications, objectives, initiatives, principles, and decisions.
 
 Framework alignment is distinct from formal modelling notation. GovEA can map content to TOGAF concepts and produce TOGAF-friendly reports without adding mandatory ADM workflow, ArchiMate modelling, or meta-model customization.
+
+---
+
+## 11. Deployment & Operations
+
+Makes the operator-facing surface (deploy, monitor, upgrade) explicit so the cost of running GovEA is legible before deployment.
+
+| Capability | Status | Description |
+|---|---|---|
+| Deployment | Implemented | Container-based deployment with Podman or Docker, three documented workflows, env-var-only configuration |
+| Health & Monitoring | Partially implemented | Platform audit log captures operator-relevant events; dedicated `/api/healthz` endpoint and documented log shape are planned |
+| Upgrade & Migration | Not implemented | Schema transition from pre-production `db:push` to migration files lands with the first real tenant; cross-links to [#4](https://github.com/roballred/GovEA/issues/4) |
+
+Current reality: deployment is solid (the `pnpm demo:*` workflows are exercised by CI on every PR), monitoring is operator-roll-your-own, and the upgrade story is forthcoming. The group was added to close [ARB Finding #10](https://github.com/roballred/GovEA/issues/10) — making the cost of ownership visible to evaluating Central IT directors.
 
 ---
 


### PR DESCRIPTION
## Summary

Both children of [#10](https://github.com/roballred/GovEA/issues/10) (ARB Finding — Thomas Reed, Central IT Director: *\"the cost of ownership is invisible\"*). Bundled because they reinforce each other — the new group benefits from the Scope field, and the field is most useful on a group like deployment-operations whose contents are at different release-readiness.

## #510 — Scope field

- **[STYLE.md](business-architecture/STYLE.md)** documents the convention: \`**Scope:** v1 | v2 | out of scope\` immediately under the H1, before \`## What It Does\`. \`out of scope\` requires an inline rationale; silent declarations are not allowed.
- **Backfilled on all 11 group parent files** (7 CMS, 4 EA). 10 are \`v1\`; \`integration\` is \`v2\` (Planned per its own Implementation Status).
- **Lint enforcement deferred** — backfill is a content decision, not yet a structural requirement. If enforcement lands later it applies to group parents first.
- **Leaf-level backfill** explicitly deferred per the issue's allowance (\"may opt to scope to group parents only and file a follow-up\"). Sub-capability files inherit their parent's scope unless they meaningfully deviate.

## #511 — Deployment & Operations capability group

New \`business-architecture/capabilities/cms/deployment-operations/\` with parent + 3 leaves:

| File | Scope | Status | Covers |
|---|---|---|---|
| [deployment-operations.md](business-architecture/capabilities/cms/deployment-operations/deployment-operations.md) | v1 | — | Group parent: success criteria, rules, what's in and out of scope for operating GovEA |
| [do-deployment.md](business-architecture/capabilities/cms/deployment-operations/do-deployment.md) | v1 | Shipped (v1) | Container-based deploy, env-var configuration, three \`pnpm demo:*\` workflows |
| [do-health-monitoring.md](business-architecture/capabilities/cms/deployment-operations/do-health-monitoring.md) | v1 | Partial | Platform audit log captures operator events; \`/api/healthz\` + log-shape contract are planned |
| [do-upgrade-migration.md](business-architecture/capabilities/cms/deployment-operations/do-upgrade-migration.md) | v1 | Planned | Schema transition from pre-prod \`db:push\` to migrations once a tenant exists; cross-links to [#4](https://github.com/roballred/GovEA/issues/4) |

**[README.md](./README.md)** gained a *\"What does it take to run this?\"* subsection inside the existing \"Cost & Why Not an Existing Tool\" — a five-row table covering deployment / configuration / monitoring / upgrades / admin time, each linking to the matching capability doc.

**[capabilities.md](./capabilities.md)** gained section 11 (Deployment & Operations) in the main inventory.

## Test plan

- [x] \`docs-lint\` passes (106 files; was 102 before — +4 new files)
- [x] All Scope: lines are syntactically valid per the new STYLE.md rule (10× v1, 1× v2, 4× v1 on the new files)
- [x] No DB or code change; pure documentation slice

## Capability traceability

Capability: \`governance/standards\` (#510); \`cms-deployment-operations\` (#511)
Persona: instance-administrator (primary), department-director, elected-official, enterprise-architect
Closes #510, #511

Partial close of parent #10 — both sub-issues land here; the parent can close once you confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)