### PR TITLE
fix(taxonomy): drop blank / non-UUID term IDs before insert (#631)

### DIFF
--- a/apps/govea/src/lib/entity-taxonomy-helpers.ts
+++ b/apps/govea/src/lib/entity-taxonomy-helpers.ts
@@ -114,6 +114,20 @@ export async function getEntityTaxonomyValues(organizationId: string, entityType
  * Pass the caller's transaction handle as `tx` so this helper participates in
  * the same transaction as the surrounding mutation and audit write (#416).
  */
+// Optional single-select taxonomy fields render an empty `<option value="">`
+// for the "— None —" case. When the form submits, `formData.getAll(...)` for
+// that field includes an empty string. Without filtering, the empty string
+// reaches the DB as a `uuid` column value and Postgres throws
+// `invalid input syntax for type uuid: ""` (#631). Also defends against
+// whitespace-only values in case of caller-side trimming bugs.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function sanitizeTaxonomyTermIds(termIds: string[]): string[] {
+  return termIds
+    .map(id => id.trim())
+    .filter(id => UUID_REGEX.test(id))
+}
+
 export async function syncEntityTaxonomyValues(
   tx: DBOrTx,
   organizationId: string,
@@ -128,9 +142,10 @@ export async function syncEntityTaxonomyValues(
       eq(entityTaxonomyValues.entityId, entityId),
     ))
 
-  if (termIds.length > 0) {
+  const validTermIds = sanitizeTaxonomyTermIds(termIds)
+  if (validTermIds.length > 0) {
     await tx.insert(entityTaxonomyValues).values(
-      termIds.map(termId => ({
+      validTermIds.map(termId => ({
         organizationId,
         entityType,
         entityId,

--- a/apps/govea/tests/integration/taxonomy-blank-value.test.ts
+++ b/apps/govea/tests/integration/taxonomy-blank-value.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests: syncEntityTaxonomyValues drops blank / malformed term IDs (#631)
+ *
+ * Production bug: Application save crashed with
+ *   `invalid input syntax for type uuid: ""`
+ * because optional single-select taxonomy fields submit `taxonomyTermIds=""`
+ * (the "— None —" option's value) and the helper inserted the empty string
+ * straight into the `uuid` column. Fix lives in `syncEntityTaxonomyValues` so
+ * every entity type that uses optional taxonomy benefits.
+ *
+ * Capability: cm-taxonomy-management
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  taxonomyTerms, entityTaxonomyValues, applications,
+} from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import {
+  sanitizeTaxonomyTermIds,
+  syncEntityTaxonomyValues,
+} from '@/lib/entity-taxonomy-helpers'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+const VALID_UUID = '11111111-2222-3333-4444-555555555555'
+const ANOTHER_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+describe('sanitizeTaxonomyTermIds (#631)', () => {
+  it('drops empty strings', () => {
+    expect(sanitizeTaxonomyTermIds([''])).toEqual([])
+    expect(sanitizeTaxonomyTermIds([VALID_UUID, ''])).toEqual([VALID_UUID])
+  })
+
+  it('drops whitespace-only values', () => {
+    expect(sanitizeTaxonomyTermIds(['   ', VALID_UUID])).toEqual([VALID_UUID])
+  })
+
+  it('trims surrounding whitespace on valid UUIDs', () => {
+    expect(sanitizeTaxonomyTermIds([`  ${VALID_UUID}  `])).toEqual([VALID_UUID])
+  })
+
+  it('drops malformed values that are not UUIDs', () => {
+    expect(sanitizeTaxonomyTermIds(['not-a-uuid', VALID_UUID])).toEqual([VALID_UUID])
+    expect(sanitizeTaxonomyTermIds(['12345', '', VALID_UUID, ''])).toEqual([VALID_UUID])
+  })
+
+  it('preserves all valid UUIDs and their order', () => {
+    expect(sanitizeTaxonomyTermIds([VALID_UUID, ANOTHER_UUID])).toEqual([VALID_UUID, ANOTHER_UUID])
+  })
+
+  it('accepts upper-case UUIDs (case-insensitive)', () => {
+    expect(sanitizeTaxonomyTermIds([VALID_UUID.toUpperCase()])).toEqual([VALID_UUID.toUpperCase()])
+  })
+
+  it('handles an empty input array', () => {
+    expect(sanitizeTaxonomyTermIds([])).toEqual([])
+  })
+
+  it('handles input that is entirely blank', () => {
+    expect(sanitizeTaxonomyTermIds(['', '   ', ''])).toEqual([])
+  })
+})
+
+describe('syncEntityTaxonomyValues (#631 integration)', () => {
+  let orgId: string
+  let applicationId: string
+  let termIdA: string
+  let termIdB: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+
+    // Seed one application to attach taxonomy rows to.
+    const [app] = await db.insert(applications).values({
+      id: randomUUID(),
+      organizationId: orgId,
+      name: 'Test App for #631',
+    }).returning()
+    applicationId = app.id
+
+    // Seed two taxonomy terms so we have real UUIDs to verify round-trip
+    // behaviour. The FK on entity_taxonomy_values.taxonomy_term_id refuses
+    // arbitrary UUIDs, so the test must reference actual term rows.
+    const [t1, t2] = await Promise.all([
+      db.insert(taxonomyTerms).values({
+        id: randomUUID(),
+        organizationId: orgId,
+        name: 'Test Tier 1',
+        slug: 'test-tier-1',
+      }).returning().then(rows => rows[0]),
+      db.insert(taxonomyTerms).values({
+        id: randomUUID(),
+        organizationId: orgId,
+        name: 'Test Tier 2',
+        slug: 'test-tier-2',
+      }).returning().then(rows => rows[0]),
+    ])
+    termIdA = t1.id
+    termIdB = t2.id
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  async function readTermsFor(entityId: string): Promise<string[]> {
+    const rows = await db.select().from(entityTaxonomyValues).where(
+      and(
+        eq(entityTaxonomyValues.organizationId, orgId),
+        eq(entityTaxonomyValues.entityType, 'application'),
+        eq(entityTaxonomyValues.entityId, entityId),
+      ),
+    )
+    return rows.map(r => r.taxonomyTermId).sort()
+  }
+
+  it('accepts a fully-empty term list (the "no taxonomy selected" case) without throwing', async () => {
+    await expect(
+      db.transaction(tx => syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, [])),
+    ).resolves.not.toThrow()
+    expect(await readTermsFor(applicationId)).toEqual([])
+  })
+
+  it('accepts a list containing only blank strings without throwing (#631 reproducer)', async () => {
+    // This is the literal payload Application edit was sending. Pre-fix this
+    // threw `invalid input syntax for type uuid: ""`.
+    await expect(
+      db.transaction(tx => syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, [''])),
+    ).resolves.not.toThrow()
+    expect(await readTermsFor(applicationId)).toEqual([])
+  })
+
+  it('inserts valid term IDs and skips blanks in the same call', async () => {
+    await db.transaction(tx =>
+      syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, ['', termIdA, '', termIdB]),
+    )
+    expect(await readTermsFor(applicationId)).toEqual([termIdA, termIdB].sort())
+  })
+
+  it('replaces existing rows on subsequent calls — including replace-with-empty', async () => {
+    // After the previous test, the entity carries two term rows. Replacing
+    // with [''] should clear them and not crash.
+    await db.transaction(tx =>
+      syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, ['']),
+    )
+    expect(await readTermsFor(applicationId)).toEqual([])
+  })
+
+  it('drops malformed (non-UUID) inputs without throwing', async () => {
+    await db.transaction(tx =>
+      syncEntityTaxonomyValues(tx, orgId, 'application', applicationId, ['not-a-uuid', termIdA]),
+    )
+    expect(await readTermsFor(applicationId)).toEqual([termIdA])
+  })
+})


### PR DESCRIPTION
## Summary

Production crash captured in Azure demo logs:

\`\`\`
invalid input syntax for type uuid: ""
\`\`\`

Last seen \`2026-05-22T20:35:05Z\` on revision \`govea-dev--0000093\`, digest \`2626942351\`. Reproduced by saving any entity with an optional single-select taxonomy field left at the \`— None —\` option.

## Root cause

\`TaxonomyInputs\` renders the \"none\" option as \`<option value=\"\">\`. When the form submits, \`formData.getAll('taxonomyTermIds')\` returns \`[\"\"]\`. The string flows through the calling action into \`syncEntityTaxonomyValues\`, which inserts it directly into the \`uuid\` column \`taxonomy_term_id\` — and Postgres rejects the empty string at the parser.

## Fix

A new \`sanitizeTaxonomyTermIds(termIds)\` helper in \`@/lib/entity-taxonomy-helpers\` that:

1. Trims surrounding whitespace
2. Keeps only well-formed UUIDs (matched against the standard 8-4-4-4-12 hex pattern, case-insensitive)

\`syncEntityTaxonomyValues\` calls it before inserting. Doing the filter in the shared helper means **every entity type benefits** — applications, capabilities, personas, ADRs, initiatives, objectives, services, value streams, principles, glossary, debt, and data-architecture objects — not just the application action that surfaced the crash.

## Test plan

13 new tests in \`tests/integration/taxonomy-blank-value.test.ts\` (all passing locally in 96 ms):

**\`sanitizeTaxonomyTermIds\` (8 unit-style cases against the pure function):**
- empty strings dropped
- whitespace-only values dropped
- surrounding whitespace trimmed on valid UUIDs
- malformed (non-UUID) strings dropped
- valid UUIDs preserved with order intact
- upper-case UUIDs accepted (case-insensitive)
- empty input array
- entirely-blank input array

**\`syncEntityTaxonomyValues\` (5 DB-backed integration cases):**
- empty list (the \"no taxonomy selected\" baseline)
- list with only blank strings (**the #631 reproducer** — pre-fix this was the failing path)
- valid IDs + blanks in the same call (blanks dropped, valid IDs inserted)
- replace-with-blank clears existing rows
- malformed non-UUID inputs dropped

Regression check: existing taxonomy and import suites still pass (\`entity-taxonomy-helpers\`, \`taxonomy-dedup\`, \`capabilities-import\` — 18 tests across the three).

\`tsc --noEmit\` clean.

## Acceptance criteria from the issue

- [x] Creating an application with optional single-select taxonomy left blank succeeds
- [x] Editing an application and setting optional single-select taxonomy to \"None\" succeeds and clears the taxonomy value
- [x] \`syncEntityTaxonomyValues\` does not attempt to insert empty strings
- [x] Regression coverage exists for blank taxonomy term IDs
- [x] Once deployed, demo logs should no longer show digest \`2626942351\` for this path (the parser-side error case is structurally unreachable)

## Capability traceability

Capability: \`cm-taxonomy-management\`
Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)