### PR TITLE
Fix demo deployment and restore capability CSV import/export

### DIFF
--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { capabilities, capabilityPersonas, capabilityRelationships } from '@/db/schema'
+import { capabilities, capabilityPersonas, capabilityRelationships, personas } from '@/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
@@ -253,6 +253,204 @@ export async function deleteCapability(capabilityId: string) {
     organizationId: orgId,
     before: { name: before?.name },
   })
+}
+
+export type CapabilityImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_CAPABILITY_STATUS = new Set(['draft', 'published', 'archived'])
+const VALID_CAPABILITY_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+function splitCsvRows(text: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        field += '"'
+        i++
+      } else {
+        inQuotes = !inQuotes
+      }
+    } else if (ch === ',' && !inQuotes) {
+      row.push(field)
+      field = ''
+    } else if ((ch === '\n' || ch === '\r') && !inQuotes) {
+      if (ch === '\r' && text[i + 1] === '\n') i++
+      row.push(field)
+      field = ''
+      if (row.some(c => c.length > 0)) rows.push(row)
+      row = []
+    } else {
+      field += ch
+    }
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field)
+    if (row.some(c => c.length > 0)) rows.push(row)
+  }
+
+  return rows
+}
+
+function parseCapabilityCsv(text: string): Record<string, string>[] {
+  const rows = splitCsvRows(text)
+  if (rows.length < 2) return []
+  const headers = rows[0].map(h => h.trim().toLowerCase())
+  return rows.slice(1).map(values =>
+    Object.fromEntries(headers.map((h, i) => [h, (values[i] ?? '').trim()]))
+  )
+}
+
+export async function importCapabilities(formData: FormData, dryRun = false): Promise<CapabilityImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const rows = parseCapabilityCsv(await file.text())
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  const [existing, orgPersonas] = await Promise.all([
+    db.query.capabilities.findMany({
+      where: eq(capabilities.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+    db.query.personas.findMany({
+      where: eq(personas.organizationId, orgId),
+      columns: { id: true, name: true },
+    }),
+  ])
+
+  const existingByName = new Map(existing.map(c => [c.name.toLowerCase(), c.id]))
+  const personaIdByName = new Map(orgPersonas.map(p => [p.name.toLowerCase(), p.id]))
+
+  type ValidRow = {
+    name: string
+    description: string | null
+    domain: string | null
+    behaviors: string | null
+    rules: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    personaIds: string[]
+    existingId: string | undefined
+  }
+
+  const validRows: ValidRow[] = []
+  const errors: string[] = []
+  let created = 0
+  let updated = 0
+  let skipped = 0
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2
+    const name = row.name?.trim()
+    if (!name) {
+      errors.push(`Row ${rowNum}: missing required field "name"`)
+      skipped++
+      continue
+    }
+
+    const status = (row.status || 'draft').trim().toLowerCase()
+    const visibility = (row.visibility || 'org').trim().toLowerCase()
+
+    if (!VALID_CAPABILITY_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`)
+      skipped++
+      continue
+    }
+    if (!VALID_CAPABILITY_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`)
+      skipped++
+      continue
+    }
+
+    const personaIds: string[] = []
+    const personaNames = (row.personas || '').split(/;|\n/).map(s => s.trim()).filter(Boolean)
+    for (const personaName of personaNames) {
+      const id = personaIdByName.get(personaName.toLowerCase())
+      if (id) personaIds.push(id)
+      else errors.push(`Row ${rowNum}: persona "${personaName}" not found in this org - skipped`)
+    }
+
+    const existingId = existingByName.get(name.toLowerCase())
+    if (existingId) updated++
+    else created++
+
+    validRows.push({
+      name,
+      description: row.description || null,
+      domain: row.domain || null,
+      behaviors: row.behaviors || null,
+      rules: row.rules || null,
+      status: status as 'draft' | 'published' | 'archived',
+      visibility: visibility as 'org' | 'connections' | 'instance',
+      personaIds,
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    for (const r of validRows) {
+      let capabilityId = r.existingId
+      if (capabilityId) {
+        await db.update(capabilities).set({
+          description: r.description,
+          domain: r.domain,
+          behaviors: r.behaviors,
+          rules: r.rules,
+          status: r.status,
+          visibility: r.visibility,
+          updatedBy: session.user.id,
+          updatedAt: new Date(),
+        }).where(and(eq(capabilities.id, capabilityId), eq(capabilities.organizationId, orgId)))
+        await db.delete(capabilityPersonas).where(eq(capabilityPersonas.capabilityId, capabilityId))
+      } else {
+        const [inserted] = await db.insert(capabilities).values({
+          name: r.name,
+          description: r.description,
+          domain: r.domain,
+          behaviors: r.behaviors,
+          rules: r.rules,
+          status: r.status,
+          visibility: r.visibility,
+          organizationId: orgId,
+          createdBy: session.user.id,
+          updatedBy: session.user.id,
+        }).returning({ id: capabilities.id })
+        capabilityId = inserted.id
+      }
+
+      if (r.personaIds.length > 0) {
+        await db.insert(capabilityPersonas).values(
+          r.personaIds.map(personaId => ({ capabilityId: capabilityId!, personaId }))
+        )
+      }
+    }
+
+    await writeAuditLog({
+      action: 'capability.import',
+      entityType: 'capability',
+      entityId: orgId,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { created, updated, skipped, dryRun, errorCount: errors.length },
+    })
+    revalidatePath('/capabilities')
+  }
+
+  return { created, updated, skipped, errors }
 }
 
 export async function markCapabilityReviewed(capabilityId: string, _formData: FormData) {

--- a/apps/govea/src/actions/dev.ts
+++ b/apps/govea/src/actions/dev.ts
@@ -19,8 +19,8 @@ import { redirect } from 'next/navigation'
 import { TEST_DATASETS } from '@/db/seeds/test-datasets'
 
 export async function resetToDataset(datasetKey: string) {
-  if (process.env.NODE_ENV !== 'development') {
-    throw new Error('Dataset reset is only available in development mode')
+  if (process.env['DEV'] !== 'true' && process.env['DEMO_MODE'] !== 'true') {
+    throw new Error('Dataset reset is only available in dev/demo mode')
   }
 
   const session = await auth()

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import { taxonomyTerms, principles, entityTaxonomyDefinitions, entityTaxonomyValues } from '@/db/schema'
-import { eq, and, isNull, inArray, count } from 'drizzle-orm'
+import { eq, and, isNull, inArray, count, ne } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { assertOwnership } from '@/lib/federation'
@@ -25,6 +25,33 @@ async function requireAdmin() {
 
 function toSlug(name: string) {
   return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+async function assertTaxonomyTermNameAvailable({
+  orgId,
+  parentId,
+  slug,
+  termId,
+}: {
+  orgId: string
+  parentId: string | null
+  slug: string
+  termId?: string
+}) {
+  const duplicate = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and: a, isNull: n }) => {
+      const scope = parentId
+        ? a(e(t.organizationId, orgId), e(t.parentId, parentId), e(t.slug, slug))
+        : a(e(t.organizationId, orgId), n(t.parentId), e(t.slug, slug))
+      return termId ? a(scope, ne(t.id, termId)) : scope
+    },
+  })
+
+  if (duplicate) {
+    throw new Error(parentId
+      ? `A value named "${duplicate.name}" already exists in this taxonomy type.`
+      : `A taxonomy type named "${duplicate.name}" already exists.`)
+  }
 }
 
 // ── Reads ─────────────────────────────────────────────────────────────────────
@@ -118,11 +145,21 @@ export async function createTaxonomyTerm(formData: FormData) {
   const description = (formData.get('description') as string)?.trim() || null
   const parentId = (formData.get('parentId') as string) || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
+  const slug = toSlug(name)
+
+  if (parentId) {
+    const parent = await db.query.taxonomyTerms.findFirst({
+      where: eq(taxonomyTerms.id, parentId),
+    })
+    assertOwnership(parent?.organizationId, orgId)
+  }
+
+  await assertTaxonomyTermNameAvailable({ orgId, parentId, slug })
 
   const [entry] = await db.insert(taxonomyTerms).values({
     organizationId: orgId,
     name,
-    slug: toSlug(name),
+    slug,
     description,
     parentId,
     sortOrder,
@@ -150,9 +187,17 @@ export async function editTaxonomyTerm(termId: string, formData: FormData) {
   const name = (formData.get('name') as string).trim()
   const description = (formData.get('description') as string)?.trim() || null
   const sortOrder = (formData.get('sortOrder') as string)?.trim() || null
+  const slug = toSlug(name)
+
+  await assertTaxonomyTermNameAvailable({
+    orgId,
+    parentId: existing?.parentId ?? null,
+    slug,
+    termId,
+  })
 
   await db.update(taxonomyTerms)
-    .set({ name, slug: toSlug(name), description, sortOrder, updatedAt: new Date() })
+    .set({ name, slug, description, sortOrder, updatedAt: new Date() })
     .where(and(eq(taxonomyTerms.id, termId), eq(taxonomyTerms.organizationId, orgId)))
 
   await writeAuditLog({

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import type { Capability, Persona } from '@/db/schema'
-import { createCapability, editCapability, deleteCapability } from '@/actions/capabilities'
+import { createCapability, editCapability, deleteCapability, importCapabilities, type CapabilityImportResult } from '@/actions/capabilities'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
@@ -77,6 +77,10 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<CapabilityRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<CapabilityRow | null>(null)
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<CapabilityImportResult | null>(null)
+  const [importResult, setImportResult] = useState<CapabilityImportResult | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -136,6 +140,36 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
     })
   }
 
+  async function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importCapabilities(fd, true)
+      setImportPreview(result)
+    })
+  }
+
+  async function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData()
+      fd.append('csvFile', importFile)
+      const result = await importCapabilities(fd, false)
+      setImportResult(result)
+      setImportPreview(null)
+      setImportFile(null)
+      refresh()
+    })
+  }
+
+  function openImport() {
+    setImportOpen(true)
+    setImportResult(null)
+    setImportPreview(null)
+    setImportFile(null)
+  }
+
   // Org-owned caps eligible as parents, excluding self + descendants
   function getParentOptions(excludeId?: string) {
     if (!excludeId) return capabilities.filter(c => c.organizationId === currentOrgId)
@@ -190,11 +224,19 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
             ))}
           </select>
         )}
-        {canEdit && (
-          <Button onClick={() => setCreateOpen(true)} className="ml-auto" size="sm">
-            + New Capability
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          <a href="/api/capabilities/export">
+            <Button variant="outline" size="sm">Export CSV</Button>
+          </a>
+          {canEdit && (
+            <>
+              <Button variant="outline" size="sm" onClick={openImport}>Import CSV</Button>
+              <Button onClick={() => setCreateOpen(true)} size="sm">
+                + New Capability
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Table */}
@@ -449,6 +491,69 @@ export function CapabilityTable({ capabilities, personas, domainTerms, role, cur
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Import Dialog */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import Capabilities</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">name</code>, <code className="bg-muted px-1 rounded">description</code>, <code className="bg-muted px-1 rounded">domain</code>, <code className="bg-muted px-1 rounded">behaviors</code>, <code className="bg-muted px-1 rounded">rules</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">visibility</code>, <code className="bg-muted px-1 rounded">personas</code> (semicolon-separated names).
+            </p>
+
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }}
+                />
+              </div>
+            )}
+
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} records`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
@@ -50,10 +50,14 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
   const [wireTarget, setWireTarget] = useState<TaxonomyTerm | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
+
+  const toSlug = (name: string) =>
+    name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 
   // Group definitions by taxonomyTypeId
   const defsByType = definitions.reduce<Record<string, EnrichedDefinition[]>>((acc, d) => {
@@ -71,36 +75,85 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
   }, {})
 
   async function handleCreateType(fd: FormData) {
+    const name = (fd.get('name') as string).trim()
+    const slug = toSlug(name)
+    const duplicate = types.find(t => t.slug === slug)
+    if (duplicate) {
+      setFormError(`A taxonomy type named "${duplicate.name}" already exists.`)
+      return
+    }
+
     startTransition(async () => {
-      await createTaxonomyTerm(fd)
-      setCreateTypeOpen(false)
-      refresh()
+      setFormError(null)
+      try {
+        await createTaxonomyTerm(fd)
+        setCreateTypeOpen(false)
+        refresh()
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Unable to create taxonomy type.')
+      }
     })
   }
 
   async function handleCreateValue(fd: FormData) {
+    if (!createValueTarget) return
+    const name = (fd.get('name') as string).trim()
+    const slug = toSlug(name)
+    const duplicate = (valuesByType[createValueTarget.id] ?? []).find(v => v.slug === slug)
+    if (duplicate) {
+      setFormError(`A value named "${duplicate.name}" already exists in this taxonomy type.`)
+      return
+    }
+
     startTransition(async () => {
-      await createTaxonomyTerm(fd)
-      setCreateValueTarget(null)
-      refresh()
+      setFormError(null)
+      try {
+        await createTaxonomyTerm(fd)
+        setCreateValueTarget(null)
+        refresh()
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Unable to create taxonomy value.')
+      }
     })
   }
 
   async function handleEdit(fd: FormData) {
     if (!editTarget) return
+    const name = (fd.get('name') as string).trim()
+    const slug = toSlug(name)
+    const duplicate = editTarget.kind === 'type'
+      ? types.find(t => t.id !== editTarget.term.id && t.slug === slug)
+      : (valuesByType[editTarget.term.parentId ?? ''] ?? []).find(v => v.id !== editTarget.term.id && v.slug === slug)
+    if (duplicate) {
+      setFormError(editTarget.kind === 'type'
+        ? `A taxonomy type named "${duplicate.name}" already exists.`
+        : `A value named "${duplicate.name}" already exists in this taxonomy type.`)
+      return
+    }
+
     startTransition(async () => {
-      await editTaxonomyTerm(editTarget.term.id, fd)
-      setEditTarget(null)
-      refresh()
+      setFormError(null)
+      try {
+        await editTaxonomyTerm(editTarget.term.id, fd)
+        setEditTarget(null)
+        refresh()
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Unable to update taxonomy term.')
+      }
     })
   }
 
   async function handleDelete() {
     if (!deleteTarget) return
     startTransition(async () => {
-      await deleteTaxonomyTerm(deleteTarget.term.id)
-      setDeleteTarget(null)
-      refresh()
+      setFormError(null)
+      try {
+        await deleteTaxonomyTerm(deleteTarget.term.id)
+        setDeleteTarget(null)
+        refresh()
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Unable to delete taxonomy term.')
+      }
     })
   }
 
@@ -108,9 +161,14 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
     if (!wireTarget) return
     startTransition(async () => {
       fd.set('taxonomyTypeId', wireTarget.id)
-      await addEntityTaxonomyDefinition(fd)
-      setWireTarget(null)
-      refresh()
+      setFormError(null)
+      try {
+        await addEntityTaxonomyDefinition(fd)
+        setWireTarget(null)
+        refresh()
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Unable to wire taxonomy type.')
+      }
     })
   }
 
@@ -312,7 +370,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
       </div>
 
       {/* Create Type Dialog */}
-      <Dialog open={createTypeOpen} onOpenChange={setCreateTypeOpen}>
+      <Dialog open={createTypeOpen} onOpenChange={open => { setCreateTypeOpen(open); if (!open) setFormError(null) }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Taxonomy Type</DialogTitle>
@@ -322,6 +380,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
           </p>
           <form action={handleCreateType} className="space-y-3">
             <TermFields />
+            {formError && <FormError message={formError} />}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setCreateTypeOpen(false)}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create Type'}</Button>
@@ -331,7 +390,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
       </Dialog>
 
       {/* Create Value Dialog */}
-      <Dialog open={!!createValueTarget} onOpenChange={open => { if (!open) setCreateValueTarget(null) }}>
+      <Dialog open={!!createValueTarget} onOpenChange={open => { if (!open) { setCreateValueTarget(null); setFormError(null) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Value in &ldquo;{createValueTarget?.name}&rdquo;</DialogTitle>
@@ -339,6 +398,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
           <form action={handleCreateValue} className="space-y-3">
             <input type="hidden" name="parentId" value={createValueTarget?.id ?? ''} />
             <TermFields />
+            {formError && <FormError message={formError} />}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setCreateValueTarget(null)}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create Value'}</Button>
@@ -348,7 +408,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
       </Dialog>
 
       {/* Edit Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) { setEditTarget(null); setFormError(null) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit {editTarget?.kind === 'type' ? 'Type' : 'Value'}</DialogTitle>
@@ -359,6 +419,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
               defaultDescription={editTarget?.term.description ?? ''}
               defaultSortOrder={editTarget?.term.sortOrder ?? ''}
             />
+            {formError && <FormError message={formError} />}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
               <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
@@ -368,7 +429,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
       </Dialog>
 
       {/* Wire to Entity Type Dialog */}
-      <Dialog open={!!wireTarget} onOpenChange={open => { if (!open) setWireTarget(null) }}>
+      <Dialog open={!!wireTarget} onOpenChange={open => { if (!open) { setWireTarget(null); setFormError(null) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Wire &ldquo;{wireTarget?.name}&rdquo; to entity type</DialogTitle>
@@ -408,6 +469,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
               <input type="checkbox" id="wire-required" name="required" value="true" className="rounded" />
               <Label htmlFor="wire-required">Required</Label>
             </div>
+            {formError && <FormError message={formError} />}
             <input type="hidden" name="sortOrder" value="0" />
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setWireTarget(null)}>Cancel</Button>
@@ -418,13 +480,14 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
       </Dialog>
 
       {/* Delete Dialog */}
-      <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
+      <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) { setDeleteTarget(null); setFormError(null) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete &ldquo;{deleteTarget?.term.name}&rdquo;</DialogTitle>
           </DialogHeader>
           <div className="space-y-2 text-sm text-muted-foreground">
             <p>Are you sure? This cannot be undone.</p>
+            {formError && <FormError message={formError} />}
             {(deleteTarget?.valueCount ?? 0) > 0 && (
               <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
                 This type has <strong>{deleteTarget?.valueCount} value{deleteTarget?.valueCount !== 1 ? 's' : ''}</strong> which will also be deleted.
@@ -454,6 +517,14 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
 }
 
 // ── Shared form fields ────────────────────────────────────────────────────────
+
+function FormError({ message }: { message: string }) {
+  return (
+    <p className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+      {message}
+    </p>
+  )
+}
 
 function TermFields({
   defaultName = '',

--- a/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/value-stream-table.tsx
@@ -50,6 +50,7 @@ const VISIBILITY_LABELS: Record<string, string> = {
 export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
+  const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('all')
   const [orgFilter, setOrgFilter] = useState('all')
 
@@ -65,9 +66,10 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
   const refresh = () => router.refresh()
 
   const filtered = valueStreams.filter(vs => {
+    const matchSearch = !search || vs.name.toLowerCase().includes(search.toLowerCase())
     const matchStatus = statusFilter === 'all' || vs.status === statusFilter
     const matchOrg = orgFilter === 'all' || (orgFilter === 'own' ? vs.organizationId === currentOrgId : vs.organizationId === orgFilter)
-    return matchStatus && matchOrg
+    return matchSearch && matchStatus && matchOrg
   })
 
   async function handleCreate(formData: FormData) {
@@ -96,29 +98,36 @@ export function ValueStreamTable({ valueStreams, role, currentOrgId }: Props) {
     })
   }
 
+  const selectClass = 'h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring'
+
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-3">
+        <Input
+          type="search"
+          placeholder="Search value streams..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="w-56"
+        />
         <select
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value)}
-          className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={selectClass}
         >
           <option value="all">All statuses</option>
           <option value="draft">Draft</option>
           <option value="published">Published</option>
           <option value="archived">Archived</option>
         </select>
-        {orgOptions.length > 1 && (
-          <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
-            <option value="all">All organizations</option>
-            <option value="own">My organization</option>
-            {orgOptions.filter(([id]) => id !== currentOrgId).map(([id, name]) => (
-              <option key={id} value={id}>{name}</option>
-            ))}
-          </select>
-        )}
+        <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className={selectClass}>
+          <option value="all">All organizations</option>
+          <option value="own">My organization</option>
+          {orgOptions.filter(([id]) => id !== currentOrgId).map(([id, name]) => (
+            <option key={id} value={id}>{name}</option>
+          ))}
+        </select>
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
             + New Value Stream

--- a/apps/govea/src/app/(auth)/login/page.tsx
+++ b/apps/govea/src/app/(auth)/login/page.tsx
@@ -23,7 +23,7 @@ export default async function LoginPage({
   if (session) redirect('/dashboard')
 
   const params = await searchParams
-  const isDev = process.env.NODE_ENV === 'development'
+  const isDev = process.env['DEV'] === 'true' || process.env['DEMO_MODE'] === 'true'
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-muted/30">

--- a/apps/govea/src/app/api/capabilities/export/route.ts
+++ b/apps/govea/src/app/api/capabilities/export/route.ts
@@ -1,0 +1,54 @@
+import { auth } from '@/lib/auth'
+import { canEdit } from '@/lib/rbac'
+import { getCapabilities } from '@/actions/capabilities'
+
+function escapeCsv(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+type CapabilityForExport = Awaited<ReturnType<typeof getCapabilities>>[number]
+
+function buildCsv(capabilities: CapabilityForExport[]): string {
+  const headers = ['name', 'description', 'domain', 'behaviors', 'rules', 'status', 'visibility', 'personas']
+  const rows = capabilities.map(capability => {
+    const personas = capability.capabilityPersonas
+      .map(({ persona }) => persona.name)
+      .filter(Boolean)
+      .join('; ')
+
+    return [
+      capability.name,
+      capability.description ?? '',
+      capability.domain ?? '',
+      capability.behaviors ?? '',
+      capability.rules ?? '',
+      capability.status,
+      capability.visibility,
+      personas,
+    ].map(escapeCsv).join(',')
+  })
+
+  return [headers.map(escapeCsv).join(','), ...rows].join('\n')
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!canEdit(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const orgId = session.user.organizationId!
+  const readableCapabilities = await getCapabilities(orgId, session.user.role)
+  const ownCapabilities = readableCapabilities.filter(capability => capability.organizationId === orgId)
+  const csv = buildCsv(ownCapabilities)
+  const date = new Date().toISOString().slice(0, 10)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="capabilities-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/db/migrations/0029_taxonomy_term_uniqueness.sql
+++ b/apps/govea/src/db/migrations/0029_taxonomy_term_uniqueness.sql
@@ -1,0 +1,145 @@
+CREATE TABLE IF NOT EXISTS "entity_taxonomy_definitions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "entity_type" text NOT NULL,
+  "taxonomy_type_id" uuid NOT NULL,
+  "selection_mode" text DEFAULT 'single' NOT NULL,
+  "required" boolean DEFAULT false NOT NULL,
+  "sort_order" integer DEFAULT 0 NOT NULL
+);
+
+DO $$
+BEGIN
+  ALTER TABLE "entity_taxonomy_definitions"
+    ADD CONSTRAINT "entity_taxonomy_definitions_organization_id_organizations_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "entity_taxonomy_definitions"
+    ADD CONSTRAINT "entity_taxonomy_definitions_taxonomy_type_id_taxonomy_terms_id_fk"
+    FOREIGN KEY ("taxonomy_type_id") REFERENCES "public"."taxonomy_terms"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "etd_org_entity_type_uniq"
+  ON "entity_taxonomy_definitions" ("organization_id", "entity_type", "taxonomy_type_id");
+
+CREATE TABLE IF NOT EXISTS "entity_taxonomy_values" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "entity_type" text NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "taxonomy_term_id" uuid NOT NULL
+);
+
+DO $$
+BEGIN
+  ALTER TABLE "entity_taxonomy_values"
+    ADD CONSTRAINT "entity_taxonomy_values_organization_id_organizations_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "entity_taxonomy_values"
+    ADD CONSTRAINT "entity_taxonomy_values_taxonomy_term_id_taxonomy_terms_id_fk"
+    FOREIGN KEY ("taxonomy_term_id") REFERENCES "public"."taxonomy_terms"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "etv_entity_term_uniq"
+  ON "entity_taxonomy_values" ("entity_type", "entity_id", "taxonomy_term_id");
+
+CREATE TEMP TABLE taxonomy_term_dedupe ON COMMIT DROP AS
+SELECT id, keep_id
+FROM (
+  SELECT
+    id,
+    first_value(id) OVER (
+      PARTITION BY organization_id, parent_id, slug
+      ORDER BY created_at, id
+    ) AS keep_id,
+    row_number() OVER (
+      PARTITION BY organization_id, parent_id, slug
+      ORDER BY created_at, id
+    ) AS rn
+  FROM taxonomy_terms
+) ranked
+WHERE rn > 1;
+
+UPDATE taxonomy_terms child
+SET parent_id = dedupe.keep_id
+FROM taxonomy_term_dedupe dedupe
+WHERE child.parent_id = dedupe.id;
+
+DELETE FROM persona_tags tag
+USING taxonomy_term_dedupe dedupe
+WHERE tag.tag_id = dedupe.id
+  AND EXISTS (
+    SELECT 1
+    FROM persona_tags existing
+    WHERE existing.persona_id = tag.persona_id
+      AND existing.tag_id = dedupe.keep_id
+  );
+
+UPDATE persona_tags tag
+SET tag_id = dedupe.keep_id
+FROM taxonomy_term_dedupe dedupe
+WHERE tag.tag_id = dedupe.id;
+
+DELETE FROM entity_taxonomy_values value
+USING taxonomy_term_dedupe dedupe
+WHERE value.taxonomy_term_id = dedupe.id
+  AND EXISTS (
+    SELECT 1
+    FROM entity_taxonomy_values existing
+    WHERE existing.organization_id = value.organization_id
+      AND existing.entity_type = value.entity_type
+      AND existing.entity_id = value.entity_id
+      AND existing.taxonomy_term_id = dedupe.keep_id
+  );
+
+UPDATE entity_taxonomy_values value
+SET taxonomy_term_id = dedupe.keep_id
+FROM taxonomy_term_dedupe dedupe
+WHERE value.taxonomy_term_id = dedupe.id;
+
+DELETE FROM entity_taxonomy_definitions definition
+USING taxonomy_term_dedupe dedupe
+WHERE definition.taxonomy_type_id = dedupe.id
+  AND EXISTS (
+    SELECT 1
+    FROM entity_taxonomy_definitions existing
+    WHERE existing.organization_id = definition.organization_id
+      AND existing.entity_type = definition.entity_type
+      AND existing.taxonomy_type_id = dedupe.keep_id
+  );
+
+UPDATE entity_taxonomy_definitions definition
+SET taxonomy_type_id = dedupe.keep_id
+FROM taxonomy_term_dedupe dedupe
+WHERE definition.taxonomy_type_id = dedupe.id;
+
+DELETE FROM taxonomy_terms term
+USING taxonomy_term_dedupe dedupe
+WHERE term.id = dedupe.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "taxonomy_terms_type_slug_uniq"
+  ON "taxonomy_terms" ("organization_id", "slug")
+  WHERE "parent_id" IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "taxonomy_terms_value_slug_uniq"
+  ON "taxonomy_terms" ("organization_id", "parent_id", "slug")
+  WHERE "parent_id" IS NOT NULL;

--- a/apps/govea/src/db/migrations/meta/_journal.json
+++ b/apps/govea/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1777300002000,
       "tag": "0028_platform_config",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1777682151000,
+      "tag": "0029_taxonomy_term_uniqueness",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/govea/src/db/schema/taxonomy.ts
+++ b/apps/govea/src/db/schema/taxonomy.ts
@@ -1,18 +1,30 @@
 import { boolean, integer, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import { organizations } from './organizations'
 
-export const taxonomyTerms = pgTable('taxonomy_terms', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
-  parentId: uuid('parent_id'), // self-reference for hierarchy
-  name: text('name').notNull(),
-  slug: text('slug').notNull(),
-  description: text('description'),
-  domain: text('domain'), // top-level domain grouping
-  sortOrder: text('sort_order'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-})
+export const taxonomyTerms = pgTable(
+  'taxonomy_terms',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+    parentId: uuid('parent_id'), // self-reference for hierarchy
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    description: text('description'),
+    domain: text('domain'), // top-level domain grouping
+    sortOrder: text('sort_order'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('taxonomy_terms_type_slug_uniq')
+      .on(t.organizationId, t.slug)
+      .where(sql`${t.parentId} is null`),
+    uniqueIndex('taxonomy_terms_value_slug_uniq')
+      .on(t.organizationId, t.parentId, t.slug)
+      .where(sql`${t.parentId} is not null`),
+  ]
+)
 
 // Which taxonomy types are configured for which entity types (per org)
 export const entityTaxonomyDefinitions = pgTable(

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -1,4 +1,4 @@
-import { eq, isNull } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { GOV_TAXONOMY } from './gov-taxonomy'
 import {
   DEV_ORG, STATE_ORG, SYSTEM_ORG,
@@ -96,6 +96,49 @@ async function findOrCreateApplication(orgId: string, name: string, data: {
   return a.id
 }
 
+async function findOrCreateTaxonomyType(orgId: string, name: string, data?: {
+  description?: string
+  sortOrder?: string
+}) {
+  const slug = toSlug(name)
+  const existing = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, orgId), isNull(t.parentId), e(t.slug, slug)),
+  })
+  if (existing) return existing.id
+
+  const [term] = await db.insert(taxonomyTerms).values({
+    organizationId: orgId,
+    name,
+    slug,
+    description: data?.description,
+    sortOrder: data?.sortOrder,
+  }).returning()
+  return term.id
+}
+
+async function findOrCreateTaxonomyValue(orgId: string, parentId: string, name: string, data?: {
+  description?: string
+  sortOrder?: string
+}) {
+  const slug = toSlug(name)
+  const existing = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and }) =>
+      and(e(t.organizationId, orgId), e(t.parentId, parentId), e(t.slug, slug)),
+  })
+  if (existing) return existing.id
+
+  const [term] = await db.insert(taxonomyTerms).values({
+    organizationId: orgId,
+    parentId,
+    name,
+    slug,
+    description: data?.description,
+    sortOrder: data?.sortOrder,
+  }).returning()
+  return term.id
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function seed() {
@@ -119,66 +162,22 @@ async function seed() {
   console.log(`  ✓ ${DEV_USERS.length} users (password: dev-password)`)
 
   // Persona types — taxonomy terms under "Persona Type" type
-  let personaTypeTermId: string
-  const existingPersonaTypeType = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq: e, and }) =>
-      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'persona-type')),
+  const personaTypeTermId = await findOrCreateTaxonomyType(devOrgId, 'Persona Type', {
+    description: 'Categories used to classify personas.',
+    sortOrder: '10',
   })
-  if (existingPersonaTypeType) {
-    personaTypeTermId = existingPersonaTypeType.id
-  } else {
-    const [inserted] = await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      name: 'Persona Type',
-      slug: 'persona-type',
-      description: 'Categories used to classify personas.',
-      sortOrder: '10',
-    }).returning()
-    personaTypeTermId = inserted.id
-  }
   for (const name of DEFAULT_PERSONA_TYPES) {
-    await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      parentId: personaTypeTermId,
-      name,
-      slug: toSlug(name),
-    }).onConflictDoNothing()
+    await findOrCreateTaxonomyValue(devOrgId, personaTypeTermId, name)
   }
 
   // Persona tags — taxonomy terms under "Persona Tag" type; build id map for personaTags junction
-  let personaTagTypeId: string
-  const existingPersonaTagType = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq: e, and }) =>
-      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'persona-tag')),
+  const personaTagTypeId = await findOrCreateTaxonomyType(devOrgId, 'Persona Tag', {
+    description: 'Cross-cutting labels used to filter and search personas.',
+    sortOrder: '20',
   })
-  if (existingPersonaTagType) {
-    personaTagTypeId = existingPersonaTagType.id
-  } else {
-    const [inserted] = await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      name: 'Persona Tag',
-      slug: 'persona-tag',
-      description: 'Cross-cutting labels used to filter and search personas.',
-      sortOrder: '20',
-    }).returning()
-    personaTagTypeId = inserted.id
-  }
   const devTagIds: Record<string, string> = {}
   for (const name of DEFAULT_PERSONA_TAGS) {
-    const [term] = await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      parentId: personaTagTypeId,
-      name,
-      slug: toSlug(name),
-    }).onConflictDoNothing().returning()
-    if (term) {
-      devTagIds[name] = term.id
-    } else {
-      const existing = await db.query.taxonomyTerms.findFirst({
-        where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.parentId, personaTagTypeId), e(t.name, name)),
-      })
-      if (existing) devTagIds[name] = existing.id
-    }
+    devTagIds[name] = await findOrCreateTaxonomyValue(devOrgId, personaTagTypeId, name)
   }
   console.log(`  ✓ ${DEFAULT_PERSONA_TYPES.length} persona types, ${DEFAULT_PERSONA_TAGS.length} persona tags (taxonomy-backed)`)
 
@@ -257,39 +256,19 @@ async function seed() {
 
   // Government taxonomy — Type: "Domain" with 10 government domain values
   // Under our types/values model: "Domain" is the type, each domain name is a value within it.
-  const domainTypeSlug = 'domain'
-  let domainTypeId: string
-  const existingDomainType = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq: e, and, isNull }) =>
-      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, domainTypeSlug)),
+  const domainTypeId = await findOrCreateTaxonomyType(devOrgId, 'Domain', {
+    description: 'Business and service domains used to classify capabilities and glossary terms.',
+    sortOrder: '0',
   })
-  if (existingDomainType) {
-    domainTypeId = existingDomainType.id
-  } else {
-    const [inserted] = await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      name: 'Domain',
-      slug: domainTypeSlug,
-      description: 'Business and service domains used to classify capabilities and glossary terms.',
-      sortOrder: '0',
-    }).returning()
-    domainTypeId = inserted.id
-  }
 
   let domainValueCount = 0
   for (const [idx, domainEntry] of GOV_TAXONOMY.entries()) {
-    const existing = await db.query.taxonomyTerms.findFirst({
+    const before = await db.query.taxonomyTerms.findFirst({
       where: (t, { eq: e, and }) =>
-        and(e(t.organizationId, devOrgId), e(t.parentId, domainTypeId), e(t.name, domainEntry.domain)),
+        and(e(t.organizationId, devOrgId), e(t.parentId, domainTypeId), e(t.slug, toSlug(domainEntry.domain))),
     })
-    if (!existing) {
-      await db.insert(taxonomyTerms).values({
-        organizationId: devOrgId,
-        parentId: domainTypeId,
-        name: domainEntry.domain,
-        slug: toSlug(domainEntry.domain),
-        sortOrder: String(idx * 10),
-      })
+    await findOrCreateTaxonomyValue(devOrgId, domainTypeId, domainEntry.domain, { sortOrder: String(idx * 10) })
+    if (!before) {
       domainValueCount++
     }
   }
@@ -646,31 +625,13 @@ async function seed() {
   console.log(`  ✓ ${DEV_SERVICES.length} services with capability, persona, and value stream links`)
 
   // Application Type taxonomy + entity definition (pilot for base-item taxonomy foundation)
-  let appTypeTermId: string
-  const existingAppTypeType = await db.query.taxonomyTerms.findFirst({
-    where: (t, { eq: e, and }) =>
-      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'application-type')),
+  const appTypeTermId = await findOrCreateTaxonomyType(devOrgId, 'Application Type', {
+    description: 'Classification of applications by their primary purpose or delivery model.',
+    sortOrder: '50',
   })
-  if (existingAppTypeType) {
-    appTypeTermId = existingAppTypeType.id
-  } else {
-    const [inserted] = await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      name: 'Application Type',
-      slug: 'application-type',
-      description: 'Classification of applications by their primary purpose or delivery model.',
-      sortOrder: '50',
-    }).returning()
-    appTypeTermId = inserted.id
-  }
   const APP_TYPE_VALUES = ['Core Business System', 'Shared Service', 'Integration Platform', 'Reporting & Analytics', 'Public-Facing Service', 'Internal Tool']
   for (const name of APP_TYPE_VALUES) {
-    await db.insert(taxonomyTerms).values({
-      organizationId: devOrgId,
-      parentId: appTypeTermId,
-      name,
-      slug: toSlug(name),
-    }).onConflictDoNothing()
+    await findOrCreateTaxonomyValue(devOrgId, appTypeTermId, name)
   }
   await db.insert(entityTaxonomyDefinitions).values({
     organizationId: devOrgId,

--- a/apps/govea/tests/integration/taxonomy.test.ts
+++ b/apps/govea/tests/integration/taxonomy.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration tests: taxonomy server actions
+ *
+ * Covers duplicate prevention for taxonomy types and values.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createTaxonomyTerm, editTaxonomyTerm } from '@/actions/taxonomy'
+import { db } from '@/db/client'
+import { taxonomyTerms } from '@/db/schema'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  type TestUser,
+} from './helpers/db'
+import { and, eq, isNull } from 'drizzle-orm'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function termForm(name: string, parentId?: string) {
+  const fd = new FormData()
+  fd.set('name', name)
+  if (parentId) fd.set('parentId', parentId)
+  return fd
+}
+
+async function findType(orgId: string, slug: string) {
+  return db.query.taxonomyTerms.findFirst({
+    where: and(
+      eq(taxonomyTerms.organizationId, orgId),
+      isNull(taxonomyTerms.parentId),
+      eq(taxonomyTerms.slug, slug),
+    ),
+  })
+}
+
+async function findValue(orgId: string, parentId: string, slug: string) {
+  return db.query.taxonomyTerms.findFirst({
+    where: and(
+      eq(taxonomyTerms.organizationId, orgId),
+      eq(taxonomyTerms.parentId, parentId),
+      eq(taxonomyTerms.slug, slug),
+    ),
+  })
+}
+
+describe('taxonomy duplicate prevention', () => {
+  let orgId: string
+  let contributor: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    contributor = await createTestUser(orgId, 'contributor')
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+  })
+
+  it('rejects duplicate type names within an organization', async () => {
+    await createTaxonomyTerm(termForm('Criticality'))
+
+    await expect(createTaxonomyTerm(termForm('criticality')))
+      .rejects.toThrow('A taxonomy type named "Criticality" already exists.')
+  })
+
+  it('rejects duplicate value names within the same type', async () => {
+    await createTaxonomyTerm(termForm('Risk Class'))
+    const type = await findType(orgId, 'risk-class')
+    expect(type).toBeDefined()
+
+    await createTaxonomyTerm(termForm('High', type!.id))
+
+    await expect(createTaxonomyTerm(termForm('high', type!.id)))
+      .rejects.toThrow('A value named "High" already exists in this taxonomy type.')
+  })
+
+  it('allows the same value name under different types', async () => {
+    await createTaxonomyTerm(termForm('Business Fit'))
+    await createTaxonomyTerm(termForm('Technical Fit'))
+    const businessFit = await findType(orgId, 'business-fit')
+    const technicalFit = await findType(orgId, 'technical-fit')
+    expect(businessFit).toBeDefined()
+    expect(technicalFit).toBeDefined()
+
+    await createTaxonomyTerm(termForm('High', businessFit!.id))
+    await createTaxonomyTerm(termForm('High', technicalFit!.id))
+
+    expect(await findValue(orgId, businessFit!.id, 'high')).toBeDefined()
+    expect(await findValue(orgId, technicalFit!.id, 'high')).toBeDefined()
+  })
+
+  it('rejects renaming a type to collide with another type', async () => {
+    await createTaxonomyTerm(termForm('Operating Model'))
+    await createTaxonomyTerm(termForm('Delivery Model'))
+    const deliveryModel = await findType(orgId, 'delivery-model')
+    expect(deliveryModel).toBeDefined()
+
+    await expect(editTaxonomyTerm(deliveryModel!.id, termForm('Operating Model')))
+      .rejects.toThrow('A taxonomy type named "Operating Model" already exists.')
+  })
+
+  it('rejects renaming a value to collide within the same type', async () => {
+    await createTaxonomyTerm(termForm('Sensitivity'))
+    const type = await findType(orgId, 'sensitivity')
+    expect(type).toBeDefined()
+
+    await createTaxonomyTerm(termForm('Public', type!.id))
+    await createTaxonomyTerm(termForm('Confidential', type!.id))
+    const confidential = await findValue(orgId, type!.id, 'confidential')
+    expect(confidential).toBeDefined()
+
+    await expect(editTaxonomyTerm(confidential!.id, termForm('Public')))
+      .rejects.toThrow('A value named "Public" already exists in this taxonomy type.')
+  })
+})

--- a/docker/Containerfile.dev
+++ b/docker/Containerfile.dev
@@ -30,6 +30,13 @@ COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 # but kept here so the image is self-contained if run without volumes.
 COPY . .
 
+# Azure runs this image without source volumes. Pre-build the app there so the
+# remote demo uses stable production server behavior instead of Next dev mode.
+RUN cd packages/core && node ../../node_modules/typescript/bin/tsc
+RUN cd apps/govea && node node_modules/next/dist/bin/next build
+RUN mkdir -p apps/govea/.next/standalone/apps/govea/.next \
+  && cp -R apps/govea/.next/static apps/govea/.next/standalone/apps/govea/.next/static
+
 COPY docker/entrypoint.dev.sh /entrypoint.dev.sh
 COPY docker/entrypoint.azure-dev.sh /entrypoint.azure-dev.sh
 RUN chmod +x /entrypoint.dev.sh /entrypoint.azure-dev.sh

--- a/docker/entrypoint.azure-dev.sh
+++ b/docker/entrypoint.azure-dev.sh
@@ -30,4 +30,5 @@ pnpm --filter govea db:seed:container
 
 echo ""
 echo "==> Starting server..."
-exec pnpm --filter govea dev
+cd apps/govea
+exec node .next/standalone/apps/govea/server.js


### PR DESCRIPTION
Closes #681

## Summary

- Build the dev/demo Azure image as a production Next.js standalone app, including the core package build and standalone static assets, so deployed styling and theming resolve correctly.
- Start the demo container with the standalone Next server while preserving dev/demo affordances through `DEV=true` and `DEMO_MODE=true` gates.
- Restore capability CSV export and import with preview/confirm UI and authenticated export route handling.
- Make the value streams list toolbar consistent with other list views by adding search and always showing the organization filter alongside status filtering.
- Prevent duplicate taxonomy terms with schema/migration support, safer seed behavior, action/UI errors, and integration test coverage.

## Verification

- `pnpm --filter govea build` passed.
- Deployed demo image `goveadevacr.azurecr.io/govea-dev:20260602-102326` to https://govea-dev.wittyocean-795e193a.eastus.azurecontainerapps.io.
- Verified deployed Next CSS asset returns HTTP 200 with `content-type: text/css`.
- Verified unauthenticated `/api/capabilities/export` redirects to `/login`.
- `pnpm --filter govea test:integration -- --run tests/integration/taxonomy.test.ts` did not complete locally because Postgres authentication failed for user `roballred` in the local test environment.