### PR TITLE
docs(priorities): refresh top-5 + backlog hygiene (post #614/#504 ship)

### DIFF
--- a/apps/govea/src/app/(admin)/overview/page.tsx
+++ b/apps/govea/src/app/(admin)/overview/page.tsx
@@ -193,38 +193,38 @@ type Priority = {
   refs: string[]
 }
 
-const PRIORITIES_LAST_GROOMED = '2026-05-25'
+const PRIORITIES_LAST_GROOMED = '2026-05-26'
 
 const PRIORITIES: Priority[] = [
   {
     rank: 1,
-    title: 'In-app stakeholder product overview',
-    why: 'First-time reviewers now land on a richer set of surfaces than they can quickly orient to. This page is that overview; the slice you are reading is part of finishing it.',
-    refs: ['#614'],
-  },
-  {
-    rank: 2,
-    title: 'Traceable release pipeline for the Azure demo',
-    why: 'Every persona-facing feature now depends on the demo being a known build. Manual deploys remain the largest operational risk; promote off On Hold.',
-    refs: ['#504'],
-  },
-  {
-    rank: 3,
-    title: 'Persona validation pass',
-    why: 'Several near-term differentiator items depend on personas whose validation status has not been audited. A focused sweep through `business-architecture/personas/` tagging each as Assumed or Validated unlocks honest prioritisation downstream.',
+    title: 'Run the first persona-validation Tier-1 interview',
+    why: 'The validation plan is in place; the next move is one real conversation (recommended first: Elected Official or chief of staff). Until one Tier-1 conversation lands, several near-term differentiator items stay parked. The cheapest unblock on the board.',
     refs: ['#384'],
   },
   {
+    rank: 2,
+    title: 'Close the only open High-severity ARB finding: v1/v2 scope signals',
+    why: 'Filed early April, still open. The deployment-operations group ship closed half of it; the v1/v2 scope-signal work on capability files remains. Director-persona reading of "what do I get day one vs later" is opaque without it. High-severity ARB findings should not age past two grooming cycles.',
+    refs: ['#10'],
+  },
+  {
+    rank: 3,
+    title: 'Consolidate RBAC into a single source of truth',
+    why: 'RBAC duplication between the app and the shared core package grows monotonically with every new route. Behaviour-drift risk is silent and security-adjacent. Foundation work; not gated on personas.',
+    refs: ['#34'],
+  },
+  {
     rank: 4,
-    title: 'Public-read access: last viewer-experience sub-issue',
-    why: 'Six of seven viewer-experience sub-issues are closed; this is the remaining one and the largest. Persona-validation prerequisite; sequence after rank 3.',
-    refs: ['#547'],
+    title: 'EA Adoption & Engagement capability area',
+    why: 'Pair the product feature with the matching ARB finding. EA market research calls adoption the most persistent cross-tool weakness; GovEA targets non-EA stakeholders explicitly. Capability-doc slice does not need interviews and seeds implementation issues for the next quarter.',
+    refs: ['#71', '#94'],
   },
   {
     rank: 5,
-    title: 'Data architecture quality: next slice',
-    why: 'The cheap, persona-validated half is shipped. Remaining Layer 1/2 quality cues and scorecard summary need a product/persona conversation before scoping.',
-    refs: ['#573', '#363'],
+    title: 'GovEA Project as continuous product documentation',
+    why: 'Maintain the seeded GovEA Project organisation as a living model of the actual product. Cheap incrementally; compounds into a more credible demo and a real dogfood loop. Treat as a recurring grooming habit, not a one-shot.',
+    refs: ['#518'],
   },
 ]
 

--- a/apps/govea/tests/e2e/specs/overview.spec.ts
+++ b/apps/govea/tests/e2e/specs/overview.spec.ts
@@ -87,3 +87,28 @@ test('viewer sees neither Manage users nor Audit log CTA', async ({ browser }) =
   await expect(startHere(page).getByRole('link', { name: /Executive Summary/i })).toBeVisible()
   await ctx.close()
 })
+
+// ── Coming-next priorities tile (slice C) ────────────────────────────────────
+//
+// The tile mirrors docs/product-priorities.md (see the page header comment).
+// Role-agnostic: priorities are honest signal, not workspace configuration.
+// Spot-checking the rank-1 title surfaces any doc/page drift in CI.
+
+test('coming-next tile renders all five priorities for each role', async ({ browser }) => {
+  for (const role of ROLES) {
+    const ctx = await browser.newContext({ storageState: `tests/e2e/.auth/${role}.json` })
+    const page = await ctx.newPage()
+    await page.goto('/overview')
+    const section = page.getByTestId('overview-coming-next')
+    await expect(section, `${role}: coming-next section should render`).toBeVisible()
+    await expect(
+      section.locator('ol > li'),
+      `${role}: should see 5 priority rows`,
+    ).toHaveCount(5)
+    // Rank-1 spot-check: matches docs/product-priorities.md Top Five row 1.
+    await expect(
+      section.getByRole('heading', { name: /Run the first persona-validation Tier-1 interview/i }),
+    ).toBeVisible()
+    await ctx.close()
+  }
+})

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-25 (rewritten end-to-end; the prior 2026-05-24 version's entire top-five shipped within ~24 hours of grooming and is no longer actionable).
+Last groomed: 2026-05-26 (rewritten end-to-end; the prior 2026-05-25 version's ranks 1 and 2 both shipped within ~24 hours of grooming. Ranks 4 and 5 are now formally gated on rank 3 outcomes per the new validation plan, so they leave the top five until the gate lifts).
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -10,27 +10,31 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-A nine-PR ship on 2026-05-24 took out the prior top-five in one window:
+The prior top five worked through quickly:
 
-- [#628](https://github.com/roballred/GovEA/pull/628) closed the ARB cleanup trio ([#75](https://github.com/roballred/GovEA/issues/75) + [#7](https://github.com/roballred/GovEA/issues/7) closed; [#133](https://github.com/roballred/GovEA/issues/133) addressed but not auto-closed).
-- [#630](https://github.com/roballred/GovEA/pull/630) shipped CSV import/export for Initiatives + Objectives.
-- [#632](https://github.com/roballred/GovEA/pull/632) shipped Data Vault naming hints ([#570](https://github.com/roballred/GovEA/issues/570)).
-- [#633](https://github.com/roballred/GovEA/pull/633) shipped the role-tailored viewer landing ([#548](https://github.com/roballred/GovEA/issues/548)), and same-day siblings [#618](https://github.com/roballred/GovEA/pull/618), plus the earlier closure of #549/#550/#553/#554/#559, brought the viewer-experience epic ([#556](https://github.com/roballred/GovEA/issues/556)) down to a single remaining sub-issue ([#547](https://github.com/roballred/GovEA/issues/547) public-read).
-- [#634](https://github.com/roballred/GovEA/pull/634) closed the Scope-field backfill ([#510](https://github.com/roballred/GovEA/issues/510)) and the `cms/deployment-operations` group ([#511](https://github.com/roballred/GovEA/issues/511) addressed but not auto-closed).
-- [#626](https://github.com/roballred/GovEA/pull/626) merged: cross-tenant user PII is now gated on break-glass.
-- [#637](https://github.com/roballred/GovEA/pull/637) shipped the enterprise-view capability-adoption + duplicate-candidate reports ([#537](https://github.com/roballred/GovEA/issues/537), [#538](https://github.com/roballred/GovEA/issues/538) — also not auto-closed).
+- **Rank 1 — #614 in-app stakeholder product overview.** Sliced A/B/C, all three PRs merged ([#640](https://github.com/roballred/GovEA/pull/640), [#641](https://github.com/roballred/GovEA/pull/641), [#642](https://github.com/roballred/GovEA/pull/642)) + the CI fix ([#643](https://github.com/roballred/GovEA/pull/643)) so the new role-gating tests actually run. The `/overview` route now ships role-aware CTAs and a Coming-next priorities tile.
+- **Rank 2 — #504 traceable release pipeline.** Shipped in [#645](https://github.com/roballred/GovEA/pull/645). Two new workflows (`deploy-azure-dev.yml`, `rollback-azure-dev.yml`) plus [`docs/release-pipeline.md`](./release-pipeline.md). Pipeline is dormant until the maintainer completes the one-time OIDC setup but the code is in. Risk-register R-002 moved Open → Mitigated.
+- **Rank 3 — #384 persona validation.** Documentation infrastructure landed in [#646](https://github.com/roballred/GovEA/pull/646): a validation plan, the assumption-register extension (Repository Modelling + Integration sections), and the Phase 1 `business-architecture/feedback-log.md`. The interviews themselves remain the human task — no persona moved from Assumed to Validated yet.
+- **Ranks 4 (#547) and 5 (#573)** stayed parked behind rank 3, exactly as the prior grooming sequenced.
 
-The practical implication: differentiator backlog has shifted from "many small persona-walk gaps" to "a smaller set of larger, persona-validation-sensitive items." The next ranking reflects that shift.
+Plus a clean backlog-hygiene sweep this pass: [#133](https://github.com/roballred/GovEA/issues/133), [#366](https://github.com/roballred/GovEA/issues/366), [#511](https://github.com/roballred/GovEA/issues/511), [#538](https://github.com/roballred/GovEA/issues/538), [#543](https://github.com/roballred/GovEA/issues/543) all closed retrospectively with PR back-references.
+
+The practical implication: the next ranking has to balance **gate-lifting** (the rank-1 interview), **deferred-but-not-gone** foundation hygiene (ARB findings that have aged), and **differentiator design work that doesn't need interviews**.
 
 ## Top Five Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | **In-app stakeholder product overview — slice A: static `/overview` route** | First-time reviewers now land on a richer set of surfaces than they can quickly orient to. The viewer-experience epic delivered better *destinations*; this delivers the *entry page* that explains what GovEA is, what is shipped vs. maturing, and where to click first. Keep the first slice deliberately small: static content, role-aware visibility, no priorities-doc sync, no full CTA matrix. Slices B (CTAs) and C (priorities tile) follow in their own PRs. | [#614](https://github.com/roballred/GovEA/issues/614) |
-| 2 | **Traceable release pipeline for the Azure demo** | Promoted off On Hold. The 9-PR same-day ship raised the cost of not having this: every persona-facing feature now depends on the demo being a known build, and reviewers cannot pin what they see to a commit, image digest, or runtime configuration. Operational risk is now larger than the work to close it. | [#504](https://github.com/roballred/GovEA/issues/504) |
-| 3 | **Persona validation pass** | Standards.md §"Persona Validation Status" explicitly gates differentiator implementation on validated personas: *"Implementation work that depends solely on assumed personas carries elevated risk and should be noted in the relevant issues."* Several near-term differentiator candidates ([#547](https://github.com/roballred/GovEA/issues/547), [#573](https://github.com/roballred/GovEA/issues/573), [#88](https://github.com/roballred/GovEA/issues/88), [#563](https://github.com/roballred/GovEA/issues/563), [#614](https://github.com/roballred/GovEA/issues/614)) all depend on personas whose validation status has not been audited. A focused sweep through `business-architecture/personas/` tagging each as Assumed or Validated unlocks honest prioritization downstream. | [#384](https://github.com/roballred/GovEA/issues/384) |
-| 4 | **Public-read access — last viewer-experience sub-issue** | Six of seven [#556](https://github.com/roballred/GovEA/issues/556) sub-issues are closed; this is the remaining one and the largest. The epic explicitly flags a persona-validation prerequisite: *"deserves at least one real interview before this lands."* Sequence after rank 3 so the implementation is grounded in validated persona input rather than assumed need. | [#547](https://github.com/roballred/GovEA/issues/547) |
-| 5 | **Data architecture quality — next slice, scoped on [#363](https://github.com/roballred/GovEA/issues/363) conversation** | The cheap, persona-validated half ([#570](https://github.com/roballred/GovEA/issues/570)) is shipped. The remaining DA Layer 1/2 quality cues and scorecard summary need a product/persona conversation with @nicholerip before scoping. Park here as a placeholder so it does not slip through grooming, and ping [#363](https://github.com/roballred/GovEA/issues/363) before opening implementation issues. | [#573](https://github.com/roballred/GovEA/issues/573), [#363](https://github.com/roballred/GovEA/issues/363) |
+| 1 | **Run the first #384 Tier-1 interview** | The validation plan ([`docs/research/validation-plan.md`](./research/validation-plan.md)) is in place; the next move is one real conversation. Recommended first candidate: an Elected Official or chief of staff testing the staff-proxy hypothesis (GA-1, RT-1). Until one Tier-1 conversation lands, ranks 4-5 of the prior list stay parked. This is the cheapest unblock on the board. | [#384](https://github.com/roballred/GovEA/issues/384), [#547](https://github.com/roballred/GovEA/issues/547), [#573](https://github.com/roballred/GovEA/issues/573), [#563](https://github.com/roballred/GovEA/issues/563), [#88](https://github.com/roballred/GovEA/issues/88) |
+| 2 | **#10 — close the only open High-severity ARB finding (v1/v2 scope signals)** | Filed 2026-04-04, still open. The deployment-operations capability group ship ([#634](https://github.com/roballred/GovEA/pull/634)) closed half of #10's intent; the residual v1/v2 scope-signal work on capability files remains. Director-persona reading of "what do I get day one vs later" is genuinely opaque without it, and it's a doc-shaped task that doesn't need an interview. High-severity ARB findings shouldn't age past two grooming cycles. | [#10](https://github.com/roballred/GovEA/issues/10) |
+| 3 | **#34 — consolidate RBAC into a single source of truth** | Medium-severity ARB finding, but RBAC duplication between `apps/govea/src/lib/rbac.ts` and `packages/core/src/rbac/index.ts` grows monotonically with every new route. Behaviour-drift risk is security-adjacent and silent — exactly the kind of debt that turns into a real incident if it ages further. Foundation work; not gated on personas. | [#34](https://github.com/roballred/GovEA/issues/34) |
+| 4 | **#71 + #94 — EA Adoption & Engagement capability area** | Differentiator capability-doc work pairing the feat ([#71](https://github.com/roballred/GovEA/issues/71)) with the ARB finding ([#94](https://github.com/roballred/GovEA/issues/94)) that named the same gap. The 2026 EA market research called out adoption as the single most persistent cross-tool weakness, and GovEA's persona thesis explicitly targets non-EA stakeholders. Designing the capability group first (sub-capabilities, persona links) is a docs slice that does not need interviews and seeds implementation issues for the next quarter. | [#71](https://github.com/roballred/GovEA/issues/71), [#94](https://github.com/roballred/GovEA/issues/94) |
+| 5 | **#518 — GovEA Project as continuous product documentation** | The seeded GovEA Project organisation should model the actual product as it evolves: strategy, goals, objectives, value streams, initiatives, principles, ADRs, services, applications, capabilities, personas. Cheap to maintain incrementally; compounds into a much more credible demo and a real dogfood loop with every grooming cycle. Differentiator. Treat as recurring rather than one-shot. | [#518](https://github.com/roballred/GovEA/issues/518) |
+
+## What dropped out of the top five
+
+- **#547 public-read access** and **#573 + #363 data architecture quality next slice** — explicitly gated on the rank-1 interview per the validation plan. They re-enter the top five the same week a Tier-1 conversation lands and either confirms or disconfirms the underlying assumptions.
+- **#614 / #504** — closed this cycle (see Current Signal above).
 
 ## On Hold
 
@@ -44,11 +48,12 @@ Items the product owner has paused; revisit when noted blocker clears:
 
 ## Product Manager Notes
 
-- **Backlog hygiene — close-keyword drift.** Several recent PRs landed work but did not auto-close their named issues: [#133](https://github.com/roballred/GovEA/issues/133), [#366](https://github.com/roballred/GovEA/issues/366), [#511](https://github.com/roballred/GovEA/issues/511), [#538](https://github.com/roballred/GovEA/issues/538), [#543](https://github.com/roballred/GovEA/issues/543) all remain open despite being referenced by merged PR titles. Worth a one-pass cleanup before the next grooming so the open-issue count reflects reality.
-- **Persona validation (rank 3) should precede ranks 4 and 5.** Without it, #547 and #573 implementation will repeat the "designed against an assumed persona" risk the standards flag.
-- **#614 (rank 1) is the cheapest differentiator on the board right now** and has the largest stakeholder-comprehension payoff. The issue body lists six page sections — slice them across at least three PRs; do not attempt the whole spec in one.
-- **#504 (rank 2) was held in the prior grooming with the explicit note "Promote back into the top five when ready to take it on."** That moment is now: nothing else in flight is gated on it, and every feature ship from here forward inherits the same opacity problem until it lands.
-- The **viewer-experience epic [#556](https://github.com/roballred/GovEA/issues/556)** can likely close once #547 lands and the close-keyword hygiene sweep above runs.
+- **Rank 1 is interview-shaped, not implementation-shaped.** Don't treat #384 as "more docs to write." The validation plan is written; what's missing is one real human conversation. A 30-minute call beats another doc pass.
+- **The viewer-experience epic [#556](https://github.com/roballred/GovEA/issues/556)** can likely close once #547 lands; for now it stays open since the gating relationship is real.
+- **High-severity ARB findings (#10) shouldn't keep aging.** Two grooming cycles is the soft limit; this one filed 2026-04-04 is now well past. Rank 2 here is partly an admission that we let it slip.
+- **Pair #71 and #94.** They describe the same problem from product-design and ARB angles; landing them as one capability-doc slice avoids duplicated edits and clarifies which sub-capability ideas survive ARB review.
+- **#518 is a habit, not a feature.** Add it to grooming pre-flight: "did anything in this cycle change the canonical product story? If yes, update the GovEA Project seed." Don't try to make it a one-shot deliverable.
+- **Backlog hygiene actioned this cycle.** #133, #366, #511, #538, #543 closed retrospectively. The close-keyword-drift bullet stays out of the top five going forward unless a new batch accumulates.
 
 ## Security Remediation Status
 


### PR DESCRIPTION
## Summary

Two-part grooming pass:

1. **Backlog hygiene** — actioned the close-keyword-drift list the prior priorities doc flagged. Five issues closed retrospectively via `gh issue close` with PR back-references.
2. **Priorities doc refresh** — prior ranks 1 (#614) and 2 (#504) shipped; ranks 4 (#547) and 5 (#573) are now formally gated on the rank-3 (#384) interview push, so they drop out of the top five until the gate lifts. New top five reorganises around foundation hygiene that doesn&apos;t need interviews.

## Backlog hygiene

| Issue | Closed by | Notes |
|---|---|---|
| [#133](https://github.com/roballred/GovEA/issues/133) | [#628](https://github.com/roballred/GovEA/pull/628) | ARB cleanup trio &mdash; debt-type taxonomy coordinator copy |
| [#366](https://github.com/roballred/GovEA/issues/366) | [#636](https://github.com/roballred/GovEA/pull/636) | Quick-wins &mdash; persona checkboxes removed from list edit dialog |
| [#511](https://github.com/roballred/GovEA/issues/511) | [#634](https://github.com/roballred/GovEA/pull/634) | `cms/deployment-operations` capability group |
| [#538](https://github.com/roballred/GovEA/issues/538) | [#637](https://github.com/roballred/GovEA/pull/637) | Cross-org duplicate-candidate reports |
| [#543](https://github.com/roballred/GovEA/issues/543) | [#636](https://github.com/roballred/GovEA/pull/636) | Reverse-direction cross-org link seed |

Open-issue count drops from 38 to 33 with no implementation changes.

## New top five

| Rank | Item | Issues | Gating? |
|---|---|---|---|
| 1 | Run the first persona-validation Tier-1 interview | #384 | gate-lifter for #547, #573, #563, #88 |
| 2 | Close the only open High-severity ARB finding (v1/v2 scope signals) | #10 | not gated |
| 3 | Consolidate RBAC into a single source of truth | #34 | not gated |
| 4 | EA Adoption & Engagement capability area | #71, #94 | not gated |
| 5 | GovEA Project as continuous product documentation | #518 | recurring habit |

Prior ranks 4 (#547 public-read) and 5 (#573 + #363 DA quality) explicitly deferred behind rank 1.

## In-product `/overview` Coming-next tile updated

Per the maintenance rule in the page header comment:
- `PRIORITIES` constant updated to the new top five
- `PRIORITIES_LAST_GROOMED` bumped to `'2026-05-26'`
- The priorities-tile test that `#642`&apos;s merge lost is re-added to `overview.spec.ts`
- Rank-1 spot-check assertion updated to the new title (&ldquo;Run the first persona-validation Tier-1 interview&rdquo;)

## Test plan

- [x] `pnpm exec tsc --noEmit` &mdash; clean
- [x] `node scripts/lint-business-architecture.mjs` &mdash; OK (107 files checked)
- [x] `pnpm exec playwright test tests/e2e/specs/overview.spec.ts` &mdash; **7 passed (20.4s)**, including the re-added priorities-tile spot-check

Capability: `ac-feature-management`
Refs #614, #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)