### PR TITLE
chore(quick-wins): persona-type cascade + capability dialog cleanup + reverse seed (closes #49, #366, #543)

### DIFF
--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { taxonomyTerms, principles, entityTaxonomyDefinitions } from '@/db/schema'
+import { taxonomyTerms, principles, entityTaxonomyDefinitions, personas } from '@/db/schema'
 import { eq, and, isNull, inArray, count } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -239,7 +239,49 @@ export async function deleteTaxonomyTerm(termId: string) {
     }
   }
 
+  // ── Persona-type cascade (#49) ──────────────────────────────────────────
+  // personas.type stores the taxonomy term NAME as plain text (no FK), same
+  // pattern as principles.principleType. Unlike principles (which BLOCKS the
+  // delete when in use), the persona-type design is cascade-to-null so the
+  // type is removed and the persona itself is preserved. Computed inside the
+  // transaction below so the rename + audit stay atomic.
+  let cascadeNullForNames: string[] = []
+  if (existing) {
+    if (existing.parentId !== null) {
+      // Deleting a value — check if its parent is "Persona Type"
+      const parent = await db.query.taxonomyTerms.findFirst({
+        where: eq(taxonomyTerms.id, existing.parentId),
+      })
+      if (parent?.slug === 'persona-type') {
+        cascadeNullForNames = [existing.name]
+      }
+    } else if (existing.slug === 'persona-type') {
+      // Deleting the "Persona Type" parent — cascade every child's name
+      const children = await db.query.taxonomyTerms.findMany({
+        where: and(eq(taxonomyTerms.parentId, termId), eq(taxonomyTerms.organizationId, orgId)),
+        columns: { name: true },
+      })
+      cascadeNullForNames = children.map(c => c.name)
+    }
+  }
+
   await db.transaction(async (tx) => {
+    // Persona-type cascade: null out personas.type for affected names BEFORE
+    // deleting the taxonomy rows. We use IN(...) so the cascade for "Persona
+    // Type" parent deletes hits every child in a single statement. Capture
+    // the affected count for the audit log so the cascade is visible.
+    let personasNulledCount = 0
+    if (cascadeNullForNames.length > 0) {
+      const updated = await tx.update(personas)
+        .set({ type: null, updatedAt: new Date() })
+        .where(and(
+          eq(personas.organizationId, orgId),
+          inArray(personas.type, cascadeNullForNames),
+        ))
+        .returning({ id: personas.id })
+      personasNulledCount = updated.length
+    }
+
     // When deleting a type, also delete its values (not promote — orphaned values are useless)
     // When deleting a value, just delete it
     if (existing?.parentId === null) {
@@ -257,6 +299,14 @@ export async function deleteTaxonomyTerm(termId: string) {
       userId: session.user.id,
       organizationId: orgId,
       before: { name: existing?.name },
+      // #49 — record the cascade so an audit reader can see the persona impact
+      metadata: cascadeNullForNames.length > 0
+        ? {
+            cascade: 'personas.type → null',
+            affectedNames: cascadeNullForNames,
+            personasNulledCount,
+          }
+        : undefined,
     })
   })
 }

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -510,20 +510,9 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
             />
             <MarkdownEditor label="Behaviors" name="behaviors" id="create-behaviors" rows={4} placeholder="Markdown supported — use - bullets, **bold**, etc." />
             <MarkdownEditor label="Rules" name="rules" id="create-rules" rows={3} placeholder="Markdown supported — use - bullets, **bold**, etc." />
-            <div className="space-y-1.5">
-              <Label>Personas</Label>
-              <div className="rounded-md border border-input bg-transparent px-3 py-2 max-h-36 overflow-y-auto space-y-1">
-                {personas.length === 0
-                  ? <p className="text-sm text-muted-foreground">No personas yet.</p>
-                  : personas.map(p => (
-                    <label key={p.id} className="flex items-center gap-2 text-sm cursor-pointer">
-                      <input type="checkbox" name="personaIds" value={p.id} className="rounded" />
-                      {p.name}
-                    </label>
-                  ))
-                }
-              </div>
-            </div>
+            {/* #366 — persona links are managed live from the detail page's
+                RelationshipPanel, not bulk-replaced on save here. Keeps the
+                create / edit dialogs to scalar fields only. */}
             <TaxonomyInputs defs={taxonomyDefinitions} currentValues={[]} />
             <div className="space-y-1.5">
               <Label>Status</Label>
@@ -586,26 +575,15 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
             />
             <MarkdownEditor label="Behaviors" name="behaviors" id="edit-behaviors" rows={4} defaultValue={editTarget?.behaviors ?? ''} placeholder="Markdown supported — use - bullets, **bold**, etc." />
             <MarkdownEditor label="Rules" name="rules" id="edit-rules" rows={3} defaultValue={editTarget?.rules ?? ''} placeholder="Markdown supported — use - bullets, **bold**, etc." />
-            <div className="space-y-1.5">
-              <Label>Personas</Label>
-              <div className="rounded-md border border-input bg-transparent px-3 py-2 max-h-36 overflow-y-auto space-y-1">
-                {personas.length === 0
-                  ? <p className="text-sm text-muted-foreground">No personas yet.</p>
-                  : personas.map(p => (
-                    <label key={p.id} className="flex items-center gap-2 text-sm cursor-pointer">
-                      <input
-                        type="checkbox"
-                        name="personaIds"
-                        value={p.id}
-                        defaultChecked={editTarget?.capabilityPersonas.some(cp => cp.persona.id === p.id)}
-                        className="rounded"
-                      />
-                      {p.name}
-                    </label>
-                  ))
-                }
-              </div>
-            </div>
+            {/* #366 — persona links are managed live from the detail page's
+                RelationshipPanel. The bulk checkbox path is removed; the
+                existing persona ids are preserved as hidden inputs so the
+                edit action's replace-on-save semantics don't silently drop
+                them. Same pattern the inline edit button (capability-edit-
+                button.tsx) uses. */}
+            {editTarget?.capabilityPersonas.map(cp => (
+              <input key={cp.persona.id} type="hidden" name="personaIds" value={cp.persona.id} />
+            ))}
             <TaxonomyInputs
               defs={taxonomyDefinitions}
               currentValues={taxonomyValueMap[editTarget?.id ?? ''] ?? []}

--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -1749,6 +1749,10 @@ export const DEV_DATA_ATTRIBUTE_SHARES = [
 
 // ─── Cross-org links ──────────────────────────────────────────────────────────
 
+// Riverdale (source) → ODS (target). Exercises the OUTBOUND request and
+// awaiting-target-approval flow from the source persona's perspective
+// (Riverdale's Agency EA Coordinator sees "pending the target org's approval"
+// in the federation activity panel).
 export const DEV_CROSS_ORG_LINKS = [
   {
     sourceCapabilityName: 'Digital Identity & Authentication',
@@ -1764,6 +1768,30 @@ export const DEV_CROSS_ORG_LINKS = [
     sourceCapabilityName: 'Budget Reporting',
     targetCapabilityName: 'State Grants Management',
     linkType: 'maps_to' as const,
+  },
+]
+
+// ODS (source) → Riverdale (target). #543 — adds the reverse direction so
+// the Agency EA Coordinator persona at Riverdale (Alice) can exercise the
+// INBOUND-approval flow that mo-connection-approval.md describes. Without
+// these, the "Awaiting your approval" branch in cross-org-links-panel.tsx
+// is unreachable in the dev seed.
+//
+// Picked believable scenarios: the state's identity service implements a
+// city-level entitlement check (state extends down into city's licensing
+// flow), and the state's open-data feed pulls service-request data from the
+// city. Both target Riverdale capabilities Alice owns and lands as
+// `status: 'pending'` so they appear in her approval queue.
+export const STATE_INBOUND_CROSS_ORG_LINKS = [
+  {
+    sourceCapabilityName: 'Statewide Identity Verification', // ODS
+    targetCapabilityName: 'Business License Management',     // Riverdale
+    linkType: 'implements' as const,
+  },
+  {
+    sourceCapabilityName: 'Open Data Platform',              // ODS
+    targetCapabilityName: 'Service Request Management',      // Riverdale
+    linkType: 'extends' as const,
   },
 ]
 

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -11,7 +11,7 @@ import {
   DEV_DATA_ENTITIES, DEV_DATA_ATTRIBUTES, DEV_DATA_LINKS, DEV_DATA_BUSINESS_KEYS,
   DEV_DATA_ENTITY_RELATIONS, DEV_DATA_ATTRIBUTE_SHARES,
   STATE_PERSONAS, STATE_CAPABILITIES, STATE_APPLICATIONS,
-  DEV_CROSS_ORG_LINKS,
+  DEV_CROSS_ORG_LINKS, STATE_INBOUND_CROSS_ORG_LINKS,
   GOVEA_PROJECT_ORG, GOVEA_PROJECT_USERS,
   GOVEA_PROJECT_PERSONAS, GOVEA_PROJECT_CAPABILITIES, GOVEA_PROJECT_APPLICATIONS,
   GOVEA_PROJECT_VALUE_STREAMS, GOVEA_PROJECT_OBJECTIVES, GOVEA_PROJECT_INITIATIVES,
@@ -1571,6 +1571,48 @@ async function seed() {
         .where(eq(crossOrgLinks.id, existingLink.id))
     }
     console.log(`  ✓ Cross-org link (${link.linkType}): "${link.sourceCapabilityName}" → "${link.targetCapabilityName}"`)
+  }
+
+  // ── Reverse-direction cross-org links (#543) ──────────────────────────────
+  // The links above are all Riverdale → ODS, leaving Alice (Agency EA
+  // Coordinator at Riverdale) with zero inbound requests to approve in the
+  // seed. The "Awaiting your approval" branch in cross-org-links-panel.tsx
+  // was unreachable. Seed the reverse direction so the inbound-approval flow
+  // is exercisable end-to-end in the dev demo.
+
+  const existingReverseConnection = await db.query.orgConnections.findFirst({
+    where: (t, { eq: e, and }) => and(e(t.fromOrgId, stateOrgId), e(t.toOrgId, devOrgId)),
+  })
+  if (!existingReverseConnection) {
+    await db.insert(orgConnections).values({ fromOrgId: stateOrgId, toOrgId: devOrgId, status: 'active' })
+  }
+  console.log('  ✓ Reverse org connection (active): Office of Digital Services → City of Riverdale')
+
+  for (const link of STATE_INBOUND_CROSS_ORG_LINKS) {
+    const sourceCapId = stateCapabilityIds[link.sourceCapabilityName]
+    const targetCapId = devCapabilityIds[link.targetCapabilityName]
+    if (!sourceCapId || !targetCapId) continue
+
+    const existingLink = await db.query.crossOrgLinks.findFirst({
+      where: (t, { eq: e, and }) => and(e(t.sourceEntityId, sourceCapId), e(t.targetEntityId, targetCapId)),
+    })
+    if (!existingLink) {
+      await db.insert(crossOrgLinks).values({
+        sourceOrgId: stateOrgId,
+        sourceEntityType: 'capability',
+        sourceEntityId: sourceCapId,
+        targetOrgId: devOrgId,
+        targetEntityType: 'capability',
+        targetEntityId: targetCapId,
+        linkType: link.linkType,
+        status: 'pending',
+      })
+    } else if (existingLink.status !== 'pending' || existingLink.linkType !== link.linkType) {
+      await db.update(crossOrgLinks)
+        .set({ status: 'pending', linkType: link.linkType })
+        .where(eq(crossOrgLinks.id, existingLink.id))
+    }
+    console.log(`  ✓ Inbound cross-org link (${link.linkType}): "${link.sourceCapabilityName}" → "${link.targetCapabilityName}" [Riverdale-side awaits approval]`)
   }
 
   // ── Org 5: City of Hartfield (TOGAF overlay demo) ───────────────────────

--- a/apps/govea/tests/integration/persona-type-cascade.test.ts
+++ b/apps/govea/tests/integration/persona-type-cascade.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression: deleteTaxonomyTerm cascades to personas.type (#49)
+ *
+ * personas.type stores the taxonomy term NAME as plain text (no FK). Deleting
+ * a persona-type value or its "Persona Type" parent should clear personas.type
+ * to NULL for matching rows in the same org so the table and type filter
+ * don't display orphan strings. Audit log captures the cascade.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { personas, taxonomyTerms, auditLog } from '@/db/schema'
+import { and, eq, desc } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
+import { deleteTaxonomyTerm } from '@/actions/taxonomy'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+const mockRevalidate = vi.hoisted(() => vi.fn())
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidate }))
+
+async function seedPersonaTypeRoot(orgId: string): Promise<string> {
+  const [row] = await db.insert(taxonomyTerms).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    name: 'Persona Type',
+    slug: 'persona-type',
+    parentId: null,
+  }).returning()
+  return row.id
+}
+
+async function seedPersonaTypeChild(orgId: string, parentId: string, name: string): Promise<{ id: string; name: string }> {
+  const [row] = await db.insert(taxonomyTerms).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    parentId,
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, '-'),
+  }).returning()
+  return { id: row.id, name: row.name }
+}
+
+async function seedPersona(orgId: string, name: string, type: string | null) {
+  const [row] = await db.insert(personas).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    name,
+    type,
+  }).returning()
+  return row
+}
+
+describe('deleteTaxonomyTerm — persona-type cascade (#49)', () => {
+  let orgId: string
+  let admin: TestUser
+  let otherOrgId: string
+
+  beforeAll(async () => {
+    orgId = (await createTestOrg()).id
+    otherOrgId = (await createTestOrg()).id
+    admin = await createTestUser(orgId, 'admin')
+    mockAuth.mockResolvedValue(makeSession(admin))
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgId)
+    await cleanupOrg(otherOrgId)
+  })
+
+  it('nulls personas.type when the matching type VALUE is deleted', async () => {
+    const root = await seedPersonaTypeRoot(orgId)
+    const staff = await seedPersonaTypeChild(orgId, root, 'Staff')
+    const resident = await seedPersonaTypeChild(orgId, root, 'Resident')
+
+    const alice = await seedPersona(orgId, 'Alice', staff.name)
+    const bob = await seedPersona(orgId, 'Bob', staff.name)
+    const carol = await seedPersona(orgId, 'Carol', resident.name)
+
+    await deleteTaxonomyTerm(staff.id)
+
+    const [aliceRow, bobRow, carolRow] = await Promise.all([
+      db.query.personas.findFirst({ where: eq(personas.id, alice.id) }),
+      db.query.personas.findFirst({ where: eq(personas.id, bob.id) }),
+      db.query.personas.findFirst({ where: eq(personas.id, carol.id) }),
+    ])
+
+    expect(aliceRow?.type).toBeNull()
+    expect(bobRow?.type).toBeNull()
+    // Untouched — only the deleted type's name was nulled
+    expect(carolRow?.type).toBe('Resident')
+  })
+
+  it('does not touch personas in a different org with the same type name', async () => {
+    // Same name in a different org — must not be affected
+    const otherRoot = await seedPersonaTypeRoot(otherOrgId)
+    const otherStaff = await seedPersonaTypeChild(otherOrgId, otherRoot, 'OtherOrgStaff')
+    const isolated = await seedPersona(otherOrgId, 'Isolated', otherStaff.name)
+
+    // Also create the same-named type in orgId so we can delete it
+    const root = await db.query.taxonomyTerms.findFirst({
+      where: and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.slug, 'persona-type')),
+    })
+    const sameName = await seedPersonaTypeChild(orgId, root!.id, 'OtherOrgStaff')
+    const sameNameUser = await seedPersona(orgId, 'SameName', sameName.name)
+
+    await deleteTaxonomyTerm(sameName.id)
+
+    const [isolatedRow, sameNameRow] = await Promise.all([
+      db.query.personas.findFirst({ where: eq(personas.id, isolated.id) }),
+      db.query.personas.findFirst({ where: eq(personas.id, sameNameUser.id) }),
+    ])
+
+    expect(isolatedRow?.type).toBe('OtherOrgStaff')  // untouched (different org)
+    expect(sameNameRow?.type).toBeNull()             // cascaded (same org)
+  })
+
+  it('nulls every matching persona when the "Persona Type" PARENT is deleted', async () => {
+    // Fresh org so the parent isn't shared with the previous test
+    const localOrgId = (await createTestOrg()).id
+    const localAdmin = await createTestUser(localOrgId, 'admin')
+    mockAuth.mockResolvedValue(makeSession(localAdmin))
+
+    const root = await seedPersonaTypeRoot(localOrgId)
+    const staff = await seedPersonaTypeChild(localOrgId, root, 'Staff')
+    const resident = await seedPersonaTypeChild(localOrgId, root, 'Resident')
+    const vendor = await seedPersonaTypeChild(localOrgId, root, 'Vendor')
+
+    const p1 = await seedPersona(localOrgId, 'P1', staff.name)
+    const p2 = await seedPersona(localOrgId, 'P2', resident.name)
+    const p3 = await seedPersona(localOrgId, 'P3', vendor.name)
+    const p4 = await seedPersona(localOrgId, 'P4', null)  // already null
+
+    await deleteTaxonomyTerm(root)
+
+    const rows = await db.select().from(personas).where(eq(personas.organizationId, localOrgId))
+    for (const p of rows) {
+      expect(p.type, `${p.name} should have null type after parent delete`).toBeNull()
+    }
+    expect(rows.find(r => r.id === p1.id)).toBeDefined()
+    expect(rows.find(r => r.id === p4.id)).toBeDefined()
+    // Avoid unused-var lint complaints
+    void p2; void p3
+
+    // All three child terms must also be gone
+    const remainingChildren = await db.select().from(taxonomyTerms).where(
+      and(eq(taxonomyTerms.organizationId, localOrgId), eq(taxonomyTerms.parentId, root)),
+    )
+    expect(remainingChildren).toHaveLength(0)
+
+    await cleanupOrg(localOrgId)
+    mockAuth.mockResolvedValue(makeSession(admin))
+  })
+
+  it('does NOT cascade when the deleted term is unrelated to "Persona Type"', async () => {
+    const localOrgId = (await createTestOrg()).id
+    const localAdmin = await createTestUser(localOrgId, 'admin')
+    mockAuth.mockResolvedValue(makeSession(localAdmin))
+
+    // Seed an unrelated taxonomy type (parent slug != persona-type) and a
+    // persona whose type happens to match the child's NAME by coincidence.
+    const [unrelatedRoot] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: localOrgId,
+      name: 'Application Tier', slug: 'application-tier', parentId: null,
+    }).returning()
+    const [tier1] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: localOrgId,
+      parentId: unrelatedRoot.id, name: 'Tier 1', slug: 'tier-1',
+    }).returning()
+
+    const survivor = await seedPersona(localOrgId, 'NameCollision', tier1.name)
+
+    await deleteTaxonomyTerm(tier1.id)
+
+    const after = await db.query.personas.findFirst({ where: eq(personas.id, survivor.id) })
+    expect(after?.type).toBe('Tier 1')  // untouched — wrong parent
+
+    await cleanupOrg(localOrgId)
+    mockAuth.mockResolvedValue(makeSession(admin))
+  })
+
+  it('writes the cascade detail to the audit log', async () => {
+    const localOrgId = (await createTestOrg()).id
+    const localAdmin = await createTestUser(localOrgId, 'admin')
+    mockAuth.mockResolvedValue(makeSession(localAdmin))
+
+    const root = await seedPersonaTypeRoot(localOrgId)
+    const staff = await seedPersonaTypeChild(localOrgId, root, 'Staff')
+    await seedPersona(localOrgId, 'A', staff.name)
+    await seedPersona(localOrgId, 'B', staff.name)
+
+    await deleteTaxonomyTerm(staff.id)
+
+    const [latest] = await db.select()
+      .from(auditLog)
+      .where(and(eq(auditLog.organizationId, localOrgId), eq(auditLog.action, 'taxonomy.delete')))
+      .orderBy(desc(auditLog.createdAt))
+      .limit(1)
+
+    expect(latest).toBeDefined()
+    expect(latest.metadata).toMatchObject({
+      cascade: 'personas.type → null',
+      affectedNames: ['Staff'],
+      personasNulledCount: 2,
+    })
+
+    await cleanupOrg(localOrgId)
+    mockAuth.mockResolvedValue(makeSession(admin))
+  })
+})


### PR DESCRIPTION
## Summary

Three small persona-walk follow-ups bundled. Each is well-scoped and independent; together they take ~30 minutes of review.

## #49 — clear persona type field when type is deleted

**Production gap.** Deleting a persona-type taxonomy value (e.g. *Staff*) left every persona row with \`type = 'Staff'\` carrying an orphan string. The type vanished from the type selector but kept showing up in the list table and the filter dropdown.

**Fix** in \`deleteTaxonomyTerm\` (\`apps/govea/src/actions/taxonomy.ts\`): before deleting the term row, detect whether it's a value (or parent) of the \"Persona Type\" taxonomy and cascade \`personas.type → NULL\` for every matching row in the same org. Runs in the same transaction as the delete so the cascade and the delete stay atomic. Audit log gains a \`metadata\` block recording the cascade details (\`affectedNames\`, \`personasNulledCount\`) so the impact is visible in \`/audit\`.

Org isolation preserved: same-named types in different orgs do not affect each other.

## #366 — remove persona checkboxes from capability list table edit dialog

The capability list-table dialog rendered persona checkboxes and the action did a **bulk replace** of \`capability_personas\` on save. The detail-page \`RelationshipPanel\` manages personas live with immediate saves. Two paths, same relationship, different semantics — contributors editing from the list could silently drop persona links by not re-ticking checkboxes after another contributor added one.

**Fix:** drop the checkbox blocks from both create and edit dialogs in \`capability-table.tsx\`. The edit dialog preserves existing persona ids as **hidden inputs** (same pattern \`capability-edit-button.tsx\` already uses) so the action's replace-on-save still sees the current set and the links are not dropped. Persona link management now flows exclusively through the detail page's \`RelationshipPanel\`.

## #543 — seed reverse-direction cross-org links

The dev seed defined three cross-org links — all Riverdale → ODS. The \"Awaiting your approval\" panel in \`cross-org-links-panel.tsx\` was unreachable for Alice (Agency EA Coordinator at Riverdale): she had 3 outbound and 0 inbound. The audit could not exercise the inbound-approval flow.

**Fix:** \`STATE_INBOUND_CROSS_ORG_LINKS\` adds two reverse-direction entries (ODS as source, Riverdale capability as target), plus a reverse org connection so the federation substrate is symmetric. Both land as \`status: 'pending'\` and appear in Alice's inbound queue.

Smoke-tested: after re-seeding the dev DB, direct \`psql\` query confirms 5 cross-org links (3 Riverdale-sourced + 2 ODS-sourced).

```
         source_org         | link_type  | status
----------------------------+------------+---------
 City of Riverdale          | extends    | pending
 City of Riverdale          | maps_to    | pending
 City of Riverdale          | implements | pending
 Office of Digital Services | implements | pending  ← new
 Office of Digital Services | extends    | pending  ← new
```

No app code change for #543; seed only.

## Test plan

- [x] **5 new integration tests** in \`tests/integration/persona-type-cascade.test.ts\` (583 ms):
  - cascade on value delete
  - org isolation (same name in another org untouched)
  - cascade on \"Persona Type\" parent delete (nulls every child)
  - non-cascade for unrelated taxonomy parent (e.g. \"Application Tier / Tier 1\" stays put)
  - audit log records cascade \`metadata\`
- [x] **Regression**: existing \`taxonomy-dedup\` (5) and \`entity-taxonomy-helpers\` (2) still pass
- [x] **Seed smoke-test** confirms reverse-direction links land with correct shape
- [x] \`tsc --noEmit\` clean

## Capability traceability

Capability: \`cms/iam\` (taxonomy admin); \`cms/multi-org\` (cross-org seed); \`cms/portfolio\` (capability list edit dialog)
Persona: cms-administrator (#49 / #366); agency-ea-coordinator (#543)
Closes #49, #366, #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)