### PR TITLE
fix(import): normalize CSV status/visibility enum case across all importers

### DIFF
--- a/apps/govea/src/actions/adrs.ts
+++ b/apps/govea/src/actions/adrs.ts
@@ -399,8 +399,8 @@ export async function importADRs(formData: FormData, dryRun = false): Promise<AD
     if (!number) { errors.push(`Row ${rowNum}: missing required field "number"`); skipped++; continue }
     if (!title) { errors.push(`Row ${rowNum}: missing required field "title"`); skipped++; continue }
 
-    const status = (row['status'] || 'proposed').trim()
-    const visibility = (row['visibility'] || 'org').trim()
+    const status = (row['status'] || 'proposed').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
     if (!VALID_ADR_STATUS.has(status)) {
       errors.push(`Row ${rowNum}: invalid status "${status}"`)
       skipped++; continue

--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -492,9 +492,9 @@ export async function importApplications(formData: FormData, dryRun = false): Pr
     const name = row['name']?.trim()
     if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
 
-    const lifecycleStatus = row['lifecycle_status'] || 'active'
-    const status = row['status'] || 'draft'
-    const visibility = row['visibility'] || 'org'
+    const lifecycleStatus = (row['lifecycle_status'] || 'active').trim().toLowerCase()
+    const status = (row['status'] || 'draft').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
 
     if (!VALID_LIFECYCLE.has(lifecycleStatus)) {
       errors.push(`Row ${rowNum}: invalid lifecycle_status "${lifecycleStatus}"`)

--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -526,8 +526,8 @@ export async function importCapabilities(formData: FormData, dryRun = false): Pr
     if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
 
     const capabilityTypeRaw = (row['capability_type'] || '').trim().toLowerCase()
-    const status = (row['status'] || 'draft').trim()
-    const visibility = (row['visibility'] || 'org').trim()
+    const status = (row['status'] || 'draft').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
 
     if (!VALID_CAPABILITY_TYPE.has(capabilityTypeRaw)) {
       errors.push(`Row ${rowNum}: invalid capability_type "${capabilityTypeRaw}" (expected "business", "technical", or empty)`)

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -476,8 +476,8 @@ export async function importInitiatives(formData: FormData, dryRun = false): Pro
     const name = row['name']?.trim()
     if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
 
-    const status = (row['status'] || 'proposed').trim()
-    const visibility = (row['visibility'] || 'org').trim()
+    const status = (row['status'] || 'proposed').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
     if (!VALID_INITIATIVE_STATUS.has(status)) {
       errors.push(`Row ${rowNum}: invalid status "${status}"`)
       skipped++; continue

--- a/apps/govea/src/actions/objectives.ts
+++ b/apps/govea/src/actions/objectives.ts
@@ -333,8 +333,8 @@ export async function importObjectives(formData: FormData, dryRun = false): Prom
     const name = row['name']?.trim()
     if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
 
-    const status = (row['status'] || 'draft').trim()
-    const visibility = (row['visibility'] || 'org').trim()
+    const status = (row['status'] || 'draft').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
     if (!VALID_OBJECTIVE_STATUS.has(status)) {
       errors.push(`Row ${rowNum}: invalid status "${status}"`)
       skipped++; continue

--- a/apps/govea/src/actions/personas.ts
+++ b/apps/govea/src/actions/personas.ts
@@ -321,8 +321,8 @@ export async function importPersonas(formData: FormData, dryRun = false): Promis
     const name = row['name']?.trim()
     if (!name) { errors.push(`Row ${rowNum}: missing required field "name"`); skipped++; continue }
 
-    const status = (row['status'] || 'draft').trim()
-    const visibility = (row['visibility'] || 'org').trim()
+    const status = (row['status'] || 'draft').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
 
     if (!VALID_PERSONA_STATUS.has(status)) {
       errors.push(`Row ${rowNum}: invalid status "${status}"`)

--- a/apps/govea/tests/integration/capabilities-import.test.ts
+++ b/apps/govea/tests/integration/capabilities-import.test.ts
@@ -156,6 +156,32 @@ describe('importCapabilities (#596)', () => {
     expect(result.errors.some(e => e.includes('invalid capability_type'))).toBe(true)
   })
 
+  it('accepts capitalized enum values for status / visibility / capability_type (#677)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    // Regression for #677: status and visibility used to be case-sensitive
+    // while capability_type was lowercased, so title-cased values from Excel /
+    // natural typing were rejected inconsistently. All three are now normalized.
+    const csv = [
+      'name,description,domain,behaviors,rules,capability_type,status,visibility,personas',
+      'Cased Enums Cap,desc,IT,,,Business,Published,Org,',
+      'Mixed Enums Cap,desc,IT,,,TECHNICAL,Archived,Connections,',
+    ].join('\n')
+
+    const result = await importCapabilities(csvForm(csv), false)
+    expect(result.errors).toEqual([])
+    expect(result.created).toBe(2)
+    expect(result.skipped).toBe(0)
+
+    const a = await db.query.capabilities.findFirst({
+      where: and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Cased Enums Cap')),
+    })
+    expect(a).toMatchObject({ capabilityType: 'business', status: 'published', visibility: 'org' })
+    const b = await db.query.capabilities.findFirst({
+      where: and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Mixed Enums Cap')),
+    })
+    expect(b).toMatchObject({ capabilityType: 'technical', status: 'archived', visibility: 'connections' })
+  })
+
   it('dryRun does not write rows', async () => {
     mockAuth.mockResolvedValue(makeSession(admin))
     const csv = [


### PR DESCRIPTION
## Summary

Fixes **#677**: CSV import rejected title-cased `status` / `visibility` values (e.g. `Published`, `Org`) while accepting capitalized `capability_type` — the same casing failed inconsistently across columns, making import errors look arbitrary.

I diagnosed this by running the importer directly against the integration DB (not by reading code): `capability_type=Business` imported fine, but `status=Published` and `visibility=Org` were skipped with `invalid status "Published"` / `invalid visibility "Org"`.

## Root cause

`status` / `visibility` were `.trim()`-ed but not lowercased before being checked against lowercase-only allow-sets; `capability_type` was lowercased. The asymmetry exists in **all six per-entity importers** (capabilities, applications, objectives, initiatives, adrs, personas); applications additionally lacked `.trim()` on its enum columns.

## Fix

`.trim().toLowerCase()` on every enum-validated CSV column (`status`, `visibility`, and applications' `lifecycle_status`). Every allowed enum value is lowercase by definition, so normalizing is safe and makes all importers consistent with `capability_type`.

## Behaviour after fix (verified)

| Input | Before | After |
|---|---|---|
| `status=Published`, `visibility=Org` | skipped (invalid) | ✅ imported |
| `capability_type=TECHNICAL` | accepted | ✅ accepted |
| `status=active` (genuinely invalid) | rejected | ✅ still rejected, clear error |

## Test plan

- [x] Added regression test: capitalized `status`/`visibility`/`capability_type` import successfully and persist normalized values (capability suite 11 → 12 tests).
- [x] `pnpm --filter govea test:integration import` — **70 passed** (all six importers).
- [x] `tsc --noEmit` clean; eslint clean on changed files (0 errors).

## Notes / out of scope

- Genuinely invalid values still produce clear per-row errors — unchanged.
- Separate import gotchas observed while diagnosing, **not** addressed here (each its own concern if worth fixing): a **camelCase header** like `capabilityType` is silently ignored rather than flagged; **semicolon-delimited** files (EU-locale Excel) fail every row as `missing required field "name"` because the parser is comma-only. Happy to file follow-ups if you want either improved.

Capability: ac-backup-export
Closes #677
Refs #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
