### PR TITLE
Align AGENTS.md with GovEA operating policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,57 @@
-# GovEA — Project Instructions for AI Agents
+# GovEA — Project Instructions for OpenAI Codex
 
-> **Governing document:** [Standards.md](./Standards.md) defines the principles, workflow, and traceability requirements for all AI-assisted work on this project. This file extends those standards with general agent context. If anything here conflicts with Standards.md, Standards.md governs.
+> **Before any work, read CLAUDE.md, Standards.md, and docs/AI-SESSION-START.md — they are authoritative and override this file. If this file conflicts with them, they govern.**
 
-## What This Is
+This file is a Codex-specific pointer and guardrail layer. It does not replace the project operating policy, traceability rules, database workflow, or governing AI standards.
 
-GovEA is a free, open source enterprise architecture tool built specifically for state and local government.
+## Required Reading Order
 
-Built on the [EasyEA](https://github.com/roballred/EasyEA) methodology — people-centered, lightweight, designed for everyday work rather than compliance theater.
+1. [`Standards.md`](./Standards.md) — governing document for AI-assisted work, EasyEA traceability, personas, capabilities, issue-first development, and PR review.
+2. [`CLAUDE.md`](./CLAUDE.md) — operational policy for GovEA, including the database workflow, required pre-flight checklist, and commit/PR traceability format.
+3. [`docs/AI-SESSION-START.md`](./docs/AI-SESSION-START.md) — canonical session bootstrap with current workflow, CI, GitHub CLI, deployment, and drift-prone operating policies.
 
-## EasyEA Reference
+Read those documents before editing files, running mutating commands, creating branches, or opening PRs.
 
-The methodology behind GovEA lives at https://github.com/roballred/EasyEA. Key concepts:
-- People-centered: start with personas, not systems
-- 7-step lightweight workflow
-- ARB review with 10 distinct reviewer personas (simulated in v2)
-- Plain-language outputs for elected officials and non-technical stakeholders
+## Branch & PR Hygiene (required)
 
----
+- Always start from current origin/main; never reuse or revive an existing branch.
+- A PR behind main at open time must be rebased onto main before review; if it can't cleanly rebase, start over from main.
+- One concern per PR. Never bundle unrelated changes.
+- Never reopen or re-push a closed PR or deleted branch. If closed work is still needed, open a NEW branch off current main and a NEW PR.
+- Check before writing: search main for an existing implementation before adding a feature; if it already exists, stop.
+- Schema changes use `db:push` + `src/db/sql/*.sql` (apply-triggers). NEVER create `apps/govea/src/db/migrations/` — that directory is drift; delete it if it appears.
 
-## User Roles
+## Pre-Flight Checklist
 
-| Role | Access |
-|---|---|
-| Admin | Full access — users, org settings, all content |
-| Contributor | Create and edit EA content — no user management, no delete |
-| Viewer | Read-only, published content only |
+Before writing code or docs, complete the full checklist in [`CLAUDE.md`](./CLAUDE.md):
 
-SSO users default to Viewer. Admins promote as needed.
+- Confirm a GitHub issue exists with clear scope.
+- Confirm the issue has a `Capability:` or `Capability group:` line using the relevant EasyEA capability ID from `business-architecture/capabilities/`.
+- Confirm the issue names the persona(s) served.
+- Confirm acceptance criteria are clear enough to know when the work is done.
 
-## GitHub
+If the task arrives informally, create the issue first and confirm its content before implementing. If no capability doc fits, say so explicitly in the issue instead of inventing a capability ID.
 
-Repo: https://github.com/roballred/GovEA
+## Traceability Requirements
+
+Every implementation commit must include the capability ID and issue reference in the message body:
+
+```text
+Capability: <capability-id>
+Closes #<issue-number>
+```
+
+Every PR description must include:
+
+- `Closes #<issue-number>`
+- `Capability: <capability-id>` or `Capability group: <group>`
+- `Persona: <persona>`
+- What changed, why it changed, and how it was verified
+
+Use [`CLAUDE.md`](./CLAUDE.md) for the full required format. Traceability is part of the product governance model, not optional PR decoration.
+
+## Scope Discipline
+
+Keep each branch and PR focused on the issue being closed. Do not include opportunistic fixes, unrelated refactors, generated migrations, deployment topology, local environment files, or cleanup that belongs in a separate issue.
+
+Before opening a PR, verify the diff contains only intended files. If unexpected files appear, stop and remove them from the branch before pushing.


### PR DESCRIPTION
Closes #688
Capability: rm-end-to-end-traceability
Persona: Enterprise Architect (Central IT); Agency EA Coordinator; human maintainer/reviewer using AI-assisted contributions

## Summary

- Points Codex sessions at `CLAUDE.md`, `Standards.md`, and `docs/AI-SESSION-START.md` as authoritative required reading.
- Adds the required branch and PR hygiene rules directly to `AGENTS.md`.
- Summarizes pre-flight and traceability requirements so future Codex work includes issue, capability, persona, and acceptance criteria before implementation.
- Calls out the current `db:push` + `src/db/sql/*.sql` workflow and blocks committed `apps/govea/src/db/migrations/` drift.

## Verification

- Confirmed branch was created from current `origin/main`.
- Confirmed `origin/main...HEAD` changes only `AGENTS.md`.
- Confirmed no `apps/govea/src/db/migrations/` directory exists.
- Follow-up CI guard proposal opened separately as #689.