### PR TITLE
fix(import): auto-detect semicolon-delimited CSVs (closes #679)

### DIFF
--- a/apps/govea/src/actions/applications.ts
+++ b/apps/govea/src/actions/applications.ts
@@ -417,7 +417,11 @@ const VALID_LIFECYCLE = new Set(['active', 'sunset', 'decommissioned', 'planned'
 const VALID_STATUS = new Set(['draft', 'published', 'archived'])
 const VALID_VISIBILITY = new Set(['org', 'connections', 'instance'])
 
-function parseCsvLine(line: string): string[] {
+// NOTE: applications has its own line-based parser (no multi-line-cell support),
+// a pre-existing divergence from the shared `lib/csv.ts` tracked by #696. The
+// delimiter-detection below mirrors `lib/csv.ts` so the #679 semicolon bug is
+// fixed here too; consolidation onto the shared parser stays with #696.
+function parseCsvLine(line: string, delimiter: ',' | ';' = ','): string[] {
   const result: string[] = []
   let current = ''
   let inQuotes = false
@@ -426,7 +430,7 @@ function parseCsvLine(line: string): string[] {
     if (ch === '"') {
       if (inQuotes && line[i + 1] === '"') { current += '"'; i++ }
       else inQuotes = !inQuotes
-    } else if (ch === ',' && !inQuotes) {
+    } else if (ch === delimiter && !inQuotes) {
       result.push(current); current = ''
     } else {
       current += ch
@@ -439,11 +443,15 @@ function parseCsvLine(line: string): string[] {
 function parseCsv(text: string): Record<string, string>[] {
   const lines = text.trim().split(/\r?\n/)
   if (lines.length < 2) return []
-  const headers = parseCsvLine(lines[0]).map(h => h.trim())
+  // Sniff the delimiter from the header line (see #679 / lib/csv.ts).
+  const headerLine = lines[0]
+  const delimiter: ',' | ';' =
+    (headerLine.match(/;/g) || []).length > (headerLine.match(/,/g) || []).length ? ';' : ','
+  const headers = parseCsvLine(headerLine, delimiter).map(h => h.trim())
   return lines.slice(1)
     .filter(l => l.trim())
     .map(line => {
-      const values = parseCsvLine(line)
+      const values = parseCsvLine(line, delimiter)
       return Object.fromEntries(headers.map((h, i) => [h, (values[i] ?? '').trim()]))
     })
 }

--- a/apps/govea/src/lib/csv.ts
+++ b/apps/govea/src/lib/csv.ts
@@ -11,7 +11,29 @@ export function escapeCsv(val: string): string {
   return val
 }
 
-export function splitCsvRows(text: string): string[][] {
+/**
+ * Detects the field delimiter from the header line (#679). GovEA exports
+ * comma-delimited CSVs, but uses `;` *inside* multi-value fields (e.g. persona
+ * lists, via `splitSemicolonList`). Spreadsheets in many non-US locales
+ * (notably Excel across much of Europe) export `;`-delimited files instead;
+ * those previously imported as a single garbage column, failing every row with
+ * a misleading `missing required field "name"`.
+ *
+ * We sniff only the *header* line — which never contains multi-value list
+ * values — and choose whichever of `,` / `;` appears more often. This means a
+ * normal comma file with `;` inside data rows is unaffected (the header has
+ * commas, no semicolons), preserving the Export→Import round-trip, while a
+ * genuinely semicolon-delimited file is parsed correctly. Ties and the common
+ * case default to comma.
+ */
+export function detectDelimiter(text: string): ',' | ';' {
+  const header = text.split(/\r?\n/, 1)[0] ?? ''
+  const commas = (header.match(/,/g) || []).length
+  const semicolons = (header.match(/;/g) || []).length
+  return semicolons > commas ? ';' : ','
+}
+
+export function splitCsvRows(text: string, delimiter: ',' | ';' = ','): string[][] {
   const rows: string[][] = []
   let row: string[] = []
   let field = ''
@@ -21,7 +43,7 @@ export function splitCsvRows(text: string): string[][] {
     if (ch === '"') {
       if (inQuotes && text[i + 1] === '"') { field += '"'; i++ }
       else inQuotes = !inQuotes
-    } else if (ch === ',' && !inQuotes) {
+    } else if (ch === delimiter && !inQuotes) {
       row.push(field); field = ''
     } else if ((ch === '\n' || ch === '\r') && !inQuotes) {
       if (ch === '\r' && text[i + 1] === '\n') i++
@@ -40,7 +62,7 @@ export function splitCsvRows(text: string): string[][] {
 }
 
 export function parseCsv(text: string): Record<string, string>[] {
-  const rows = splitCsvRows(text)
+  const rows = splitCsvRows(text, detectDelimiter(text))
   if (rows.length < 2) return []
   const headers = rows[0].map(h => h.trim())
   return rows.slice(1).map(values =>

--- a/apps/govea/tests/unit/csv.test.ts
+++ b/apps/govea/tests/unit/csv.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for shared CSV helpers (#596, #604) — delimiter handling (#679).
+ *
+ * GovEA exports comma-delimited CSVs that use `;` *inside* multi-value fields.
+ * Non-US-locale spreadsheets export `;`-delimited files; those used to import
+ * as a single garbage column, failing every row with a misleading
+ * `missing required field "name"`. parseCsv now sniffs the header delimiter.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseCsv, detectDelimiter, splitCsvRows } from '@/lib/csv'
+
+describe('detectDelimiter (#679)', () => {
+  it('defaults to comma for a normal header', () => {
+    expect(detectDelimiter('name,description,status\n')).toBe(',')
+  })
+
+  it('detects semicolon when the header is semicolon-delimited', () => {
+    expect(detectDelimiter('name;description;status\n')).toBe(';')
+  })
+
+  it('stays comma when the header has only commas, even if data rows contain ";"', () => {
+    // Round-trip safety: a GovEA export puts ";" inside multi-value fields,
+    // but the header itself is comma-only.
+    const csv = 'name,personas\nPermit Issuance,"Clerk; Director"\n'
+    expect(detectDelimiter(csv)).toBe(',')
+  })
+
+  it('picks the majority delimiter for a mixed header', () => {
+    expect(detectDelimiter('name;description;full, legal name\n')).toBe(';')
+  })
+})
+
+describe('parseCsv delimiter handling (#679)', () => {
+  it('parses a comma-delimited file (unchanged behaviour)', () => {
+    const rows = parseCsv('name,description,status\nPermit Issuance,Issue permits,published\n')
+    expect(rows).toEqual([
+      { name: 'Permit Issuance', description: 'Issue permits', status: 'published' },
+    ])
+  })
+
+  it('parses a semicolon-delimited file instead of failing every row', () => {
+    const rows = parseCsv('name;description;status\nPermit Issuance;Issue permits;published\n')
+    expect(rows).toEqual([
+      { name: 'Permit Issuance', description: 'Issue permits', status: 'published' },
+    ])
+    // Regression guard: the whole line must NOT collapse into one "name" field.
+    expect(rows[0].name).toBe('Permit Issuance')
+    expect(rows[0].status).toBe('published')
+  })
+
+  it('preserves ";"-separated multi-value fields in a comma-delimited file', () => {
+    const rows = parseCsv('name,personas\nPermit Issuance,"Clerk; Director"\n')
+    expect(rows[0].personas).toBe('Clerk; Director')
+  })
+})
+
+describe('splitCsvRows delimiter param', () => {
+  it('still splits on comma by default', () => {
+    expect(splitCsvRows('a,b,c\n')).toEqual([['a', 'b', 'c']])
+  })
+
+  it('splits on semicolon when asked', () => {
+    expect(splitCsvRows('a;b;c\n', ';')).toEqual([['a', 'b', 'c']])
+  })
+})


### PR DESCRIPTION
Closes #679

## Summary

Semicolon-delimited CSVs — the normal export format from Excel in many non-US locales — imported as a single garbage column, so every row failed with a misleading `missing required field "name"` even though the data was fine. This sniffs the field delimiter from the header and parses accordingly.

## The fix (and why header-only sniffing)

GovEA exports **comma**-delimited CSVs but uses `;` *inside* multi-value fields (persona lists, via `splitSemicolonList`). A naive delimiter swap would break GovEA's own Export→Import round-trip. So detection looks **only at the header line**, which never contains multi-value list values:

- A normal comma header (with `;` only in data rows) → comma. Round-trip preserved.
- A genuinely `;`-delimited header → semicolon. Imports correctly.
- Whichever delimiter appears more in the header wins; ties/common case default to comma.

This implements the issue's Option 1 (auto-handle) rather than just Option 2 (clear error), because header-only sniffing removes the ambiguity the issue flagged — and it requires zero changes to the importers.

## Changes

- **`lib/csv.ts`** — `detectDelimiter()`; `splitCsvRows(text, delimiter)`; `parseCsv()` detects + passes it. Fixes the 5 importers on the shared parser (capabilities, initiatives, objectives, adrs, personas).
- **`actions/applications.ts`** — applications has its own line-based parser (a pre-existing divergence from the shared lib, tracked by **#696**). I mirrored the same header sniff there so the bug is fixed for applications too; full consolidation onto the shared parser stays with #696 (not bundled here).
- **`tests/unit/csv.test.ts`** — new regression coverage.

## Verification

- `vitest run tests/unit/csv.test.ts` → **9/9 pass** (semicolon parses; comma unchanged; `;`-in-data round-trip preserved; mixed/majority header)
- `tsc --noEmit` → clean
- `eslint` on changed files → clean

## Acceptance criteria (#679)

- [x] Semicolon-delimited CSV imports correctly (Option 1) instead of the misleading error
- [x] Comma-delimited files behave exactly as before (no regression) — covered by tests
- [x] Shared across the per-entity importers via `lib/csv.ts` (+ applications' own parser patched, with #696 noted for consolidation)
- [x] Regression test covering `;`-delimited input

## Traceability

Closes #679
Capability: ac-backup-export
Refs #596, #677, #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)