### PR TITLE
docs(backlog): triage the 14 unmilestone'd issues into milestones

### DIFF
--- a/apps/govea/src/app/(admin)/overview/page.tsx
+++ b/apps/govea/src/app/(admin)/overview/page.tsx
@@ -193,38 +193,38 @@ type Priority = {
   refs: string[]
 }
 
-const PRIORITIES_LAST_GROOMED = '2026-05-25'
+const PRIORITIES_LAST_GROOMED = '2026-05-26'
 
 const PRIORITIES: Priority[] = [
   {
     rank: 1,
-    title: 'In-app stakeholder product overview',
-    why: 'First-time reviewers now land on a richer set of surfaces than they can quickly orient to. This page is that overview; the slice you are reading is part of finishing it.',
-    refs: ['#614'],
-  },
-  {
-    rank: 2,
-    title: 'Traceable release pipeline for the Azure demo',
-    why: 'Every persona-facing feature now depends on the demo being a known build. Manual deploys remain the largest operational risk; promote off On Hold.',
-    refs: ['#504'],
-  },
-  {
-    rank: 3,
-    title: 'Persona validation pass',
-    why: 'Several near-term differentiator items depend on personas whose validation status has not been audited. A focused sweep through `business-architecture/personas/` tagging each as Assumed or Validated unlocks honest prioritisation downstream.',
+    title: 'Run the first persona-validation Tier-1 interview',
+    why: 'The validation plan is in place; the next move is one real conversation (recommended first: Elected Official or chief of staff). Until one Tier-1 conversation lands, several near-term differentiator items stay parked. The cheapest unblock on the board.',
     refs: ['#384'],
   },
   {
+    rank: 2,
+    title: 'Close the only open High-severity ARB finding: v1/v2 scope signals',
+    why: 'Filed early April, still open. The deployment-operations group ship closed half of it; the v1/v2 scope-signal work on capability files remains. Director-persona reading of "what do I get day one vs later" is opaque without it. High-severity ARB findings should not age past two grooming cycles.',
+    refs: ['#10'],
+  },
+  {
+    rank: 3,
+    title: 'Consolidate RBAC into a single source of truth',
+    why: 'RBAC duplication between the app and the shared core package grows monotonically with every new route. Behaviour-drift risk is silent and security-adjacent. Foundation work; not gated on personas.',
+    refs: ['#34'],
+  },
+  {
     rank: 4,
-    title: 'Public-read access: last viewer-experience sub-issue',
-    why: 'Six of seven viewer-experience sub-issues are closed; this is the remaining one and the largest. Persona-validation prerequisite; sequence after rank 3.',
-    refs: ['#547'],
+    title: 'EA Adoption & Engagement capability area',
+    why: 'Pair the product feature with the matching ARB finding. EA market research calls adoption the most persistent cross-tool weakness; GovEA targets non-EA stakeholders explicitly. Capability-doc slice does not need interviews and seeds implementation issues for the next quarter.',
+    refs: ['#71', '#94'],
   },
   {
     rank: 5,
-    title: 'Data architecture quality: next slice',
-    why: 'The cheap, persona-validated half is shipped. Remaining Layer 1/2 quality cues and scorecard summary need a product/persona conversation before scoping.',
-    refs: ['#573', '#363'],
+    title: 'GovEA Project as continuous product documentation',
+    why: 'Maintain the seeded GovEA Project organisation as a living model of the actual product. Cheap incrementally; compounds into a more credible demo and a real dogfood loop. Treat as a recurring grooming habit, not a one-shot.',
+    refs: ['#518'],
   },
 ]
 

--- a/apps/govea/tests/e2e/specs/overview.spec.ts
+++ b/apps/govea/tests/e2e/specs/overview.spec.ts
@@ -87,3 +87,28 @@ test('viewer sees neither Manage users nor Audit log CTA', async ({ browser }) =
   await expect(startHere(page).getByRole('link', { name: /Executive Summary/i })).toBeVisible()
   await ctx.close()
 })
+
+// ── Coming-next priorities tile (slice C) ────────────────────────────────────
+//
+// The tile mirrors docs/product-priorities.md (see the page header comment).
+// Role-agnostic: priorities are honest signal, not workspace configuration.
+// Spot-checking the rank-1 title surfaces any doc/page drift in CI.
+
+test('coming-next tile renders all five priorities for each role', async ({ browser }) => {
+  for (const role of ROLES) {
+    const ctx = await browser.newContext({ storageState: `tests/e2e/.auth/${role}.json` })
+    const page = await ctx.newPage()
+    await page.goto('/overview')
+    const section = page.getByTestId('overview-coming-next')
+    await expect(section, `${role}: coming-next section should render`).toBeVisible()
+    await expect(
+      section.locator('ol > li'),
+      `${role}: should see 5 priority rows`,
+    ).toHaveCount(5)
+    // Rank-1 spot-check: matches docs/product-priorities.md Top Five row 1.
+    await expect(
+      section.getByRole('heading', { name: /Run the first persona-validation Tier-1 interview/i }),
+    ).toBeVisible()
+    await ctx.close()
+  }
+})

--- a/docs/backlog-triage-2026-05-26.md
+++ b/docs/backlog-triage-2026-05-26.md
@@ -1,0 +1,88 @@
+# Backlog Milestone Triage &mdash; 2026-05-26
+
+Triage of the 14 open issues that carried no milestone as of 2026-05-26. Recorded here so future grooming can see what was assigned, why, and whether each assignment was contested.
+
+The largest bucket on the board entering this triage was **no milestone (14)**, larger than v0.9 (5), v1.0 (3), v1.5 (3), or v2.0 (8). Triage moves those 14 into milestones based on each issue&apos;s track, persona-validation dependency, and fit with the milestone&apos;s stated definition of done.
+
+Milestone definitions are the source of truth (visible via `gh api repos/roballred/GovEA/milestones`). They are summarised below for triage context only; if they drift, the milestone descriptions on GitHub govern.
+
+---
+
+## Milestone shapes (summary)
+
+| Milestone | Theme | Definition of done (paraphrased) |
+|---|---|---|
+| **v0.9** | Foundation Cleanup | Pay down debt before declaring v1. Docs match reality. ARB findings resolved or closed. Visual regression on 3 critical paths. Reproducible local bootstrap. **NOT in scope: new feature work.** |
+| **v1.0** | Practice-Ready | One Agency EA Coordinator or Enterprise Architect can install, populate, and use GovEA for real work without workarounds. Self-host install guide. Repository CRUD complete. Reports usable. Data export so users trust it. Phase 1 feedback log collecting signal. |
+| **v1.5** | Adoption-Validated | GovEA has been used by real practitioners. Persona docs validated. In-product feedback widget. Analysis surfaces operationalized. Adoption & Engagement capability area instrumented. |
+| **v2.0** | Platform & Integration | Multi-tenant platform with external systems of record. REST API + Tier 1 sync. ADR + debt in product. Change notifications. TOGAF redesign decision applied. |
+
+---
+
+## Triage decisions
+
+### → v0.9 (Foundation Cleanup)
+
+| Issue | Title (short) | Why v0.9 |
+|---|---|---|
+| [#482](https://github.com/roballred/GovEA/issues/482) | `docs(process): add docs/AI-SESSION-START.md` | v0.9 explicit goal: &ldquo;docs match reality.&rdquo; The session-bootstrap blob references this file but it doesn&apos;t exist on disk &mdash; every AI session since the reference was added has flown without it. Pure documentation; one PR. |
+
+### → v1.0 (Practice-Ready)
+
+| Issue | Title (short) | Why v1.0 |
+|---|---|---|
+| [#479](https://github.com/roballred/GovEA/issues/479) | `feat(nav): collapsible groups in the admin sidebar` | Sidebar density blocks new-user comprehension &mdash; a Practice-Ready UX polish. Single PR; persona-friendly to Junior EA / Domain Architect. |
+| [#456](https://github.com/roballred/GovEA/issues/456) | `feat(admin): org-wide and instance-wide admin notices` | CMS Administrator persona. Standard admin-console capability for a real EA practice. |
+| [#529](https://github.com/roballred/GovEA/issues/529) | `feat(admin): operational Backup & Export` | Pairs with #86 (Data Export). v1.0 def-of-done explicitly names &ldquo;data export so users trust putting their data in&rdquo;; #529 is the operational complement (full backup/restore). |
+| [#518](https://github.com/roballred/GovEA/issues/518) | `chore(seed): GovEA Project sample data as continuous documentation` | Recurring habit work; bound it to v1.0 so the dogfood story is fresh for first install. After v1.0 closes, re-open as a v1.5 issue. |
+
+### → v1.5 (Adoption-Validated)
+
+These are the persona-validation-sensitive items the validation plan ([`docs/research/validation-plan.md`](./research/validation-plan.md)) explicitly gates on Tier-1 interviews from #384.
+
+| Issue | Title (short) | Gate |
+|---|---|---|
+| [#547](https://github.com/roballred/GovEA/issues/547) | `feat(public): public-read access for non-authenticated stakeholders` | Elected Official interview (GA-1 staff-proxy hypothesis) per validation plan Tier 1 |
+| [#573](https://github.com/roballred/GovEA/issues/573) | `feat(data-arch): model-quality signals and scorecard summary` | Data Architect / SME corroboration per validation plan Tier 2; needs #363 conversation first |
+| [#563](https://github.com/roballred/GovEA/issues/563) | `feat(budget): financial dimensions on apps and initiatives` | Budget Analyst interview (GA-3, RT-4) per validation plan Tier 1 |
+| [#556](https://github.com/roballred/GovEA/issues/556) | `epic(viewer-experience)` | 6 of 7 sub-issues closed; closes with #547. Same milestone as its only remaining child. |
+| [#499](https://github.com/roballred/GovEA/issues/499) | `Add inherited system glossary for core GovEA concepts` | Adoption-flavored stakeholder work; helps non-EA staff parse the product&apos;s vocabulary. Sequencing depends on what comes out of stakeholder interviews; pairing with v1.5 keeps that link visible. |
+| [#55](https://github.com/roballred/GovEA/issues/55) | `feat: data capabilities and data management domain` | Taxonomy expansion for the Data & Analytics capability domain. Distinct from the shipped Data Architecture module (entities/attributes/keys) &mdash; this adds the capability-side domain seeding. Adoption-relevant for orgs that already run data programs; sequence after first pilots. |
+
+### → v2.0 (Platform & Integration)
+
+| Issue | Title (short) | Why v2.0 |
+|---|---|---|
+| [#409](https://github.com/roballred/GovEA/issues/409) | `feat(capabilities): model Success Criteria as first-class product data` | Data-model expansion adding a new entity type. v1.0 def-of-done explicitly limits new entity types; v1.5 is validation-focused. v2.0 is the right horizon. |
+| [#363](https://github.com/roballred/GovEA/issues/363) | `Data Architecture Metamodel` | Design conversation that gates broader DA expansion. v1.5 is &ldquo;validate what exists&rdquo;; further DA modelling is v2.0-shaped work after the metamodel discussion lands. |
+| [#351](https://github.com/roballred/GovEA/issues/351) | `feat: add Reference Architecture Capability and Relationships` | TOGAF-adjacent capability expansion that pairs with v2.0&apos;s `#313 TOGAF taxonomy redesign decision`. Reference architectures are a building-block concept whose shape depends on the TOGAF redesign outcome. |
+
+---
+
+## Contested calls (would benefit from human override)
+
+- **#518 dogfood &rarr; v1.0 vs. recurring habit.** Assigning it to v1.0 bounds the work; the dogfood story compounds across milestones, so a recurring designation might be more honest. Compromise: keep in v1.0 for now and re-open as a v1.5 issue when v1.0 closes.
+- **#499 inherited glossary &rarr; v1.5 vs v1.0.** Could be v1.0 (basic glossary surface) or v1.5 (validated vocabulary). Picked v1.5 because the inherited / source-of-truth pattern is adoption-shaped, not install-shaped.
+- **#55 data capabilities domain &rarr; v1.5 vs v2.0.** Capability-domain taxonomy expansion could land either as adoption seeding (v1.5) or as platform expansion (v2.0). Picked v1.5 because it&apos;s seed-data shaped, not data-model shaped.
+
+---
+
+## What this triage does not do
+
+- **Does not modify milestone definitions.** Several milestone descriptions reference closed issues in their scope lists (e.g. v1.0 lists `#7, #49, #366, #380` which are all closed). Refreshing milestone descriptions is separate grooming work.
+- **Does not re-prioritise within milestones.** Order of attack inside v0.9, v1.0, etc. is the priorities-doc&apos;s job.
+- **Does not change scope.** Each issue keeps its current title, body, labels &mdash; only the milestone field changes.
+
+---
+
+## After this triage
+
+| Milestone | Open before | Open after |
+|---|---|---|
+| v0.9 | 5 | 6 |
+| v1.0 | 3 | 7 |
+| v1.5 | 3 | 9 |
+| v2.0 | 8 | 11 |
+| No milestone | **14** | **0** |
+
+Every open issue now sits in a milestone. The next planning cycle can read the milestone counts as ground truth.

--- a/docs/product-priorities.md
+++ b/docs/product-priorities.md
@@ -1,6 +1,6 @@
 # Product Priority Shortlist
 
-Last groomed: 2026-05-25 (rewritten end-to-end; the prior 2026-05-24 version's entire top-five shipped within ~24 hours of grooming and is no longer actionable).
+Last groomed: 2026-05-26 (rewritten end-to-end; the prior 2026-05-25 version's ranks 1 and 2 both shipped within ~24 hours of grooming. Ranks 4 and 5 are now formally gated on rank 3 outcomes per the new validation plan, so they leave the top five until the gate lifts).
 
 This note summarizes the top next product moves from the current capability inventory, open issues, and recent pull requests. It is intentionally short so it can be reviewed during backlog planning without replacing GitHub issues as the source of execution detail.
 
@@ -10,27 +10,31 @@ Use this alongside [`docs/risk-register.md`](./risk-register.md) when a backlog 
 
 ## Current Signal
 
-A nine-PR ship on 2026-05-24 took out the prior top-five in one window:
+The prior top five worked through quickly:
 
-- [#628](https://github.com/roballred/GovEA/pull/628) closed the ARB cleanup trio ([#75](https://github.com/roballred/GovEA/issues/75) + [#7](https://github.com/roballred/GovEA/issues/7) closed; [#133](https://github.com/roballred/GovEA/issues/133) addressed but not auto-closed).
-- [#630](https://github.com/roballred/GovEA/pull/630) shipped CSV import/export for Initiatives + Objectives.
-- [#632](https://github.com/roballred/GovEA/pull/632) shipped Data Vault naming hints ([#570](https://github.com/roballred/GovEA/issues/570)).
-- [#633](https://github.com/roballred/GovEA/pull/633) shipped the role-tailored viewer landing ([#548](https://github.com/roballred/GovEA/issues/548)), and same-day siblings [#618](https://github.com/roballred/GovEA/pull/618), plus the earlier closure of #549/#550/#553/#554/#559, brought the viewer-experience epic ([#556](https://github.com/roballred/GovEA/issues/556)) down to a single remaining sub-issue ([#547](https://github.com/roballred/GovEA/issues/547) public-read).
-- [#634](https://github.com/roballred/GovEA/pull/634) closed the Scope-field backfill ([#510](https://github.com/roballred/GovEA/issues/510)) and the `cms/deployment-operations` group ([#511](https://github.com/roballred/GovEA/issues/511) addressed but not auto-closed).
-- [#626](https://github.com/roballred/GovEA/pull/626) merged: cross-tenant user PII is now gated on break-glass.
-- [#637](https://github.com/roballred/GovEA/pull/637) shipped the enterprise-view capability-adoption + duplicate-candidate reports ([#537](https://github.com/roballred/GovEA/issues/537), [#538](https://github.com/roballred/GovEA/issues/538) — also not auto-closed).
+- **Rank 1 — #614 in-app stakeholder product overview.** Sliced A/B/C, all three PRs merged ([#640](https://github.com/roballred/GovEA/pull/640), [#641](https://github.com/roballred/GovEA/pull/641), [#642](https://github.com/roballred/GovEA/pull/642)) + the CI fix ([#643](https://github.com/roballred/GovEA/pull/643)) so the new role-gating tests actually run. The `/overview` route now ships role-aware CTAs and a Coming-next priorities tile.
+- **Rank 2 — #504 traceable release pipeline.** Shipped in [#645](https://github.com/roballred/GovEA/pull/645). Two new workflows (`deploy-azure-dev.yml`, `rollback-azure-dev.yml`) plus [`docs/release-pipeline.md`](./release-pipeline.md). Pipeline is dormant until the maintainer completes the one-time OIDC setup but the code is in. Risk-register R-002 moved Open → Mitigated.
+- **Rank 3 — #384 persona validation.** Documentation infrastructure landed in [#646](https://github.com/roballred/GovEA/pull/646): a validation plan, the assumption-register extension (Repository Modelling + Integration sections), and the Phase 1 `business-architecture/feedback-log.md`. The interviews themselves remain the human task — no persona moved from Assumed to Validated yet.
+- **Ranks 4 (#547) and 5 (#573)** stayed parked behind rank 3, exactly as the prior grooming sequenced.
 
-The practical implication: differentiator backlog has shifted from "many small persona-walk gaps" to "a smaller set of larger, persona-validation-sensitive items." The next ranking reflects that shift.
+Plus a clean backlog-hygiene sweep this pass: [#133](https://github.com/roballred/GovEA/issues/133), [#366](https://github.com/roballred/GovEA/issues/366), [#511](https://github.com/roballred/GovEA/issues/511), [#538](https://github.com/roballred/GovEA/issues/538), [#543](https://github.com/roballred/GovEA/issues/543) all closed retrospectively with PR back-references.
+
+The practical implication: the next ranking has to balance **gate-lifting** (the rank-1 interview), **deferred-but-not-gone** foundation hygiene (ARB findings that have aged), and **differentiator design work that doesn't need interviews**.
 
 ## Top Five Next Things To Do
 
 | Rank | Recommended next thing | Why now | Primary issue(s) |
 |---|---|---|---|
-| 1 | **In-app stakeholder product overview — slice A: static `/overview` route** | First-time reviewers now land on a richer set of surfaces than they can quickly orient to. The viewer-experience epic delivered better *destinations*; this delivers the *entry page* that explains what GovEA is, what is shipped vs. maturing, and where to click first. Keep the first slice deliberately small: static content, role-aware visibility, no priorities-doc sync, no full CTA matrix. Slices B (CTAs) and C (priorities tile) follow in their own PRs. | [#614](https://github.com/roballred/GovEA/issues/614) |
-| 2 | **Traceable release pipeline for the Azure demo** | Promoted off On Hold. The 9-PR same-day ship raised the cost of not having this: every persona-facing feature now depends on the demo being a known build, and reviewers cannot pin what they see to a commit, image digest, or runtime configuration. Operational risk is now larger than the work to close it. | [#504](https://github.com/roballred/GovEA/issues/504) |
-| 3 | **Persona validation pass** | Standards.md §"Persona Validation Status" explicitly gates differentiator implementation on validated personas: *"Implementation work that depends solely on assumed personas carries elevated risk and should be noted in the relevant issues."* Several near-term differentiator candidates ([#547](https://github.com/roballred/GovEA/issues/547), [#573](https://github.com/roballred/GovEA/issues/573), [#88](https://github.com/roballred/GovEA/issues/88), [#563](https://github.com/roballred/GovEA/issues/563), [#614](https://github.com/roballred/GovEA/issues/614)) all depend on personas whose validation status has not been audited. A focused sweep through `business-architecture/personas/` tagging each as Assumed or Validated unlocks honest prioritization downstream. | [#384](https://github.com/roballred/GovEA/issues/384) |
-| 4 | **Public-read access — last viewer-experience sub-issue** | Six of seven [#556](https://github.com/roballred/GovEA/issues/556) sub-issues are closed; this is the remaining one and the largest. The epic explicitly flags a persona-validation prerequisite: *"deserves at least one real interview before this lands."* Sequence after rank 3 so the implementation is grounded in validated persona input rather than assumed need. | [#547](https://github.com/roballred/GovEA/issues/547) |
-| 5 | **Data architecture quality — next slice, scoped on [#363](https://github.com/roballred/GovEA/issues/363) conversation** | The cheap, persona-validated half ([#570](https://github.com/roballred/GovEA/issues/570)) is shipped. The remaining DA Layer 1/2 quality cues and scorecard summary need a product/persona conversation with @nicholerip before scoping. Park here as a placeholder so it does not slip through grooming, and ping [#363](https://github.com/roballred/GovEA/issues/363) before opening implementation issues. | [#573](https://github.com/roballred/GovEA/issues/573), [#363](https://github.com/roballred/GovEA/issues/363) |
+| 1 | **Run the first #384 Tier-1 interview** | The validation plan ([`docs/research/validation-plan.md`](./research/validation-plan.md)) is in place; the next move is one real conversation. Recommended first candidate: an Elected Official or chief of staff testing the staff-proxy hypothesis (GA-1, RT-1). Until one Tier-1 conversation lands, ranks 4-5 of the prior list stay parked. This is the cheapest unblock on the board. | [#384](https://github.com/roballred/GovEA/issues/384), [#547](https://github.com/roballred/GovEA/issues/547), [#573](https://github.com/roballred/GovEA/issues/573), [#563](https://github.com/roballred/GovEA/issues/563), [#88](https://github.com/roballred/GovEA/issues/88) |
+| 2 | **#10 — close the only open High-severity ARB finding (v1/v2 scope signals)** | Filed 2026-04-04, still open. The deployment-operations capability group ship ([#634](https://github.com/roballred/GovEA/pull/634)) closed half of #10's intent; the residual v1/v2 scope-signal work on capability files remains. Director-persona reading of "what do I get day one vs later" is genuinely opaque without it, and it's a doc-shaped task that doesn't need an interview. High-severity ARB findings shouldn't age past two grooming cycles. | [#10](https://github.com/roballred/GovEA/issues/10) |
+| 3 | **#34 — consolidate RBAC into a single source of truth** | Medium-severity ARB finding, but RBAC duplication between `apps/govea/src/lib/rbac.ts` and `packages/core/src/rbac/index.ts` grows monotonically with every new route. Behaviour-drift risk is security-adjacent and silent — exactly the kind of debt that turns into a real incident if it ages further. Foundation work; not gated on personas. | [#34](https://github.com/roballred/GovEA/issues/34) |
+| 4 | **#71 + #94 — EA Adoption & Engagement capability area** | Differentiator capability-doc work pairing the feat ([#71](https://github.com/roballred/GovEA/issues/71)) with the ARB finding ([#94](https://github.com/roballred/GovEA/issues/94)) that named the same gap. The 2026 EA market research called out adoption as the single most persistent cross-tool weakness, and GovEA's persona thesis explicitly targets non-EA stakeholders. Designing the capability group first (sub-capabilities, persona links) is a docs slice that does not need interviews and seeds implementation issues for the next quarter. | [#71](https://github.com/roballred/GovEA/issues/71), [#94](https://github.com/roballred/GovEA/issues/94) |
+| 5 | **#518 — GovEA Project as continuous product documentation** | The seeded GovEA Project organisation should model the actual product as it evolves: strategy, goals, objectives, value streams, initiatives, principles, ADRs, services, applications, capabilities, personas. Cheap to maintain incrementally; compounds into a much more credible demo and a real dogfood loop with every grooming cycle. Differentiator. Treat as recurring rather than one-shot. | [#518](https://github.com/roballred/GovEA/issues/518) |
+
+## What dropped out of the top five
+
+- **#547 public-read access** and **#573 + #363 data architecture quality next slice** — explicitly gated on the rank-1 interview per the validation plan. They re-enter the top five the same week a Tier-1 conversation lands and either confirms or disconfirms the underlying assumptions.
+- **#614 / #504** — closed this cycle (see Current Signal above).
 
 ## On Hold
 
@@ -44,11 +48,12 @@ Items the product owner has paused; revisit when noted blocker clears:
 
 ## Product Manager Notes
 
-- **Backlog hygiene — close-keyword drift.** Several recent PRs landed work but did not auto-close their named issues: [#133](https://github.com/roballred/GovEA/issues/133), [#366](https://github.com/roballred/GovEA/issues/366), [#511](https://github.com/roballred/GovEA/issues/511), [#538](https://github.com/roballred/GovEA/issues/538), [#543](https://github.com/roballred/GovEA/issues/543) all remain open despite being referenced by merged PR titles. Worth a one-pass cleanup before the next grooming so the open-issue count reflects reality.
-- **Persona validation (rank 3) should precede ranks 4 and 5.** Without it, #547 and #573 implementation will repeat the "designed against an assumed persona" risk the standards flag.
-- **#614 (rank 1) is the cheapest differentiator on the board right now** and has the largest stakeholder-comprehension payoff. The issue body lists six page sections — slice them across at least three PRs; do not attempt the whole spec in one.
-- **#504 (rank 2) was held in the prior grooming with the explicit note "Promote back into the top five when ready to take it on."** That moment is now: nothing else in flight is gated on it, and every feature ship from here forward inherits the same opacity problem until it lands.
-- The **viewer-experience epic [#556](https://github.com/roballred/GovEA/issues/556)** can likely close once #547 lands and the close-keyword hygiene sweep above runs.
+- **Rank 1 is interview-shaped, not implementation-shaped.** Don't treat #384 as "more docs to write." The validation plan is written; what's missing is one real human conversation. A 30-minute call beats another doc pass.
+- **The viewer-experience epic [#556](https://github.com/roballred/GovEA/issues/556)** can likely close once #547 lands; for now it stays open since the gating relationship is real.
+- **High-severity ARB findings (#10) shouldn't keep aging.** Two grooming cycles is the soft limit; this one filed 2026-04-04 is now well past. Rank 2 here is partly an admission that we let it slip.
+- **Pair #71 and #94.** They describe the same problem from product-design and ARB angles; landing them as one capability-doc slice avoids duplicated edits and clarifies which sub-capability ideas survive ARB review.
+- **#518 is a habit, not a feature.** Add it to grooming pre-flight: "did anything in this cycle change the canonical product story? If yes, update the GovEA Project seed." Don't try to make it a one-shot deliverable.
+- **Backlog hygiene actioned this cycle.** #133, #366, #511, #538, #543 closed retrospectively. The close-keyword-drift bullet stays out of the top five going forward unless a new batch accumulates.
 
 ## Security Remediation Status
 


### PR DESCRIPTION
## Summary

Acts on the methodology observation in the previous priorities review: **the &ldquo;no milestone&rdquo; bucket was the largest on the board (14 issues) &mdash; bigger than any active milestone.** That made the milestone counts unreliable and made every top-5 ranking sit on shifting sand.

Assignments are already applied via `gh issue edit`. This PR documents the rationale.

## Result

| Milestone | Open before | Open after |
|---|---|---|
| v0.9 | 5 | **6** |
| v1.0 | 3 | **7** |
| v1.5 | 3 | **9** |
| v2.0 | 8 | **11** |
| No milestone | **14** | **0** |

Every open issue now sits in a milestone. The next planning cycle can read milestone counts as ground truth.

## Triage rationale

Full per-issue rationale lives in `docs/backlog-triage-2026-05-26.md`. Quick summary:

### → v0.9 Foundation Cleanup
- **#482** AI session-start doc &mdash; v0.9 explicit goal is &ldquo;docs match reality&rdquo;; the file is referenced from the session-bootstrap blob but doesn&apos;t exist on disk.

### → v1.0 Practice-Ready
- **#479** collapsible nav, **#456** admin notices, **#529** backup & export, **#518** GovEA Project dogfood
- All are user-facing capabilities a first installer needs.

### → v1.5 Adoption-Validated
- **#547** public-read, **#573** DA quality signals, **#563** budget dimensions, **#556** viewer-experience epic, **#499** inherited glossary, **#55** data capabilities domain
- All are gated on or sequenced behind the #384 Tier-1 interview push.

### → v2.0 Platform & Integration
- **#409** Success Criteria first-class data, **#363** DA Metamodel, **#351** Reference Architecture
- Data-model expansion and TOGAF-adjacent capability work that sits behind the v2.0 integration push.

## Contested calls flagged for human override

The doc explicitly calls out three assignments where reasonable people could disagree:
- **#518** dogfood &rarr; v1.0 vs. recurring habit
- **#499** inherited glossary &rarr; v1.5 vs. v1.0
- **#55** data capabilities domain &rarr; v1.5 vs. v2.0

Override via `gh issue edit <n> --milestone <name>` if you disagree.

## What this PR does not do

- Does not modify any milestone description. Several descriptions reference closed issues in their scope lists (e.g. v1.0 lists `#7, #49, #366, #380` &mdash; all closed). Refreshing milestone descriptions is separate grooming work and a good candidate for the next cleanup pass.
- Does not re-prioritise within milestones &mdash; that&apos;s the priorities-doc&apos;s job.
- Does not change scope, labels, or bodies on any issue. Only the milestone field changes.

## Test plan

- [x] `gh issue list --state open` confirms 33 issues, 0 without milestone
- [x] Each milestone count matches the doc&apos;s prediction (6 / 7 / 9 / 11)

Capability: process / methodology &mdash; not user-facing
Refs #614 (priorities-doc maintenance pattern), #384 (validation-plan gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)