### PR TITLE
docs(research): persona validation prep — plan, register extension, feedback log (#384)

### DIFF
--- a/business-architecture/feedback-log.md
+++ b/business-architecture/feedback-log.md
@@ -1,0 +1,77 @@
+# Practice-Fit Feedback Log
+
+**Phase 1 of [#103](https://github.com/roballred/GovEA/issues/103), activated by [#384](https://github.com/roballred/GovEA/issues/384).**
+
+Running log of practice-fit issues heard from real users &mdash; things in GovEA that don&apos;t fit how their team actually works. Manually maintained until #103 Phase 2 ships the in-app affordance.
+
+This log captures **disconfirmation evidence**. A row here is more valuable than a row in the persona file claiming everything was confirmed.
+
+---
+
+## How to use
+
+### When to log
+
+- Any time a real user (interview subject, demo viewer, pilot partner, friendly reviewer) says something that contradicts a persona claim, a feature behaviour, or an assumption in [`docs/research/stakeholder-assumption-register.md`](../docs/research/stakeholder-assumption-register.md).
+- Any time a stakeholder asks for something GovEA can&apos;t do that we expected them to expect.
+- Any time someone&apos;s mental model of an EA concept (capability, initiative, traceability, roadmap, confidence) materially differs from ours.
+
+### When not to log
+
+- Bug reports. File a GitHub issue.
+- Feature requests with no underlying assumption story. File a GitHub issue.
+- Internal-team opinions about UI polish. Use the regular PR review path.
+
+### Cadence
+
+Reviewed at every backlog grooming pass. Rows older than two grooming cycles are either:
+- **Acted on** &mdash; an issue or capability-doc change exists that addresses the feedback, link it in the &ldquo;Action / decision&rdquo; column.
+- **Parked** &mdash; explicitly recorded as &ldquo;not changing behaviour&rdquo; with a reason.
+- **Stale** &mdash; if the relevant feature has materially changed since the row was written, mark the row as superseded and link to a follow-up row if one exists.
+
+---
+
+## Scope (initial focus)
+
+#384 scopes Phase 1 logging to recently-shipped analysis and reporting surfaces. Until that scope expands, target feedback on:
+
+| Surface | Why it&apos;s in scope |
+|---|---|
+| Executive Summary (`/executive`) | Stakeholder-facing report; persona claims are densest here |
+| Heatmap Analysis | Risk-portfolio view that depends on Repository Confidence labels |
+| Impact Analysis (Application + Capability detail pages) | Decommission-consequence assumptions, RM-1 / RM-3 territory |
+| Capability Map + Mermaid diagram | RM-2 / RM-5 territory; recognition + jargon questions |
+| Guided Answers (`/answers?q=`) | GA-1/GA-3/GA-5 entire stack |
+| Repository Confidence Summary | RC-1 through RC-5 |
+| Roadmap Timeline (`/roadmap`) | RT-1 through RT-5 |
+| Stakeholder traceability views | RM-2, RT-5 |
+| In-app product Overview (`/overview`) | New stakeholder landing; confirm or disconfirm whether it actually orients first-time reviewers |
+
+When a row is logged against a surface outside this list, the row still counts &mdash; the scope is a focus, not a filter.
+
+---
+
+## Log
+
+Newest first. Add new rows at the top of the table.
+
+| Date | Source persona | Feature / context | What didn&apos;t fit | Severity | Action / decision |
+|---|---|---|---|---|---|
+| _(empty)_ | _(awaiting first conversation)_ | _(see validation plan)_ | _(see validation plan)_ | _(P1 / P2 / P3)_ | _(link to GitHub issue or short note)_ |
+
+---
+
+## Notes on the columns
+
+- **Date** &mdash; conversation date, not date logged.
+- **Source persona** &mdash; the persona profile the source fits, not a name. Use the persona file stem (e.g. `enterprise-architect`, `elected-official`). One row per distinct piece of feedback even if the same conversation produced several.
+- **Feature / context** &mdash; the GovEA surface the feedback is about, or `(general)` if it&apos;s broader. Use route names (`/executive`) where possible.
+- **What didn&apos;t fit** &mdash; one or two sentences describing the gap. Quote where the words matter.
+- **Severity** &mdash; rough triage. P1 if it likely changes a feature&apos;s value proposition; P2 if it degrades; P3 if it&apos;s friction.
+- **Action / decision** &mdash; either a GitHub issue link, a capability-doc / persona-doc commit reference, or an explicit &ldquo;not changing &mdash; reason&rdquo; note.
+
+---
+
+## Aging policy
+
+When a row has been on this log for more than three months without an action or decision recorded, raise it in the next product-priorities grooming pass. Stale unacted feedback is itself a signal &mdash; either the disconfirmation didn&apos;t matter, or the team is dodging it.

--- a/docs/research/stakeholder-assumption-register.md
+++ b/docs/research/stakeholder-assumption-register.md
@@ -2,8 +2,9 @@
 
 **Purpose:** Map each stakeholder-facing feature to the specific assumptions it depends on, ranked by consequence if the assumption is wrong. Use to prioritize which interview answers matter most before the next build.
 
-**Features covered:** Repository Confidence Summary, Roadmap Timeline, Guided Answers
-**Related issue:** [#216](https://github.com/roballred/GovEA/issues/216)
+**Features covered:** Repository Confidence Summary, Roadmap Timeline, Guided Answers, Repository Modelling (completeness + capability mapping), Integration & Reconciliation
+**Related issues:** [#216](https://github.com/roballred/GovEA/issues/216), [#384](https://github.com/roballred/GovEA/issues/384)
+**Companion docs:** [`validation-plan.md`](./validation-plan.md), [`stakeholder-interview-guide.md`](./stakeholder-interview-guide.md), [`business-architecture/feedback-log.md`](../../business-architecture/feedback-log.md)
 
 **Priority ratings:**
 - **P1** — wrong assumption likely breaks the feature's value proposition entirely
@@ -54,6 +55,42 @@
 
 ---
 
+## Repository Modelling
+
+Added 2026-05-26 for [#384](https://github.com/roballred/GovEA/issues/384). These assumptions sit underneath the repository&apos;s ability to be trusted at all &mdash; they affect every analysis surface, not just one feature.
+
+| ID | Assumption | Persona | If wrong | Priority |
+|----|-----------|---------|----------|----------|
+| RM-1 | Enterprise Architects are willing to maintain capability-to-application linkage as an explicit, ongoing chore | Enterprise Architect (Central IT) | Linkages are entered once and rot. Every downstream confidence / impact / roadmap view inherits stale data and stakeholders silently lose trust. | P1 |
+| RM-2 | Agency EA Coordinators recognise their agency&apos;s applications and services in the centrally-modelled catalogue | Agency EA Coordinator | Agency coordinators can&apos;t find their work in the central model and disengage. Federation features fail before they start. | P1 |
+| RM-3 | The "completeness score" surfaced to admins is interpreted as a quality signal worth acting on, not vanity metrics | Enterprise Architect | Score is dismissed. The cleanup-action ranking is ignored. Repository drifts even when GovEA tells the architect exactly what to fix. | P1 |
+| RM-4 | Domain Architects will accept ownership of a slice of the catalogue when that ownership is named, rather than treating EA work as central-IT&apos;s job | Domain Architect | Domain ownership defaults back to the central EA, who can&apos;t cover every domain, so coverage stays shallow. | P2 |
+| RM-5 | "Capability" reads as an actionable concept to non-EA staff in government (not just to TOGAF-trained architects) | Agency EA Coordinator, Department Director | "Capability" is read as jargon or as a synonym for "feature" or "system" &mdash; the whole information model loses meaning to its primary stakeholders. | P2 |
+| RM-6 | Enterprise Architects find value in seeing what other agencies have catalogued (cross-org visibility), and that visibility justifies the federation effort | Enterprise Architect, Agency EA Coordinator | Federation is built but never used. Single-org becomes the only mode anyone runs. | P3 |
+
+**Riskiest assumption:** RM-1. Linkage rot is the failure mode that quietly invalidates every downstream surface. If maintaining linkages is too expensive for architects, GovEA degrades into a one-time-modelled directory, not a living architecture.
+
+---
+
+## Integration & Reconciliation
+
+Added 2026-05-26 for [#384](https://github.com/roballred/GovEA/issues/384). These assumptions gate named connector work; pin them down before the first integration ships.
+
+| ID | Assumption | Persona | If wrong | Priority |
+|----|-----------|---------|----------|----------|
+| IN-1 | Manual reconciliation between GovEA and an external system of record (CMDB, ITSM, budget) is the EA team&apos;s pain, not someone else&apos;s | Enterprise Architect, Programme Director | The pain lives in finance, ops, or a service-desk team that doesn&apos;t use GovEA &mdash; an EA-side integration solves the wrong team&apos;s problem. | P1 |
+| IN-2 | Data drift between GovEA and the source system happens often enough that an automated freshness signal is meaningfully more useful than a "last synced" timestamp | Enterprise Architect, Agency EA Coordinator | Architects only need to reconcile occasionally; the connector becomes a nice-to-have rather than a must-have, and integration work over-indexes on a sporadic pain. | P1 |
+| IN-3 | The right first integration target is the CMDB, not the ITSM, budget, or DevOps tool | Enterprise Architect | First connector is built against the wrong source of truth &mdash; reconciliation effort moves but doesn&apos;t reduce overall. | P1 |
+| IN-4 | The agency has the political ability to ask the system-of-record team for read-access credentials &mdash; not just the technical ability | Programme Director, Agency EA Coordinator | Connector ships but can&apos;t be turned on in any real agency without an inter-team escalation that nobody wants to drive. | P2 |
+| IN-5 | A push-based or webhook-driven integration is preferred over scheduled polling | Enterprise Architect | Implementation picks the wrong default; first pilots demand the opposite shape and the work is partly rebuilt. | P2 |
+| IN-6 | When GovEA disagrees with a system of record, the architect believes GovEA &mdash; not the other system | Enterprise Architect | Integration becomes one-way reads only; GovEA is treated as the &ldquo;maybe&rdquo; copy and stops being authoritative for any cross-system question. | P3 |
+
+**Riskiest assumption:** IN-1. If reconciliation pain lives in a non-EA team, an integration that ships into the EA UI is solving for the wrong audience even when it works technically.
+
+---
+
 ## Cross-cutting risk
 
 GA-1 and RT-1 share a structural assumption: that elected officials and budget staff use the tool themselves, not through a staff proxy. If the actual user is always a chief of staff or a budget aide, the UX decisions (reading level, question prompts, confidence labels) need to optimize for a different person than the named persona. This is the single most consequential thing to confirm or refute in interviews.
+
+RM-1 and IN-2 share a structural assumption about **maintenance willingness**: that someone will keep linkages or sync signals current. If that maintenance work is too expensive in either case, the failure mode is the same &mdash; the data lies, and confidence surfaces lie with it. Test both in the same architect interview to keep travel/calendar cost low.

--- a/docs/research/validation-plan.md
+++ b/docs/research/validation-plan.md
@@ -1,0 +1,101 @@
+# Persona Validation Plan
+
+**Issue:** [#384](https://github.com/roballred/GovEA/issues/384)
+**Related:** [`stakeholder-assumption-register.md`](./stakeholder-assumption-register.md), [`stakeholder-interview-guide.md`](./stakeholder-interview-guide.md), [`business-architecture/feedback-log.md`](../../business-architecture/feedback-log.md), [#103](https://github.com/roballred/GovEA/issues/103)
+
+This document is the **operating plan** for moving GovEA personas from `Assumed` to `Validated`. The persona files under `business-architecture/personas/` define each persona; this plan defines how we go and test them.
+
+Standards.md §&ldquo;Persona Validation Status&rdquo; gates implementation work that depends solely on assumed personas. This plan is how we lift that gate.
+
+---
+
+## Current state (2026-05-26)
+
+All 16 personas under `business-architecture/personas/` carry **Validation Status: Assumed**. None are yet Validated. That is honest, not a problem &mdash; the problem is that several near-term backlog items (#547, #573, #88, #563, #614) depend on persona-grounded decisions and the gate has not yet been lifted.
+
+The two extended-design-conversation personas (`enterprise-data-architect`, `data-modeler`) are partially-grounded in a single SME (Nichole). They will move to Validated when corroborated by at least one additional practitioner; that bar is in the persona file already.
+
+---
+
+## Validation bar
+
+A persona moves from `Assumed` to `Validated` when **at least one** of the following is true and recorded in the persona file:
+
+1. At least one **structured interview** (recorded notes or transcript) with a real person who fits the persona profile, in a state or local government context, confirms the persona&apos;s goals, pain points, and critical insight without major contradictions.
+2. At least one **direct observation** of someone in the role using a tool that solves a similar need (their current EA tool, a spreadsheet, a CMDB, etc.) corroborates the pains the persona claims.
+3. For the two SME-conversation personas (`enterprise-data-architect`, `data-modeler`): one additional practitioner corroborates the SME&apos;s framing.
+
+A single conversation moves a persona to Validated; the next conversations sharpen specifics, surface variations, and feed `feedback-log.md`.
+
+If an interview **disconfirms** a major persona claim, the persona file is updated and a corresponding backlog issue is filed before any implementation work proceeds against that persona.
+
+---
+
+## Priority order
+
+Sequenced by how many open or near-term backlog items each persona unblocks. Validating from the top of this list down has the highest leverage.
+
+### Tier 1 &mdash; gating multiple backlog items
+
+| Persona | Backlog items currently dependent | Priority assumption(s) to test (see register) |
+|---|---|---|
+| **Elected Official** | #547 (public-read), #614 (slices already shipped), #556 epic descendants | GA-1, RT-1, RT-2, RT-3, RC-1, RC-2 |
+| **Budget & Performance Analyst** | #563 (financial dimensions), #573 (DA quality), guided answers scope | GA-3, RT-2, RT-4, RC-3 |
+| **Enterprise Architect (Central IT)** | #103 (feedback capture), #538 (duplicate-candidate report &mdash; already shipped, validation now retrospective), every repository-modelling decision | RM-1, RM-3, IN-1, IN-3 |
+| **Agency EA Coordinator** | #538, #543 (cross-org seeding), federation work | RM-2, RM-5, IN-4 |
+
+### Tier 2 &mdash; gating one backlog item or shaping next-quarter design
+
+| Persona | Backlog items currently dependent | Priority assumption(s) |
+|---|---|---|
+| **Programme Director** | #87 (change notifications &mdash; substrate shipped, behavior validation), #88 (maturity assessment) | IN-1, IN-4 |
+| **Domain Architect** | #581 (domain ownership &mdash; partial), open glossary/menu-language work | RM-4 |
+| **Enterprise Data Architect** + **Data Modeler** | #573, #363 (DA metamodel conversation) | (corroborate SME framing &mdash; no register row yet, but the persona file&apos;s "Moves to Validated when" bar applies) |
+| **Early-Maturity Practice Lead** | Starter-content + onboarding follow-ups (#587 descendants) | (no register row yet; record fresh assumptions from first interview) |
+
+### Tier 3 &mdash; nice to validate, low gating risk
+
+`Consultant / SI`, `Junior EA Analyst`, `Department Director`, `Business Stakeholder`, `Content Viewer`, `Instance Administrator`, `CMS Administrator`. These influence smaller surfaces or are validated indirectly when adjacent personas are interviewed.
+
+---
+
+## Interview pipeline
+
+Use [`stakeholder-interview-guide.md`](./stakeholder-interview-guide.md) for stakeholder personas (Elected Official, Budget Analyst). Architect-side personas need their own guide; create one in the same shape when scheduling the first Tier 1 architect conversation.
+
+**Recommended order for the next four conversations:**
+
+1. **Elected Official or chief of staff** &mdash; test the staff-proxy hypothesis (GA-1, RT-1) before any further public-read or stakeholder-view work. Easiest to reach; biggest unknown.
+2. **Budget & Performance Analyst** &mdash; test GA-3 (cost-centre / FTE / contract questions). If they don&apos;t map to GovEA&apos;s entity types, Budget-Analyst-targeted features need re-scoping before #563 starts.
+3. **Central-IT Enterprise Architect (not the SME)** &mdash; test RM-1 (linkage-maintenance willingness) and IN-1 (where reconciliation pain actually lives). This is the single most consequential architect conversation for the repository-modelling and integration tracks.
+4. **Agency EA Coordinator** &mdash; test RM-2 (recognition in central catalogue) and RM-5 (whether &ldquo;capability&rdquo; reads as jargon). Pairs well with #538 / federation conversations.
+
+Each session is 30&ndash;45 minutes. Take notes on **surprises** &mdash; disconfirming an assumption is more valuable than confirming one.
+
+---
+
+## After each interview
+
+1. **Update the persona file.** Change `Validation Status: Assumed` to `Validation Status: Validated` only if the bar above is met, and add a one-line note: who, when, what was confirmed or disconfirmed. Keep the prior `Assumed` paragraph (for history); append the new Validated line above it.
+2. **Update [`stakeholder-assumption-register.md`](./stakeholder-assumption-register.md).** Each P1/P2 row that was tested gets a new column entry: `Validated`, `Disconfirmed`, or `Unclear`. Disconfirmed rows fire a backlog issue (next step).
+3. **File backlog issues** for any disconfirmed assumption whose feature is shipped or in flight. The issue title should start with `validation:` so they group cleanly.
+4. **Log a row in [`feedback-log.md`](../../business-architecture/feedback-log.md).** Date, persona, feature, what didn&apos;t fit, action taken.
+
+---
+
+## Exit criteria for #384
+
+This issue is done when:
+
+- [ ] Tier 1 personas have an interview scheduled or a documented reason they can&apos;t be (e.g. no candidate in network).
+- [ ] At least the riskiest assumption per Tier 1 persona (RC-1, RT-2, GA-3, RM-1, IN-1) is marked Validated, Disconfirmed, or Unclear in the register.
+- [ ] `feedback-log.md` has at least one real entry per recently-shipped analysis/reporting surface (see the file&apos;s scope section).
+- [ ] Any Disconfirmed P1 has a backlog issue filed before the next product-priorities grooming.
+
+The current PR (the one introducing this document) is a **preparation slice only** &mdash; it ships the plan, the register extension, and the empty feedback log structure. The interviews themselves are a human task that closes the rest of #384.
+
+---
+
+## Why this is not in the app
+
+Per #384&apos;s explicit instruction, the in-app feedback capture (Phase 2 of #103) is **out of scope** for this issue. The Phase 1 manual log under `business-architecture/feedback-log.md` is the operating surface until #103 Phase 2 lands. Do not duplicate the future in-app affordance work here.


### PR DESCRIPTION
## Summary

Preparation slice of [#384](https://github.com/roballred/GovEA/issues/384). Ships the **documentation infrastructure** that makes the next-four-conversation interview push actionable. The interviews themselves remain a human task &mdash; Claude cannot conduct them and explicitly does not invent findings.

This is the **rank-3 item** on the current product priorities. Standards.md §&ldquo;Persona Validation Status&rdquo; gates ranks 4 (#547) and 5 (#573) implementation on this work; this PR makes the gate liftable.

## What ships

| File | What it does |
|---|---|
| `docs/research/validation-plan.md` _(new)_ | Names which personas to validate first, in what order, against which assumptions, and what counts as Validated vs Disconfirmed. Sequenced by how many backlog items each persona currently gates. Recommends the next four conversations + the riskiest assumption to test in each. Defines exit criteria for #384. |
| `docs/research/stakeholder-assumption-register.md` _(extended)_ | Adds **Repository Modelling** (RM-1 ... RM-6) and **Integration & Reconciliation** (IN-1 ... IN-6) sections per #384&apos;s explicit scope. Adds RM-1 + IN-2 as a shared maintenance-willingness cross-cutting risk to test in the same architect interview. |
| `business-architecture/feedback-log.md` _(new)_ | **Phase 1 of [#103](https://github.com/roballred/GovEA/issues/103), activated.** Manual practice-fit feedback log scoped to recently-shipped analysis/reporting surfaces (Executive, Heatmap, Impact, Capability Map, Guided Answers, Confidence Summary, Roadmap, Traceability, /overview). Defines when to log, when not to, the aging policy, column semantics. Explicit deferral of in-app capture to #103 Phase 2. |

## What this PR is explicitly NOT doing

- **No persona file is moved Assumed → Validated.** All 16 personas under `business-architecture/personas/` keep their current honest Assumed framing. Moving any to Validated requires a real interview the validation plan describes; Claude cannot run those.
- **No invented findings.** The feedback log table is seeded with a single empty placeholder row + an &ldquo;awaiting first conversation&rdquo; marker. No fictional &ldquo;a budget analyst told us...&rdquo; rows.
- **No duplication of #103 Phase 2.** The in-app feedback affordance stays out of scope per #384&apos;s explicit instruction.

## #384 acceptance criteria

Coverage by this PR:

- [x] A short interview/validation plan exists for the highest-risk assumptions in the register &mdash; `validation-plan.md`
- [x] Repository-modelling and integration assumptions targeted in this cycle are explicitly listed &mdash; register extension
- [x] Phase 1 manual feedback logging from #103 is active and scoped to recently shipped analysis/reporting surfaces &mdash; `feedback-log.md`
- [x] This issue links to #103 rather than duplicating the future in-app feedback-capture work &mdash; both new docs link to #103 explicitly and call out the Phase 2 deferral
- [ ] **Findings feed back into issue prioritization, persona docs, and capability docs** &mdash; requires the actual interviews; the validation plan&apos;s &ldquo;After each interview&rdquo; section is the operating procedure for this step

#384 closes when a human has run at least one Tier 1 interview per the plan and the findings land as either persona-file edits or backlog issues.

## Test plan

- [x] `node scripts/lint-business-architecture.mjs` &mdash; clean (`107 files checked`)
- [x] Manual review: every persona-file `Validation Status` line untouched
- [x] Manual review: feedback log seeded empty, not populated with imagined findings

Capability: `rm-repository-completeness`, `fd-repository-confidence-summary`, `ea/integration`
Persona: Elected Official; Budget & Performance Analyst; Enterprise Architect (Central IT); Agency EA Coordinator; Programme Director
Refs #384, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)