### PR TITLE
ci: run overview.spec.ts in the smoke job (#614 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,11 @@ jobs:
           DEV: "true"
 
       - name: Run E2E smoke tests
-        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts
+        # smoke.spec.ts is the route-health sweep; overview.spec.ts (#614)
+        # adds role-aware /overview CTA-gating + Coming-next-tile coverage.
+        # Other specs (iam.spec.ts, auth-security.spec.ts) intentionally
+        # stay out of CI for now — they mutate state and are run locally.
+        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

[#641](https://github.com/roballred/GovEA/pull/641) and [#642](https://github.com/roballred/GovEA/pull/642) shipped `apps/govea/tests/e2e/specs/overview.spec.ts` to cover the role-aware `/overview` CTA gating and the Coming-next priorities tile, but `.github/workflows/ci.yml` hard-codes a single spec path:

```yaml
run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts
```

So the new spec sits in the repo but never executes in CI. Locally all 7 cases pass; in CI they were silently skipped, which is what surfaced when @roballred flagged &ldquo;PR 641 failed tests&rdquo; &mdash; the tests didn&apos;t fail, they didn&apos;t run.

## What changed

One-line CI workflow tweak: pass both spec files to Playwright.

```diff
-        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts
+        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts
```

Inline comment notes that `iam.spec.ts` and `auth-security.spec.ts` intentionally stay out of CI (they mutate state and are run locally). That choice is preserved.

## Why this matters

Without this fix:
- #614&apos;s explicit acceptance criterion &ldquo;Viewer users can read the page and use CTAs only to routes they are authorized to access&rdquo; isn&apos;t actually enforced on PRs.
- A future regression of the role-gating logic in `apps/govea/src/app/(admin)/overview/page.tsx` would land in main with green CI.
- The Coming-next tile&apos;s 5-row invariant (slice C) isn&apos;t guarded.

## Test plan

- [x] Locally: `pnpm exec playwright test tests/e2e/specs/overview.spec.ts` &mdash; **7 passed (17.8s)**
- [ ] CI run of this PR — `E2E smoke tests` job should now report 7 + N tests instead of just N from smoke.spec.ts

Capability: `ac-feature-management`
Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)