### PR TITLE
feat(enterprise-view): capability adoption + duplicate-candidate reports (#537, #538)

### DIFF
--- a/apps/govea/src/app/(admin)/reports/enterprise-adoption/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/enterprise-adoption/page.tsx
@@ -74,7 +74,7 @@ export default async function EnterpriseAdoptionReport() {
 
       {report.publishedCount === 0 ? (
         <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
-          Your organization has no <code className="rounded bg-muted px-1">instance</code>-visibility capabilities yet. Set a capability's visibility to <em>Instance-wide</em> for it to show up here.
+          Your organization has no <code className="rounded bg-muted px-1">instance</code>-visibility capabilities yet. Set a capability&apos;s visibility to <em>Instance-wide</em> for it to show up here.
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/govea/src/app/(admin)/reports/enterprise-adoption/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/enterprise-adoption/page.tsx
@@ -1,0 +1,125 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getCapabilityAdoption } from '@/lib/enterprise-view'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const LINK_TYPE_BADGE: Record<string, string> = {
+  implements: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  extends:    'bg-blue-100 text-blue-800 border-blue-200',
+  maps_to:    'bg-violet-100 text-violet-800 border-violet-200',
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  active:   'bg-emerald-100 text-emerald-800 border-emerald-200',
+  pending:  'bg-amber-100 text-amber-800 border-amber-200',
+  rejected: 'bg-slate-100 text-slate-700 border-slate-200',
+}
+
+/**
+ * Capability Adoption report (#537). For each instance-visibility capability
+ * the caller's org publishes, lists the agencies that have linked to it and
+ * with what link type / status. Aggregates a top-line summary so the EA can
+ * see "X capabilities published · Y adopted · Z pending approval" at a glance.
+ */
+export default async function EnterpriseAdoptionReport() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const orgId = session.user.organizationId!
+
+  const report = await getCapabilityAdoption(orgId)
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+          <Link href="/reports" className="hover:underline">Reports</Link>
+          <span>/</span>
+          <span>Capability Adoption</span>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">Capability Adoption</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Which agencies have linked to the capabilities your organization publishes instance-wide. Inbound capability→capability links only.
+        </p>
+      </div>
+
+      {/* Top-line aggregates */}
+      <div className="grid gap-3 sm:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-1.5">
+            <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Published</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{report.publishedCount}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1.5">
+            <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Adopted</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{report.adoptedCount}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1.5">
+            <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Pending approval</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{report.pendingApprovalCount}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1.5">
+            <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Distinct agencies</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{report.agencyCount}</CardContent>
+        </Card>
+      </div>
+
+      {report.publishedCount === 0 ? (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          Your organization has no <code className="rounded bg-muted px-1">instance</code>-visibility capabilities yet. Set a capability's visibility to <em>Instance-wide</em> for it to show up here.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {report.capabilities.map(c => (
+            <Card key={c.id} className={cn(c.links.length === 0 && 'opacity-70')}>
+              <CardHeader className="pb-2">
+                <div className="flex items-baseline justify-between gap-3">
+                  <CardTitle className="text-base">
+                    <Link href={`/capabilities/${c.id}`} className="hover:underline">{c.name}</Link>
+                  </CardTitle>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {c.links.length === 0
+                      ? 'No agency links yet'
+                      : `${c.links.length} link${c.links.length === 1 ? '' : 's'} from ${new Set(c.links.map(l => l.sourceOrgId)).size} agenc${new Set(c.links.map(l => l.sourceOrgId)).size === 1 ? 'y' : 'ies'}`}
+                  </span>
+                </div>
+                {c.domain && (
+                  <p className="text-xs text-muted-foreground">{c.domain}</p>
+                )}
+              </CardHeader>
+              {c.links.length > 0 && (
+                <CardContent className="space-y-1.5 pt-0">
+                  {c.links.map(l => (
+                    <div key={`${l.sourceCapabilityId}-${l.linkType}`} className="flex items-center justify-between gap-3 text-sm">
+                      <div className="min-w-0 flex-1">
+                        <span className="font-medium">{l.sourceOrgName}</span>
+                        <span className="text-muted-foreground"> — </span>
+                        <Link href={`/capabilities/${l.sourceCapabilityId}`} className="hover:underline">{l.sourceCapabilityName}</Link>
+                      </div>
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        <span className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium', LINK_TYPE_BADGE[l.linkType])}>
+                          {l.linkType.replace('_', ' ')}
+                        </span>
+                        <span className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 text-xs font-medium', STATUS_BADGE[l.status])}>
+                          {l.status}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/reports/enterprise-duplicates/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/enterprise-duplicates/page.tsx
@@ -42,7 +42,7 @@ export default async function EnterpriseDuplicatesReport() {
 
       {candidates.length === 0 ? (
         <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
-          No candidate duplicates surfaced across the capabilities you can currently see. As more agencies connect and publish capabilities, this report will populate. (Same-org duplicates are intentionally excluded — that's a different concern handled inside each org's catalog.)
+          No candidate duplicates surfaced across the capabilities you can currently see. As more agencies connect and publish capabilities, this report will populate. (Same-org duplicates are intentionally excluded — that&apos;s a different concern handled inside each org&apos;s catalog.)
         </div>
       ) : (
         <div className="space-y-8">

--- a/apps/govea/src/app/(admin)/reports/enterprise-duplicates/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/enterprise-duplicates/page.tsx
@@ -1,0 +1,102 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { findDuplicateCapabilityCandidates } from '@/lib/enterprise-view'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Capability Duplicates report (#538). Surfaces candidate-pair duplicates
+ * across connected agencies using a domain-grouped name-token Jaccard
+ * heuristic. First cut — pairs the EA can review side by side; no automated
+ * consolidation action.
+ */
+export default async function EnterpriseDuplicatesReport() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const orgId = session.user.organizationId!
+
+  const candidates = await findDuplicateCapabilityCandidates(orgId)
+
+  // Group rendered candidates by domain so the EA scans by area.
+  const byDomain = new Map<string, typeof candidates>()
+  for (const c of candidates) {
+    const k = c.domain ?? '(no domain)'
+    const list = byDomain.get(k) ?? []
+    list.push(c)
+    byDomain.set(k, list)
+  }
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+          <Link href="/reports" className="hover:underline">Reports</Link>
+          <span>/</span>
+          <span>Capability Duplicates</span>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">Capability Duplicates</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Candidate duplicate capabilities across connected agencies. Pairs are flagged when their names share enough meaningful tokens within the same domain. First-cut heuristic — review side-by-side and decide whether consolidation makes sense.
+        </p>
+      </div>
+
+      {candidates.length === 0 ? (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          No candidate duplicates surfaced across the capabilities you can currently see. As more agencies connect and publish capabilities, this report will populate. (Same-org duplicates are intentionally excluded — that's a different concern handled inside each org's catalog.)
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {Array.from(byDomain.entries()).map(([domain, pairs]) => (
+            <section key={domain}>
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                {domain} <span className="font-normal text-muted-foreground">— {pairs.length} candidate pair{pairs.length === 1 ? '' : 's'}</span>
+              </h2>
+              <div className="space-y-3">
+                {pairs.map((c, i) => (
+                  <Card key={`${c.a.id}-${c.b.id}-${i}`}>
+                    <CardHeader className="pb-2">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <CardTitle className="text-sm font-semibold">Possible overlap</CardTitle>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          similarity {Math.round(c.similarity * 100)}%
+                        </span>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="grid gap-3 sm:grid-cols-2 pt-0">
+                      <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                          {c.a.orgName}
+                        </p>
+                        <p className="text-sm font-medium">
+                          <Link href={`/capabilities/${c.a.id}`} className="hover:underline">{c.a.name}</Link>
+                        </p>
+                        {c.a.description && (
+                          <p className="text-xs text-muted-foreground line-clamp-3">{c.a.description}</p>
+                        )}
+                      </div>
+                      <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                          {c.b.orgName}
+                        </p>
+                        <p className="text-sm font-medium">
+                          <Link href={`/capabilities/${c.b.id}`} className="hover:underline">{c.b.name}</Link>
+                        </p>
+                        {c.b.description && (
+                          <p className="text-xs text-muted-foreground line-clamp-3">{c.b.description}</p>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground pt-2">
+        Heuristic: token-set Jaccard similarity over capability names (stopwords removed) within the same <code className="bg-muted px-1 rounded">domain</code>. Same-org pairs are excluded. Refinements over time may add semantic similarity, shared-applications signal, or vendor overlap.
+      </p>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/reports/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/page.tsx
@@ -44,6 +44,35 @@ export default async function ReportsPage() {
         </div>
       </section>
 
+      {/* #537 + #538 — Enterprise Architect persona aggregations across the
+          multi-org federation substrate. Visible to every authenticated user
+          (they aggregate only what the caller can already read). */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Enterprise View</h2>
+        <div className="rounded-lg border border-border bg-card divide-y">
+          <Link
+            href="/reports/enterprise-adoption"
+            className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors group"
+          >
+            <div>
+              <p className="text-sm font-medium group-hover:text-primary transition-colors">Capability Adoption</p>
+              <p className="text-xs text-muted-foreground mt-0.5">Which agencies have linked to the capabilities your organization publishes instance-wide. Inbound capability→capability links, aggregated.</p>
+            </div>
+            <span className="text-muted-foreground text-sm">→</span>
+          </Link>
+          <Link
+            href="/reports/enterprise-duplicates"
+            className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors group"
+          >
+            <div>
+              <p className="text-sm font-medium group-hover:text-primary transition-colors">Capability Duplicates</p>
+              <p className="text-xs text-muted-foreground mt-0.5">Candidate-pair duplicates across connected agencies. Domain-grouped, side-by-side. First-cut heuristic — review and decide whether consolidation makes sense.</p>
+            </div>
+            <span className="text-muted-foreground text-sm">→</span>
+          </Link>
+        </div>
+      </section>
+
       {frameworkOverlay && (
         <section className="space-y-3">
           <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">TOGAF Framework</h2>

--- a/apps/govea/src/lib/enterprise-view.ts
+++ b/apps/govea/src/lib/enterprise-view.ts
@@ -1,0 +1,271 @@
+/**
+ * Enterprise-view queries (#537, #538).
+ *
+ * Reads-only aggregation helpers for the central-IT Enterprise Architect:
+ *
+ *   - getCapabilityAdoption(orgId) — for each instance-visibility capability
+ *     owned by the org, return the list of agencies that have linked to it.
+ *     Powers the "Capability Adoption" report.
+ *
+ *   - findDuplicateCapabilityCandidates(orgId) — across all capabilities the
+ *     caller can read (own + federated), surface candidate-pair duplicates
+ *     using a domain-grouped token-Jaccard heuristic. Powers the "Capability
+ *     Duplicates" report.
+ *
+ * Both honour the same federation rules `getCapabilities` enforces; they
+ * never expose content the caller cannot already read through normal
+ * detail-page navigation.
+ */
+
+import { db } from '@/db/client'
+import { capabilities, crossOrgLinks, organizations } from '@/db/schema'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getConnectedOrgIds } from '@/lib/federation'
+
+type LinkType = 'implements' | 'extends' | 'maps_to'
+type LinkStatus = 'pending' | 'active' | 'rejected'
+
+// ── Capability Adoption (#537) ─────────────────────────────────────────────
+
+export type AdoptionLink = {
+  /** The agency that linked to my capability. */
+  sourceOrgId: string
+  sourceOrgName: string
+  /** Their capability that does the linking. */
+  sourceCapabilityId: string
+  sourceCapabilityName: string
+  linkType: LinkType
+  status: LinkStatus
+}
+
+export type AdoptedCapability = {
+  id: string
+  name: string
+  description: string | null
+  domain: string | null
+  /** Inbound capability→capability links. */
+  links: AdoptionLink[]
+}
+
+export type AdoptionReport = {
+  /** Total instance-visibility capabilities the org publishes. */
+  publishedCount: number
+  /** Number of those with at least one inbound capability link. */
+  adoptedCount: number
+  /** Number of inbound links currently `status: 'pending'`. */
+  pendingApprovalCount: number
+  /** Distinct agency count across all inbound links. */
+  agencyCount: number
+  /** Every published capability (adopted or not), in name order. */
+  capabilities: AdoptedCapability[]
+}
+
+/**
+ * Compute the adoption report for `orgId`. Considers only capabilities the
+ * org marks `visibility: 'instance'` (those a peer org can actually link to).
+ * `connections`-visibility capabilities are out of scope — by definition
+ * they are only visible to specifically-connected orgs and don't function as
+ * a true enterprise-wide offering.
+ */
+export async function getCapabilityAdoption(orgId: string): Promise<AdoptionReport> {
+  const published = await db.query.capabilities.findMany({
+    where: and(eq(capabilities.organizationId, orgId), eq(capabilities.visibility, 'instance')),
+    orderBy: (c, { asc }) => [asc(c.name)],
+    columns: { id: true, name: true, description: true, domain: true },
+  })
+  if (published.length === 0) {
+    return { publishedCount: 0, adoptedCount: 0, pendingApprovalCount: 0, agencyCount: 0, capabilities: [] }
+  }
+
+  const publishedIds = published.map(p => p.id)
+
+  // Inbound capability→capability links targeting any of my capabilities.
+  const inboundRows = await db.select({
+    sourceOrgId: crossOrgLinks.sourceOrgId,
+    sourceCapabilityId: crossOrgLinks.sourceEntityId,
+    targetCapabilityId: crossOrgLinks.targetEntityId,
+    linkType: crossOrgLinks.linkType,
+    status: crossOrgLinks.status,
+  })
+    .from(crossOrgLinks)
+    .where(and(
+      eq(crossOrgLinks.targetOrgId, orgId),
+      eq(crossOrgLinks.sourceEntityType, 'capability'),
+      eq(crossOrgLinks.targetEntityType, 'capability'),
+      inArray(crossOrgLinks.targetEntityId, publishedIds),
+    ))
+
+  if (inboundRows.length === 0) {
+    return {
+      publishedCount: published.length,
+      adoptedCount: 0,
+      pendingApprovalCount: 0,
+      agencyCount: 0,
+      capabilities: published.map(p => ({ ...p, links: [] })),
+    }
+  }
+
+  // Resolve org names and capability names in two cheap lookups.
+  const sourceOrgIds = [...new Set(inboundRows.map(r => r.sourceOrgId))]
+  const sourceCapIds = [...new Set(inboundRows.map(r => r.sourceCapabilityId))]
+
+  const [orgRows, capRows] = await Promise.all([
+    db.select({ id: organizations.id, name: organizations.name })
+      .from(organizations)
+      .where(inArray(organizations.id, sourceOrgIds)),
+    db.select({ id: capabilities.id, name: capabilities.name })
+      .from(capabilities)
+      .where(inArray(capabilities.id, sourceCapIds)),
+  ])
+  const orgNameById = new Map(orgRows.map(r => [r.id, r.name]))
+  const capNameById = new Map(capRows.map(r => [r.id, r.name]))
+
+  // Build per-target index.
+  const linksByTarget = new Map<string, AdoptionLink[]>()
+  for (const row of inboundRows) {
+    const link: AdoptionLink = {
+      sourceOrgId: row.sourceOrgId,
+      sourceOrgName: orgNameById.get(row.sourceOrgId) ?? '(unknown org)',
+      sourceCapabilityId: row.sourceCapabilityId,
+      sourceCapabilityName: capNameById.get(row.sourceCapabilityId) ?? '(unknown capability)',
+      linkType: row.linkType,
+      status: row.status,
+    }
+    const existing = linksByTarget.get(row.targetCapabilityId) ?? []
+    existing.push(link)
+    linksByTarget.set(row.targetCapabilityId, existing)
+  }
+
+  return {
+    publishedCount: published.length,
+    adoptedCount: linksByTarget.size,
+    pendingApprovalCount: inboundRows.filter(r => r.status === 'pending').length,
+    agencyCount: sourceOrgIds.length,
+    capabilities: published.map(p => ({ ...p, links: linksByTarget.get(p.id) ?? [] })),
+  }
+}
+
+// ── Capability Duplicate Detection (#538) ──────────────────────────────────
+
+export type DuplicateCandidate = {
+  domain: string | null
+  similarity: number  // 0..1 Jaccard on meaningful name tokens
+  a: { id: string; name: string; description: string | null; orgId: string; orgName: string }
+  b: { id: string; name: string; description: string | null; orgId: string; orgName: string }
+}
+
+// Stopwords that carry no meaningful overlap signal. Tuned for government IT
+// capability names; conservative — we'd rather flag a false positive than
+// hide a real overlap. Filtered out before Jaccard.
+const NAME_STOPWORDS = new Set([
+  'a', 'an', 'and', 'the', 'of', 'for', 'to', 'in', 'on', 'with', 'by',
+  'system', 'systems', 'service', 'services', 'platform', 'platforms',
+  'management', 'application', 'applications', 'integration', 'integrations',
+  'capability', 'capabilities',
+])
+
+// 0.33 catches the realistic "one of three meaningful tokens shared" case
+// (e.g. "Online Permitting" vs "Permitting & Licensing System" → {permitting}
+// shared, {online, permitting, licensing} union → 1/3). Tightening above this
+// silently hides real candidate pairs in the data the audit walked.
+const JACCARD_THRESHOLD = 0.33
+const MIN_TOKEN_LENGTH = 3
+
+function tokenize(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(t => t.length >= MIN_TOKEN_LENGTH && !NAME_STOPWORDS.has(t)),
+  )
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let intersection = 0
+  for (const x of a) if (b.has(x)) intersection++
+  const union = a.size + b.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+/**
+ * Find candidate duplicate pairs across the caller's visible capabilities.
+ *
+ * Algorithm: group capabilities by `domain` (null is its own group); within
+ * each group, compare every pair by Jaccard similarity on meaningful name
+ * tokens. Pairs ≥ JACCARD_THRESHOLD are returned, sorted by similarity DESC.
+ *
+ * Same-org pairs are excluded — duplication *within* one org is a separate
+ * concern; this report is for the EA looking *across* agencies.
+ */
+export async function findDuplicateCapabilityCandidates(orgId: string): Promise<DuplicateCandidate[]> {
+  const connectedOrgIds = await getConnectedOrgIds(orgId)
+
+  // Same federation rule as getCapabilities — instance-wide + own + connected.
+  const visible = await db.query.capabilities.findMany({
+    where: (c, { eq: e, or, and: a, inArray: ia }) => {
+      const own = e(c.organizationId, orgId)
+      const instanceWide = e(c.visibility, 'instance')
+      const connected = connectedOrgIds.length === 0
+        ? undefined
+        : a(ia(c.organizationId, connectedOrgIds), ia(c.visibility, ['connections', 'instance']))
+      return connected ? or(own, instanceWide, connected) : or(own, instanceWide)
+    },
+    columns: { id: true, name: true, description: true, domain: true, organizationId: true },
+  })
+
+  if (visible.length < 2) return []
+
+  // Resolve org names once.
+  const ownerOrgIds = [...new Set(visible.map(v => v.organizationId))]
+  const orgRows = await db.select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(inArray(organizations.id, ownerOrgIds))
+  const orgNameById = new Map(orgRows.map(r => [r.id, r.name]))
+
+  // Pre-tokenize once.
+  const indexed = visible.map(c => ({
+    ...c,
+    tokens: tokenize(c.name),
+    orgName: orgNameById.get(c.organizationId) ?? '(unknown org)',
+  }))
+
+  // Group by domain key (null becomes the empty string for grouping).
+  const byDomain = new Map<string, typeof indexed>()
+  for (const c of indexed) {
+    const k = c.domain ?? ''
+    const list = byDomain.get(k) ?? []
+    list.push(c)
+    byDomain.set(k, list)
+  }
+
+  const out: DuplicateCandidate[] = []
+  for (const [domainKey, group] of byDomain) {
+    if (group.length < 2) continue
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i], b = group[j]
+        if (a.organizationId === b.organizationId) continue  // intra-org excluded
+        const sim = jaccard(a.tokens, b.tokens)
+        if (sim < JACCARD_THRESHOLD) continue
+        out.push({
+          domain: domainKey === '' ? null : domainKey,
+          similarity: sim,
+          a: { id: a.id, name: a.name, description: a.description, orgId: a.organizationId, orgName: a.orgName },
+          b: { id: b.id, name: b.name, description: b.description, orgId: b.organizationId, orgName: b.orgName },
+        })
+      }
+    }
+  }
+
+  out.sort((a, b) => b.similarity - a.similarity)
+  return out
+}
+
+// Exported for unit-testability. The pages don't use it directly.
+export const _testing = {
+  tokenize,
+  jaccard,
+  JACCARD_THRESHOLD,
+  NAME_STOPWORDS,
+}

--- a/apps/govea/tests/integration/enterprise-view.test.ts
+++ b/apps/govea/tests/integration/enterprise-view.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests: getCapabilityAdoption (#537) +
+ *                    findDuplicateCapabilityCandidates (#538)
+ *
+ * Both run against the real DB so federation visibility behaviour is
+ * exercised (instance-wide vs connections-only vs org-only, plus the
+ * cross-org connection requirement).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  capabilities, crossOrgLinks, orgConnections,
+} from '@/db/schema'
+import { randomUUID } from 'node:crypto'
+import {
+  getCapabilityAdoption,
+  findDuplicateCapabilityCandidates,
+} from '@/lib/enterprise-view'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+// All tests in this file share a Postgres instance with other integration
+// suites. `instance`-visibility capabilities are globally visible by
+// federation rule, so any seeded name could collide with another suite's
+// data and produce flaky pair matches. Prefix every seeded name with a
+// per-run high-entropy token so cross-suite tokens never overlap.
+const RUN_PREFIX = `t${randomUUID().slice(0, 8)}`
+const n = (s: string) => `${RUN_PREFIX} ${s}`
+
+let stateOrgId: string
+let cityAOrgId: string
+let cityBOrgId: string
+
+beforeAll(async () => {
+  ;[stateOrgId, cityAOrgId, cityBOrgId] = await Promise.all([
+    createTestOrg().then(o => o.id),
+    createTestOrg().then(o => o.id),
+    createTestOrg().then(o => o.id),
+  ])
+  // State <-> CityA and State <-> CityB connections, both active. CityA <-> CityB intentionally absent.
+  await db.insert(orgConnections).values([
+    { fromOrgId: stateOrgId, toOrgId: cityAOrgId, status: 'active' },
+    { fromOrgId: cityAOrgId, toOrgId: stateOrgId, status: 'active' },
+    { fromOrgId: stateOrgId, toOrgId: cityBOrgId, status: 'active' },
+    { fromOrgId: cityBOrgId, toOrgId: stateOrgId, status: 'active' },
+  ])
+})
+
+afterAll(async () => {
+  await Promise.all([
+    cleanupOrg(stateOrgId),
+    cleanupOrg(cityAOrgId),
+    cleanupOrg(cityBOrgId),
+  ])
+})
+
+async function seedCap(orgId: string, name: string, visibility: 'org' | 'connections' | 'instance' = 'instance', domain?: string) {
+  const [row] = await db.insert(capabilities).values({
+    id: randomUUID(),
+    organizationId: orgId,
+    name,
+    visibility,
+    domain: domain ?? null,
+  }).returning()
+  return row
+}
+
+async function seedLink(sourceOrgId: string, sourceCapId: string, targetOrgId: string, targetCapId: string, linkType: 'implements' | 'extends' | 'maps_to', status: 'pending' | 'active' | 'rejected' = 'pending') {
+  const [row] = await db.insert(crossOrgLinks).values({
+    sourceOrgId,
+    sourceEntityType: 'capability',
+    sourceEntityId: sourceCapId,
+    targetOrgId,
+    targetEntityType: 'capability',
+    targetEntityId: targetCapId,
+    linkType,
+    status,
+  }).returning()
+  return row
+}
+
+describe('getCapabilityAdoption (#537)', () => {
+  it('returns zero totals when the org publishes no instance-visibility capabilities', async () => {
+    const isolated = await createTestOrg()
+    const report = await getCapabilityAdoption(isolated.id)
+    expect(report.publishedCount).toBe(0)
+    expect(report.adoptedCount).toBe(0)
+    expect(report.pendingApprovalCount).toBe(0)
+    expect(report.agencyCount).toBe(0)
+    expect(report.capabilities).toEqual([])
+    await cleanupOrg(isolated.id)
+  })
+
+  it('counts only instance-visibility capabilities as published', async () => {
+    const orgId = (await createTestOrg()).id
+    await seedCap(orgId, n('Instance Cap'), 'instance')
+    await seedCap(orgId, n('Connections Cap'), 'connections')
+    await seedCap(orgId, n('Org Only Cap'), 'org')
+
+    const report = await getCapabilityAdoption(orgId)
+    expect(report.publishedCount).toBe(1)
+    expect(report.capabilities.map(c => c.name)).toEqual([n('Instance Cap')])
+    await cleanupOrg(orgId)
+  })
+
+  it('aggregates inbound links across multiple agencies and statuses', async () => {
+    const stateCap1 = await seedCap(stateOrgId, n('Statewide Identity'))
+    const stateCap2 = await seedCap(stateOrgId, n('Open Data Feed'))
+    const stateCap3 = await seedCap(stateOrgId, n('Lonely Cap'))  // no inbound
+
+    const cityACap1 = await seedCap(cityAOrgId, n('City A Auth'), 'connections')
+    const cityACap2 = await seedCap(cityAOrgId, n('City A Data'), 'connections')
+    const cityBCap1 = await seedCap(cityBOrgId, n('City B Auth'), 'connections')
+
+    // City A links into both state caps; City B links into one
+    await seedLink(cityAOrgId, cityACap1.id, stateOrgId, stateCap1.id, 'implements', 'active')
+    await seedLink(cityAOrgId, cityACap2.id, stateOrgId, stateCap2.id, 'extends', 'pending')
+    await seedLink(cityBOrgId, cityBCap1.id, stateOrgId, stateCap1.id, 'implements', 'pending')
+
+    const report = await getCapabilityAdoption(stateOrgId)
+    expect(report.publishedCount).toBe(3)
+    expect(report.adoptedCount).toBe(2)        // cap1 + cap2; cap3 has none
+    expect(report.pendingApprovalCount).toBe(2) // one cap1 + one cap2
+    expect(report.agencyCount).toBe(2)          // CityA + CityB
+
+    const cap1Row = report.capabilities.find(c => c.id === stateCap1.id)!
+    expect(cap1Row.links).toHaveLength(2)
+
+    const cap3Row = report.capabilities.find(c => c.id === stateCap3.id)!
+    expect(cap3Row.links).toEqual([])
+  })
+
+  it('excludes outbound links (where this org is the SOURCE, not target)', async () => {
+    const stateOnlyOrg = (await createTestOrg()).id
+    const peerOrg = (await createTestOrg()).id
+    await db.insert(orgConnections).values([
+      { fromOrgId: stateOnlyOrg, toOrgId: peerOrg, status: 'active' },
+      { fromOrgId: peerOrg, toOrgId: stateOnlyOrg, status: 'active' },
+    ])
+
+    const myCap = await seedCap(stateOnlyOrg, n('My Cap'), 'instance')
+    const peerCap = await seedCap(peerOrg, n('Peer Cap'), 'instance')
+
+    // I link OUT to peer. This should NOT count as adoption of my capability.
+    await seedLink(stateOnlyOrg, myCap.id, peerOrg, peerCap.id, 'implements', 'active')
+
+    const report = await getCapabilityAdoption(stateOnlyOrg)
+    expect(report.publishedCount).toBe(1)
+    expect(report.adoptedCount).toBe(0)
+    expect(report.capabilities[0].links).toEqual([])
+
+    await cleanupOrg(stateOnlyOrg)
+    await cleanupOrg(peerOrg)
+  })
+})
+
+// Filter candidates to those that involve a name we control via RUN_PREFIX,
+// so cross-suite `instance`-vis caps in the shared DB can't make assertions
+// flaky. Pure tests for the heuristic itself live in
+// tests/unit/enterprise-view-heuristic.test.ts.
+const myPair = (c: { a: { name: string }, b: { name: string } }) =>
+  c.a.name.startsWith(RUN_PREFIX) && c.b.name.startsWith(RUN_PREFIX)
+
+describe('findDuplicateCapabilityCandidates (#538)', () => {
+  it('produces no candidates for an isolated org with no peers and zero caps', async () => {
+    const isolated = (await createTestOrg()).id
+    const candidates = await findDuplicateCapabilityCandidates(isolated)
+    expect(candidates.filter(myPair)).toEqual([])
+    await cleanupOrg(isolated)
+  })
+
+  it('flags name-overlap pairs within the same domain across orgs', async () => {
+    const orgA = (await createTestOrg()).id
+    const orgB = (await createTestOrg()).id
+    await db.insert(orgConnections).values([
+      { fromOrgId: orgA, toOrgId: orgB, status: 'active' },
+      { fromOrgId: orgB, toOrgId: orgA, status: 'active' },
+    ])
+    await seedCap(orgA, n('Online Permitting'),  'instance', n('Permitting & Licensing'))
+    await seedCap(orgB, n('Permitting & Licensing System'),  'instance', n('Permitting & Licensing'))
+
+    const candidates = await findDuplicateCapabilityCandidates(orgA)
+    const minePairs = candidates.filter(myPair)
+    expect(minePairs.length).toBeGreaterThanOrEqual(1)
+    const pair = minePairs.find(c =>
+      (c.a.name === n('Online Permitting') || c.b.name === n('Online Permitting')) &&
+      (c.a.name === n('Permitting & Licensing System') || c.b.name === n('Permitting & Licensing System'))
+    )
+    expect(pair).toBeDefined()
+    expect(pair!.similarity).toBeGreaterThan(0)
+
+    await cleanupOrg(orgA)
+    await cleanupOrg(orgB)
+  })
+
+  it('does NOT flag pairs in different domains', async () => {
+    const orgA = (await createTestOrg()).id
+    const orgB = (await createTestOrg()).id
+    await db.insert(orgConnections).values([
+      { fromOrgId: orgA, toOrgId: orgB, status: 'active' },
+      { fromOrgId: orgB, toOrgId: orgA, status: 'active' },
+    ])
+    await seedCap(orgA, n('Identity Verification A'), 'instance', n('Information Technology'))
+    await seedCap(orgB, n('Identity Verification B'), 'instance', n('Public Safety'))
+
+    const candidates = await findDuplicateCapabilityCandidates(orgA)
+    const minePairs = candidates.filter(myPair)
+    const found = minePairs.find(c =>
+      c.a.name.includes('Identity Verification') && c.b.name.includes('Identity Verification')
+    )
+    expect(found).toBeUndefined()
+
+    await cleanupOrg(orgA)
+    await cleanupOrg(orgB)
+  })
+
+  it('does NOT flag intra-org pairs (same org should never appear)', async () => {
+    const orgA = (await createTestOrg()).id
+    await seedCap(orgA, n('Permitting Online'),  'instance', n('Permitting'))
+    await seedCap(orgA, n('Online Permitting'),  'instance', n('Permitting'))
+
+    const candidates = await findDuplicateCapabilityCandidates(orgA)
+    for (const c of candidates.filter(myPair)) {
+      expect(c.a.orgId).not.toBe(c.b.orgId)
+    }
+    await cleanupOrg(orgA)
+  })
+
+  it('respects federation visibility — never surfaces capabilities the caller cannot read', async () => {
+    const orgA = (await createTestOrg()).id
+    const orgB = (await createTestOrg()).id
+    // NO connection between orgA and orgB. orgB has an `org`-only capability.
+    await seedCap(orgA, n('Permit Issuance'), 'instance', n('Permitting'))
+    await seedCap(orgB, n('Permit Management'), 'org',    n('Permitting'))
+
+    const candidates = await findDuplicateCapabilityCandidates(orgA)
+    // orgB's org-visibility capability is not readable from orgA — should not appear.
+    const found = candidates.find(c =>
+      c.a.name === n('Permit Management') || c.b.name === n('Permit Management')
+    )
+    expect(found).toBeUndefined()
+
+    await cleanupOrg(orgA)
+    await cleanupOrg(orgB)
+  })
+
+  it('returns candidates sorted by similarity descending', async () => {
+    const orgA = (await createTestOrg()).id
+    const orgB = (await createTestOrg()).id
+    await db.insert(orgConnections).values([
+      { fromOrgId: orgA, toOrgId: orgB, status: 'active' },
+      { fromOrgId: orgB, toOrgId: orgA, status: 'active' },
+    ])
+
+    // High-similarity pair (2/3 shared)
+    await seedCap(orgA, n('Permit Issuance'), 'instance', n('Permitting & Licensing'))
+    await seedCap(orgB, n('Permit Issuance Hub'), 'instance', n('Permitting & Licensing'))
+
+    // Lower-similarity pair (1/3 shared)
+    await seedCap(orgA, n('Building Inspection'), 'instance', n('Permitting & Licensing'))
+    await seedCap(orgB, n('Building Permits Online'), 'instance', n('Permitting & Licensing'))
+
+    const candidates = await findDuplicateCapabilityCandidates(orgA)
+    const sorted = candidates.filter(myPair)
+    for (let i = 0; i < sorted.length - 1; i++) {
+      expect(sorted[i].similarity).toBeGreaterThanOrEqual(sorted[i + 1].similarity)
+    }
+    await cleanupOrg(orgA)
+    await cleanupOrg(orgB)
+  })
+})

--- a/apps/govea/tests/unit/enterprise-view-heuristic.test.ts
+++ b/apps/govea/tests/unit/enterprise-view-heuristic.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the duplicate-detection heuristic (#538).
+ *
+ * The actual report integrates with the DB; here we exercise the pure
+ * tokenize + jaccard pieces so the heuristic can be tuned without spinning
+ * up Postgres.
+ */
+import { describe, it, expect } from 'vitest'
+import { _testing } from '@/lib/enterprise-view'
+
+const { tokenize, jaccard, JACCARD_THRESHOLD, NAME_STOPWORDS } = _testing
+
+describe('tokenize', () => {
+  it('lowercases and splits on non-alphanumeric', () => {
+    expect(Array.from(tokenize('Permit Issuance')).sort()).toEqual(['issuance', 'permit'])
+  })
+
+  it('drops tokens shorter than 3 chars (avoids "a", "to", "id")', () => {
+    expect(Array.from(tokenize('GIS Mapping')).sort()).toEqual(['gis', 'mapping'])
+    expect(Array.from(tokenize('Pay Tax')).sort()).toEqual(['pay', 'tax'])
+    expect(Array.from(tokenize('Add a Tag')).sort()).toEqual(['add', 'tag'])
+  })
+
+  it('drops stopwords', () => {
+    expect(Array.from(tokenize('Capability Management System')).sort()).toEqual([])
+    expect(Array.from(tokenize('Permit Management System')).sort()).toEqual(['permit'])
+  })
+
+  it('handles punctuation', () => {
+    expect(Array.from(tokenize("Driver's Licence")).sort()).toEqual(['driver', 'licence'])
+    expect(Array.from(tokenize('License & Permit Management')).sort()).toEqual(['license', 'permit'])
+  })
+
+  it('returns an empty set for empty input', () => {
+    expect(tokenize('').size).toBe(0)
+    expect(tokenize('   ').size).toBe(0)
+  })
+
+  it('stopword list rejects the documented terms', () => {
+    expect(NAME_STOPWORDS.has('management')).toBe(true)
+    expect(NAME_STOPWORDS.has('system')).toBe(true)
+    expect(NAME_STOPWORDS.has('service')).toBe(true)
+    expect(NAME_STOPWORDS.has('capability')).toBe(true)
+  })
+})
+
+describe('jaccard', () => {
+  it('is 1 when sets are identical', () => {
+    expect(jaccard(tokenize('Permit Issuance'), tokenize('Permit Issuance'))).toBe(1)
+  })
+
+  it('is 0 when sets are disjoint', () => {
+    expect(jaccard(tokenize('Permit Issuance'), tokenize('Budget Reporting'))).toBe(0)
+  })
+
+  it('is 0 when one set is empty', () => {
+    expect(jaccard(tokenize(''), tokenize('Permit Issuance'))).toBe(0)
+    expect(jaccard(tokenize('Capability System'), tokenize('Permit Issuance'))).toBe(0) // first all-stopwords
+  })
+
+  it('partial overlap returns intersection-over-union', () => {
+    // "Permit Issuance" → {permit, issuance}
+    // "Permit Management" → {permit} (management is a stopword)
+    // intersection = {permit}, union = {permit, issuance} → 1/2
+    expect(jaccard(tokenize('Permit Issuance'), tokenize('Permit Management'))).toBeCloseTo(0.5, 5)
+  })
+
+  it('three-way candidate cluster behaves sensibly', () => {
+    const a = tokenize('Permit Issuance')
+    const b = tokenize('Permitting')                    // single token, no overlap with "permit issuance" — "permitting" ≠ "permit"
+    const c = tokenize('License & Permit Management')
+    expect(jaccard(a, b)).toBe(0)
+    expect(jaccard(a, c)).toBeGreaterThan(0)
+    expect(jaccard(b, c)).toBe(0)
+  })
+})
+
+describe('threshold', () => {
+  it('matches the documented value', () => {
+    expect(JACCARD_THRESHOLD).toBeGreaterThanOrEqual(0.25)
+    expect(JACCARD_THRESHOLD).toBeLessThan(0.5)
+  })
+
+  it('flags meaningful real-world pairs above the threshold', () => {
+    // "Good catch" cases the report should surface.
+    expect(jaccard(tokenize('Identity & Authentication'), tokenize('Digital Identity')))
+      .toBeGreaterThanOrEqual(JACCARD_THRESHOLD)  // 1/3
+    expect(jaccard(tokenize('Online Permitting'), tokenize('Permitting & Licensing System')))
+      .toBeGreaterThanOrEqual(JACCARD_THRESHOLD)  // 1/3
+    expect(jaccard(tokenize('Permit Issuance'), tokenize('Permit Issuance Hub')))
+      .toBeGreaterThanOrEqual(JACCARD_THRESHOLD)  // 2/3
+  })
+
+  it('does NOT flag unrelated capabilities sharing only a stopword', () => {
+    // Both have "Management" (stopword) — should not be flagged as duplicates.
+    expect(jaccard(tokenize('Budget Management'), tokenize('Permit Management'))).toBe(0)
+  })
+
+  it('demonstrates a known gap: no stemming or lemmatisation', () => {
+    // "request" vs "requests" do not match — pinned here so the limit is
+    // explicit. Future improvement: lightweight stemming.
+    expect(jaccard(tokenize('Service Request Management'), tokenize('Service Requests')))
+      .toBeLessThan(JACCARD_THRESHOLD)
+  })
+})


### PR DESCRIPTION
## Summary

Two new Reports pages aggregating cross-org capability data for the Enterprise Architect persona. Both surfaced during the EA persona audit (#535) as the persona's two most concrete value-add capabilities; named together as the largest open cluster after the viewer experience.

Bundled because both ride on the same multi-org federation substrate and share a new helper (\`@/lib/enterprise-view\`). Two distinct pages so each can grow independently.

## #537 — \`/reports/enterprise-adoption\` (Capability Adoption)

For each \`instance\`-visibility capability the caller's org publishes:

| Column | What it shows |
|---|---|
| Top-line aggregates | Published / Adopted / Pending approval / Distinct agencies |
| Per-capability card | Domain + inbound capability→capability links (which agencies linked, link type, status) |
| Empty rows | Listed but dimmed, so the publish-side ratio is visible at a glance |

## #538 — \`/reports/enterprise-duplicates\` (Capability Duplicates)

Across capabilities the caller can read (own + federated, honouring the same rules \`getCapabilities\` enforces):

- Group by \`domain\`
- Within each domain, compare every **cross-org** pair by **Jaccard similarity** on meaningful name tokens (stopwords removed)
- Flag pairs at similarity ≥ **0.33**; sort by similarity DESC
- Render side-by-side cards: name, description, owner org
- Same-org pairs excluded — that's a separate concern

First-cut heuristic, no automated consolidation action — surface, not act. Documented out-of-scope: semantic similarity, shared-application overlap, vendor-consolidation detection.

## Library

New \`apps/govea/src/lib/enterprise-view.ts\`:
- \`getCapabilityAdoption(orgId): AdoptionReport\`
- \`findDuplicateCapabilityCandidates(orgId): DuplicateCandidate[]\`
- \`tokenize\` / \`jaccard\` exposed via \`_testing\` for unit pinning

## UI

\`/reports\` landing gained a new **Enterprise View** section linking to both reports. No new UI primitives — uses the existing Card / Link patterns.

## Test plan

**25 new tests, all passing locally in 225 ms:**

\`tests/unit/enterprise-view-heuristic.test.ts\` (15 tests) — tokenize / jaccard / threshold behaviour against representative real-world capability-name pairs. Includes a documented heuristic gap (no stemming, so \"request\" ≠ \"requests\") pinned in a test.

\`tests/integration/enterprise-view.test.ts\` (10 tests) — real-DB exercises of:
- Federation visibility (caller cannot see capabilities they couldn't already read)
- Intra-org exclusion (same-org pairs never surface)
- Cross-domain non-flag (\"Identity Verification\" in IT vs Public Safety is not flagged)
- Outbound-link non-counting (adoption counts inbound only)
- Similarity sort order (DESC)
- Full adoption aggregation path

All test capability names carry a per-run UUID prefix so cross-suite \`instance\`-visibility data in the shared Postgres can't create flaky matches.

\`tsc --noEmit\` clean. \`docs-lint\` clean.

## Out of scope (documented in code + UI copy)

- Semantic similarity beyond token overlap (LLM / embeddings)
- Shared-application overlap signal
- Vendor / SaaS consolidation detection
- Automated consolidation actions

## Capability traceability

Capability: \`mo-cross-org-linking\`; \`mo-content-visibility\`
Persona: enterprise-architect
Closes #537, #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)