### PR TITLE
docs(capabilities): surface v1/v2 Scope to non-technical readers (closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,22 +182,24 @@ Azure deployments can build images in the cloud via `az acr build` and do not re
 
 ## Capabilities
 
-GovEA's capability surface spans 10 groups, each driven by government EA practitioner personas and validated through the EasyEA workflow:
+GovEA's capability surface spans 12 groups, each driven by government EA practitioner personas and validated through the EasyEA workflow. The **Scope** column tells a non-technical reader which groups are in v1 (current release) vs. deferred to v2 — addressing the ARB finding (#10) that "26 sub-capabilities with no prioritization signal is not useful to a non-technical decision-maker."
 
-| Group | Description |
-|---|---|
-| Repository & Modelling | Architecture repository, traceability, ADRs, debt tracking |
-| Application & IT Portfolio | Portfolio management, technology lifecycle, rationalisation |
-| Business & Capability Architecture | Capability mapping, strategy alignment, operating model |
-| Planning & Analysis | Value streams, roadmapping, scenario planning, heatmaps |
-| Governance & Compliance | Review processes, regulatory mapping, audit trail |
-| Integration | ITSM, CMDB, DevOps, cloud, and business system connectors |
-| Collaboration & Stakeholder Engagement | Role-based access, stakeholder views, change notifications |
-| Reporting & Documentation | Plain-language outputs, configurable reports, KPI tracking |
-| Framework Alignment | Optional TOGAF/SAFe-style overlays, mappings, and framework-aware reports |
-| Data Architecture | Data entities, attributes, categories, business keys, and semantic relationships for data-architecture work |
+| Group | Scope | Description |
+|---|---|---|
+| Identity & Access Management | v1 | OIDC SSO, role-based access, instance administration, immutable audit trail |
+| Content Management | v1 | Authoring workflow, draft/published/archived status, visibility scopes, taxonomy |
+| Portfolio Management | v1 | Applications, ADRs, architecture debt, capability-application linkage |
+| Planning & Roadmap | v1 | Goals, strategic objectives, initiatives, executive roadmap timeline |
+| Frontend Display | v1 | Executive summary, heatmap, roadmap, impact analysis, guided answers, the Overview page |
+| Admin Configuration | v1 | Per-org themes, modules, email configuration, taxonomy admin, notices |
+| Multi-Organization Federation | v1 | Cross-org connections, federated content, cross-org capability links |
+| Repository & Modelling | v1 | Capability mapping, persona modelling, repository completeness, traceability views |
+| Data Architecture | v1 | Entities, attributes, business keys, semantic relationships, Chen-notation diagram |
+| Framework Alignment | v1 | Optional TOGAF/SAFe overlays, mappings, framework-aware reports |
+| Deployment & Operations | v1 | Containerised deployment, health/monitoring, upgrade/migration procedures |
+| Integration | v2 | ITSM, CMDB, DevOps, cloud, and business system connectors — deferred to v2 (#382) |
 
-For the full capability inventory, including implementation status, see [`capabilities.md`](./capabilities.md).
+For the full capability inventory, including implementation status against scope, see [`capabilities.md`](./capabilities.md).
 
 Capabilities are defined one at a time through the EasyEA workflow: persona validation -> capability definition -> ARB review -> implementation issues. Framework alignment is treated as an optional overlay: it may map GovEA content to TOGAF or other frameworks, but it does not replace the core GovEA model.
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -8,19 +8,22 @@ Capability definitions live in [`business-architecture/capabilities/`](./busines
 
 ## Capability Groups
 
-| # | Group | Status |
-|---|---|---|
-| 1 | [Identity & Access Management](#1-identity--access-management) | Implemented |
-| 2 | [Content Management](#2-content-management) | Partially implemented |
-| 3 | [Portfolio Management](#3-portfolio-management) | Partially implemented |
-| 4 | [Planning & Roadmap](#4-planning--roadmap) | Implemented |
-| 5 | [Frontend Display](#5-frontend-display) | Partially implemented |
-| 6 | [Admin Configuration](#6-admin-configuration) | Partially implemented |
-| 7 | [Multi-Organization Federation](#7-multi-organization-federation) | Prototype |
-| 8 | [Repository & Modelling](#8-repository--modelling) | Partially implemented |
-| 9 | [Data Architecture](#9-data-architecture) | Partially implemented |
-| 10 | [Framework Alignment](#10-framework-alignment) | Partially implemented |
-| 11 | [Deployment & Operations](#11-deployment--operations) | Partially implemented |
+The **Scope** column shows whether a group is in v1 (current release) or v2 (deferred), defined in each group's parent file under `business-architecture/capabilities/`. The **Status** column shows what's actually shipped today against that scope. Scope is the canonical signal for non-technical readers planning around the roadmap; Status reflects the current implementation surface.
+
+| # | Group | Scope | Status |
+|---|---|---|---|
+| 1 | [Identity & Access Management](#1-identity--access-management) | v1 | Implemented |
+| 2 | [Content Management](#2-content-management) | v1 | Partially implemented |
+| 3 | [Portfolio Management](#3-portfolio-management) | v1 | Partially implemented |
+| 4 | [Planning & Roadmap](#4-planning--roadmap) | v1 | Implemented |
+| 5 | [Frontend Display](#5-frontend-display) | v1 | Partially implemented |
+| 6 | [Admin Configuration](#6-admin-configuration) | v1 | Partially implemented |
+| 7 | [Multi-Organization Federation](#7-multi-organization-federation) | v1 | Prototype |
+| 8 | [Repository & Modelling](#8-repository--modelling) | v1 | Partially implemented |
+| 9 | [Data Architecture](#9-data-architecture) | v1 | Partially implemented |
+| 10 | [Framework Alignment](#10-framework-alignment) | v1 | Partially implemented |
+| 11 | [Deployment & Operations](#11-deployment--operations) | v1 | Partially implemented |
+| 12 | [Integration](business-architecture/capabilities/ea/integration/integration.md) | v2 | Not started — deferred to v2 (#10, #382) |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes [#10](https://github.com/roballred/GovEA/issues/10), the **only open High-severity ARB finding** (filed 2026-04-04 by Thomas Reed / Central IT Director). Standards.md says High-severity findings must be resolved before implementation continues on affected capabilities; this finding has been aging for ~7 weeks.

## What was already done before this PR

Most of #10's recommended action shipped via the split sub-issues:

| Sub-issue | What it shipped | PR |
|---|---|---|
| [#510](https://github.com/roballred/GovEA/issues/510) | Scope field on all 12 capability group parent files | #634 |
| [#511](https://github.com/roballred/GovEA/issues/511) | `cms/deployment-operations` group + 3 sub-capabilities | #634 |
| _(in earlier README work)_ | README "What does it take to run this?" operational summary | shipped |

So the gating "capability files carry v1/v2 scope" and "deployment/operations capability exists" parts are done. The High-severity ARB has been *substantively* resolved for some time but stayed open because the residual wasn't closed cleanly.

## What this PR finishes

The director-persona ARB framing was: *"26 sub-capabilities with no prioritization signal is not useful to a non-technical decision-maker."* The source-of-truth files now carry Scope, but the **summary docs that a non-technical reader hits first** (`capabilities.md`, `README.md`) didn't surface it. This PR fixes that.

### `capabilities.md`

- **New Scope column** on the "Capability Groups" table alongside Status
- **Adds row 12 for the Integration group** &mdash; the only v2 group; it had been silently missing from the inventory entirely
- Short explanatory paragraph: Scope is the planning signal; Status is the implementation signal; the two together answer "what do I get day one vs later"

### `README.md`

- `## Capabilities` section refreshed end-to-end
- Previous table used **pre-rename group names** ("Application & IT Portfolio", "Business & Capability Architecture", "Governance & Compliance", "Collaboration & Stakeholder Engagement", "Reporting & Documentation") that no longer match any canonical capability group. Also stated "10 groups" when the inventory has 12.
- New table matches the 11 canonical v1 groups + Integration (v2), with a Scope column
- Header text explicitly references the ARB finding so a future grooming reader can find the connection without digging

## What this PR explicitly does NOT do

- **Leaf (sub-capability) Scope fields stay optional** per STYLE.md when they match parent scope. No leaf currently deviates: Integration&apos;s 10 leaves inherit v2 from parent; deployment-operations&apos; 3 leaves all explicitly state `Scope: v1`. No leaf-level work needed for #10.
- **No Status changes** &mdash; the Status column reflects implementation reality, refreshed in grooming cycles.

## Verified

- [x] `node scripts/lint-business-architecture.mjs` &mdash; OK (107 files)
- [x] Internal link to `business-architecture/capabilities/ea/integration/integration.md` resolves
- [x] Group names in both tables match the actual `business-architecture/capabilities/` directory layout
- [x] All 12 group parents already carry the `**Scope:**` field they need (audited; see commit message)

## Top-5 / v0.9 progress after this lands

| Issue | Status |
|---|---|
| #10 — ARB v1/v2 scope signals | **this PR (closes)** |
| #34 — RBAC consolidation | open |
| #35 — Reproducible local bootstrap | open |
| #119 — Visual regression tests | open |
| #120 — Critical-path coverage targets | open |
| #482 — AI session-start doc | open (#652) |

Closing #10 removes the last High-severity ARB finding from the board.

Capability group: cms/deployment-operations, ea/integration
Capability: do-deployment, do-health-monitoring, do-upgrade-migration
Persona: Department Director; Elected Official; CMS Administrator
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)