### PR TITLE
feat(taxonomy): add slug uniqueness guard for recipe upsert (closes #684)

### DIFF
--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -27,6 +27,46 @@ function toSlug(name: string) {
   return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
+/**
+ * Throws a user-friendly error if a sibling taxonomy term would collide on
+ * name or slug within the same (org, parent) scope — mirroring the two DB
+ * unique guards in `src/db/sql/taxonomy-terms-dedup.sql`
+ * (`..._org_parent_name_unique` and `..._org_parent_slug_unique`, #554/#684).
+ *
+ * Without this, a duplicate surfaces as a raw Postgres unique-violation stack
+ * trace. `excludeId` lets edits skip the row being edited.
+ *
+ * Note: name and slug are checked separately because toSlug() normalises —
+ * "Data Architecture" and "Data  Architecture" have distinct names but the
+ * same slug, so a name-only check would let a slug collision through to the
+ * DB. The slug guard is the key the recipe upsert (#671) relies on.
+ */
+async function assertTaxonomyTermAvailable(
+  orgId: string,
+  parentId: string | null,
+  name: string,
+  slug: string,
+  excludeId?: string,
+) {
+  const siblings = await db.query.taxonomyTerms.findMany({
+    where: (t, { eq: e, and: a, isNull: n }) =>
+      parentId
+        ? a(e(t.organizationId, orgId), e(t.parentId, parentId))
+        : a(e(t.organizationId, orgId), n(t.parentId)),
+    columns: { id: true, name: true, slug: true },
+  })
+  const scope = parentId ? 'this taxonomy type' : 'taxonomy types'
+  for (const s of siblings) {
+    if (excludeId && s.id === excludeId) continue
+    if (s.name.toLowerCase() === name.toLowerCase()) {
+      throw new Error(`A term named "${s.name}" already exists in ${scope}.`)
+    }
+    if (s.slug === slug) {
+      throw new Error(`A term with the same identifier ("${slug}") already exists in ${scope}.`)
+    }
+  }
+}
+
 // ── Reads ─────────────────────────────────────────────────────────────────────
 
 export async function getTaxonomyTerms() {
@@ -134,12 +174,15 @@ export async function createTaxonomyTerm(formData: FormData) {
   const description = (formData.get('description') as string)?.trim() || null
   const parentId = (formData.get('parentId') as string) || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
+  const slug = toSlug(name)
+
+  await assertTaxonomyTermAvailable(orgId, parentId, name, slug)
 
   await db.transaction(async (tx) => {
     const [entry] = await tx.insert(taxonomyTerms).values({
       organizationId: orgId,
       name,
-      slug: toSlug(name),
+      slug,
       description,
       parentId,
       sortOrder,
@@ -168,10 +211,13 @@ export async function editTaxonomyTerm(termId: string, formData: FormData) {
   const name = (formData.get('name') as string).trim()
   const description = (formData.get('description') as string)?.trim() || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
+  const slug = toSlug(name)
+
+  await assertTaxonomyTermAvailable(orgId, existing?.parentId ?? null, name, slug, termId)
 
   await db.transaction(async (tx) => {
     await tx.update(taxonomyTerms)
-      .set({ name, slug: toSlug(name), description, sortOrder, updatedAt: new Date() })
+      .set({ name, slug, description, sortOrder, updatedAt: new Date() })
       .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
 
     await writeAuditLog(tx, {

--- a/apps/govea/src/db/sql/taxonomy-terms-dedup.sql
+++ b/apps/govea/src/db/sql/taxonomy-terms-dedup.sql
@@ -113,12 +113,115 @@ WHERE etv.entity_type = d.entity_type
   AND etv.taxonomy_term_id = d.taxonomy_term_id
   AND etv.ctid <> d.keep_ctid;
 
--- Step 2: install the uniqueness guard.
+-- Step 1b: collapse duplicate (org, parent, slug) groups — issue #684.
 --
--- Drop the prior index name if it exists (in case the constraint definition
+-- The (org, parent, name) dedupe above leaves a narrower class of duplicates
+-- untouched: rows whose *names* differ but whose *slugs* collide, because
+-- toSlug() normalises ("Data Architecture" and "Data  Architecture" both map
+-- to "data-architecture"). The recipe-install / import path (#671) upserts on
+-- slug — ON CONFLICT (organization_id, parent_id, slug) — so slug must be a
+-- real unique key, not just name. We collapse slug-collision groups onto the
+-- oldest survivor with the same FK re-point pattern as Step 1.
+--
+-- This runs AFTER the name dedupe, so any group here is genuinely a
+-- distinct-name / same-slug collision. The survivor keeps its own name; the
+-- losers' references are migrated to it.
+WITH slug_ranks AS (
+  SELECT
+    id,
+    organization_id,
+    parent_id,
+    slug,
+    ROW_NUMBER() OVER (
+      PARTITION BY organization_id, parent_id, slug
+      ORDER BY created_at ASC, id ASC
+    ) AS rn,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY organization_id, parent_id, slug
+      ORDER BY created_at ASC, id ASC
+    ) AS survivor_id
+  FROM taxonomy_terms
+),
+slug_losers AS (
+  SELECT id AS loser_id, survivor_id
+  FROM slug_ranks
+  WHERE rn > 1
+),
+fix_slug_persona_tags AS (
+  UPDATE persona_tags pt
+  SET tag_id = l.survivor_id
+  FROM slug_losers l
+  WHERE pt.tag_id = l.loser_id
+  RETURNING pt.persona_id
+),
+fix_slug_etv AS (
+  UPDATE entity_taxonomy_values etv
+  SET taxonomy_term_id = l.survivor_id
+  FROM slug_losers l
+  WHERE etv.taxonomy_term_id = l.loser_id
+  RETURNING etv.entity_id
+),
+fix_slug_etd AS (
+  UPDATE entity_taxonomy_definitions etd
+  SET taxonomy_type_id = l.survivor_id
+  FROM slug_losers l
+  WHERE etd.taxonomy_type_id = l.loser_id
+  RETURNING etd.entity_type
+),
+fix_slug_children AS (
+  UPDATE taxonomy_terms child
+  SET parent_id = l.survivor_id
+  FROM slug_losers l
+  WHERE child.parent_id = l.loser_id
+  RETURNING child.id
+)
+DELETE FROM taxonomy_terms
+WHERE id IN (SELECT loser_id FROM slug_losers);
+
+-- Re-dedupe the junction tables again (the slug collapse can create the same
+-- identical-row duplicates the name collapse did).
+WITH pt_dupes AS (
+  SELECT persona_id, tag_id, MIN(ctid) AS keep_ctid
+  FROM persona_tags
+  GROUP BY persona_id, tag_id
+  HAVING count(*) > 1
+)
+DELETE FROM persona_tags pt
+USING pt_dupes d
+WHERE pt.persona_id = d.persona_id
+  AND pt.tag_id = d.tag_id
+  AND pt.ctid <> d.keep_ctid;
+
+WITH etv_dupes AS (
+  SELECT entity_type, entity_id, taxonomy_term_id, MIN(ctid) AS keep_ctid
+  FROM entity_taxonomy_values
+  GROUP BY entity_type, entity_id, taxonomy_term_id
+  HAVING count(*) > 1
+)
+DELETE FROM entity_taxonomy_values etv
+USING etv_dupes d
+WHERE etv.entity_type = d.entity_type
+  AND etv.entity_id = d.entity_id
+  AND etv.taxonomy_term_id = d.taxonomy_term_id
+  AND etv.ctid <> d.keep_ctid;
+
+-- Step 2: install the uniqueness guards.
+--
+-- Drop the prior index names if they exist (in case a constraint definition
 -- evolves later); CREATE UNIQUE INDEX with IF NOT EXISTS would skip the
 -- creation entirely on re-run, but we want this file idempotent against
 -- definition changes, so DROP + CREATE is the safer shape.
+--
+-- Two guards, both NULLS NOT DISTINCT so top-level types (parent_id IS NULL)
+-- are treated as real keys:
+--   * name guard — preserves the #554 behaviour (no two identically-named
+--     siblings).
+--   * slug guard — the stable machine key the recipe upsert (#671) targets
+--     via ON CONFLICT (organization_id, parent_id, slug).
 DROP INDEX IF EXISTS taxonomy_terms_org_parent_name_unique;
 CREATE UNIQUE INDEX taxonomy_terms_org_parent_name_unique
   ON taxonomy_terms (organization_id, parent_id, name) NULLS NOT DISTINCT;
+
+DROP INDEX IF EXISTS taxonomy_terms_org_parent_slug_unique;
+CREATE UNIQUE INDEX taxonomy_terms_org_parent_slug_unique
+  ON taxonomy_terms (organization_id, parent_id, slug) NULLS NOT DISTINCT;

--- a/apps/govea/tests/integration/taxonomy-dedup.test.ts
+++ b/apps/govea/tests/integration/taxonomy-dedup.test.ts
@@ -92,3 +92,62 @@ describe('taxonomy_terms uniqueness guard (#554)', () => {
     }
   })
 })
+
+describe('taxonomy_terms slug uniqueness guard (#684)', () => {
+  // The slug guard (taxonomy_terms_org_parent_slug_unique) is the key the
+  // recipe-install upsert (#671) targets via ON CONFLICT (org, parent, slug).
+  // It catches a class the name guard misses: distinct names that normalise to
+  // the same slug.
+  let orgId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('rejects distinct names that collide on slug (same org, null parent)', async () => {
+    // "Data Architecture" and "Data  Architecture" (double space) have
+    // different names but both slugify to "data-architecture". The name guard
+    // lets the second through; the slug guard must catch it.
+    const slug = 'data-architecture-' + randomUUID().slice(0, 8)
+    await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Data Architecture A', slug,
+    })
+    await expect(db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Data Architecture B', slug,
+    })).rejects.toThrow()
+  })
+
+  it('allows the same slug under different parents', async () => {
+    const [parentA] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'slug-parent-A', slug: 'slug-parent-a',
+    }).returning()
+    const [parentB] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'slug-parent-B', slug: 'slug-parent-b',
+    }).returning()
+
+    await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: parentA.id,
+      name: 'Child One', slug: 'shared-slug',
+    })
+    await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: parentB.id,
+      name: 'Child Two', slug: 'shared-slug',
+    })
+
+    const rows = await db.select().from(taxonomyTerms).where(eq(taxonomyTerms.organizationId, orgId))
+    expect(rows.filter(r => r.slug === 'shared-slug')).toHaveLength(2)
+  })
+
+  it('NULLS NOT DISTINCT: two NULL parents with the same slug collide', async () => {
+    const slug = 'null-parent-slug-' + randomUUID().slice(0, 8)
+    await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Null Parent Slug One', slug,
+    })
+    await expect(db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Null Parent Slug Two', slug,
+    })).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Adds the one piece of #684 that wasn't already shipped: a **slug** uniqueness guard on `taxonomy_terms`, which the TOGAF recipe-install/import path (#671) needs for `ON CONFLICT (organization_id, parent_id, slug)`.

**Context — most of #684 was already done.** While building this I found #554 already shipped a `(org, parent, name)` uniqueness guard, the dedupe pass, `NULLS NOT DISTINCT` handling, and integration tests (`src/db/sql/taxonomy-terms-dedup.sql`, `tests/integration/taxonomy-dedup.test.ts`). The real remaining gap was that the guard keyed on **name**, not **slug** — and `toSlug()` normalises, so distinct names can collide on slug (`"Data Architecture"` vs `"Data  Architecture"` → both `data-architecture`). A name-only guard lets that through to the recipe upsert. So #684 is rescoped down to just the slug guard (confirmed with the product owner).

## Changes

- **`src/db/sql/taxonomy-terms-dedup.sql`** — adds a Step-1b slug-collision dedupe pass (same FK re-point pattern as the existing name pass: persona_tags, entity_taxonomy_values, entity_taxonomy_definitions, child re-parenting), then a second unique index `taxonomy_terms_org_parent_slug_unique (org, parent, slug) NULLS NOT DISTINCT`. Idempotent; re-applied by `db:apply-triggers` exactly like the existing guard. The name guard is preserved.
- **`actions/taxonomy.ts`** — `assertTaxonomyTermAvailable()` pre-check in `createTaxonomyTerm`/`editTaxonomyTerm` so duplicates surface a friendly message instead of a raw Postgres constraint stack trace. Checks **both** name and slug (they can diverge); `excludeId` lets edits skip themselves.
- **`tests/integration/taxonomy-dedup.test.ts`** — new `#684` describe block: distinct names colliding on slug are rejected; same slug under different parents allowed; `NULLS NOT DISTINCT` for null parents.

## Verification

- `pnpm --filter govea exec tsc --noEmit` — clean
- `pnpm --filter govea exec eslint` (changed files) — clean
- Integration tests run against Postgres 16 in CI (local DB not available this session).

## Acceptance criteria (#684)

- [x] Duplicate `taxonomy_terms` rejected at the DB layer — now on **slug** too, not just name
- [x] Top-level types and child values both handled w.r.t. NULL `parent_id` (NULLS NOT DISTINCT)
- [x] Existing duplicates de-duped before the constraint applies (slug pass added)
- [x] `createTaxonomyTerm`/`editTaxonomyTerm` surface a friendly error
- [x] Re-running the seed is a no-op (seed already idempotent on main; constraint backstops it)
- [x] Integration test covering the slug guard
- [x] Compatible with #671's `ON CONFLICT (organization_id, parent_id, slug)` upsert — this provides exactly that index

## Notes

- Scope deliberately narrowed from the original #684 issue text because #554 already shipped the rest; the issue's "reuse #682's migration/test" path was moot (that branch was 167 commits stale — #682 closed).
- Builds on the project's `src/db/sql/*.sql` + `db:apply-triggers` mechanism, **not** a drizzle migration — matching how the existing taxonomy guard ships.

Capability: ea/framework-alignment
Closes #684
Refs #671, #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)