### PR TITLE
docs(capabilities): use ./ prefix on Integration capability link

### DIFF
--- a/capabilities.md
+++ b/capabilities.md
@@ -23,7 +23,7 @@ The **Scope** column shows whether a group is in v1 (current release) or v2 (def
 | 9 | [Data Architecture](#9-data-architecture) | v1 | Partially implemented |
 | 10 | [Framework Alignment](#10-framework-alignment) | v1 | Partially implemented |
 | 11 | [Deployment & Operations](#11-deployment--operations) | v1 | Partially implemented |
-| 12 | [Integration](business-architecture/capabilities/ea/integration/integration.md) | v2 | Not started — deferred to v2 (#10, #382) |
+| 12 | [Integration](./business-architecture/capabilities/ea/integration/integration.md) | v2 | Not started — deferred to v2 (#10, #382) |
 
 ---
 


### PR DESCRIPTION
Closes #692

## What changed

In `capabilities.md`, the **Integration** row (capability group 12) linked to its definition file without the leading `./` used everywhere else in the document:

```diff
-| 12 | [Integration](business-architecture/capabilities/ea/integration/integration.md) | ...
+| 12 | [Integration](./business-architecture/capabilities/ea/integration/integration.md) | ...
```

Every other relative file link in this doc uses the `./` prefix (e.g. the intro paragraph's `[business-architecture/capabilities/](./business-architecture/capabilities/)` on line 5). This one row was the exception.

## Why

Normalising to a `./`-prefixed relative path matches the document's own convention and resolves consistently across markdown renderers (some resolve bare relative paths differently depending on the base). The target file (`business-architecture/capabilities/ea/integration/integration.md`) exists and is unchanged — this is purely a link-formatting fix.

## How it was tested

- Verified the link target exists on disk.
- Confirmed no in-document `## 12` / Integration section anchor exists, so an external file link (rather than an anchor like rows 1–11) is the correct form here.
- Single-line, docs-only change; no code paths affected.

## Traceability

- **Closes:** #692
- **Capability:** `ac-framework-alignment` *(tentative — this row is part of the capability-group catalogue; please correct the mapping if another ID fits better)*

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
