### PR TITLE
feat(admin): operational backup IMPORT — archive restore (#529 PR2, closes #529)

### DIFF
--- a/apps/govea/src/actions/backup.ts
+++ b/apps/govea/src/actions/backup.ts
@@ -1,0 +1,61 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { auth } from '@/lib/auth'
+import { isAdmin } from '@/lib/rbac'
+import { importArchive, recordImport, BackupImportError } from '@/lib/backup-import'
+
+/**
+ * Server action invoked by /settings/backup&apos;s import form (#529 PR2).
+ *
+ * Two destructive-action gates the action enforces in addition to admin-role:
+ *   1. The form supplies `confirm` = the literal string `RESTORE`.
+ *      Mirrors the ac-backup-export capability rule: "the admin must
+ *      confirm before proceeding." Typed token > checkbox because typing
+ *      is hard to do accidentally.
+ *   2. A JSON file must be present and parseable.
+ *
+ * On success, redirects back to /settings/backup with a success query
+ * param the page can render. On validation failure, throws an Error that
+ * Next.js surfaces in the form&apos;s error boundary.
+ */
+export async function importArchiveFromForm(formData: FormData): Promise<void> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+  if (!session.user.organizationId) throw new Error('No organization context')
+
+  const confirm = (formData.get('confirm') as string ?? '').trim()
+  if (confirm !== 'RESTORE') {
+    throw new Error('Type RESTORE to confirm import (case-sensitive)')
+  }
+
+  const file = formData.get('file')
+  if (!(file instanceof File) || file.size === 0) {
+    throw new Error('Select an archive JSON file to import')
+  }
+  // 50 MB guard — the largest archive observed in dogfood is well under
+  // 5 MB; anything past 50 MB is almost certainly the wrong file. Keeps
+  // a malicious-or-mistaken upload from blowing the request body limit.
+  if (file.size > 50 * 1024 * 1024) {
+    throw new Error('Archive larger than 50 MB; aborting (check the file)')
+  }
+
+  const bytes = file.size
+  const body = await file.text()
+
+  try {
+    await importArchive(session.user.organizationId, session.user.id, body)
+    await recordImport(session.user.organizationId, bytes)
+  } catch (e) {
+    // BackupImportError messages are user-facing; other errors stay as-is.
+    if (e instanceof BackupImportError) throw new Error(e.message)
+    throw e
+  }
+
+  // Revalidate everything: import replaces almost the entire content
+  // surface, so a per-route revalidate would miss something.
+  revalidatePath('/', 'layout')
+  redirect('/settings/backup?imported=1')
+}

--- a/apps/govea/src/app/(admin)/settings/backup/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/backup/page.tsx
@@ -4,6 +4,10 @@ import { isAdmin } from '@/lib/rbac'
 import { db } from '@/db/client'
 import { organizations } from '@/db/schema'
 import { eq } from 'drizzle-orm'
+import { importArchiveFromForm } from '@/actions/backup'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 
 /** Format a byte count as a short human string ("1.2 MB", "850 KB", etc.). */
 function formatBytes(bytes: number): string {
@@ -20,26 +24,35 @@ function formatLastExport(at: Date | null, bytes: number | null): string {
 }
 
 /**
- * /settings/backup — operational backup & export (#529 PR1).
+ * /settings/backup — operational backup & export (#529 PR1 + PR2).
  *
  * Admin-only. Three download buttons (Recipe / Content / Archive); each
  * triggers a JSON file download via `/api/backup/*` and updates the
  * `lastExportAt` timestamp surfaced here and on the dashboard.
  *
- * Import is the natural follow-up (PR2) — left as a "coming soon" note
- * here so admins know where it will live.
+ * Import (PR2): replaces the org&apos;s content + config with an uploaded
+ * archive. Destructive; requires typing RESTORE to enable the submit
+ * button. See `lib/backup-import.ts` for the wipe-then-restore replayer.
  */
-export default async function BackupSettingsPage() {
+export default async function BackupSettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ imported?: string }>
+}) {
   const session = await auth()
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) redirect('/dashboard')
   if (!session.user.organizationId) redirect('/dashboard')
+
+  const params = await searchParams
+  const showImportSuccess = params?.imported === '1'
 
   const org = await db.query.organizations.findFirst({
     where: eq(organizations.id, session.user.organizationId),
   })
 
   const lastExportStr = formatLastExport(org?.lastExportAt ?? null, org?.lastExportBytes ?? null)
+  const lastImportStr = formatLastExport(org?.lastImportAt ?? null, org?.lastImportBytes ?? null)
 
   return (
     <div className="max-w-3xl space-y-8">
@@ -60,10 +73,28 @@ export default async function BackupSettingsPage() {
         </p>
       </div>
 
-      <section className="rounded-lg border bg-card p-5">
+      {showImportSuccess && (
+        <div
+          role="status"
+          className="rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-900/20 dark:border-emerald-700 px-4 py-3 text-sm"
+        >
+          <p className="font-medium text-emerald-900 dark:text-emerald-200">
+            Archive imported successfully.
+          </p>
+          <p className="text-emerald-800 dark:text-emerald-300/80 mt-0.5">
+            The organization&apos;s content and configuration have been replaced.
+          </p>
+        </div>
+      )}
+
+      <section className="rounded-lg border bg-card p-5 space-y-2">
         <div className="flex items-baseline justify-between gap-4">
           <h2 className="text-base font-semibold">Last export</h2>
           <span className="text-xs text-muted-foreground">{lastExportStr}</span>
+        </div>
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 className="text-base font-semibold">Last import</h2>
+          <span className="text-xs text-muted-foreground">{lastImportStr}</span>
         </div>
       </section>
 
@@ -138,17 +169,56 @@ export default async function BackupSettingsPage() {
         </div>
       </section>
 
-      <section className="rounded-lg border border-dashed bg-card p-5">
-        <h2 className="text-base font-semibold">Import</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Restoring from a previous archive is a destructive operation that
-          replaces the current content. Coming in a follow-up PR of{' '}
-          <a href="https://github.com/roballred/GovEA/issues/529" target="_blank" rel="noopener noreferrer" className="underline">
-            #529
-          </a>{' '}
-          with an explicit destructive-action confirmation per the capability
-          rules.
-        </p>
+      <section className="rounded-lg border border-red-300 dark:border-red-900 bg-red-50/30 dark:bg-red-950/10 p-5 space-y-4">
+        <div>
+          <h2 className="text-base font-semibold text-red-900 dark:text-red-200">
+            Import &mdash; destructive
+          </h2>
+          <p className="text-sm text-red-800 dark:text-red-300/80 mt-1">
+            Replaces this organization&apos;s entire content and configuration
+            with the uploaded archive. Users, audit log, and SMTP credentials
+            are preserved. Federation connections are cleared. There is no
+            undo &mdash; export an archive first if you might want one.
+          </p>
+        </div>
+        <form action={importArchiveFromForm} className="space-y-4">
+          <div>
+            <Label htmlFor="file">Archive JSON file</Label>
+            <Input
+              id="file"
+              name="file"
+              type="file"
+              accept="application/json,.json"
+              required
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Must be an Archive export from this build (format 1.0).
+              Recipe-only and content-only imports are not yet supported.
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="confirm">
+              Type <code className="rounded bg-red-100 dark:bg-red-950/40 px-1 py-0.5 text-[11px] font-mono">RESTORE</code> to enable import
+            </Label>
+            <Input
+              id="confirm"
+              name="confirm"
+              type="text"
+              placeholder="RESTORE"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              required
+              pattern="RESTORE"
+              title="Type RESTORE (case-sensitive) to confirm"
+            />
+          </div>
+          <div>
+            <Button type="submit" variant="destructive">
+              Import archive (replaces current data)
+            </Button>
+          </div>
+        </form>
       </section>
     </div>
   )

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -142,6 +142,14 @@ export const organizations = pgTable('organizations', {
    * to flag suspiciously-empty exports.
    */
   lastExportBytes: integer('last_export_bytes'),
+  /**
+   * #529 PR2: timestamp of the last successful archive import. Symmetric
+   * with `lastExportAt` so the dashboard can show "last restored" when an
+   * import has overwritten the content more recently than the last export.
+   * Null = never imported.
+   */
+  lastImportAt: timestamp('last_import_at'),
+  lastImportBytes: integer('last_import_bytes'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 })

--- a/apps/govea/src/lib/backup-import.ts
+++ b/apps/govea/src/lib/backup-import.ts
@@ -1,0 +1,425 @@
+/**
+ * Operational backup IMPORT (#529 PR2).
+ *
+ * Takes an archive JSON produced by `buildArchiveExport` and replays it into
+ * the destination organization, replacing the org&apos;s current content and
+ * configuration. Companion to `lib/backup-export.ts`.
+ *
+ * Hard rules from the ac-backup-export capability:
+ *   - Import is a destructive operation. The admin must confirm via the UI
+ *     (typed token); this lib trusts the caller has done that.
+ *   - Excluded entities (users, SMTP credentials, audit log, notifications,
+ *     sessions, completeness snapshots) are NEVER touched by import. Users
+ *     stay signed in. Audit history is preserved (it&apos;s append-only at the
+ *     DB layer per #417).
+ *
+ * Design choices recorded for review:
+ *   - **Archive shape only.** Recipe-only and content-only imports would
+ *     each need their own partial-wipe logic; out of scope for PR2.
+ *   - **UUIDs preserved.** Junctions reference parent rows by id; preserving
+ *     the export&apos;s ids means we can replay junctions verbatim without
+ *     remapping. The destination is wiped first, so collisions can&apos;t
+ *     happen.
+ *   - **createdBy / updatedBy forced to the importing admin.** Original
+ *     createdBy UUIDs from the export may not exist in the destination
+ *     user table; rather than fail or set null, we credit the importing
+ *     admin so the audit trail is honest about who actually wrote the row.
+ *   - **Cross-org links cleared.** They reference cross-tenant ids that
+ *     won&apos;t survive the wipe. Federation has to be re-established after
+ *     import — a documented consequence of restore, not a bug.
+ *   - **Same-org restore only in PR2.** UUIDs are table-unique (not
+ *     scoped per org), so importing into a different org would collide
+ *     on primary keys against the source org&apos;s rows. Cross-org
+ *     migration with UUID remapping is a future PR.
+ */
+
+import { eq, or } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  organizations,
+  personas, capabilities, applications, services,
+  valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
+  strategicObjectives, objectiveCapabilities, objectiveValueStreams,
+  goals, goalObjectives,
+  initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
+  adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
+  principles, principleCapabilities, principleAdrs,
+  glossaryTerms, glossaryTermSources,
+  serviceCapabilities, servicePersonas, serviceValueStreams,
+  capabilityPersonas, applicationCapabilities, capabilityRelationships,
+  taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues,
+  customFieldSchemas,
+  architectureDebtItems, debtCapabilities, debtApplications, debtInitiatives, debtAdrs,
+  crossOrgLinks,
+} from '@/db/schema'
+import { writeAuditLog } from '@/lib/audit'
+import { BACKUP_FORMAT_VERSION } from '@/lib/backup-export'
+
+export interface ImportResult {
+  inserted: Record<string, number>
+  sourceOrgId: string
+  sourceOrgSlug: string
+}
+
+export class BackupImportError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BackupImportError'
+  }
+}
+
+// ── Envelope + payload validation ─────────────────────────────────────────
+
+interface ArchiveBundle {
+  envelope: {
+    format: string
+    shape: string
+    exportedAt: string
+    orgId: string
+    orgName: string
+    orgSlug: string
+    excludes: string[]
+  }
+  recipe: {
+    organization: Record<string, unknown>
+    taxonomy: { terms: unknown[]; entityDefinitions: unknown[] }
+    customFields: { schemas: unknown[] }
+  }
+  content: {
+    personas: unknown[]
+    capabilities: unknown[]
+    applications: unknown[]
+    services: unknown[]
+    valueStreams: unknown[]
+    objectives: unknown[]
+    goals: unknown[]
+    initiatives: unknown[]
+    adrs: unknown[]
+    principles: unknown[]
+    glossary: unknown[]
+    architectureDebt: unknown[]
+    relationships: Record<string, unknown[]>
+  }
+}
+
+function parseArchive(jsonBody: string): ArchiveBundle {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonBody)
+  } catch (e) {
+    throw new BackupImportError(`Not valid JSON: ${(e as Error).message}`)
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new BackupImportError('Archive root must be an object')
+  }
+  const obj = parsed as Record<string, unknown>
+  const env = obj.envelope as ArchiveBundle['envelope'] | undefined
+  if (!env || typeof env !== 'object') {
+    throw new BackupImportError('Missing envelope')
+  }
+  if (env.format !== BACKUP_FORMAT_VERSION) {
+    throw new BackupImportError(
+      `Unsupported format version: ${env.format} (this build accepts ${BACKUP_FORMAT_VERSION})`,
+    )
+  }
+  if (env.shape !== 'archive') {
+    throw new BackupImportError(
+      `Only 'archive' imports are supported in this release (got '${env.shape}')`,
+    )
+  }
+  if (!obj.recipe || !obj.content) {
+    throw new BackupImportError('Archive must contain both `recipe` and `content` keys')
+  }
+  return obj as unknown as ArchiveBundle
+}
+
+// ── Insert helpers ────────────────────────────────────────────────────────
+//
+// Each helper takes raw export rows (with their original ids), normalises
+// them for insert by overriding createdBy/updatedBy and rewriting
+// organizationId to the destination, then inserts. Returns the count.
+
+interface InsertCtx {
+  destOrgId: string
+  userId: string
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0]
+}
+
+function normalize<T extends Record<string, unknown>>(
+  row: T,
+  ctx: InsertCtx,
+  opts?: { overrideOrgId?: boolean },
+): T {
+  const out: Record<string, unknown> = { ...row }
+  if (opts?.overrideOrgId !== false) out.organizationId = ctx.destOrgId
+  if ('createdBy' in out) out.createdBy = ctx.userId
+  if ('updatedBy' in out) out.updatedBy = ctx.userId
+  // Drizzle expects Date objects, not strings; coerce known timestamp fields.
+  for (const key of ['createdAt', 'updatedAt', 'lastReviewedAt', 'lastExportAt']) {
+    const v = out[key]
+    if (typeof v === 'string') out[key] = new Date(v)
+  }
+  return out as T
+}
+
+// ── Replayer ──────────────────────────────────────────────────────────────
+
+/**
+ * Wipe destination org content + recipe; replay archive into the same org.
+ * Single transaction. Throws BackupImportError on validation failure or
+ * raw error on FK / constraint failure.
+ *
+ * Returns counts of inserted rows per entity, for the audit + UI summary.
+ */
+export async function importArchive(
+  destOrgId: string,
+  importingUserId: string,
+  jsonBody: string,
+): Promise<ImportResult> {
+  const bundle = parseArchive(jsonBody)
+  const { envelope, recipe, content } = bundle
+
+  // PR2 constraint: same-org only. Cross-org restore would collide on
+  // primary keys against the source org's rows. Future PR can regenerate
+  // UUIDs + rewrite junction references for the migration case.
+  if (envelope.orgId !== destOrgId) {
+    throw new BackupImportError(
+      `Archive is for org ${envelope.orgSlug} (${envelope.orgId}); ` +
+      `import target is a different organization. Cross-org restore is ` +
+      `not yet supported in this release.`,
+    )
+  }
+
+  const inserted: Record<string, number> = {}
+
+  await db.transaction(async (tx) => {
+    const ctx: InsertCtx = { destOrgId, userId: importingUserId, tx }
+
+    // 1. Wipe destination org's cross-org links (both directions).
+    await tx.delete(crossOrgLinks).where(
+      or(eq(crossOrgLinks.sourceOrgId, destOrgId), eq(crossOrgLinks.targetOrgId, destOrgId)),
+    )
+
+    // 2. Wipe content top-level rows (cascades junctions, value-stream stages
+    //    + stage caps + personas, glossary sources, debt junctions, etc).
+    //    Per-table eq() — drizzle column identity is per-table, no shared filter.
+    await tx.delete(architectureDebtItems).where(eq(architectureDebtItems.organizationId, destOrgId))
+    await tx.delete(principles).where(eq(principles.organizationId, destOrgId))
+    await tx.delete(adrs).where(eq(adrs.organizationId, destOrgId))
+    await tx.delete(initiatives).where(eq(initiatives.organizationId, destOrgId))
+    await tx.delete(goals).where(eq(goals.organizationId, destOrgId))
+    await tx.delete(strategicObjectives).where(eq(strategicObjectives.organizationId, destOrgId))
+    await tx.delete(valueStreams).where(eq(valueStreams.organizationId, destOrgId))
+    await tx.delete(services).where(eq(services.organizationId, destOrgId))
+    await tx.delete(glossaryTerms).where(eq(glossaryTerms.organizationId, destOrgId))
+    await tx.delete(applications).where(eq(applications.organizationId, destOrgId))
+    await tx.delete(capabilities).where(eq(capabilities.organizationId, destOrgId))
+    await tx.delete(personas).where(eq(personas.organizationId, destOrgId))
+
+    // 3. Wipe recipe rows.
+    await tx.delete(entityTaxonomyValues).where(eq(entityTaxonomyValues.organizationId, destOrgId))
+    await tx.delete(entityTaxonomyDefinitions).where(eq(entityTaxonomyDefinitions.organizationId, destOrgId))
+    await tx.delete(taxonomyTerms).where(eq(taxonomyTerms.organizationId, destOrgId))
+    await tx.delete(customFieldSchemas).where(eq(customFieldSchemas.organizationId, destOrgId))
+
+    // 4. Update org row with recipe.organization settings (preserves
+    //    columns we don't restore: name/slug, FKs, suspendedAt, etc).
+    const orgSettings = recipe.organization as Record<string, unknown>
+    await tx.update(organizations).set({
+      theme: orgSettings.theme as string ?? 'govea',
+      enabledModules: orgSettings.enabledModules as Record<string, boolean> ?? {},
+      // jsonb columns serialize/deserialize as plain objects.
+      confidenceSettings: orgSettings.confidenceSettings as never ?? null,
+      completenessSettings: orgSettings.completenessSettings as never ?? null,
+      securitySettings: orgSettings.securitySettings as never ?? null,
+      updatedAt: new Date(),
+    }).where(eq(organizations.id, destOrgId))
+
+    // 5. Recipe inserts (config first so taxonomy is available for content).
+    if (recipe.customFields.schemas.length) {
+      await tx.insert(customFieldSchemas).values(
+        (recipe.customFields.schemas as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.customFieldSchemas = recipe.customFields.schemas.length
+    }
+    if (recipe.taxonomy.terms.length) {
+      await tx.insert(taxonomyTerms).values(
+        (recipe.taxonomy.terms as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.taxonomyTerms = recipe.taxonomy.terms.length
+    }
+    if (recipe.taxonomy.entityDefinitions.length) {
+      await tx.insert(entityTaxonomyDefinitions).values(
+        (recipe.taxonomy.entityDefinitions as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.entityTaxonomyDefinitions = recipe.taxonomy.entityDefinitions.length
+    }
+
+    // 6. Content parents (top-level rows).
+    if (content.personas.length) {
+      await tx.insert(personas).values(
+        (content.personas as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.personas = content.personas.length
+    }
+    if (content.capabilities.length) {
+      await tx.insert(capabilities).values(
+        (content.capabilities as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.capabilities = content.capabilities.length
+    }
+    if (content.applications.length) {
+      await tx.insert(applications).values(
+        (content.applications as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.applications = content.applications.length
+    }
+    if (content.services.length) {
+      await tx.insert(services).values(
+        (content.services as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.services = content.services.length
+    }
+    if (content.valueStreams.length) {
+      await tx.insert(valueStreams).values(
+        (content.valueStreams as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.valueStreams = content.valueStreams.length
+    }
+    if (content.objectives.length) {
+      await tx.insert(strategicObjectives).values(
+        (content.objectives as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.objectives = content.objectives.length
+    }
+    if (content.goals.length) {
+      await tx.insert(goals).values(
+        (content.goals as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.goals = content.goals.length
+    }
+    if (content.initiatives.length) {
+      await tx.insert(initiatives).values(
+        (content.initiatives as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.initiatives = content.initiatives.length
+    }
+
+    // ADRs: two-phase. Insert with supersededBy=null first, then update each
+    // to its actual supersededBy id (so the FK references an already-inserted
+    // row regardless of input order).
+    if (content.adrs.length) {
+      const adrRows = (content.adrs as Record<string, unknown>[]).map(r => normalize(r, ctx))
+      const adrSupersedes = adrRows
+        .map(r => ({ id: r.id as string, supersededBy: r.supersededBy as string | null | undefined }))
+        .filter(r => r.supersededBy)
+      // Insert with supersededBy nulled out.
+      const firstPass = adrRows.map(r => ({ ...r, supersededBy: null }))
+      await tx.insert(adrs).values(firstPass as never)
+      // Resolve supersession chain.
+      for (const { id, supersededBy } of adrSupersedes) {
+        await tx.update(adrs).set({ supersededBy }).where(eq(adrs.id, id))
+      }
+      inserted.adrs = adrRows.length
+    }
+
+    if (content.principles.length) {
+      await tx.insert(principles).values(
+        (content.principles as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.principles = content.principles.length
+    }
+    if (content.glossary.length) {
+      await tx.insert(glossaryTerms).values(
+        (content.glossary as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.glossary = content.glossary.length
+    }
+    if (content.architectureDebt.length) {
+      await tx.insert(architectureDebtItems).values(
+        (content.architectureDebt as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.architectureDebt = content.architectureDebt.length
+    }
+
+    // 7. Junctions + scoped extras.
+    const rel = content.relationships
+    const replayJunction = async (
+      table: Parameters<typeof tx.insert>[0],
+      key: keyof typeof rel,
+      overrideOrgId: boolean,
+    ) => {
+      const rows = (rel[key] ?? []) as Record<string, unknown>[]
+      if (rows.length === 0) return
+      const values = rows.map(r => normalize(r, ctx, { overrideOrgId }))
+      await tx.insert(table).values(values as never)
+      inserted[key as string] = rows.length
+    }
+
+    // Junctions with no organizationId column: overrideOrgId=false.
+    await replayJunction(capabilityPersonas, 'capabilityPersonas', false)
+    await replayJunction(applicationCapabilities, 'applicationCapabilities', false)
+    await replayJunction(capabilityRelationships, 'capabilityRelationships', false)
+    await replayJunction(valueStreamStages, 'valueStreamStages', false)
+    await replayJunction(valueStreamStageCapabilities, 'valueStreamStageCapabilities', false)
+    await replayJunction(valueStreamPersonas, 'valueStreamPersonas', false)
+    await replayJunction(objectiveCapabilities, 'objectiveCapabilities', false)
+    await replayJunction(objectiveValueStreams, 'objectiveValueStreams', false)
+    await replayJunction(goalObjectives, 'goalObjectives', false)
+    await replayJunction(initiativeCapabilities, 'initiativeCapabilities', false)
+    await replayJunction(initiativeApplications, 'initiativeApplications', false)
+    await replayJunction(initiativeObjectives, 'initiativeObjectives', false)
+    await replayJunction(adrCapabilities, 'adrCapabilities', false)
+    await replayJunction(adrApplications, 'adrApplications', false)
+    await replayJunction(adrInitiatives, 'adrInitiatives', false)
+    await replayJunction(adrObjectives, 'adrObjectives', false)
+    await replayJunction(principleCapabilities, 'principleCapabilities', false)
+    await replayJunction(principleAdrs, 'principleAdrs', false)
+    await replayJunction(glossaryTermSources, 'glossaryTermSources', false)
+    await replayJunction(serviceCapabilities, 'serviceCapabilities', false)
+    await replayJunction(servicePersonas, 'servicePersonas', false)
+    await replayJunction(serviceValueStreams, 'serviceValueStreams', false)
+    await replayJunction(debtCapabilities, 'debtCapabilities', false)
+    await replayJunction(debtApplications, 'debtApplications', false)
+    await replayJunction(debtInitiatives, 'debtInitiatives', false)
+    await replayJunction(debtAdrs, 'debtAdrs', false)
+
+    // entityTaxonomyValues HAS organizationId — override to destination.
+    await replayJunction(entityTaxonomyValues, 'entityTaxonomyValues', true)
+
+    // 8. Audit log. organizationId is the destination; before captures the
+    //    source envelope so the operator can see what was restored.
+    await writeAuditLog(tx, {
+      action: 'admin_backup.import_archive',
+      entityType: 'organization',
+      entityId: destOrgId,
+      userId: importingUserId,
+      organizationId: destOrgId,
+      before: {
+        sourceOrgId: envelope.orgId,
+        sourceOrgSlug: envelope.orgSlug,
+        exportedAt: envelope.exportedAt,
+        format: envelope.format,
+      },
+      after: { inserted },
+    })
+  })
+
+  return {
+    inserted,
+    sourceOrgId: envelope.orgId,
+    sourceOrgSlug: envelope.orgSlug,
+  }
+}
+
+/**
+ * Updates `lastImportAt` + `lastImportBytes` on the destination org row.
+ * Mirrors the recordExport bookkeeping shape for symmetry on the dashboard.
+ */
+export async function recordImport(orgId: string, bytes: number): Promise<void> {
+  await db
+    .update(organizations)
+    .set({ lastImportAt: new Date(), lastImportBytes: bytes })
+    .where(eq(organizations.id, orgId))
+}
+

--- a/apps/govea/tests/integration/backup-import.test.ts
+++ b/apps/govea/tests/integration/backup-import.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Integration tests: operational backup IMPORT (#529 PR2).
+ *
+ * Covers:
+ *   - Bad envelope rejected (non-JSON, missing envelope, wrong format,
+ *     wrong shape, missing recipe/content)
+ *   - Round-trip: export org A archive → wipe → import → ids restored
+ *   - createdBy normalized to importing admin on inserted rows
+ *   - Cross-org isolation: importing into org A doesn't disturb org B
+ *   - Cross-org restore: importing org A archive into org B places
+ *     content in org B
+ *   - Cross-org links wiped on import
+ *   - Audit log entry written with sourceOrgId in `before`
+ *   - recordImport bookkeeping
+ *
+ * Capability: ac-backup-export
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { eq, and } from 'drizzle-orm'
+import { db } from '@/db/client'
+import {
+  organizations, personas, capabilities,
+  crossOrgLinks, auditLog,
+} from '@/db/schema'
+import { buildArchiveExport } from '@/lib/backup-export'
+import { importArchive, recordImport, BackupImportError } from '@/lib/backup-import'
+import {
+  cleanupOrg,
+  createTestOrg,
+  createTestUser,
+  insertCapability,
+  insertPersona,
+  insertApplication,
+  type TestOrg,
+  type TestUser,
+} from './helpers/db'
+
+let orgA: TestOrg
+let orgB: TestOrg
+let adminA: TestUser
+let adminB: TestUser
+
+beforeAll(async () => {
+  ;[orgA, orgB] = await Promise.all([createTestOrg(), createTestOrg()])
+  ;[adminA, adminB] = await Promise.all([
+    createTestUser(orgA.id, 'admin'),
+    createTestUser(orgB.id, 'admin'),
+  ])
+  await insertCapability(orgA.id, { name: `Cap-A1-${Date.now()}`, status: 'published' })
+  await insertCapability(orgA.id, { name: `Cap-A2-${Date.now()}`, status: 'published' })
+  await insertPersona(orgA.id, { name: `Persona-A1-${Date.now()}`, status: 'published' })
+  await insertApplication(orgA.id, { name: `App-A1-${Date.now()}`, status: 'published' })
+  await insertPersona(orgB.id, { name: `Persona-B1-${Date.now()}`, status: 'published' })
+})
+
+afterAll(async () => {
+  await cleanupOrg(orgA.id)
+  await cleanupOrg(orgB.id)
+})
+
+// ── Envelope validation ───────────────────────────────────────────────────
+
+describe('envelope validation', () => {
+  it('rejects non-JSON input', async () => {
+    await expect(importArchive(orgA.id, adminA.id, 'not json')).rejects.toThrow(BackupImportError)
+  })
+
+  it('rejects missing envelope', async () => {
+    await expect(importArchive(orgA.id, adminA.id, '{}')).rejects.toThrow(/envelope/i)
+  })
+
+  it('rejects unsupported format version', async () => {
+    const fake = JSON.stringify({
+      envelope: { format: '99.0', shape: 'archive', orgId: 'x', orgSlug: 'x', orgName: 'x', exportedAt: '', excludes: [] },
+      recipe: {},
+      content: {},
+    })
+    await expect(importArchive(orgA.id, adminA.id, fake)).rejects.toThrow(/format version/i)
+  })
+
+  it('rejects non-archive shape', async () => {
+    const fake = JSON.stringify({
+      envelope: { format: '1.0', shape: 'recipe', orgId: 'x', orgSlug: 'x', orgName: 'x', exportedAt: '', excludes: [] },
+      recipe: {},
+      content: {},
+    })
+    await expect(importArchive(orgA.id, adminA.id, fake)).rejects.toThrow(/archive/i)
+  })
+
+  it("rejects archive missing recipe or content", async () => {
+    const fake = JSON.stringify({
+      envelope: { format: '1.0', shape: 'archive', orgId: 'x', orgSlug: 'x', orgName: 'x', exportedAt: '', excludes: [] },
+      content: {},
+    })
+    await expect(importArchive(orgA.id, adminA.id, fake)).rejects.toThrow(/recipe.*content/i)
+  })
+})
+
+// ── Round-trip ────────────────────────────────────────────────────────────
+
+describe('round-trip: export → wipe → import', () => {
+  it('preserves capability ids and counts', async () => {
+    const before = await db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgA.id),
+    })
+    const beforeIds = new Set(before.map(c => c.id))
+    expect(before.length).toBeGreaterThan(0)
+
+    const archive = await buildArchiveExport(orgA.id)
+    await db.delete(capabilities).where(eq(capabilities.organizationId, orgA.id))
+    expect((await db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgA.id),
+    })).length).toBe(0)
+
+    const result = await importArchive(orgA.id, adminA.id, archive.body)
+    expect(result.sourceOrgId).toBe(orgA.id)
+    expect(result.sourceOrgSlug).toBe(orgA.slug)
+
+    const restored = await db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgA.id),
+    })
+    expect(restored.length).toBe(before.length)
+    const restoredIds = new Set(restored.map(c => c.id))
+    for (const id of beforeIds) expect(restoredIds.has(id)).toBe(true)
+  })
+
+  it('normalizes createdBy to the importing admin on restored rows', async () => {
+    const archive = await buildArchiveExport(orgA.id)
+    await importArchive(orgA.id, adminA.id, archive.body)
+    const restored = await db.query.personas.findMany({
+      where: eq(personas.organizationId, orgA.id),
+    })
+    expect(restored.length).toBeGreaterThan(0)
+    for (const p of restored) expect(p.createdBy).toBe(adminA.id)
+  })
+})
+
+// ── Cross-org isolation ──────────────────────────────────────────────────
+
+describe('cross-org isolation', () => {
+  it('importing org A archive into org A leaves org B untouched', async () => {
+    const before = await db.query.personas.findMany({
+      where: eq(personas.organizationId, orgB.id),
+    })
+    const archive = await buildArchiveExport(orgA.id)
+    await importArchive(orgA.id, adminA.id, archive.body)
+    const after = await db.query.personas.findMany({
+      where: eq(personas.organizationId, orgB.id),
+    })
+    expect(after.length).toBe(before.length)
+    expect(after.map(p => p.id).sort()).toEqual(before.map(p => p.id).sort())
+  })
+
+  it('rejects cross-org restore (envelope orgId must match destination)', async () => {
+    // PR2 constraint: import is same-org only. Cross-org migration is
+    // future work because UUIDs are table-unique and would collide.
+    const archive = await buildArchiveExport(orgA.id)
+    await expect(importArchive(orgB.id, adminB.id, archive.body))
+      .rejects.toThrow(/different organization|cross-org/i)
+  })
+})
+
+// ── Cross-org link wipe ──────────────────────────────────────────────────
+
+describe('cross-org link wipe', () => {
+  it('clears outbound cross-org links on the destination', async () => {
+    // Ensure orgB has at least one capability so we can build a link.
+    let orgBCap = (await db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgB.id),
+    }))[0]
+    if (!orgBCap) {
+      await insertCapability(orgB.id, { name: `Cap-B-link-${Date.now()}`, status: 'published' })
+      orgBCap = (await db.query.capabilities.findMany({
+        where: eq(capabilities.organizationId, orgB.id),
+      }))[0]
+    }
+    const orgACap = (await db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgA.id),
+    }))[0]
+    if (!orgACap) throw new Error('no orgA capability')
+
+    await db.insert(crossOrgLinks).values({
+      sourceOrgId: orgA.id,
+      sourceEntityType: 'capability',
+      sourceEntityId: orgACap.id,
+      targetOrgId: orgB.id,
+      targetEntityType: 'capability',
+      targetEntityId: orgBCap.id,
+      linkType: 'extends',
+      status: 'active',
+    })
+
+    const archive = await buildArchiveExport(orgA.id)
+    await importArchive(orgA.id, adminA.id, archive.body)
+
+    const remaining = await db.query.crossOrgLinks.findMany({
+      where: and(eq(crossOrgLinks.sourceOrgId, orgA.id), eq(crossOrgLinks.targetOrgId, orgB.id)),
+    })
+    expect(remaining.length).toBe(0)
+  })
+})
+
+// ── Audit ────────────────────────────────────────────────────────────────
+
+describe('audit log', () => {
+  it('writes admin_backup.import_archive with sourceOrgId in before', async () => {
+    const archive = await buildArchiveExport(orgA.id)
+    await importArchive(orgA.id, adminA.id, archive.body)
+    const row = await db.query.auditLog.findFirst({
+      where: and(
+        eq(auditLog.action, 'admin_backup.import_archive'),
+        eq(auditLog.organizationId, orgA.id),
+      ),
+      orderBy: (t, { desc }) => [desc(t.createdAt)],
+    })
+    expect(row).toBeDefined()
+    const before = row?.before as Record<string, unknown> | undefined
+    expect(before?.sourceOrgId).toBe(orgA.id)
+    expect(before?.sourceOrgSlug).toBe(orgA.slug)
+    expect(before?.format).toBe('1.0')
+    const after = row?.after as Record<string, unknown> | undefined
+    expect(after?.inserted).toBeDefined()
+  })
+})
+
+// ── recordImport ─────────────────────────────────────────────────────────
+
+describe('recordImport', () => {
+  it('updates lastImportAt + lastImportBytes', async () => {
+    await recordImport(orgA.id, 67890)
+    const row = await db.query.organizations.findFirst({
+      where: eq(organizations.id, orgA.id),
+      columns: { lastImportAt: true, lastImportBytes: true },
+    })
+    expect(row?.lastImportBytes).toBe(67890)
+    expect(row?.lastImportAt).toBeInstanceOf(Date)
+  })
+})


### PR DESCRIPTION
## Summary

Completes [#529](https://github.com/roballred/GovEA/issues/529) by adding the **import half** of `ac-backup-export`. PR1 shipped exports + the dashboard surface; this PR2 adds destructive-confirm upload, transactional wipe-and-replay restore, `lastImportAt` bookkeeping, and the audit-log entry that closes the loop.

After this lands, the capability is **fully shipped end-to-end**: an admin can back up the system and restore it from the same UI.

## What ships (5 files)

| File | Change |
|---|---|
| `apps/govea/src/db/schema/organizations.ts` | + `lastImportAt`, `lastImportBytes` (symmetric with PR1&apos;s lastExport*) |
| `apps/govea/src/lib/backup-import.ts` *(new, 425 lines)* | Archive validator + transactional wipe-and-replayer |
| `apps/govea/src/actions/backup.ts` *(new)* | Server action with typed-token gate + 50 MB guard |
| `apps/govea/src/app/(admin)/settings/backup/page.tsx` | Replaces the &ldquo;coming soon&rdquo; stub with the real destructive-confirm import form |
| `apps/govea/tests/integration/backup-import.test.ts` *(new, 12 tests)* | All passing |

## Restore semantics (documented in code header)

| Aspect | Behaviour |
|---|---|
| Scope | Wipes the destination org's content + recipe; replays from archive |
| Users | Preserved (export never includes users; admin stays signed in) |
| Audit log | Preserved (append-only at DB layer per #417) |
| SMTP credentials | Preserved (never in export) |
| Federation links | Cleared on import (FKs reference cross-tenant ids that won&apos;t survive the wipe) |
| UUIDs | Preserved from archive (junctions just work, no remapping) |
| `createdBy` / `updatedBy` on inserted rows | Forced to importing admin (original UUIDs may not exist in destination user table; audit trail is honest about who did the restore) |

## PR2 constraint: same-org restore only

Cross-org migration would PK-collide because UUIDs are table-unique (not scoped per org). PR2 rejects mismatched envelope.orgId with a clear user-facing message. Cross-org with UUID remapping is future work — left as a future PR rather than over-engineered into this slice.

## Three destructive-confirm gates

1. **Admin role required.** `isAdmin(session.user)` or 403.
2. **Typed token.** Form requires `confirm = "RESTORE"` (case-sensitive). HTML5 `pattern="RESTORE"` for client-side; server re-checks.
3. **50 MB file size guard.** Sanity check — largest dogfood archive observed is ~150 KB. Anything past 50 MB is the wrong file.

## Browser-verified end-to-end round-trip

Signed in as Riverdale Admin on the local dev stack:

1. `GET /api/backup/archive` → 13 capabilities, 11 personas, 8 applications, 156 KB body
2. Navigated to `/settings/backup`; uploaded the archive via the form; typed `RESTORE`; submitted
3. Redirected to `/settings/backup?imported=1`; green success banner rendered
4. Re-fetched archive: **13 capabilities / 11 personas / 8 applications** — round-trip preserved everything
5. No console errors

## Local gate status

- [x] **12/12** backup-import integration tests pass
- [x] **11/11** PR1 backup-export tests still pass (no regression)
- [x] `tsc --noEmit` clean
- [x] eslint: **0 errors, 41 warnings** (= `main` baseline)
- [x] business-architecture lint OK

## Out of scope (future PR3 if needed)

- Cross-org restore with UUID remapping
- Recipe-only / content-only imports
- Partial / selective restore by entity type
- Background-job mode for very large archives

## v1.0 Practice-Ready milestone status (after this lands)

| Issue | Status |
|---|---|
| #73 ADR CRUD | done |
| #86 Data Export design | done |
| #103 Phase 2 | open (interview-gated on #384) |
| #456 Admin notices | done |
| #479 Collapsible nav | done |
| #518 Dogfood refresh | done |
| **#529 Backup & Export** | **closes with this PR** |

After #660 merges, **only #103 remains in v1.0** — and it's explicitly gated on the rank-1 interview push.

Capability: `ac-backup-export`
Persona: `cms-administrator`
Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)