### PR TITLE
docs(design): ADR-0002 ADM-as-classification + resolved TOGAF recipe decisions

### DIFF
--- a/docs/decisions/0002-adm-as-classification.md
+++ b/docs/decisions/0002-adm-as-classification.md
@@ -1,0 +1,77 @@
+# ADR-0002: ADM Stages as Optional Classification
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Amends:** [ADR-0001](./0001-togaf-adm-scope.md) (consequence #3)
+**Issues:** [#665](https://github.com/roballred/GovEA/issues/665), [#313](https://github.com/roballred/GovEA/issues/313)
+
+---
+
+## Context
+
+[ADR-0001](./0001-togaf-adm-scope.md) (Accepted, 2026-04-26) adopted "Option B": TOGAF as an optional, org-level overlay with **no ADM enforcement**. Its consequence #3 stated:
+
+> ADM phase tracking is explicitly out of scope for v1 and v2. There is no modelling of ADM phases (Preliminary, A through H, Requirements Management) as workflow states. There are no phase-gated approvals, phase transition rules, or ADM-structured dashboards. Implementing this would require validated demand from real government users who cannot adopt GovEA without it.
+
+ADR-0001 also required that any change to this position be made through a **new ADR**.
+
+Two things have changed since 2026-04-26:
+
+1. **The architectural direction shifted from a hard-coded overlay to taxonomy-backed configuration** (#665, #313, and `docs/design/togaf-recipe-reconciliation.md`). TOGAF concepts — including Architecture Domains — are being reframed as ordinary taxonomy types installed by an admin-run recipe, not as bespoke product features.
+2. **The lead architect has set the direction** that ADM stages should be available as a taxonomy type (one of the recipe's example types), purely as a classification vocabulary an architect can tag work with — not as a workflow.
+
+ADR-0001's consequence #3 conflated two distinct things: ADM **as enforced workflow** (phase gates, approvals, transition rules) and ADM **as classification** (a label you can put on a record). The first remains undesirable for GovEA's EasyEA-first positioning. The second is just another taxonomy type and is consistent with how every other classification in GovEA already works.
+
+---
+
+## Decision
+
+**ADM stages are permitted as an optional classification taxonomy. ADM as enforced workflow remains out of scope.**
+
+Specifically, amending ADR-0001 consequence #3:
+
+1. **ADM stages MAY exist as a taxonomy type** (e.g. a type named "ADM Phase" with values Preliminary, A: Architecture Vision, … H: Architecture Change Management, Requirements Management). They are created by the TOGAF recipe like any other taxonomy type — a parent `taxonomy_terms` row with child value rows — and bound to entities via `entity_taxonomy_definitions`.
+
+2. **ADM stages are classification only.** A record may be *tagged* with an ADM phase. There is:
+   - **no phase-gated approval** — tagging a record with "C: Information Systems Architectures" grants or blocks nothing;
+   - **no phase transition rule** — any record can carry any phase, changed freely at any time;
+   - **no ADM-structured workflow or required progression** — GovEA does not model moving an org "through" the ADM.
+
+3. **Reporting on ADM tags is permitted** as read-only classification reporting (e.g. "which capabilities are tagged to which phase"). This is the same generic group-by-taxonomy-type reporting available for any type. It is not an ADM governance dashboard and asserts no conformance.
+
+4. **The EasyEA workflow remains the default and primary value proposition**, unchanged. ADM tags are invisible to organisations that do not install the TOGAF recipe, and — via the framework `audience` flag (see below) — invisible to non-architect roles and stakeholder-facing reports even when installed.
+
+5. **What still requires a further ADR:** any move from classification to *enforcement* — phase gates, approvals tied to phase, mandatory progression, or presenting ADM as a required operating model. That bar (validated demand from at least two government organisations, plus design review) carries forward from ADR-0001 unchanged for the enforcement case.
+
+---
+
+## Rationale
+
+**Why this is consistent with ADR-0001's intent, not a reversal:**
+ADR-0001's concern was that "TOGAF scaffolding can become a constraint — teams implementing all of TOGAF lose stakeholder patience before delivering value." That risk lives entirely in *enforcement* — phase gates and mandatory progression. A label an architect can optionally apply carries none of that weight. ADR-0001 already permits tagging capabilities and applications with TOGAF **domain** labels ("annotation, not enforcement"); ADM-as-classification is the same kind of annotation applied to a different vocabulary.
+
+**Why allow it now:**
+Once TOGAF support is taxonomy-backed, *excluding* ADM as a taxonomy type would require special-case code to forbid one specific vocabulary — more complexity to prevent a capability, not less. Permitting ADM-as-classification is the simpler, more honest position: the taxonomy system treats it like everything else, and the recipe ships it as an example type.
+
+**Why keep the enforcement bar:**
+Nothing in the market research changed the conclusion that ADM *workflow* enforcement is wrong for GovEA's positioning. This ADR narrows ADR-0001's prohibition to where it belongs (enforcement) rather than abandoning it.
+
+---
+
+## Consequences
+
+- The TOGAF recipe (#665, Slice 2) MAY install an "ADM Phase" taxonomy type and bind it to capabilities and/or initiatives as optional classification.
+- ADM-tag reporting is available through the generic group-by-taxonomy-type report engine (#665, Slice 3). No bespoke ADM dashboard is built.
+- Framework taxonomy types (TOGAF domains, ADM phase) carry an `audience: 'framework'` marker so they remain invisible to viewer-role users and to stakeholder-facing reports by default, preserving ADR-0001's "no framework jargon for Department Directors" guarantee without the now-removed overlay toggle.
+- No phase-gating, approval, or transition logic is introduced anywhere. Any future attempt to add it requires a new ADR and the two-org demand bar.
+- ADR-0001 remains in force in all other respects; only its consequence #3 is narrowed by this decision.
+
+---
+
+## Related
+
+- [ADR-0001](./0001-togaf-adm-scope.md) — TOGAF and ADM scope boundary (amended by this ADR)
+- [`docs/design/togaf-recipe-reconciliation.md`](../design/togaf-recipe-reconciliation.md) — recipe/taxonomy reconciliation and resolved decisions
+- [#665](https://github.com/roballred/GovEA/issues/665) — replace TOGAF overlay with taxonomy-backed recipe
+- [#313](https://github.com/roballred/GovEA/issues/313) — taxonomy-backed TOGAF domains and ADM stages
+- [EasyEA methodology](https://github.com/roballred/EasyEA)

--- a/docs/design/togaf-recipe-reconciliation.md
+++ b/docs/design/togaf-recipe-reconciliation.md
@@ -131,10 +131,12 @@ These are genuine product/architecture calls, not implementation details — the
 - [x] The hard-coded surfaces to retire are enumerated (§3)
 - [x] A slice sequence exists with #313 repositioned as the content spec for #665 Slice 2 (§4)
 - [x] The ADR-0001 boundary is called out and the ADM question separated from the domain question (§5)
-- [ ] D1–D4 answered by a human / ARB (§6) — **the gate before any implementation issue is opened**
+- [x] D1–D4 answered (§6, §9) — resolved by the lead architect 2026-05-30; see §9
 
 ## 8. Next actions
 
 1. Post this reconciliation on #665 and #313 (link the doc); re-scope #313 as "content spec for #665 Slice 2."
 2. Put D1–D4 to ARB / the maintainer.
 3. Once D1–D4 land, open the **Slice 1** implementation issue: framework-agnostic recipe-import schema + idempotency/stable-key resolver, extending `lib/backup-export.ts`'s envelope. (That issue also serves R-007 portability.)
+
+> **Update 2026-05-30:** D1–D4 are resolved (§9) and the slices are filed (§10). ADM is recorded in [ADR-0002](../decisions/0002-adm-as-classification.md). §5–§6 above are retained for history; §9 is authoritative where they differ (notably: D1 needs no `scheme` column, and ADM-as-classification is permitted, not deferred).

--- a/docs/design/togaf-recipe-reconciliation.md
+++ b/docs/design/togaf-recipe-reconciliation.md
@@ -140,3 +140,33 @@ These are genuine product/architecture calls, not implementation details — the
 3. Once D1–D4 land, open the **Slice 1** implementation issue: framework-agnostic recipe-import schema + idempotency/stable-key resolver, extending `lib/backup-export.ts`'s envelope. (That issue also serves R-007 portability.)
 
 > **Update 2026-05-30:** D1–D4 are resolved (§9) and the slices are filed (§10). ADM is recorded in [ADR-0002](../decisions/0002-adm-as-classification.md). §5–§6 above are retained for history; §9 is authoritative where they differ (notably: D1 needs no `scheme` column, and ADM-as-classification is permitted, not deferred).
+
+---
+
+## 9. Decisions — resolved by lead architect (2026-05-30)
+
+The lead architect set the direction below; D1–D4 are resolved and the implementation slices (§10) are unblocked. The ADM call is recorded formally in **[ADR-0002](../decisions/0002-adm-as-classification.md)**.
+
+| # | Decision | Resolution | Why it's simpler than the doc's original framing |
+|---|---|---|---|
+| **D1** | Domain vocabulary modelling | **Parent type term is the namespace.** A taxonomy "type" is already a top-level `taxonomy_terms` row whose children are its values (how "Domain", "Application Type", etc. work today). The TOGAF domain type is just a named type with a **stable slug** (e.g. `togaf-architecture-domain`) for machine lookup. | No `scheme`/`family` column needed — the named parent term *is* the scheme. Zero schema change. |
+| **D2** | ADM stages in scope? | **Yes, as classification taxonomy** (type "ADM Phase" with Preliminary, A–H, Requirements Management). No phase gates, approvals, or transition rules. Recorded in **ADR-0002**, which narrows ADR-0001 consequence #3 to the *enforcement* case only. | Excluding one specific vocabulary would need special-case code; permitting it is the no-op path. |
+| **D3** | Existing `framework_mappings` rows | **Migrate** to `entity_taxonomy_values`, keyed `(entity_type, entity_id, concept_label)` → domain term slug. Preserves the Hartfield demo. | One idempotent migration; no stranded data. |
+| **D4** | `framework-overlay` module flag | **Remove it.** "Is TOGAF on?" becomes "are the recipe's taxonomy types present?" — settings-free. Add an **`audience: 'framework'` marker on the taxonomy type** so framework types stay hidden from viewer-role users and stakeholder reports (the principled replacement for the toggle that ADR-0001 still requires). | Presence-based; the `audience` flag is a small, *general* taxonomy feature, not TOGAF-specific. |
+
+**Additional direction (beyond D1–D4):**
+
+- **Reports — generic engine + TOGAF preset.** Build a framework-agnostic "group by any taxonomy type" report engine; ship TOGAF as a **saved preset** (Application Landscape grouped by the domain type; an ADM-coverage view grouped by the ADM-Phase type). The preset finds its type by the stable slug from D1. New classification views then cost almost nothing.
+- **Delivery — built-in curated catalog.** The TOGAF recipe is **defined in-repo as data** and run via an admin **"Install"** action from a Recipes list. **No file upload in v1** — avoids the parsing/validation/security surface. File-based recipe import (the #529-envelope-extension path) is a deliberately deferred follow-on.
+- **Recipe scope — turnkey, not just dropdowns.** The TOGAF recipe installs **taxonomy types + terms + entity bindings, _plus_ glossary terms, _plus_ a starter set of architecture principles, _plus_ report presets**. "Install TOGAF" yields a usable, explained TOGAF surface, not two empty selects.
+- **TOGAF is recipe #1, not a special case.** The engine is framework-agnostic; NIST, FEAF, a state reference model, etc. each become their own recipe later.
+
+## 10. Implementation slices (filed as issues, gated on ADR-0002)
+
+| Slice | Issue | Scope | Depends on |
+|---|---|---|---|
+| **S1** | [#671](https://github.com/roballred/GovEA/issues/671) | Generic recipe-install **engine**: idempotent upsert by `(org, slug)` for taxonomy types/terms/bindings + glossary + principles + presets; the `audience` flag; admin **Install** action; built-in catalog list. | ADR-0002 accepted |
+| **S2** | [#672](https://github.com/roballred/GovEA/issues/672) | **TOGAF recipe definition** (data): domain type + values, ADM-Phase type + values, TOGAF glossary terms, starter principles, report presets. | S1 |
+| **S3** | [#673](https://github.com/roballred/GovEA/issues/673) | Generic **group-by-taxonomy-type report engine** + TOGAF Application Landscape and ADM-coverage **presets**; repoint the existing report off `framework_mappings`. | S1, S2 |
+| **S4** | [#674](https://github.com/roballred/GovEA/issues/674) | **Migrate** `framework_mappings` → `entity_taxonomy_values`; preserve the Hartfield demo. | S2 |
+| **S5** | [#675](https://github.com/roballred/GovEA/issues/675) | **Teardown**: remove the `framework-overlay` module/toggle, `framework_mappings` table + actions + panel; update the `ea/framework-alignment` capability docs and ADR pointers. | S3, S4 |


### PR DESCRIPTION
## Summary

Records the lead-architect decisions that unblock the #665 TOGAF-recipe direction, and adds **ADR-0002**. Docs + ADR only — no implementation code.

> **Stacked PR.** Base is `design/665-313-togaf-recipe-reconciliation` (#670), not `main`. Review/merge #670 first; this PR's diff is just the two-doc delta on top. (GitHub will retarget this to `main` automatically once #670 merges.)

## What's in here

**`docs/decisions/0002-adm-as-classification.md` (new)** — narrows ADR-0001 consequence #3:
- ADM stages **permitted as optional classification taxonomy** (no phase gates, approvals, or transition rules).
- ADM **as enforced workflow stays out of scope**, keeping ADR-0001's two-org demand bar for that case.
- Consistent with ADR-0001's intent: the risk it guarded against is *enforcement*, not an optional label.

**`docs/design/togaf-recipe-reconciliation.md` (updated)** — new §9/§10 capturing the resolved decisions:

| # | Resolution |
|---|---|
| D1 | Parent type term **is** the namespace + a stable slug; **no schema column**. |
| D2 | ADM in scope **as classification** (ADR-0002). |
| D3 | **Migrate** `framework_mappings` → `entity_taxonomy_values`; keep the Hartfield demo. |
| D4 | **Remove** the `framework-overlay` toggle; presence-based; add an **`audience: 'framework'` flag** so framework types stay jargon-free for viewer-role + stakeholder reports (ADR-0001's jargon-hiding guarantee, minus the toggle). |

Plus: reports = **generic group-by-taxonomy-type engine + TOGAF preset**; delivery = **built-in curated in-repo catalog via an admin Install action** (no file upload in v1); recipe scope = **taxonomy + glossary + principles + report presets**; TOGAF is **recipe #1**, engine framework-agnostic.

## Implementation slices (filed as issues, gated on ADR-0002)

S1 recipe-install engine · S2 TOGAF recipe data · S3 generic report engine + presets · S4 migrate `framework_mappings` · S5 teardown. (Issue numbers added as a comment once filed.)

## Test plan

Docs-only. CI "Docs lint" runs `scripts/lint-business-architecture.mjs`, which scans only `business-architecture/`; these files live under `docs/`.

Capability: ea/framework-alignment
Refs #665, #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
