### PR TITLE
ci(policy): guard against stale PR bases and committed migrations

### DIFF
--- a/.github/workflows/pr-policy-check.yml
+++ b/.github/workflows/pr-policy-check.yml
@@ -1,0 +1,71 @@
+name: PR policy check
+
+# Enforces two GovEA operating policies at PR time, complementing pr-base-check.yml
+# (which asserts the base branch is `main`). These guards exist because external
+# automation repeatedly opened PRs from a 150+-commit-stale branch that also
+# reintroduced committed Drizzle migrations — see #682 / #687 / #689, and the
+# database-workflow policy in CLAUDE.md (#683 / #686).
+#
+#   1. no-committed-migrations — the repo uses `db:push` + `src/db/sql/*.sql`
+#      (apply-triggers) in pre-production. Committed migration files under
+#      apps/govea/src/db/migrations/ are drift and must not land.
+#   2. fresh-base — fails a PR whose base is *egregiously* behind main. This is
+#      deliberately threshold-based (MAX_COMMITS_BEHIND), NOT "behind by ≥1",
+#      so a routine merge to main doesn't turn every open PR red. Strict
+#      "up to date before merge" belongs in branch protection, not here.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  no-committed-migrations:
+    name: No committed migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fail if the PR touches apps/govea/src/db/migrations/
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          offending=$(echo "$changed" | grep '^apps/govea/src/db/migrations/' || true)
+          if [ -n "$offending" ]; then
+            echo "::error::This PR adds or modifies committed migration files, which GovEA's pre-production workflow forbids."
+            echo "::error::Schema changes use 'db:push' + src/db/sql/*.sql (apply-triggers), not committed migrations. See CLAUDE.md / #683 / #686."
+            echo "Offending files:"
+            echo "$offending" | sed 's/^/  - /'
+            exit 1
+          fi
+          echo "No committed-migration files in this PR — ok."
+
+  fresh-base:
+    name: Base not stale
+    runs-on: ubuntu-latest
+    env:
+      # Fail only when a PR is behind main by MORE than this many commits.
+      # Tune here. Catches genuinely stale branches (e.g. the 169-commit
+      # Codex bundle in #687) without nagging normal, near-current PRs.
+      MAX_COMMITS_BEHIND: "25"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fail if the PR base is badly behind main
+        run: |
+          git fetch origin main --quiet
+          behind=$(git rev-list --count HEAD..origin/main)
+          echo "PR head is $behind commit(s) behind origin/main (threshold: $MAX_COMMITS_BEHIND)."
+          if [ "$behind" -gt "$MAX_COMMITS_BEHIND" ]; then
+            echo "::error::This PR's base is $behind commits behind main (max allowed: $MAX_COMMITS_BEHIND)."
+            echo "::error::Rebase onto current main, or recreate the branch from origin/main and re-apply the change."
+            exit 1
+          fi
+          echo "Base freshness ok."


### PR DESCRIPTION
Closes #689

## Summary

Adds `.github/workflows/pr-policy-check.yml` — two PR-time guards that make GovEA's operating policy enforceable in CI, complementing the existing `pr-base-check.yml` (base-must-be-main). This is the durable defense against the failure mode that recurred via an external Codex agent (#682, #687): PRs opened from a 150+-commit-stale branch that also reintroduced committed Drizzle migrations.

## The two checks

1. **No committed migrations** — fails any PR whose diff touches `apps/govea/src/db/migrations/`. Pre-production uses `db:push` + `src/db/sql/*.sql` (apply-triggers), not committed migrations (CLAUDE.md, #683/#686). Error message points at the policy and lists offending files.
2. **Base not stale** — fails any PR whose head is behind `main` by more than `MAX_COMMITS_BEHIND` (default **25**).

## Design note (intentional)

The issue's literal wording was "fails when behind main." A strict "behind by ≥1 → fail" would turn **every** open PR red the instant anyone merges to main — constant churn. So `fresh-base` is **threshold-based**: it catches genuinely stale branches (e.g. the 169-commit bundle in #687) without nagging near-current PRs. Strict "up to date before merge" is better handled by branch-protection settings; this guard is the early, visible signal. The threshold is a single documented env var, easy to tune.

Both jobs checkout the real PR **head sha** (not the merge ref), so the behind-count and diff reflect the branch itself rather than a synthetic merge commit.

## Verification

- YAML parses; both jobs present.
- This PR self-tests the guards: it's fresh off `main` (0 behind) and touches no migrations → both checks should pass here.
- Local `docs-lint` unaffected (no business-architecture docs changed).

## Follow-up (not in this PR)

These checks won't be **required** for merge until added to the branch-protection rule for `main` (repo-admin setting). Recommend adding `No committed migrations` and `Base not stale` (and the existing `base-is-main`) to required status checks.

## Traceability

Closes #689
Capability: rm-end-to-end-traceability

🤖 Generated with [Claude Code](https://claude.com/claude-code)