### PR TITLE
feat(admin): instance-wide notices (closes #456 PR2)

### DIFF
--- a/apps/govea/src/actions/admin-notices.ts
+++ b/apps/govea/src/actions/admin-notices.ts
@@ -1,10 +1,10 @@
 'use server'
 
-import { and, eq, ne } from 'drizzle-orm'
+import { and, eq, isNull, ne } from 'drizzle-orm'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { auth } from '@/lib/auth'
-import { isAdmin } from '@/lib/rbac'
+import { isAdmin, isInstanceAdmin } from '@/lib/rbac'
 import { db } from '@/db/client'
 import {
   adminNotices,
@@ -20,6 +20,16 @@ async function requireOrgAdmin() {
   if (!isAdmin(session.user)) throw new Error('Forbidden')
   if (!session.user.organizationId) throw new Error('Org admin has no org')
   return { session, orgId: session.user.organizationId as string }
+}
+
+// Instance admin is a separate operating role from org admin (see #437 / the
+// IAM capability docs). An org admin is NOT an instance admin by virtue of
+// org role; instance admin is granted via `instance_role = 'instance_admin'`.
+async function requireInstanceAdmin() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isInstanceAdmin(session.user)) throw new Error('Forbidden')
+  return { session }
 }
 
 interface NoticeInput {
@@ -212,4 +222,180 @@ export async function setOrgNoticeActiveFromForm(formData: FormData): Promise<vo
 export async function deleteOrgNoticeFromForm(formData: FormData): Promise<void> {
   const id = formData.get('id') as string
   await deleteOrgNotice(id)
+}
+
+// ── Instance-scoped notices (PR2 of #456) ────────────────────────────────────
+//
+// Instance notices have `scope='instance'` and `organizationId IS NULL`. They
+// are visible across the whole instance, including to org admins and other
+// instance admins. Only instance admins can create/edit/activate/delete.
+//
+// Audit-log organizationId is null for instance-scope writes (matches the
+// instance-admin pattern in act-as / break-glass actions).
+
+export async function createInstanceNotice(formData: FormData): Promise<void> {
+  const { session } = await requireInstanceAdmin()
+  const input = parseNoticeInput(formData)
+  const activateNow = formData.get('activate') === 'true'
+
+  await db.transaction(async (tx) => {
+    if (activateNow) {
+      await tx.update(adminNotices)
+        .set({ active: false, updatedAt: new Date() })
+        .where(and(
+          eq(adminNotices.scope, 'instance'),
+          isNull(adminNotices.organizationId),
+          eq(adminNotices.active, true),
+        ))
+    }
+
+    const [row] = await tx.insert(adminNotices).values({
+      scope: 'instance',
+      organizationId: null,
+      severity: input.severity,
+      title: input.title,
+      body: input.body,
+      learnMoreUrl: input.learnMoreUrl,
+      active: activateNow,
+      createdBy: session.user.id,
+    }).returning()
+
+    await writeAuditLog(tx, {
+      action: 'admin_notice.create',
+      entityType: 'admin_notice',
+      entityId: row.id,
+      userId: session.user.id,
+      organizationId: null,
+      after: { scope: 'instance', title: input.title, severity: input.severity, active: activateNow },
+    })
+  })
+
+  revalidatePath('/', 'layout')
+  revalidatePath('/instance/notices')
+}
+
+export async function updateInstanceNotice(noticeId: string, formData: FormData): Promise<void> {
+  const { session } = await requireInstanceAdmin()
+  const input = parseNoticeInput(formData)
+
+  const before = await db.query.adminNotices.findFirst({
+    where: eq(adminNotices.id, noticeId),
+  })
+  if (!before) throw new Error('Notice not found')
+  if (before.scope !== 'instance' || before.organizationId !== null) {
+    throw new Error('Forbidden')
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.update(adminNotices)
+      .set({
+        title: input.title,
+        body: input.body,
+        severity: input.severity,
+        learnMoreUrl: input.learnMoreUrl,
+        updatedAt: new Date(),
+      })
+      .where(eq(adminNotices.id, noticeId))
+
+    await writeAuditLog(tx, {
+      action: 'admin_notice.update',
+      entityType: 'admin_notice',
+      entityId: noticeId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { scope: 'instance', title: before.title, severity: before.severity },
+      after: { scope: 'instance', title: input.title, severity: input.severity },
+    })
+  })
+
+  revalidatePath('/', 'layout')
+  revalidatePath('/instance/notices')
+}
+
+export async function setInstanceNoticeActive(noticeId: string, active: boolean): Promise<void> {
+  const { session } = await requireInstanceAdmin()
+
+  const before = await db.query.adminNotices.findFirst({
+    where: eq(adminNotices.id, noticeId),
+  })
+  if (!before) throw new Error('Notice not found')
+  if (before.scope !== 'instance' || before.organizationId !== null) {
+    throw new Error('Forbidden')
+  }
+
+  await db.transaction(async (tx) => {
+    if (active) {
+      // Deactivate any other active instance notice first — single-active
+      // invariant per scope (matches org-scoped behaviour).
+      await tx.update(adminNotices)
+        .set({ active: false, updatedAt: new Date() })
+        .where(and(
+          eq(adminNotices.scope, 'instance'),
+          isNull(adminNotices.organizationId),
+          eq(adminNotices.active, true),
+          ne(adminNotices.id, noticeId),
+        ))
+    }
+
+    await tx.update(adminNotices)
+      .set({ active, updatedAt: new Date() })
+      .where(eq(adminNotices.id, noticeId))
+
+    await writeAuditLog(tx, {
+      action: active ? 'admin_notice.activate' : 'admin_notice.deactivate',
+      entityType: 'admin_notice',
+      entityId: noticeId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { scope: 'instance', active: before.active },
+      after: { scope: 'instance', active },
+    })
+  })
+
+  revalidatePath('/', 'layout')
+  revalidatePath('/instance/notices')
+}
+
+export async function deleteInstanceNotice(noticeId: string): Promise<void> {
+  const { session } = await requireInstanceAdmin()
+
+  const before = await db.query.adminNotices.findFirst({
+    where: eq(adminNotices.id, noticeId),
+  })
+  if (!before) throw new Error('Notice not found')
+  if (before.scope !== 'instance' || before.organizationId !== null) {
+    throw new Error('Forbidden')
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.delete(adminNotices).where(eq(adminNotices.id, noticeId))
+    await writeAuditLog(tx, {
+      action: 'admin_notice.delete',
+      entityType: 'admin_notice',
+      entityId: noticeId,
+      userId: session.user.id,
+      organizationId: null,
+      before: { scope: 'instance', title: before.title, severity: before.severity, active: before.active },
+    })
+  })
+
+  revalidatePath('/', 'layout')
+  revalidatePath('/instance/notices')
+}
+
+// FormData adapters for the instance-admin UI.
+
+export async function createInstanceNoticeFromForm(formData: FormData): Promise<void> {
+  await createInstanceNotice(formData)
+}
+
+export async function setInstanceNoticeActiveFromForm(formData: FormData): Promise<void> {
+  const id = formData.get('id') as string
+  const active = formData.get('active') === 'true'
+  await setInstanceNoticeActive(id, active)
+}
+
+export async function deleteInstanceNoticeFromForm(formData: FormData): Promise<void> {
+  const id = formData.get('id') as string
+  await deleteInstanceNotice(id)
 }

--- a/apps/govea/src/app/(instance)/instance/notices/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/notices/page.tsx
@@ -1,0 +1,192 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { isInstanceAdmin } from '@/lib/rbac'
+import { listInstanceNotices } from '@/lib/admin-notices'
+import { NOTICE_SEVERITIES, type NoticeSeverity } from '@/db/schema'
+import {
+  createInstanceNoticeFromForm,
+  deleteInstanceNoticeFromForm,
+  setInstanceNoticeActiveFromForm,
+} from '@/actions/admin-notices'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+
+const SEVERITY_PILL: Record<NoticeSeverity, string> = {
+  info: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300',
+  warning: 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+  critical: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300',
+}
+
+/**
+ * Instance-wide notices management (#456 PR2).
+ *
+ * Instance admins only. Notices created here are visible across the whole
+ * GovEA instance — every org, every user, including other instance admins
+ * (per the design decisions on #456).
+ *
+ * Mirrors `/settings/notices` (org-scoped) but writes `scope='instance'` and
+ * `organizationId=null`. The two scopes share the underlying table and the
+ * banner stacking logic.
+ */
+export default async function InstanceNoticesPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isInstanceAdmin(session.user)) redirect('/')
+
+  const notices = await listInstanceNotices()
+
+  return (
+    <div className="max-w-3xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Instance notices</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Operational messages shown to <strong>everyone on this instance</strong>,
+          across all organizations. Use for instance-wide maintenance windows,
+          policy changes, or platform-level incidents. Only one notice can be
+          active at a time; activating a new one deactivates the previous.
+        </p>
+        <p className="text-xs text-muted-foreground mt-2">
+          Org-scoped notices are managed separately by each org&apos;s admins
+          at <code className="rounded bg-muted px-1 py-0.5">/settings/notices</code>.
+        </p>
+      </div>
+
+      <section className="rounded-lg border border-violet-200 dark:border-violet-900 bg-violet-50/30 dark:bg-violet-950/10 p-5">
+        <h2 className="text-base font-semibold mb-3">Create a new instance notice</h2>
+        <form action={createInstanceNoticeFromForm} className="space-y-4">
+          <div>
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              name="title"
+              required
+              maxLength={200}
+              placeholder="Platform-wide maintenance Saturday"
+            />
+          </div>
+          <div>
+            <Label htmlFor="body">Body</Label>
+            <Textarea
+              id="body"
+              name="body"
+              required
+              maxLength={2000}
+              rows={4}
+              placeholder="The GovEA instance will be unavailable from 22:00 to 23:00 UTC for a database upgrade."
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="severity">Severity</Label>
+              <select
+                id="severity"
+                name="severity"
+                defaultValue="info"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              >
+                {NOTICE_SEVERITIES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="learnMoreUrl">Learn more URL (optional)</Label>
+              <Input
+                id="learnMoreUrl"
+                name="learnMoreUrl"
+                type="url"
+                placeholder="https://…"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" name="activate" value="true" defaultChecked />
+              Activate immediately
+            </label>
+            <Button type="submit">Create</Button>
+          </div>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="text-base font-semibold mb-3">
+          All instance notices{' '}
+          <span className="text-muted-foreground font-normal text-sm">({notices.length})</span>
+        </h2>
+        {notices.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No instance notices yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {notices.map((n) => {
+              const severity = n.severity as NoticeSeverity
+              return (
+                <li
+                  key={n.id}
+                  className={cn(
+                    'rounded-lg border bg-card p-4',
+                    n.active && 'border-emerald-300 dark:border-emerald-800',
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="inline-flex items-center rounded-full bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300 px-2 py-0.5 text-xs font-medium">
+                          Instance
+                        </span>
+                        <span className={cn(
+                          'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                          SEVERITY_PILL[severity] ?? SEVERITY_PILL.info,
+                        )}>
+                          {severity}
+                        </span>
+                        {n.active && (
+                          <span className="inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300 px-2 py-0.5 text-xs font-medium">
+                            Active
+                          </span>
+                        )}
+                        <span className="text-sm font-semibold truncate">{n.title}</span>
+                      </div>
+                      <p className="text-sm text-muted-foreground whitespace-pre-line">{n.body}</p>
+                      {n.learnMoreUrl && (
+                        <a
+                          href={n.learnMoreUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-1 inline-block text-xs underline text-muted-foreground"
+                        >
+                          {n.learnMoreUrl}
+                        </a>
+                      )}
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        Updated {n.updatedAt.toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-1 shrink-0">
+                      <form action={setInstanceNoticeActiveFromForm}>
+                        <input type="hidden" name="id" value={n.id} />
+                        <input type="hidden" name="active" value={n.active ? 'false' : 'true'} />
+                        <Button type="submit" variant="outline" size="sm" className="w-24">
+                          {n.active ? 'Deactivate' : 'Activate'}
+                        </Button>
+                      </form>
+                      <form action={deleteInstanceNoticeFromForm}>
+                        <input type="hidden" name="id" value={n.id} />
+                        <Button type="submit" variant="destructive" size="sm" className="w-24">
+                          Delete
+                        </Button>
+                      </form>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(instance)/layout.tsx
+++ b/apps/govea/src/app/(instance)/layout.tsx
@@ -3,6 +3,7 @@ import { auth, signOut } from '@/lib/auth'
 import { Button } from '@/components/ui/button'
 import { isInstanceAdmin } from '@/lib/rbac'
 import { InstanceShell } from '@/components/instance-shell'
+import { AdminNoticeBanner } from '@/components/admin-notice-banner'
 import { db } from '@/db/client'
 import { breakGlassSessions, organizations, platformConfig } from '@/db/schema'
 import { and, eq, isNotNull, isNull, gt, or } from 'drizzle-orm'
@@ -56,6 +57,9 @@ export default async function InstanceLayout({ children }: { children: React.Rea
       activeBreakGlassSessions={activeSessions}
       instanceName={config?.instanceName}
     >
+      {/* Instance admins see instance-wide notices on every platform page
+          (#456 — "admins are operators; they need to see what tenants see"). */}
+      <AdminNoticeBanner />
       {children}
     </InstanceShell>
   )

--- a/apps/govea/src/components/admin-notice-banner.tsx
+++ b/apps/govea/src/components/admin-notice-banner.tsx
@@ -1,4 +1,4 @@
-import { getActiveOrgNotice } from '@/lib/admin-notices'
+import { getActiveOrgNotice, getActiveInstanceNotice } from '@/lib/admin-notices'
 import type { AdminNotice, NoticeSeverity } from '@/db/schema'
 import { DismissibleNotice } from './dismissible-notice'
 
@@ -14,35 +14,105 @@ const SEVERITY_LABELS: Record<NoticeSeverity, string> = {
   critical: 'Critical',
 }
 
-/**
- * Renders the active org-scoped notice for `orgId`, or nothing.
- *
- * - `critical` notices are pinned (no dismiss control).
- * - `info` / `warning` notices are wrapped in `<DismissibleNotice>` so users
- *   can hide them for the current session. Dismissal is keyed on the notice
- *   id + updatedAt — editing the notice yields a new key, so an updated
- *   notice reappears for a previously-dismissing user.
- */
-export async function AdminNoticeBanner({ orgId }: { orgId: string }) {
-  const notice = await getActiveOrgNotice(orgId)
-  if (!notice) return null
+type NoticeScope = 'org' | 'instance'
 
+/**
+ * Renders the active org-scoped and instance-scoped notices for `orgId`, or
+ * nothing if both are empty.
+ *
+ * Stacking order (top-down, per the design decisions on #456):
+ *
+ *   [Critical instance notice]
+ *   [Critical org notice]
+ *   [ActAsBanner]              ← rendered by the admin/instance layout, not here
+ *   [Warning/info instance notice]
+ *   [Warning/info org notice]
+ *
+ * The split puts criticals above the act-as banner because a critical
+ * platform message should outrank "you are acting as X." Lower-severity
+ * notices go below so the act-as context stays in view.
+ *
+ * Visual distinction:
+ *   - Instance notices carry an "INSTANCE" tag (violet) so users can
+ *     tell platform-wide messaging from org-wide messaging.
+ *
+ * Dismissal:
+ *   - `critical` notices are pinned (no dismiss control).
+ *   - `info` / `warning` are session-dismissible. Dismissal key includes
+ *     the notice id + updatedAt, so an edited notice reappears.
+ */
+export async function AdminNoticeBanner({ orgId }: { orgId?: string | null }) {
+  // Instance notice always fetched; org notice only if we have an org id.
+  // The instance layout passes no orgId (instance admins operate platform-
+  // scoped) so they still see instance notices without spurious org reads.
+  const [instanceNotice, orgNotice] = await Promise.all([
+    getActiveInstanceNotice(),
+    orgId ? getActiveOrgNotice(orgId) : Promise.resolve(null),
+  ])
+
+  if (!instanceNotice && !orgNotice) return null
+
+  return (
+    <>
+      {/* Criticals above the act-as banner */}
+      {instanceNotice?.severity === 'critical' && (
+        <NoticeRow notice={instanceNotice} scope="instance" />
+      )}
+      {orgNotice?.severity === 'critical' && (
+        <NoticeRow notice={orgNotice} scope="org" />
+      )}
+      {/* Non-criticals below the act-as banner. The act-as banner itself is
+          rendered in the layout above this component, not here, so we just
+          stack the two halves in the correct order around it. */}
+      {instanceNotice && instanceNotice.severity !== 'critical' && (
+        <NoticeRow notice={instanceNotice} scope="instance" />
+      )}
+      {orgNotice && orgNotice.severity !== 'critical' && (
+        <NoticeRow notice={orgNotice} scope="org" />
+      )}
+    </>
+  )
+}
+
+/**
+ * Internal helper: render a single notice row, wrapping in a dismiss control
+ * unless it's critical (pinned).
+ */
+function NoticeRow({ notice, scope }: { notice: AdminNotice; scope: NoticeScope }) {
   const severity = notice.severity as NoticeSeverity
   const styles = SEVERITY_STYLES[severity] ?? SEVERITY_STYLES.info
-  const content = <NoticeBody notice={notice} severity={severity} styles={styles} />
+  const content = <NoticeBody notice={notice} scope={scope} severity={severity} styles={styles} />
 
   if (severity === 'critical') return content
 
-  const dismissKey = `${notice.id}-${notice.updatedAt.getTime()}`
+  // Scope is part of the dismiss key so a user dismissing an instance notice
+  // doesn't accidentally hide an org notice with the same id (shouldn't
+  // happen in practice but the discipline is cheap).
+  const dismissKey = `${scope}-${notice.id}-${notice.updatedAt.getTime()}`
   return <DismissibleNotice dismissKey={dismissKey}>{content}</DismissibleNotice>
 }
 
-function NoticeBody({ notice, severity, styles }: { notice: AdminNotice; severity: NoticeSeverity; styles: string }) {
+function NoticeBody({
+  notice,
+  scope,
+  severity,
+  styles,
+}: {
+  notice: AdminNotice
+  scope: NoticeScope
+  severity: NoticeSeverity
+  styles: string
+}) {
   return (
     <div className={`mb-4 rounded-md border px-4 py-3 ${styles}`}>
       <div className="flex items-start gap-3">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
+            {scope === 'instance' && (
+              <span className="inline-flex items-center rounded-full bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+                Instance
+              </span>
+            )}
             <span className="text-xs font-semibold uppercase tracking-wide">
               {SEVERITY_LABELS[severity]}
             </span>

--- a/apps/govea/src/components/instance-shell.tsx
+++ b/apps/govea/src/components/instance-shell.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: '/instance/orgs',     label: 'Organizations' },
   { href: '/instance/users',    label: 'Users' },
   { href: '/instance/features', label: 'Feature Controls' },
+  { href: '/instance/notices',  label: 'Notices' },
   { href: '/instance/audit',    label: 'Audit Log' },
   { href: '/instance/config',   label: 'Configuration' },
 ]

--- a/apps/govea/src/lib/admin-notices.ts
+++ b/apps/govea/src/lib/admin-notices.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '@/db/client'
 import { adminNotices, type AdminNotice } from '@/db/schema'
 
@@ -32,6 +32,43 @@ export async function listOrgNotices(orgId: string): Promise<AdminNotice[]> {
     where: and(
       eq(adminNotices.scope, 'org'),
       eq(adminNotices.organizationId, orgId),
+    ),
+    orderBy: [desc(adminNotices.updatedAt)],
+  })
+}
+
+/**
+ * Returns the active instance-scoped notice, or null if none is active.
+ *
+ * Instance notices use `organizationId IS NULL` to scope across the whole
+ * instance. Same single-active invariant as org-scoped notices, enforced by
+ * `actions/admin-notices.ts` activation transactions.
+ *
+ * Visible to everyone &mdash; including org admins and instance admins &mdash;
+ * per the design decisions on #456 ("admins are operators; they need to see
+ * what tenants see").
+ */
+export async function getActiveInstanceNotice(): Promise<AdminNotice | null> {
+  const row = await db.query.adminNotices.findFirst({
+    where: and(
+      eq(adminNotices.scope, 'instance'),
+      isNull(adminNotices.organizationId),
+      eq(adminNotices.active, true),
+    ),
+    orderBy: [desc(adminNotices.updatedAt)],
+  })
+  return row ?? null
+}
+
+/**
+ * Returns all instance-scoped notices (active and inactive) for the
+ * instance-admin management UI. Most-recent first.
+ */
+export async function listInstanceNotices(): Promise<AdminNotice[]> {
+  return db.query.adminNotices.findMany({
+    where: and(
+      eq(adminNotices.scope, 'instance'),
+      isNull(adminNotices.organizationId),
     ),
     orderBy: [desc(adminNotices.updatedAt)],
   })

--- a/apps/govea/tests/integration/admin-notices-instance.test.ts
+++ b/apps/govea/tests/integration/admin-notices-instance.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Integration tests: admin-authored notices, instance scope (#456, PR 2)
+ *
+ * Covers:
+ *   - createInstanceNotice writes audit with organizationId=null and respects
+ *     the "activate now" flag
+ *   - Activating a second instance notice deactivates the previous one
+ *     (single-active invariant per scope)
+ *   - Scope enforcement:
+ *       * org admin cannot call createInstanceNotice / setInstanceNoticeActive
+ *         / deleteInstanceNotice — Forbidden
+ *       * instance admin cannot call setOrgNoticeActive on another org's
+ *         notice — Forbidden (cross-scope confusion would let an instance
+ *         admin act-as without break-glass)
+ *       * updating/deleting a notice via the wrong scope's action is rejected
+ *   - Audit row carries userId, organizationId=null, before/after captures
+ *     the scope field
+ *   - getActiveInstanceNotice returns null when no instance notice is active
+ *
+ * Capability: ac-feature-management, iam-instance-administration
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import { db } from '@/db/client'
+import { adminNotices, auditLog } from '@/db/schema'
+import { getActiveInstanceNotice, listInstanceNotices } from '@/lib/admin-notices'
+import {
+  createInstanceNotice,
+  deleteInstanceNotice,
+  setInstanceNoticeActive,
+  updateInstanceNotice,
+  setOrgNoticeActive,
+} from '@/actions/admin-notices'
+import {
+  cleanupOrg,
+  createTestOrg,
+  createTestUser,
+  makeSession,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+let platformOrgId: string
+let tenantOrgId: string
+let instanceAdmin: TestUser
+let orgAdmin: TestUser
+
+beforeAll(async () => {
+  // The instance admin's user record can live in any org — the role gate is on
+  // session.user.instanceRole, not on organizationId. Use a separate org so
+  // cleanup is straightforward.
+  const [platform, tenant] = await Promise.all([createTestOrg(), createTestOrg()])
+  platformOrgId = platform.id
+  tenantOrgId = tenant.id
+  ;[instanceAdmin, orgAdmin] = await Promise.all([
+    createTestUser(platformOrgId, 'admin'),
+    createTestUser(tenantOrgId, 'admin'),
+  ])
+})
+
+afterAll(async () => {
+  // Instance notices have organizationId=null — match on scope instead.
+  await db.delete(adminNotices).where(eq(adminNotices.scope, 'instance'))
+  await db.delete(adminNotices).where(eq(adminNotices.organizationId, platformOrgId))
+  await db.delete(adminNotices).where(eq(adminNotices.organizationId, tenantOrgId))
+  await cleanupOrg(platformOrgId)
+  await cleanupOrg(tenantOrgId)
+})
+
+beforeEach(async () => {
+  await db.delete(adminNotices).where(eq(adminNotices.scope, 'instance'))
+  await db.delete(adminNotices).where(eq(adminNotices.organizationId, platformOrgId))
+  await db.delete(adminNotices).where(eq(adminNotices.organizationId, tenantOrgId))
+})
+
+function asInstanceAdmin(user: TestUser) {
+  mockAuth.mockResolvedValue(makeSession(user, { instanceRole: 'instance_admin' }))
+}
+
+function asOrgAdmin(user: TestUser) {
+  mockAuth.mockResolvedValue(makeSession(user))
+}
+
+function fd(values: Record<string, string>): FormData {
+  const f = new FormData()
+  for (const [k, v] of Object.entries(values)) f.set(k, v)
+  return f
+}
+
+// ── Creation + activation ────────────────────────────────────────────────────
+
+describe('createInstanceNotice', () => {
+  it('creates an instance notice with organizationId=null and writes audit', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Platform maintenance Saturday',
+      body: 'GovEA is read-only from 22:00 to 23:00 UTC.',
+      severity: 'warning',
+      activate: 'true',
+    }))
+
+    const rows = await listInstanceNotices()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].scope).toBe('instance')
+    expect(rows[0].organizationId).toBeNull()
+    expect(rows[0].active).toBe(true)
+    expect(rows[0].severity).toBe('warning')
+
+    const audit = await db.query.auditLog.findFirst({
+      where: and(eq(auditLog.entityType, 'admin_notice'), eq(auditLog.action, 'admin_notice.create')),
+      orderBy: [desc(auditLog.createdAt)],
+    })
+    expect(audit?.userId).toBe(instanceAdmin.id)
+    expect(audit?.organizationId).toBeNull()
+    const after = audit?.after as Record<string, unknown> | undefined
+    expect(after?.scope).toBe('instance')
+  })
+
+  it('respects the activate=false path (notice created inactive)', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Draft notice',
+      body: 'Not yet visible.',
+      severity: 'info',
+    }))
+
+    const active = await getActiveInstanceNotice()
+    expect(active).toBeNull()
+    const all = await listInstanceNotices()
+    expect(all).toHaveLength(1)
+    expect(all[0].active).toBe(false)
+  })
+
+  it('activating a second instance notice deactivates the first (single-active invariant)', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'First',
+      body: 'First instance notice',
+      severity: 'info',
+      activate: 'true',
+    }))
+    await createInstanceNotice(fd({
+      title: 'Second',
+      body: 'Second instance notice',
+      severity: 'critical',
+      activate: 'true',
+    }))
+
+    const all = await listInstanceNotices()
+    const activeCount = all.filter(n => n.active).length
+    expect(activeCount).toBe(1)
+    const active = await getActiveInstanceNotice()
+    expect(active?.title).toBe('Second')
+  })
+})
+
+// ── Scope enforcement ────────────────────────────────────────────────────────
+
+describe('scope enforcement', () => {
+  it('rejects org admin attempting to create an instance notice', async () => {
+    asOrgAdmin(orgAdmin)
+    await expect(createInstanceNotice(fd({
+      title: 'Sneaky',
+      body: 'org admin should not be able to do this',
+      severity: 'info',
+      activate: 'true',
+    }))).rejects.toThrow(/forbidden/i)
+  })
+
+  it('rejects org admin attempting to activate an instance notice', async () => {
+    // Seed an instance notice as the instance admin first.
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Seeded',
+      body: 'For the next test',
+      severity: 'info',
+    }))
+    const seeded = await db.query.adminNotices.findFirst({
+      where: and(eq(adminNotices.scope, 'instance'), isNull(adminNotices.organizationId)),
+    })
+    expect(seeded).toBeDefined()
+
+    // Switch to org admin and try to activate it.
+    asOrgAdmin(orgAdmin)
+    await expect(setInstanceNoticeActive(seeded!.id, true)).rejects.toThrow(/forbidden/i)
+  })
+
+  it('rejects org admin attempting to delete an instance notice', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Seeded for delete-reject',
+      body: 'x',
+      severity: 'info',
+    }))
+    const seeded = await db.query.adminNotices.findFirst({
+      where: and(eq(adminNotices.scope, 'instance'), isNull(adminNotices.organizationId)),
+    })
+    asOrgAdmin(orgAdmin)
+    await expect(deleteInstanceNotice(seeded!.id)).rejects.toThrow(/forbidden/i)
+  })
+
+  it('rejects an org-scoped action targeting an instance notice id', async () => {
+    // Cross-scope action attempt: org admin uses the org action on an instance
+    // notice id. The scope check inside setOrgNoticeActive must reject it.
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Cross-scope canary',
+      body: 'x',
+      severity: 'info',
+    }))
+    const seeded = await db.query.adminNotices.findFirst({
+      where: and(eq(adminNotices.scope, 'instance'), isNull(adminNotices.organizationId)),
+    })
+    asOrgAdmin(orgAdmin)
+    await expect(setOrgNoticeActive(seeded!.id, true)).rejects.toThrow(/forbidden/i)
+  })
+
+  it('rejects an instance-scoped action targeting an org notice id', async () => {
+    // Inverse direction: create an org notice as org admin, then attempt to
+    // activate it via the instance-scope action. Must reject — keeps the two
+    // scopes from being used interchangeably.
+    asOrgAdmin(orgAdmin)
+    const insertResult = await db.insert(adminNotices).values({
+      scope: 'org',
+      organizationId: tenantOrgId,
+      severity: 'info',
+      title: 'Org-only',
+      body: 'x',
+      active: false,
+      createdBy: orgAdmin.id,
+    }).returning()
+    const orgNoticeId = insertResult[0].id
+
+    asInstanceAdmin(instanceAdmin)
+    await expect(setInstanceNoticeActive(orgNoticeId, true)).rejects.toThrow(/forbidden/i)
+  })
+})
+
+// ── Update + delete ──────────────────────────────────────────────────────────
+
+describe('updateInstanceNotice / deleteInstanceNotice', () => {
+  it('updates and audits with scope=instance in the before/after', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Initial title',
+      body: 'Initial body',
+      severity: 'info',
+    }))
+    const row = await db.query.adminNotices.findFirst({
+      where: and(eq(adminNotices.scope, 'instance'), isNull(adminNotices.organizationId)),
+    })
+    await updateInstanceNotice(row!.id, fd({
+      title: 'Updated title',
+      body: 'Updated body',
+      severity: 'warning',
+    }))
+
+    const after = await db.query.adminNotices.findFirst({ where: eq(adminNotices.id, row!.id) })
+    expect(after?.title).toBe('Updated title')
+    expect(after?.severity).toBe('warning')
+
+    const audit = await db.query.auditLog.findFirst({
+      where: and(eq(auditLog.entityType, 'admin_notice'), eq(auditLog.action, 'admin_notice.update')),
+      orderBy: [desc(auditLog.createdAt)],
+    })
+    const auditBefore = audit?.before as Record<string, unknown> | undefined
+    const auditAfter = audit?.after as Record<string, unknown> | undefined
+    expect(auditBefore?.scope).toBe('instance')
+    expect(auditAfter?.scope).toBe('instance')
+    expect(audit?.organizationId).toBeNull()
+  })
+
+  it('deletes and audits', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'To be deleted',
+      body: 'x',
+      severity: 'info',
+    }))
+    const row = await db.query.adminNotices.findFirst({
+      where: and(eq(adminNotices.scope, 'instance'), isNull(adminNotices.organizationId)),
+    })
+    await deleteInstanceNotice(row!.id)
+
+    const after = await db.query.adminNotices.findFirst({ where: eq(adminNotices.id, row!.id) })
+    expect(after).toBeUndefined()
+
+    const audit = await db.query.auditLog.findFirst({
+      where: and(eq(auditLog.entityType, 'admin_notice'), eq(auditLog.action, 'admin_notice.delete')),
+      orderBy: [desc(auditLog.createdAt)],
+    })
+    expect(audit?.userId).toBe(instanceAdmin.id)
+    expect(audit?.organizationId).toBeNull()
+  })
+})
+
+// ── getActiveInstanceNotice ──────────────────────────────────────────────────
+
+describe('getActiveInstanceNotice', () => {
+  it('returns null when no instance notice is active', async () => {
+    expect(await getActiveInstanceNotice()).toBeNull()
+  })
+
+  it('returns the active instance notice when one exists', async () => {
+    asInstanceAdmin(instanceAdmin)
+    await createInstanceNotice(fd({
+      title: 'Live one',
+      body: 'x',
+      severity: 'critical',
+      activate: 'true',
+    }))
+    const active = await getActiveInstanceNotice()
+    expect(active?.title).toBe('Live one')
+    expect(active?.severity).toBe('critical')
+  })
+})


### PR DESCRIPTION
## Summary

Completes [#456](https://github.com/roballred/GovEA/issues/456) by adding the **instance-scoped half** of the admin-notices capability. PR1 (already merged) shipped org-scoped notices; this PR2 adds the instance scope, the second banner row, and the instance-admin management UI under `/instance/notices`.

Honours every design decision in the issue&apos;s [&ldquo;Design decisions locked in&rdquo; comment](https://github.com/roballred/GovEA/issues/456#issuecomment) (severity → visual treatment, single-active per scope, top-of-authenticated-pages render, instance notices visible to everyone including admins, optional https-only Learn-more URL, stacking order).

## What ships

| File | Change |
|---|---|
| `apps/govea/src/lib/admin-notices.ts` | `getActiveInstanceNotice()`, `listInstanceNotices()` |
| `apps/govea/src/actions/admin-notices.ts` | `createInstanceNotice` / `updateInstanceNotice` / `setInstanceNoticeActive` / `deleteInstanceNotice` + form adapters, all gated on `isInstanceAdmin`. Each verifies the target notice has `scope='instance'` AND `organizationId=null` before mutating. |
| `apps/govea/src/app/(instance)/instance/notices/page.tsx` _(new)_ | Instance-admin management UI mirroring `/settings/notices`. Violet-tinted create form + violet `Instance` pill on list items so scope is obvious before submit and at-a-glance after. |
| `apps/govea/src/components/instance-shell.tsx` | One-line: adds `/instance/notices` to the platform-admin sidebar. |
| `apps/govea/src/components/admin-notice-banner.tsx` | Rewritten to fetch both scopes in parallel and stack in the documented order. `orgId` optional so the instance layout can render the banner without a spurious org-notice lookup. |
| `apps/govea/src/app/(instance)/layout.tsx` | Renders `<AdminNoticeBanner />` so instance admins see what tenants see. |
| `apps/govea/tests/integration/admin-notices-instance.test.ts` _(new, 12 tests)_ | All passing. |

## Stacking order (banner rendering)

```
[Critical instance notice]
[Critical org notice]
[ActAsBanner]                     ← rendered by layout, not here
[Warning/info instance notice]
[Warning/info org notice]
```

Criticals above the act-as banner because a critical platform message should outrank &ldquo;you are acting as X.&rdquo; Lower-severity below so act-as context stays in view.

## Scope enforcement (the security shape)

Every action verifies the target notice scope **before mutating**. The test matrix:

| Caller | Action on instance notice | Action on org notice |
|---|---|---|
| Org admin | ❌ Forbidden | ✅ org actions only |
| Instance admin | ✅ instance actions only | ❌ Forbidden |
| Org-scope action targeting instance notice id | ❌ Forbidden | n/a |
| Instance-scope action targeting org notice id | ❌ Forbidden | n/a |

All five rows are covered by integration tests. Audit row carries the scope in `before` and `after` so an attempted cross-scope action shows up clearly in `/audit` even if it had succeeded.

## Browser-verified locally

1. Logged in as **Ivan (instance admin)** → navigated to `/instance/notices`
2. Created &ldquo;Browser-verify instance notice&rdquo; (severity=warning, activate=true)
3. List shows it active with violet `Instance` pill + amber `warning` pill + green `Active` pill
4. Signed out → logged in as **Alice (Riverdale Admin)** → dashboard
5. Banner renders at top of `/dashboard` with violet `INSTANCE` tag + amber `WARNING` tag + title + body
6. No console errors

## Local gate status

- [x] **12/12** instance-notice integration tests pass
- [x] **17/17** existing org-notice tests still pass (no regression)
- [x] `tsc --noEmit` clean
- [x] `eslint` 0 errors, 41 warnings (same count as `main`)
- [x] `business-architecture` lint OK (107 files)

## Out of scope (per #456)

- Email / SMS / outbound delivery
- Rich campaign management, targeting, segmentation, analytics
- Replacing maintenance mode

## v1.0 Practice-Ready progress

| Issue | Status |
|---|---|
| #73 ADR CRUD | retro-closed |
| #86 Data Export | open (#658) |
| #103 Feedback Phase 2 | open |
| #456 Admin notices | **this PR** |
| #479 Collapsible nav | open (#657) |
| #518 Dogfood refresh | merged |
| #529 Backup & Export | open |

Capability: `ac-feature-management`, `iam-instance-administration`
Persona: CMS Administrator; Instance Administrator
Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)