### PR TITLE
feat(admin): operational backup/export — recipe, content, archive (#529 PR1)

### DIFF
--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -181,7 +181,7 @@ export default async function DashboardPage() {
   // suppression banner when the score is currently below threshold.
   const showRanked = canEdit(session.user)
   const isAdminUser = isAdmin(session.user)
-  const [signals, mostNeeded, domainRag, confSummary, emailConfigured] = await Promise.all([
+  const [signals, mostNeeded, domainRag, confSummary, emailConfigured, lastExport] = await Promise.all([
     getCategorizedSignals(orgId),
     showRanked ? getMostNeededActions(orgId) : Promise.resolve([]),
     getDomainRagBuckets(orgId),
@@ -189,6 +189,12 @@ export default async function DashboardPage() {
     // Email banner is admin-only — contributors and viewers shouldn't see
     // an org-config nudge they can't act on (#528 capability rule).
     isAdminUser ? isEmailConfigured(orgId) : Promise.resolve(true),
+    // Last-backup surface (#529 capability rule). Admin-only; contributors
+    // and viewers cannot trigger backups so the surface is noise for them.
+    isAdminUser ? db.select({
+      lastExportAt: organizations.lastExportAt,
+      lastExportBytes: organizations.lastExportBytes,
+    }).from(organizations).where(eq(organizations.id, orgId)).limit(1).then(rows => rows[0] ?? null) : Promise.resolve(null),
   ])
   const summarySuppressed =
     (confSummary.settings.authenticatedVisibility ?? confSummary.settings.enabled) &&
@@ -260,6 +266,42 @@ export default async function DashboardPage() {
             </Link>
             .
           </p>
+        </div>
+      )}
+
+      {/* Last-backup surface (#529 ac-backup-export capability rule).
+          Admin-only; rendered as a compact line, not a full alert, since
+          a fresh install has never exported and we don't want that to
+          read as an error. Links to /settings/backup. */}
+      {isAdminUser && (
+        <div className="flex items-center justify-between gap-3 rounded-md border bg-card px-4 py-2 text-xs">
+          <span className="text-muted-foreground">
+            Last backup:{' '}
+            {lastExport?.lastExportAt ? (
+              <>
+                <span className="text-foreground font-medium">
+                  {lastExport.lastExportAt.toLocaleString()}
+                </span>
+                {lastExport.lastExportBytes != null && (
+                  <span className="text-muted-foreground">
+                    {' '}({lastExport.lastExportBytes < 1024
+                      ? `${lastExport.lastExportBytes} B`
+                      : lastExport.lastExportBytes < 1024 * 1024
+                        ? `${(lastExport.lastExportBytes / 1024).toFixed(1)} KB`
+                        : `${(lastExport.lastExportBytes / (1024 * 1024)).toFixed(1)} MB`})
+                  </span>
+                )}
+              </>
+            ) : (
+              <span className="text-foreground">Never exported</span>
+            )}
+          </span>
+          <Link
+            href="/settings/backup"
+            className="text-foreground underline underline-offset-2 hover:no-underline"
+          >
+            Back up now →
+          </Link>
         </div>
       )}
 

--- a/apps/govea/src/app/(admin)/settings/backup/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/backup/page.tsx
@@ -1,0 +1,155 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { db } from '@/db/client'
+import { organizations } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+
+/** Format a byte count as a short human string ("1.2 MB", "850 KB", etc.). */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/** Format a timestamp as a relative + absolute pair the operator can act on. */
+function formatLastExport(at: Date | null, bytes: number | null): string {
+  if (!at) return 'Never exported'
+  const sizeStr = bytes != null ? `, ${formatBytes(bytes)}` : ''
+  return `${at.toLocaleString()}${sizeStr}`
+}
+
+/**
+ * /settings/backup — operational backup & export (#529 PR1).
+ *
+ * Admin-only. Three download buttons (Recipe / Content / Archive); each
+ * triggers a JSON file download via `/api/backup/*` and updates the
+ * `lastExportAt` timestamp surfaced here and on the dashboard.
+ *
+ * Import is the natural follow-up (PR2) — left as a "coming soon" note
+ * here so admins know where it will live.
+ */
+export default async function BackupSettingsPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) redirect('/dashboard')
+  if (!session.user.organizationId) redirect('/dashboard')
+
+  const org = await db.query.organizations.findFirst({
+    where: eq(organizations.id, session.user.organizationId),
+  })
+
+  const lastExportStr = formatLastExport(org?.lastExportAt ?? null, org?.lastExportBytes ?? null)
+
+  return (
+    <div className="max-w-3xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Backup &amp; Export</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Download a full-fidelity snapshot of this organization for backup,
+          migration to a new host, or restore after data loss. Exports never
+          include user passwords, SMTP credentials, or the audit log
+          (audit is append-only at the database layer and backed up
+          separately).
+        </p>
+        <p className="text-xs text-muted-foreground mt-2">
+          For external-tool consumption (Power BI, Excel hand-offs), the
+          relationship-preserving data portability export is a separate,
+          adjacent concern &mdash; tracked in{' '}
+          <a href="https://github.com/roballred/GovEA/issues/86" target="_blank" rel="noopener noreferrer" className="underline">#86</a>.
+        </p>
+      </div>
+
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 className="text-base font-semibold">Last export</h2>
+          <span className="text-xs text-muted-foreground">{lastExportStr}</span>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold">Export</h2>
+
+        <div className="rounded-lg border bg-card p-5 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold">Recipe</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Configuration only &mdash; organization settings, taxonomy
+              types and terms, custom-field definitions, enabled modules.
+              No content rows. Use to provision a fresh install with the
+              same shape.
+            </p>
+          </div>
+          <div>
+            <a
+              href="/api/backup/recipe"
+              download
+              className="inline-flex items-center justify-center rounded-md border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Download recipe
+            </a>
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-card p-5 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold">Content</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Content rows only &mdash; personas, capabilities, applications,
+              value streams, objectives, initiatives, ADRs, principles,
+              glossary, services, debt items, and their relationships. No
+              org settings.
+            </p>
+          </div>
+          <div>
+            <a
+              href="/api/backup/content"
+              download
+              className="inline-flex items-center justify-center rounded-md border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Download content
+            </a>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-emerald-200 dark:border-emerald-900 bg-emerald-50/30 dark:bg-emerald-950/10 p-5 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold">
+              Archive
+              <span className="ml-2 inline-flex items-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300 px-2 py-0.5 text-xs font-medium">
+                Recommended
+              </span>
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Recipe and content in one bundle &mdash; the complete &ldquo;back
+              up the whole system&rdquo; shape. This is the file you restore
+              into a fresh host.
+            </p>
+          </div>
+          <div>
+            <a
+              href="/api/backup/archive"
+              download
+              className="inline-flex items-center justify-center rounded-md border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Download archive
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-dashed bg-card p-5">
+        <h2 className="text-base font-semibold">Import</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Restoring from a previous archive is a destructive operation that
+          replaces the current content. Coming in a follow-up PR of{' '}
+          <a href="https://github.com/roballred/GovEA/issues/529" target="_blank" rel="noopener noreferrer" className="underline">
+            #529
+          </a>{' '}
+          with an explicit destructive-action confirmation per the capability
+          rules.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/govea/src/app/api/backup/archive/route.ts
+++ b/apps/govea/src/app/api/backup/archive/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { buildArchiveExport, recordExport } from '@/lib/backup-export'
+
+/**
+ * GET /api/backup/archive — combined recipe+content export (#529).
+ *
+ * Admin-only. Returns a JSON file and updates `lastExportAt` / `lastExportBytes`.
+ * This is the "back up the whole system" shape — restored via the import
+ * action shipping in PR2 of #529.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!isAdmin(session.user)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (!session.user.organizationId) {
+    return NextResponse.json({ error: 'No organization context' }, { status: 400 })
+  }
+
+  const out = await buildArchiveExport(session.user.organizationId)
+  await recordExport(session.user.organizationId, out.bytes)
+
+  return new NextResponse(out.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${out.filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/apps/govea/src/app/api/backup/content/route.ts
+++ b/apps/govea/src/app/api/backup/content/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { buildContentExport, recordExport } from '@/lib/backup-export'
+
+/**
+ * GET /api/backup/content — content-only export (#529).
+ *
+ * Admin-only. Returns a JSON file and updates `lastExportAt` / `lastExportBytes`.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!isAdmin(session.user)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (!session.user.organizationId) {
+    return NextResponse.json({ error: 'No organization context' }, { status: 400 })
+  }
+
+  const out = await buildContentExport(session.user.organizationId)
+  await recordExport(session.user.organizationId, out.bytes)
+
+  return new NextResponse(out.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${out.filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/apps/govea/src/app/api/backup/recipe/route.ts
+++ b/apps/govea/src/app/api/backup/recipe/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { buildRecipeExport, recordExport } from '@/lib/backup-export'
+
+/**
+ * GET /api/backup/recipe — recipe-only export (#529).
+ *
+ * Admin-only. Returns a JSON file (`Content-Disposition: attachment`) and
+ * stamps `organizations.lastExportAt` / `lastExportBytes` for the dashboard.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!isAdmin(session.user)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (!session.user.organizationId) {
+    return NextResponse.json({ error: 'No organization context' }, { status: 400 })
+  }
+
+  const out = await buildRecipeExport(session.user.organizationId)
+  await recordExport(session.user.organizationId, out.bytes)
+
+  return new NextResponse(out.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${out.filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -1,4 +1,4 @@
-import { type AnyPgColumn, boolean, jsonb, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { type AnyPgColumn, boolean, integer, jsonb, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 export const visibilityEnum = pgEnum('visibility', ['org', 'connections', 'instance'])
 
@@ -129,6 +129,19 @@ export const organizations = pgTable('organizations', {
   suspendedReason: text('suspended_reason'),
   supportTier: text('support_tier'),
   internalNotes: text('internal_notes'),
+  /**
+   * #529: timestamp of the last successful backup export (any of recipe,
+   * content, or archive). Updated by the export endpoints in a single
+   * transaction so the dashboard surface stays accurate. Null = never
+   * exported.
+   */
+  lastExportAt: timestamp('last_export_at'),
+  /**
+   * #529: byte size of the most recent export, paired with `lastExportAt`.
+   * Useful for dashboard scale ("Last backup: 2 hours ago, 1.2 MB") and
+   * to flag suspiciously-empty exports.
+   */
+  lastExportBytes: integer('last_export_bytes'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })

--- a/apps/govea/src/lib/backup-export.ts
+++ b/apps/govea/src/lib/backup-export.ts
@@ -1,0 +1,347 @@
+/**
+ * Operational backup / export builder (#529).
+ *
+ * Three export shapes, sharing one collector so excludes (passwords, SMTP
+ * credentials, audit log) are defined in exactly one place:
+ *
+ *   - recipe  — configuration only (org settings + taxonomy + custom field
+ *               schemas + module enablement). No content rows. The "fresh
+ *               install with the same shape" shape.
+ *   - content — content rows only (personas, capabilities, applications,
+ *               value streams, objectives, initiatives, ADRs, principles,
+ *               glossary, services, debt items, plus their junction tables).
+ *               No org settings or taxonomy definitions.
+ *   - archive — both, in one bundle. The "restore my whole org elsewhere"
+ *               shape.
+ *
+ * Distinct from #86 (data portability for external consumption). #86 is for
+ * Power BI / Excel hand-offs; this is for "back up the system before an
+ * upgrade and restore it after." The two are complementary surfaces; this
+ * code is the operational half.
+ *
+ * Explicit excludes (per the ac-backup-export capability rules):
+ *   - User passwords (`users.passwordHash`)
+ *   - SMTP credentials (anything from `org-email-config`)
+ *   - Audit log (immutable at the DB layer per #417; backed up separately)
+ *   - Notifications inbox (transient operational state)
+ *   - Sessions, break-glass sessions, act-as sessions (transient auth state)
+ *   - Completeness snapshots (recomputable derived state)
+ *
+ * Returns a plain object so callers can JSON.stringify with their own
+ * indentation preference.
+ */
+
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+// Most junction tables are referenced only via `db.query.<key>.findMany({})`
+// and never directly — so they're intentionally absent from this import
+// block. Only tables we filter or eq-compare against go in.
+import {
+  organizations,
+  personas, capabilities, applications, services,
+  valueStreams,
+  strategicObjectives,
+  goals,
+  initiatives,
+  adrs,
+  principles,
+  glossaryTerms,
+  taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues,
+  customFieldSchemas,
+  architectureDebtItems,
+} from '@/db/schema'
+
+export type BackupShape = 'recipe' | 'content' | 'archive'
+
+export const BACKUP_FORMAT_VERSION = '1.0' as const
+
+/**
+ * What the consumer is told about the export at the envelope level.
+ * Implementation-status: not consumed by the import path yet — import
+ * arrives in PR2 of #529 with its own validator.
+ */
+interface BackupEnvelope {
+  format: typeof BACKUP_FORMAT_VERSION
+  shape: BackupShape
+  exportedAt: string
+  orgId: string
+  orgName: string
+  orgSlug: string
+  /**
+   * Excludes are listed verbatim in the envelope so anyone inspecting the
+   * file knows what is intentionally absent — not "missing because of a
+   * bug."
+   */
+  excludes: readonly string[]
+}
+
+const STANDARD_EXCLUDES = [
+  'users.passwordHash',
+  'email-config (SMTP credentials)',
+  'audit_log (separate append-only backup)',
+  'notifications',
+  'sessions, break-glass-sessions, act-as-sessions',
+  'completeness-snapshots (recomputable)',
+] as const
+
+// ── Configuration (recipe) collector ────────────────────────────────────────
+
+/** Configuration export — no content rows. */
+async function collectRecipe(orgId: string) {
+  const [
+    org,
+    taxTermsRows,
+    entityTaxDefs,
+    fieldSchemas,
+  ] = await Promise.all([
+    db.query.organizations.findFirst({ where: eq(organizations.id, orgId) }),
+    db.query.taxonomyTerms.findMany({ where: eq(taxonomyTerms.organizationId, orgId) }),
+    db.query.entityTaxonomyDefinitions.findMany({ where: eq(entityTaxonomyDefinitions.organizationId, orgId) }),
+    db.query.customFieldSchemas.findMany({ where: eq(customFieldSchemas.organizationId, orgId) }),
+  ])
+
+  if (!org) throw new Error('Organization not found')
+
+  // Strip volatile / sensitive bits from the org row itself before
+  // including it in the export.
+  const orgSettings = {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    theme: org.theme,
+    enabledModules: org.enabledModules,
+    confidenceSettings: org.confidenceSettings,
+    completenessSettings: org.completenessSettings,
+    // securitySettings includes session lifetimes, password policy, etc. —
+    // configuration, not credentials, so it IS included in the recipe.
+    securitySettings: org.securitySettings,
+    supportTier: org.supportTier,
+  }
+
+  return {
+    organization: orgSettings,
+    taxonomy: {
+      terms: taxTermsRows,
+      entityDefinitions: entityTaxDefs,
+    },
+    customFields: {
+      schemas: fieldSchemas,
+    },
+  }
+}
+
+// ── Content collector ──────────────────────────────────────────────────────
+
+/** Content export — every persona-, capability-, app-, etc-shaped row. */
+async function collectContent(orgId: string) {
+  const orgFilter = eq(personas.organizationId, orgId)
+  // Each collection is a flat array of rows. Junctions are collected
+  // separately under `relationships` so a reader can replay them after the
+  // primary rows are restored.
+  const [
+    personaRows, capabilityRows, applicationRows, serviceRows,
+    valueStreamRows, valueStreamStageRows, valueStreamStageCapRows, valueStreamPersonaRows,
+    objectiveRows, objectiveCapRows, objectiveVsRows,
+    goalRows, goalObjectiveRows,
+    initiativeRows, initiativeCapRows, initiativeAppRows, initiativeObjRows,
+    adrRows, adrCapRows, adrAppRows, adrIniRows, adrObjRows,
+    principleRows, principleCapRows, principleAdrRows,
+    glossaryRows, glossarySourceRows,
+    serviceCapRows, servicePersonaRows, serviceVsRows,
+    capabilityPersonaRows, applicationCapabilityRows, capabilityRelationshipRows,
+    entityTaxValueRows,
+    debtRows, debtCapRows, debtAppRows, debtIniRows, debtAdrRows,
+  ] = await Promise.all([
+    db.query.personas.findMany({ where: orgFilter }),
+    db.query.capabilities.findMany({ where: eq(capabilities.organizationId, orgId) }),
+    db.query.applications.findMany({ where: eq(applications.organizationId, orgId) }),
+    db.query.services.findMany({ where: eq(services.organizationId, orgId) }),
+    db.query.valueStreams.findMany({ where: eq(valueStreams.organizationId, orgId) }),
+    db.query.valueStreamStages.findMany({}),
+    db.query.valueStreamStageCapabilities.findMany({}),
+    db.query.valueStreamPersonas.findMany({}),
+    db.query.strategicObjectives.findMany({ where: eq(strategicObjectives.organizationId, orgId) }),
+    db.query.objectiveCapabilities.findMany({}),
+    db.query.objectiveValueStreams.findMany({}),
+    db.query.goals.findMany({ where: eq(goals.organizationId, orgId) }),
+    db.query.goalObjectives.findMany({}),
+    db.query.initiatives.findMany({ where: eq(initiatives.organizationId, orgId) }),
+    db.query.initiativeCapabilities.findMany({}),
+    db.query.initiativeApplications.findMany({}),
+    db.query.initiativeObjectives.findMany({}),
+    db.query.adrs.findMany({ where: eq(adrs.organizationId, orgId) }),
+    db.query.adrCapabilities.findMany({}),
+    db.query.adrApplications.findMany({}),
+    db.query.adrInitiatives.findMany({}),
+    db.query.adrObjectives.findMany({}),
+    db.query.principles.findMany({ where: eq(principles.organizationId, orgId) }),
+    db.query.principleCapabilities.findMany({}),
+    db.query.principleAdrs.findMany({}),
+    db.query.glossaryTerms.findMany({ where: eq(glossaryTerms.organizationId, orgId) }),
+    db.query.glossaryTermSources.findMany({}),
+    db.query.serviceCapabilities.findMany({}),
+    db.query.servicePersonas.findMany({}),
+    db.query.serviceValueStreams.findMany({}),
+    db.query.capabilityPersonas.findMany({}),
+    db.query.applicationCapabilities.findMany({}),
+    db.query.capabilityRelationships.findMany({}),
+    db.query.entityTaxonomyValues.findMany({ where: eq(entityTaxonomyValues.organizationId, orgId) }),
+    db.query.architectureDebtItems.findMany({ where: eq(architectureDebtItems.organizationId, orgId) }),
+    db.query.debtCapabilities.findMany({}),
+    db.query.debtApplications.findMany({}),
+    db.query.debtInitiatives.findMany({}),
+    db.query.debtAdrs.findMany({}),
+  ])
+
+  // Filter the unscoped junction tables to rows whose parent entity belongs
+  // to this org. (Drizzle's relational findMany on junctions doesn't
+  // automatically constrain by parent org; we do that here so the export
+  // file only contains org-relevant links.)
+  // Cast each row array down to the minimum shape we need for the id-set
+  // building below — drizzle's relational findMany returns untyped rows for
+  // tables that don't have a relations entry. The .id field is part of every
+  // row in our schema by construction.
+  const personaIds = new Set((personaRows as Array<{ id: string }>).map(r => r.id))
+  const capIds = new Set((capabilityRows as Array<{ id: string }>).map(r => r.id))
+  const appIds = new Set((applicationRows as Array<{ id: string }>).map(r => r.id))
+  const svcIds = new Set((serviceRows as Array<{ id: string }>).map(r => r.id))
+  const vsIds = new Set((valueStreamRows as Array<{ id: string }>).map(r => r.id))
+  const objIds = new Set((objectiveRows as Array<{ id: string }>).map(r => r.id))
+  const goalIds = new Set((goalRows as Array<{ id: string }>).map(r => r.id))
+  const iniIds = new Set((initiativeRows as Array<{ id: string }>).map(r => r.id))
+  const adrIds = new Set((adrRows as Array<{ id: string }>).map(r => r.id))
+  const principleIds = new Set((principleRows as Array<{ id: string }>).map(r => r.id))
+  const glossaryIds = new Set((glossaryRows as Array<{ id: string }>).map(r => r.id))
+  const debtIds = new Set((debtRows as Array<{ id: string }>).map(r => r.id))
+
+  return {
+    personas: personaRows,
+    capabilities: capabilityRows,
+    applications: applicationRows,
+    services: serviceRows,
+    valueStreams: valueStreamRows,
+    objectives: objectiveRows,
+    goals: goalRows,
+    initiatives: initiativeRows,
+    adrs: adrRows,
+    principles: principleRows,
+    glossary: glossaryRows,
+    architectureDebt: debtRows,
+    relationships: {
+      capabilityPersonas: (capabilityPersonaRows as Array<{ capabilityId: string; personaId: string }>).filter(r => capIds.has(r.capabilityId) && personaIds.has(r.personaId)),
+      applicationCapabilities: (applicationCapabilityRows as Array<{ applicationId: string; capabilityId: string }>).filter(r => appIds.has(r.applicationId) && capIds.has(r.capabilityId)),
+      capabilityRelationships: (capabilityRelationshipRows as Array<{ parentId: string; childId: string }>).filter(r => capIds.has(r.parentId) && capIds.has(r.childId)),
+      valueStreamStages: (valueStreamStageRows as Array<{ valueStreamId: string }>).filter(r => vsIds.has(r.valueStreamId)),
+      valueStreamStageCapabilities: (valueStreamStageCapRows as Array<{ capabilityId: string }>).filter(r => capIds.has(r.capabilityId)),
+      valueStreamPersonas: (valueStreamPersonaRows as Array<{ valueStreamId: string; personaId: string }>).filter(r => vsIds.has(r.valueStreamId) && personaIds.has(r.personaId)),
+      objectiveCapabilities: (objectiveCapRows as Array<{ objectiveId: string; capabilityId: string }>).filter(r => objIds.has(r.objectiveId) && capIds.has(r.capabilityId)),
+      objectiveValueStreams: (objectiveVsRows as Array<{ objectiveId: string; valueStreamId: string }>).filter(r => objIds.has(r.objectiveId) && vsIds.has(r.valueStreamId)),
+      goalObjectives: (goalObjectiveRows as Array<{ goalId: string; objectiveId: string }>).filter(r => goalIds.has(r.goalId) && objIds.has(r.objectiveId)),
+      initiativeCapabilities: (initiativeCapRows as Array<{ initiativeId: string; capabilityId: string }>).filter(r => iniIds.has(r.initiativeId) && capIds.has(r.capabilityId)),
+      initiativeApplications: (initiativeAppRows as Array<{ initiativeId: string; applicationId: string }>).filter(r => iniIds.has(r.initiativeId) && appIds.has(r.applicationId)),
+      initiativeObjectives: (initiativeObjRows as Array<{ initiativeId: string; objectiveId: string }>).filter(r => iniIds.has(r.initiativeId) && objIds.has(r.objectiveId)),
+      adrCapabilities: (adrCapRows as Array<{ adrId: string; capabilityId: string }>).filter(r => adrIds.has(r.adrId) && capIds.has(r.capabilityId)),
+      adrApplications: (adrAppRows as Array<{ adrId: string; applicationId: string }>).filter(r => adrIds.has(r.adrId) && appIds.has(r.applicationId)),
+      adrInitiatives: (adrIniRows as Array<{ adrId: string; initiativeId: string }>).filter(r => adrIds.has(r.adrId) && iniIds.has(r.initiativeId)),
+      adrObjectives: (adrObjRows as Array<{ adrId: string; objectiveId: string }>).filter(r => adrIds.has(r.adrId) && objIds.has(r.objectiveId)),
+      principleCapabilities: (principleCapRows as Array<{ principleId: string; capabilityId: string }>).filter(r => principleIds.has(r.principleId) && capIds.has(r.capabilityId)),
+      principleAdrs: (principleAdrRows as Array<{ principleId: string; adrId: string }>).filter(r => principleIds.has(r.principleId) && adrIds.has(r.adrId)),
+      glossaryTermSources: (glossarySourceRows as Array<{ termId: string }>).filter(r => glossaryIds.has(r.termId)),
+      // Service + debt junctions: drizzle's relational findMany without an
+      // explicit relations entry returns untyped rows. Annotate the filter
+      // callback parameter so strict-mode TS can infer; the shape matches
+      // the table's columns by construction.
+      serviceCapabilities: (serviceCapRows as Array<{ serviceId: string; capabilityId: string }>).filter(r => svcIds.has(r.serviceId) && capIds.has(r.capabilityId)),
+      servicePersonas: (servicePersonaRows as Array<{ serviceId: string; personaId: string }>).filter(r => svcIds.has(r.serviceId) && personaIds.has(r.personaId)),
+      serviceValueStreams: (serviceVsRows as Array<{ serviceId: string; valueStreamId: string }>).filter(r => svcIds.has(r.serviceId) && vsIds.has(r.valueStreamId)),
+      entityTaxonomyValues: entityTaxValueRows,
+      debtCapabilities: (debtCapRows as Array<{ debtItemId: string; capabilityId: string }>).filter(r => debtIds.has(r.debtItemId) && capIds.has(r.capabilityId)),
+      debtApplications: (debtAppRows as Array<{ debtItemId: string; applicationId: string }>).filter(r => debtIds.has(r.debtItemId) && appIds.has(r.applicationId)),
+      debtInitiatives: (debtIniRows as Array<{ debtItemId: string; initiativeId: string }>).filter(r => debtIds.has(r.debtItemId) && iniIds.has(r.initiativeId)),
+      debtAdrs: (debtAdrRows as Array<{ debtItemId: string; adrId: string }>).filter(r => debtIds.has(r.debtItemId) && adrIds.has(r.adrId)),
+    },
+  }
+}
+
+// ── Top-level builders ─────────────────────────────────────────────────────
+
+interface BuiltExport {
+  filename: string
+  body: string
+  bytes: number
+}
+
+function envelope(orgId: string, orgName: string, orgSlug: string, shape: BackupShape): BackupEnvelope {
+  return {
+    format: BACKUP_FORMAT_VERSION,
+    shape,
+    exportedAt: new Date().toISOString(),
+    orgId,
+    orgName,
+    orgSlug,
+    excludes: STANDARD_EXCLUDES,
+  }
+}
+
+function makeFilename(orgSlug: string, shape: BackupShape, exportedAt: string): string {
+  // ISO-8601 with `:` replaced by `-` so the filename is safe across OSes
+  // without losing the timestamp at file-system level.
+  const safeStamp = exportedAt.replace(/[:.]/g, '-')
+  return `govea-${orgSlug}-${shape}-${safeStamp}.json`
+}
+
+/** Builds a recipe-only export (config + taxonomy + custom-field schemas). */
+export async function buildRecipeExport(orgId: string): Promise<BuiltExport> {
+  const recipe = await collectRecipe(orgId)
+  const env = envelope(orgId, recipe.organization.name, recipe.organization.slug, 'recipe')
+  const body = JSON.stringify({ envelope: env, recipe }, null, 2)
+  return {
+    filename: makeFilename(recipe.organization.slug, 'recipe', env.exportedAt),
+    body,
+    bytes: Buffer.byteLength(body, 'utf8'),
+  }
+}
+
+/** Builds a content-only export (rows + relationships; no config). */
+export async function buildContentExport(orgId: string): Promise<BuiltExport> {
+  const [org, content] = await Promise.all([
+    db.query.organizations.findFirst({ where: eq(organizations.id, orgId) }),
+    collectContent(orgId),
+  ])
+  if (!org) throw new Error('Organization not found')
+  const env = envelope(orgId, org.name, org.slug, 'content')
+  const body = JSON.stringify({ envelope: env, content }, null, 2)
+  return {
+    filename: makeFilename(org.slug, 'content', env.exportedAt),
+    body,
+    bytes: Buffer.byteLength(body, 'utf8'),
+  }
+}
+
+/** Builds a combined archive (recipe + content in one envelope). */
+export async function buildArchiveExport(orgId: string): Promise<BuiltExport> {
+  const [recipe, content] = await Promise.all([
+    collectRecipe(orgId),
+    collectContent(orgId),
+  ])
+  const env = envelope(orgId, recipe.organization.name, recipe.organization.slug, 'archive')
+  const body = JSON.stringify({ envelope: env, recipe, content }, null, 2)
+  return {
+    filename: makeFilename(recipe.organization.slug, 'archive', env.exportedAt),
+    body,
+    bytes: Buffer.byteLength(body, 'utf8'),
+  }
+}
+
+/**
+ * Updates `organizations.lastExportAt` / `lastExportBytes` after a successful
+ * export. Called from the route handlers; kept here so the export-time
+ * bookkeeping lives next to the exporters themselves.
+ */
+export async function recordExport(orgId: string, bytes: number): Promise<void> {
+  await db
+    .update(organizations)
+    .set({ lastExportAt: new Date(), lastExportBytes: bytes })
+    .where(eq(organizations.id, orgId))
+}
+

--- a/apps/govea/tests/integration/backup-export.test.ts
+++ b/apps/govea/tests/integration/backup-export.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests: operational backup & export (#529 PR1).
+ *
+ * Covers:
+ *   - Recipe / Content / Archive exports return a valid envelope + payload
+ *   - Envelope explicitly lists passwordHash / SMTP / audit_log as excludes
+ *   - Content export is cross-org-isolated (no orgB rows in orgA export)
+ *   - Exclude discipline: no `passwordHash` / SMTP credential field names /
+ *     audit_log key anywhere in any export body
+ *   - recordExport updates lastExportAt + lastExportBytes
+ *
+ * Capability: ac-backup-export
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { db } from '@/db/client'
+import { organizations, personas } from '@/db/schema'
+import {
+  buildRecipeExport,
+  buildContentExport,
+  buildArchiveExport,
+  recordExport,
+  BACKUP_FORMAT_VERSION,
+} from '@/lib/backup-export'
+import {
+  cleanupOrg,
+  createTestOrg,
+  insertCapability,
+  insertPersona,
+  insertApplication,
+  type TestOrg,
+} from './helpers/db'
+
+let orgA: TestOrg
+let orgB: TestOrg
+
+beforeAll(async () => {
+  ;[orgA, orgB] = await Promise.all([createTestOrg(), createTestOrg()])
+  await insertCapability(orgA.id, { name: `Cap-A-${Date.now()}`, status: 'published' })
+  await insertPersona(orgA.id, { name: `Persona-A-${Date.now()}`, status: 'published' })
+  await insertApplication(orgA.id, { name: `App-A-${Date.now()}`, status: 'published' })
+  await insertPersona(orgB.id, { name: `Persona-B-${Date.now()}`, status: 'published' })
+})
+
+afterAll(async () => {
+  await cleanupOrg(orgA.id)
+  await cleanupOrg(orgB.id)
+})
+
+// ── Envelope shape ──────────────────────────────────────────────────────────
+
+describe('export envelope', () => {
+  it('recipe export carries the documented envelope fields', async () => {
+    const out = await buildRecipeExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.envelope.format).toBe(BACKUP_FORMAT_VERSION)
+    expect(parsed.envelope.shape).toBe('recipe')
+    expect(parsed.envelope.orgId).toBe(orgA.id)
+    expect(parsed.envelope.orgSlug).toBe(orgA.slug)
+    expect(Array.isArray(parsed.envelope.excludes)).toBe(true)
+    expect(parsed.envelope.excludes.some((s: string) => s.includes('passwordHash'))).toBe(true)
+    expect(parsed.envelope.excludes.some((s: string) => s.toLowerCase().includes('smtp'))).toBe(true)
+    expect(parsed.envelope.excludes.some((s: string) => s.includes('audit_log'))).toBe(true)
+  })
+
+  it('content export envelope has shape=content', async () => {
+    const out = await buildContentExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.envelope.shape).toBe('content')
+  })
+
+  it('archive export envelope has shape=archive and contains both halves', async () => {
+    const out = await buildArchiveExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.envelope.shape).toBe('archive')
+    expect(parsed.recipe).toBeDefined()
+    expect(parsed.content).toBeDefined()
+  })
+
+  it('filenames carry the org slug, the shape, and end with .json', async () => {
+    const out = await buildArchiveExport(orgA.id)
+    expect(out.filename).toMatch(new RegExp(`^govea-${orgA.slug}-archive-`))
+    expect(out.filename.endsWith('.json')).toBe(true)
+  })
+})
+
+// ── Content scope ───────────────────────────────────────────────────────────
+
+describe('content export', () => {
+  it('includes orgA personas + capabilities + applications', async () => {
+    const out = await buildContentExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.content.personas.length).toBeGreaterThan(0)
+    expect(parsed.content.capabilities.length).toBeGreaterThan(0)
+    expect(parsed.content.applications.length).toBeGreaterThan(0)
+  })
+
+  it('does NOT include other orgs personas (cross-org isolation)', async () => {
+    const out = await buildContentExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    const orgBPersonaIds = (await db.query.personas.findMany({
+      where: eq(personas.organizationId, orgB.id),
+    })).map(p => p.id)
+    const exportedIds = new Set<string>(parsed.content.personas.map((p: { id: string }) => p.id))
+    for (const id of orgBPersonaIds) {
+      expect(exportedIds.has(id)).toBe(false)
+    }
+  })
+
+  it('includes a relationships object with junction arrays present', async () => {
+    const out = await buildContentExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.content.relationships).toBeDefined()
+    for (const key of [
+      'capabilityPersonas',
+      'applicationCapabilities',
+      'objectiveCapabilities',
+      'initiativeCapabilities',
+      'adrCapabilities',
+    ]) {
+      expect(Array.isArray(parsed.content.relationships[key])).toBe(true)
+    }
+  })
+})
+
+// ── Exclude discipline ─────────────────────────────────────────────────────
+
+describe('exclude discipline', () => {
+  it('archive payload (recipe + content) contains no passwordHash field anywhere', async () => {
+    const out = await buildArchiveExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    // Stringify only the payload halves — the envelope intentionally names
+    // the excluded field for operator readability ("users.passwordHash").
+    const payloadStr = JSON.stringify({ recipe: parsed.recipe, content: parsed.content })
+    // Field-name shape: "passwordHash" appearing as a JSON key.
+    expect(payloadStr).not.toContain('"passwordHash"')
+    expect(payloadStr).not.toContain('"password_hash"')
+  })
+
+  it('archive payload contains no SMTP-credential field names', async () => {
+    const out = await buildArchiveExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    const payloadStr = JSON.stringify({ recipe: parsed.recipe, content: parsed.content }).toLowerCase()
+    expect(payloadStr).not.toContain('"smtppassword"')
+    expect(payloadStr).not.toContain('"smtp_password"')
+    expect(payloadStr).not.toContain('"email_password"')
+  })
+
+  it('archive export contains no audit_log section', async () => {
+    const out = await buildArchiveExport(orgA.id)
+    const parsed = JSON.parse(out.body)
+    expect(parsed.content?.auditLog).toBeUndefined()
+    expect(parsed.content?.audit_log).toBeUndefined()
+  })
+})
+
+// ── recordExport bookkeeping ───────────────────────────────────────────────
+
+describe('recordExport', () => {
+  it('updates lastExportAt + lastExportBytes on the org row', async () => {
+    await recordExport(orgA.id, 12345)
+    const after = await db.query.organizations.findFirst({
+      where: eq(organizations.id, orgA.id),
+      columns: { lastExportAt: true, lastExportBytes: true },
+    })
+    expect(after?.lastExportBytes).toBe(12345)
+    expect(after?.lastExportAt).toBeInstanceOf(Date)
+  })
+})


### PR DESCRIPTION
## Summary

Ships the **export half** of the `ac-backup-export` capability ([#529](https://github.com/roballred/GovEA/issues/529)). Import follows in PR2 with the destructive-confirm flow.

Distinct from [#86](https://github.com/roballred/GovEA/issues/86) (data portability for external consumption — Power BI, Excel hand-offs). **#529 is operational backup/restore** — the &ldquo;can I move this org to a new host?&rdquo; shape, not the &ldquo;hand off to a non-GovEA tool&rdquo; shape. Both surfaces ship in parallel.

## What ships

| File | Change |
|---|---|
| `apps/govea/src/db/schema/organizations.ts` | + `lastExportAt`, `lastExportBytes` (nullable) |
| `apps/govea/src/lib/backup-export.ts` *(new)* | Shared builder: `buildRecipeExport` / `buildContentExport` / `buildArchiveExport` / `recordExport`. STANDARD_EXCLUDES defined once; envelope lists them verbatim. |
| `apps/govea/src/app/api/backup/{recipe,content,archive}/route.ts` *(new)* | 3 admin-only GET routes returning JSON with `Content-Disposition: attachment`. |
| `apps/govea/src/app/(admin)/settings/backup/page.tsx` *(new)* | Admin-only settings page with 3 download buttons + last-export tile + import-coming-in-PR2 stub. |
| `apps/govea/src/app/(admin)/dashboard/page.tsx` | + admin-only &ldquo;Last backup: ... → Back up now&rdquo; line |
| `apps/govea/tests/integration/backup-export.test.ts` *(new, 11 tests)* | All passing |

## Three export shapes

| Shape | Contains | Excludes |
|---|---|---|
| **Recipe** | Org settings, taxonomy types/terms, custom-field schemas, modules, confidence/completeness/security settings | All content rows |
| **Content** | Personas, capabilities, applications, services, value streams, objectives, initiatives, goals, ADRs, principles, glossary, debt + every junction table | All config |
| **Archive** *(Recommended)* | Both halves in one envelope | &mdash; |

## STANDARD_EXCLUDES (defined once, listed in every envelope)

- `users.passwordHash`
- `email-config (SMTP credentials)`
- `audit_log (separate append-only backup)` &mdash; immutable at DB layer per [#417](https://github.com/roballred/GovEA/issues/417)
- `notifications`
- `sessions, break-glass-sessions, act-as-sessions`
- `completeness-snapshots (recomputable)`

The excludes list is rendered into the envelope so an operator inspecting an export file sees what is intentionally absent &mdash; not &ldquo;missing because of a bug.&rdquo;

## Browser-verified end-to-end

Signed in as Riverdale Admin:

1. `/dashboard` shows &ldquo;Last backup: Never exported → Back up now&rdquo;
2. `GET /api/backup/archive` → **200**, `application/json`, `Content-Disposition: attachment; filename="govea-city-of-riverdale-archive-2026-05-27T01-15-05-605Z.json"`, 152.5 KB body, envelope shape=archive, both halves present
3. Page reload: &ldquo;Last backup: 5/26/2026, 6:15:05 PM (152.5 KB) → Back up now&rdquo;
4. Signed in as Riverdale Contributor: `GET /api/backup/archive` → **403** `{"error":"Forbidden"}`
5. No console errors

## Local gates

- [x] **11/11** backup-export integration tests pass
- [x] `tsc --noEmit` clean
- [x] eslint: **0 errors, 41 warnings** (= main baseline)
- [x] business-architecture lint OK (107 files)

## Out of scope (PR2 of #529)

- File upload + schema validation
- Transactional restore
- Destructive-confirm UI pattern
- Per-shape import (recipe-only restore vs full-archive restore)

## v1.0 Practice-Ready progress

| Issue | Status |
|---|---|
| #73 ADR CRUD | retro-closed |
| #86 Data Export design | merged |
| #103 Phase 2 | open (interview-gated) |
| #456 Admin notices | merged |
| #479 Collapsible nav | merged |
| **#529 Backup & Export** | **this PR (PR1)** + future PR2 |

Capability: `ac-backup-export`
Persona: `cms-administrator`
Refs #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)