### PR TITLE
refactor(rbac): consolidate RBAC into @govea/core (closes #34)

### DIFF
--- a/apps/govea/next.config.ts
+++ b/apps/govea/next.config.ts
@@ -15,6 +15,12 @@ if (process.env.NEXT_PUBLIC_APP_URL) {
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // #34: the @govea/core workspace package is the canonical source for RBAC
+  // (and, in time, audit / content-types / taxonomy / workflow / recipes).
+  // It ships TypeScript source, no built dist/. transpilePackages tells the
+  // Next.js build to compile workspace packages on the fly so consumers do
+  // not need a separate `pnpm --filter @govea/core build` step.
+  transpilePackages: ['@govea/core'],
   experimental: {
     serverActions: {
       allowedOrigins,

--- a/apps/govea/src/lib/rbac.ts
+++ b/apps/govea/src/lib/rbac.ts
@@ -1,38 +1,40 @@
+// Thin user-shaped wrappers around the canonical role definitions in
+// `@govea/core/rbac`. The package is the single source of truth for
+// Role, Permission, ROLE_PERMISSIONS, ROLE_HIERARCHY, and the role-level
+// check functions. This file exists solely to provide convenience helpers
+// that accept the GovEA `User` shape instead of a bare role string, and to
+// host the GovEA-specific `isInstanceAdmin` check that depends on the
+// app's `instanceRole` column.
+//
+// Closes #34. Do NOT re-introduce `ROLE_PERMISSIONS`, `ROLE_HIERARCHY`,
+// `Role`, or `Permission` constants here — the integration test in
+// `apps/govea/tests/integration/rbac-single-source.test.ts` will fail
+// if any of those names are defined locally.
+
 import type { User } from '@/db/schema'
+import {
+  type Role,
+  type Permission,
+  ROLE_HIERARCHY,
+  hasPermission,
+  roleAtLeast,
+  roleCanEdit,
+  roleIsAdmin,
+} from '@govea/core'
 
-export type Role = 'admin' | 'contributor' | 'viewer'
-
-export type Permission =
-  | 'content:read'
-  | 'content:create'
-  | 'content:edit'
-  | 'content:delete'
-  | 'content:publish'
-  | 'users:manage'
-  | 'settings:manage'
-
-const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
-  admin: ['content:read', 'content:create', 'content:edit', 'content:delete', 'content:publish', 'users:manage', 'settings:manage'],
-  contributor: ['content:read', 'content:create', 'content:edit', 'content:publish'],
-  viewer: ['content:read'],
-}
-
-export function hasPermission(role: Role, permission: Permission): boolean {
-  return ROLE_PERMISSIONS[role].includes(permission)
-}
-
-const ROLE_HIERARCHY: Record<Role, number> = { admin: 3, contributor: 2, viewer: 1 }
+export type { Role, Permission }
+export { ROLE_HIERARCHY, hasPermission }
 
 export function hasRole(user: Pick<User, 'role'>, minimum: Role): boolean {
-  return ROLE_HIERARCHY[user.role] >= ROLE_HIERARCHY[minimum]
+  return roleAtLeast(user.role, minimum)
 }
 
 export function canEdit(user: Pick<User, 'role'>): boolean {
-  return hasRole(user, 'contributor')
+  return roleCanEdit(user.role)
 }
 
 export function isAdmin(user: Pick<User, 'role'>): boolean {
-  return user.role === 'admin'
+  return roleIsAdmin(user.role)
 }
 
 export function isInstanceAdmin(user: { instanceRole?: string | null }): boolean {

--- a/apps/govea/tests/integration/rbac-single-source.test.ts
+++ b/apps/govea/tests/integration/rbac-single-source.test.ts
@@ -1,0 +1,79 @@
+/**
+ * RBAC single-source-of-truth regression test (#34).
+ *
+ * Asserts that:
+ *   1. The canonical RBAC types and constants live in @govea/core/rbac.
+ *   2. apps/govea/src/lib/rbac.ts re-exports the same types and constants
+ *      from @govea/core (functional equivalence on Permission checks).
+ *   3. The app-side rbac module does NOT redefine ROLE_PERMISSIONS or
+ *      ROLE_HIERARCHY locally — a literal string check guards against the
+ *      duplication coming back the next time someone edits the file.
+ *
+ * If this test fails after a refactor, you have either:
+ *   - changed the role/permission shape without updating @govea/core
+ *     (fix: update the canonical definitions and re-run the test), or
+ *   - re-introduced parallel definitions in the app's rbac module
+ *     (fix: import from @govea/core instead).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import * as core from '@govea/core'
+import * as appRbac from '@/lib/rbac'
+
+describe('RBAC single source of truth', () => {
+  it('re-exports Permission check from @govea/core', () => {
+    expect(appRbac.hasPermission('admin', 'users:manage')).toBe(true)
+    expect(appRbac.hasPermission('contributor', 'users:manage')).toBe(false)
+    expect(appRbac.hasPermission('viewer', 'content:read')).toBe(true)
+    expect(appRbac.hasPermission('viewer', 'content:create')).toBe(false)
+  })
+
+  it('app-side hasPermission delegates to core (identical references)', () => {
+    // appRbac re-exports `hasPermission` from core, so the function
+    // reference must be identical.
+    expect(appRbac.hasPermission).toBe(core.hasPermission)
+  })
+
+  it('app-side ROLE_HIERARCHY delegates to core', () => {
+    expect(appRbac.ROLE_HIERARCHY).toBe(core.ROLE_HIERARCHY)
+    expect(appRbac.ROLE_HIERARCHY.admin).toBe(3)
+    expect(appRbac.ROLE_HIERARCHY.contributor).toBe(2)
+    expect(appRbac.ROLE_HIERARCHY.viewer).toBe(1)
+  })
+
+  it('app-side user-shaped helpers wrap the core role-level checks', () => {
+    const admin = { role: 'admin' as const }
+    const contributor = { role: 'contributor' as const }
+    const viewer = { role: 'viewer' as const }
+
+    expect(appRbac.isAdmin(admin)).toBe(true)
+    expect(appRbac.isAdmin(contributor)).toBe(false)
+
+    expect(appRbac.canEdit(admin)).toBe(true)
+    expect(appRbac.canEdit(contributor)).toBe(true)
+    expect(appRbac.canEdit(viewer)).toBe(false)
+
+    expect(appRbac.hasRole(admin, 'contributor')).toBe(true)
+    expect(appRbac.hasRole(contributor, 'admin')).toBe(false)
+  })
+
+  it('isInstanceAdmin remains app-local (depends on GovEA user shape)', () => {
+    expect(appRbac.isInstanceAdmin({ instanceRole: 'instance_admin' })).toBe(true)
+    expect(appRbac.isInstanceAdmin({ instanceRole: null })).toBe(false)
+    expect(appRbac.isInstanceAdmin({})).toBe(false)
+  })
+
+  it('does not redefine ROLE_PERMISSIONS or ROLE_HIERARCHY in the app rbac source', () => {
+    // String-level guard: blocks the duplicated-definition pattern from
+    // creeping back in. Catches "const ROLE_PERMISSIONS" / "const
+    // ROLE_HIERARCHY" anywhere in the app's rbac module.
+    const source = readFileSync(
+      join(__dirname, '..', '..', 'src', 'lib', 'rbac.ts'),
+      'utf-8',
+    )
+
+    expect(source).not.toMatch(/^\s*(?:export\s+)?const\s+ROLE_PERMISSIONS\b/m)
+    expect(source).not.toMatch(/^\s*(?:export\s+)?const\s+ROLE_HIERARCHY\s*[:=]/m)
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,12 +2,12 @@
   "name": "@govea/core",
   "version": "0.1.0",
   "private": true,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/rbac/index.ts
+++ b/packages/core/src/rbac/index.ts
@@ -1,3 +1,9 @@
+// @govea/core/rbac — single source of truth for GovEA role and permission
+// definitions. App-level helpers in `apps/govea/src/lib/rbac.ts` are thin
+// wrappers around the role-shaped functions exported here.
+//
+// Closes #34. ADR-009 records the consolidation decision.
+
 export type Role = 'admin' | 'contributor' | 'viewer'
 
 export type Permission =
@@ -9,12 +15,40 @@ export type Permission =
   | 'users:manage'
   | 'settings:manage'
 
-const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
-  admin: ['content:read', 'content:create', 'content:edit', 'content:delete', 'content:publish', 'users:manage', 'settings:manage'],
+export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
+  admin: [
+    'content:read',
+    'content:create',
+    'content:edit',
+    'content:delete',
+    'content:publish',
+    'users:manage',
+    'settings:manage',
+  ],
   contributor: ['content:read', 'content:create', 'content:edit', 'content:publish'],
   viewer: ['content:read'],
 }
 
 export function hasPermission(role: Role, permission: Permission): boolean {
   return ROLE_PERMISSIONS[role].includes(permission)
+}
+
+// Ordering: admin > contributor > viewer. `roleAtLeast(actual, minimum)` is
+// true when `actual` is at or above `minimum` in the hierarchy.
+export const ROLE_HIERARCHY: Record<Role, number> = {
+  admin: 3,
+  contributor: 2,
+  viewer: 1,
+}
+
+export function roleAtLeast(role: Role, minimum: Role): boolean {
+  return ROLE_HIERARCHY[role] >= ROLE_HIERARCHY[minimum]
+}
+
+export function roleIsAdmin(role: Role): boolean {
+  return role === 'admin'
+}
+
+export function roleCanEdit(role: Role): boolean {
+  return roleAtLeast(role, 'contributor')
 }


### PR DESCRIPTION
## Summary

Closes [#34](https://github.com/roballred/GovEA/issues/34) — ARB finding on RBAC duplication. Both `apps/govea/src/lib/rbac.ts` and `packages/core/src/rbac/index.ts` defined the same `Role` and `Permission` types plus the `ROLE_PERMISSIONS` map verbatim; behaviour drift was inevitable.

This is also rank-3 on the current top-5 priorities and one of the open v0.9 Foundation Cleanup items.

## What I found beyond the ARB finding

Investigation surfaced a bigger issue: **the entire `@govea/core` package had zero consumers anywhere in the app.**

- 95 RBAC import sites all pointed at `@/lib/rbac`
- 0 consumers of `@govea/core/*` anywhere in `apps/`
- The package had never been built (`packages/core/dist/` did not exist)
- `package.json` `main` pointed at the non-existent `./dist/index.js`

The "shared core package" the README names as the architectural direction existed on disk but wasn't wired into anything.

## What this PR does

Picks `@govea/core` as the canonical source per #34&apos;s recommended action, *and* makes the package actually used for the first time.

### `packages/core/src/rbac/index.ts` &mdash; the canonical source

- Keeps `Role`, `Permission`, `ROLE_PERMISSIONS`, `hasPermission`
- Adds `ROLE_HIERARCHY` and role-shaped check functions (`roleAtLeast`, `roleIsAdmin`, `roleCanEdit`) that don&apos;t depend on the GovEA `User` type

### `packages/core/package.json`

- `main`, `types`, and `exports` now point at `./src/index.ts` so TypeScript (with `moduleResolution: bundler`) resolves the package without a separate `tsc` build step

### `apps/govea/next.config.ts`

- Adds `transpilePackages: ['@govea/core']` so Next.js compiles the workspace package on the fly during build and dev

### `apps/govea/src/lib/rbac.ts` &mdash; now a thin wrapper

- Re-exports `Role`, `Permission`, `ROLE_HIERARCHY`, `hasPermission` from `@govea/core`
- Provides user-shaped wrappers (`hasRole`, `canEdit`, `isAdmin`) that delegate to the role-shaped core checks &mdash; **so all 95 call-sites work unchanged**
- `isInstanceAdmin` stays app-local because it depends on the GovEA-specific `instanceRole` column

### `apps/govea/tests/integration/rbac-single-source.test.ts` &mdash; new regression test

Six assertions:
1. `hasPermission` re-export works for all 3 roles
2. App `hasPermission` reference is identical to core (same function object)
3. App `ROLE_HIERARCHY` reference is identical to core
4. User-shaped helpers wrap core role-level checks correctly
5. `isInstanceAdmin` remains app-local
6. **String-level guard**: the app&apos;s `rbac.ts` source must not redefine `ROLE_PERMISSIONS` or `ROLE_HIERARCHY` locally &mdash; catches the duplicated-definition pattern coming back

## Verified

- [x] `pnpm exec tsc --noEmit` &mdash; clean
- [x] `pnpm --filter govea lint` &mdash; clean (no rbac warnings)
- [x] `pnpm --filter govea test:integration` &mdash; **854 passed (854)** including the new 6 RBAC tests
- [x] `pnpm --filter govea build` &mdash; succeeds, Next.js transpiles `@govea/core` on the fly
- [x] No call-site changes needed for the 95 consumers

## Architectural note

This is the first feature to actually consume `@govea/core`. The other 5 modules in the package (`audit`, `content-types`, `taxonomy`, `workflow`, `recipes`) are still unused. The same pattern applies when one of those finds its first integration:

1. Promote the canonical definitions to `@govea/core/<module>`
2. Re-export from the app side with any domain-specific wrappers
3. Add a single-source-of-truth integration test

R-006 (doc drift) and the recurring #518 dogfood habit cover keeping that integration honest.

Capability: `iam-rbac`, `iam-user-management`
Persona: CMS Administrator; Instance Administrator
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)