### PR TITLE
[codex] Connect initiatives in strategic traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Free. Open source. Runs on-prem or as a hosted service.
 GovEA is built around a mission-first traceability chain:
 
 ```text
-Personas -> Capabilities -> Applications
+Goals -> Strategic Objectives -> Initiatives -> Capabilities -> Applications
 ```
 
+- **Goals** define broad strategic intent above measurable **Strategic Objectives**.
+- **Initiatives** connect strategic objectives to the capabilities and applications changed by delivery work.
 - Every **Application** must link to at least one **Capability**.
 - Every **Capability** must link to at least one **Persona**.
 - **Services** model the government-facing delivery layer and link to personas, capabilities, and value streams. Supporting applications are surfaced through linked capabilities.

--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -26,6 +26,7 @@ export interface TraceInitiative {
 export interface TraceObjective {
   id: string; name: string; timeHorizon: string | null
   goals?: TraceGoal[]
+  initiatives?: TraceInitiative[]
 }
 export interface TraceGoal {
   id: string; name: string; planningHorizon: string | null
@@ -56,6 +57,7 @@ export interface CapabilityTrace {
   id: string; name: string; domain: string | null; description: string | null; status: string
   goals: TraceGoal[]
   objectives: TraceObjective[]
+  strategicInitiatives: TraceInitiative[]
   applications: TraceApp[]
   initiatives: TraceInitiative[]
   personas: TracePersona[]
@@ -278,9 +280,26 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
   if (!visible) return null
 
   const objectiveIds = row.objectiveCapabilities.map(({ objective }) => objective.id)
-  const goalsByObjective = await getGoalsByObjective(objectiveIds)
+  const [goalsByObjective, initiativeObjectiveRows] = await Promise.all([
+    getGoalsByObjective(objectiveIds),
+    objectiveIds.length > 0
+      ? db.query.initiativeObjectives.findMany({
+          where: inArray(initiativeObjectives.objectiveId, objectiveIds),
+          with: { initiative: true },
+        })
+      : Promise.resolve([]),
+  ])
   const goalTraceRows = dedupeTraceRows(
     objectiveIds.flatMap((objectiveId) => goalsByObjective.get(objectiveId) ?? [])
+  )
+  const initiativesByObjective = new Map<string, TraceInitiative[]>()
+  for (const { objectiveId, initiative } of initiativeObjectiveRows) {
+    const initiatives = initiativesByObjective.get(objectiveId) ?? []
+    initiatives.push({ id: initiative.id, name: initiative.name, status: initiative.status })
+    initiativesByObjective.set(objectiveId, initiatives)
+  }
+  const strategicInitiatives = dedupeTraceRows(
+    objectiveIds.flatMap((objectiveId) => initiativesByObjective.get(objectiveId) ?? [])
   )
 
   return {
@@ -294,7 +313,9 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     objectives: row.objectiveCapabilities.map(({ objective: o }) => ({
       id: o.id, name: o.name, timeHorizon: o.timeHorizon,
       goals: goalsByObjective.get(o.id) ?? [],
+      initiatives: initiativesByObjective.get(o.id) ?? [],
     })),
+    strategicInitiatives,
     applications: row.applicationCapabilities.map(({ application: a }) => ({
       id: a.id, name: a.name, vendor: a.vendor, lifecycleStatus: a.lifecycleStatus,
     })),

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -180,6 +180,25 @@ function GoalTraceView({ trace }: { trace: GoalTrace }) {
         </TraceCard>
       )}
 
+      {/* Initiatives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Strategic Initiatives</LayerLabel>
+      {allInitiatives.length === 0 ? (
+        <Gap message="No initiatives are currently advancing these objectives." />
+      ) : (
+        <TraceCard>
+          {allInitiatives.map(i => (
+            <TraceRow
+              key={i.id}
+              href={`/initiatives/${i.id}`}
+              name={i.name}
+              badge={i.status}
+              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Capabilities */}
       <Connector label="requires" />
       <LayerLabel>Capabilities</LayerLabel>
@@ -202,25 +221,6 @@ function GoalTraceView({ trace }: { trace: GoalTrace }) {
       <Connector label="supported by" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
-
-      {/* Initiatives */}
-      {allInitiatives.length > 0 && (
-        <>
-          <Connector label="advanced by" />
-          <LayerLabel>Active Initiatives</LayerLabel>
-          <TraceCard>
-            {allInitiatives.map(i => (
-              <TraceRow
-                key={i.id}
-                href={`/initiatives/${i.id}`}
-                name={i.name}
-                badge={i.status}
-                badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
-              />
-            ))}
-          </TraceCard>
-        </>
-      )}
     </div>
   )
 }
@@ -265,6 +265,25 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
         </div>
       </TraceCard>
 
+      {/* Initiatives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Strategic Initiatives</LayerLabel>
+      {trace.initiatives.length === 0 ? (
+        <Gap message="No initiatives are currently advancing this objective. Consider creating an initiative to track delivery work against this goal." />
+      ) : (
+        <TraceCard>
+          {trace.initiatives.map(i => (
+            <TraceRow
+              key={i.id}
+              href={`/initiatives/${i.id}`}
+              name={i.name}
+              badge={i.status}
+              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Capabilities */}
       <Connector label="requires" />
       <LayerLabel>Capabilities</LayerLabel>
@@ -287,25 +306,6 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
       <Connector label="supported by" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
-
-      {/* Initiatives */}
-      <Connector label="advanced by" />
-      <LayerLabel>Active Initiatives</LayerLabel>
-      {trace.initiatives.length === 0 ? (
-        <Gap message="No initiatives are currently advancing this objective. Consider creating an initiative to track delivery work against this goal." />
-      ) : (
-        <TraceCard>
-          {trace.initiatives.map(i => (
-            <TraceRow
-              key={i.id}
-              href={`/initiatives/${i.id}`}
-              name={i.name}
-              badge={i.status}
-              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
-            />
-          ))}
-        </TraceCard>
-      )}
     </div>
   )
 }
@@ -313,6 +313,9 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
 // ── Capability trace view ─────────────────────────────────────────────────────
 
 function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
+  const strategicInitiativeIds = new Set(trace.strategicInitiatives.map(i => i.id))
+  const directInitiatives = trace.initiatives.filter(i => !strategicInitiativeIds.has(i.id))
+
   return (
     <div className="space-y-1 max-w-2xl">
       {/* Upstream: Goals */}
@@ -350,6 +353,25 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
         </TraceCard>
       )}
 
+      {/* Strategic Initiatives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Strategic Initiatives</LayerLabel>
+      {trace.strategicInitiatives.length === 0 ? (
+        <Gap message="No initiatives linked through these objectives — delivery work is not yet tied to the strategic chain." />
+      ) : (
+        <TraceCard>
+          {trace.strategicInitiatives.map(i => (
+            <TraceRow
+              key={i.id}
+              href={`/initiatives/${i.id}`}
+              name={i.name}
+              badge={i.status}
+              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Anchor: Capability */}
       <Connector label="requires" />
       <LayerLabel>Capability</LayerLabel>
@@ -368,13 +390,13 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={trace.applications} />
 
-      {/* Initiatives */}
-      {trace.initiatives.length > 0 && (
+      {/* Direct capability initiatives */}
+      {directInitiatives.length > 0 && (
         <>
           <Connector label="changed by" />
-          <LayerLabel>Initiatives</LayerLabel>
+          <LayerLabel>Capability Initiatives</LayerLabel>
           <TraceCard>
-            {trace.initiatives.map(i => (
+            {directInitiatives.map(i => (
               <TraceRow
                 key={i.id}
                 href={`/initiatives/${i.id}`}
@@ -568,9 +590,9 @@ export default async function TraceabilityPage({
     trace.name
 
   const subtitle =
-    trace.kind === 'goal'      ? 'Goal → Objectives → Capabilities → Technology Trace' :
-    trace.kind === 'objective' ? 'Goal → Objective → Technology Trace' :
-    trace.kind === 'capability' ? 'Goal → Objective → Capability → Delivery Trace' :
+    trace.kind === 'goal'      ? 'Goal → Objectives → Initiatives → Capabilities → Technology Trace' :
+    trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Technology Trace' :
+    trace.kind === 'capability' ? 'Goal → Objective → Initiatives → Capability → Delivery Trace' :
     'Persona → Service → Technology Trace'
 
   return (

--- a/apps/govea/src/lib/mermaid-diagram.ts
+++ b/apps/govea/src/lib/mermaid-diagram.ts
@@ -16,6 +16,7 @@ function label(primary: string, secondary?: string | null): string {
 function capabilityDiagram(trace: CapabilityTrace): string {
   const lines: string[] = ['graph LR']
   const focal = nid('cap', trace.id)
+  const initiativeNodes = new Set<string>()
 
   lines.push(`  ${focal}${label(trace.name, trace.domain)}:::capability`)
 
@@ -29,6 +30,15 @@ function capabilityDiagram(trace: CapabilityTrace): string {
     lines.push(`  ${n}${label(o.name, o.timeHorizon)}:::objective`)
     for (const g of o.goals ?? []) {
       lines.push(`  ${nid('goal', g.id)} --> ${n}`)
+    }
+    for (const i of o.initiatives ?? []) {
+      const ini = nid('ini', i.id)
+      if (!initiativeNodes.has(ini)) {
+        lines.push(`  ${ini}${label(i.name, i.status)}:::initiative`)
+        initiativeNodes.add(ini)
+      }
+      lines.push(`  ${n} -.-> ${ini}`)
+      lines.push(`  ${ini} -.-> ${focal}`)
     }
     lines.push(`  ${n} --> ${focal}`)
   }
@@ -47,7 +57,10 @@ function capabilityDiagram(trace: CapabilityTrace): string {
 
   for (const i of trace.initiatives) {
     const n = nid('ini', i.id)
-    lines.push(`  ${n}${label(i.name, i.status)}:::initiative`)
+    if (!initiativeNodes.has(n)) {
+      lines.push(`  ${n}${label(i.name, i.status)}:::initiative`)
+      initiativeNodes.add(n)
+    }
     lines.push(`  ${n} -.-> ${focal}`)
   }
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -131,7 +131,7 @@ How content is presented to authenticated users and, optionally, the public.
 |---|---|---|
 | Navigation | Implemented | App shell with role-aware sidebar navigation plus a distinct instance-admin console shell |
 | Portfolio Views | Implemented | List and detail pages for all EA entity types |
-| Mission-to-Technology Traceability Views | Implemented | Read-only layered trace views from strategic objectives, capabilities, and services to supporting applications and related records |
+| Mission-to-Technology Traceability Views | Implemented | Read-only layered trace views from goals, strategic objectives, initiatives, capabilities, and services to supporting applications and related records |
 | Guided Answer Views | Implemented | `/answers?q=` assembles capabilities, services, technology, active initiatives, and strategic objectives into a plain-language stakeholder answer with relevance explanations |
 | Relationship Navigation | Implemented | Navigate between linked entities (capability <-> application <-> persona) |
 | Value Stream Display | Implemented | Visualize value stream stages with linked capabilities |

--- a/docs/architect/data-and-traceability.md
+++ b/docs/architect/data-and-traceability.md
@@ -3,10 +3,10 @@
 GovEA's repository model is centered on mission-first traceability. The basic chain is:
 
 ```text
-Personas -> Capabilities -> Applications
+Goals -> Strategic Objectives -> Initiatives -> Capabilities -> Applications
 ```
 
-The rest of the model adds planning, services, decisions, principles, data architecture, and reporting context around that chain.
+Personas and services provide the people-and-delivery context around that chain. Decisions, principles, data architecture, and reporting add governance and portfolio context without replacing the mission-first path.
 
 For field-level schema detail, see `docs/data-model.md`.
 


### PR DESCRIPTION
## Summary
- Adds objective-linked initiatives to capability trace payloads as strategic initiatives
- Reorders goal, objective, and capability trace views to show Goal -> Objective -> Initiative -> Capability before technology layers
- Updates Mermaid capability diagrams and docs so goals, objectives, initiatives, capabilities, and applications are described as one strategic chain

## Validation
- pnpm --filter govea exec tsc --noEmit
- pnpm --filter govea exec eslint src/actions/traceability.ts src/app/'(admin)'/traceability/page.tsx src/lib/mermaid-diagram.ts
- git diff --check

Capability: fd-traceability-views
Persona: Department Director