### PR TITLE
feat(iam): user_organization_memberships table + backfill (slice 1 of #693)

### DIFF
--- a/apps/govea/src/db/schema/users.ts
+++ b/apps/govea/src/db/schema/users.ts
@@ -1,4 +1,4 @@
-import { integer, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
+import { boolean, integer, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
 import { organizations } from './organizations'
 
 export const userRoleEnum = pgEnum('user_role', ['admin', 'contributor', 'viewer'])
@@ -61,3 +61,27 @@ export const verificationTokens = pgTable('verification_tokens', {
 
 export type User = typeof users.$inferSelect
 export type NewUser = typeof users.$inferInsert
+
+// #693 slice 1 (#703): membership model for users participating in more than
+// one organization. Behavior-neutral at introduction — nothing reads this yet;
+// auth resolution of the *active* org/role from memberships is slice 2.
+// `users.organization_id` / `users.role` remain the denormalized active/home
+// pointers (see docs/design/multi-org-membership.md). One row per (user, org),
+// one role per membership; revocation soft-deactivates (is_active=false) so the
+// historical row survives for audit.
+export const userOrganizationMemberships = pgTable('user_organization_memberships', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  role: userRoleEnum('role').notNull().default('viewer'),
+  isActive: boolean('is_active').notNull().default(true),
+  isPrimary: boolean('is_primary').notNull().default(false),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (table) => [
+  // One membership per user per organization.
+  uniqueIndex('user_org_membership_unique').on(table.userId, table.organizationId),
+])
+
+export type UserOrganizationMembership = typeof userOrganizationMemberships.$inferSelect
+export type NewUserOrganizationMembership = typeof userOrganizationMemberships.$inferInsert

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -31,7 +31,7 @@ import {
 } from './scale-fixtures'
 import { db } from '../client'
 import {
-  users, organizations,
+  users, organizations, userOrganizationMemberships,
   personas, personaTags, capabilities, applications,
   capabilityPersonas, applicationCapabilities, capabilityRelationships,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
@@ -2172,6 +2172,25 @@ async function seed() {
     await db.insert(instanceSettings).values({ disabledModules: {} })
   }
   console.log(`  ✓ instanceSettings: all ${MODULE_DEFS.length} modules enabled`)
+
+  // ── #693 slice 1 (#703): backfill user_organization_memberships ───────────
+  // Behavior-neutral — nothing reads memberships yet (auth resolution is slice
+  // 2). A single pass over every seeded user, across all orgs, so we don't have
+  // to touch each per-org user loop. One membership per user mirroring their
+  // current org/role, flagged primary. Idempotent via the (user_id,
+  // organization_id) unique index, so re-seeding is a no-op.
+  const allUsers = await db
+    .select({ id: users.id, organizationId: users.organizationId, role: users.role })
+    .from(users)
+  for (const u of allUsers) {
+    await db.insert(userOrganizationMemberships).values({
+      userId: u.id,
+      organizationId: u.organizationId,
+      role: u.role,
+      isPrimary: true,
+    }).onConflictDoNothing()
+  }
+  console.log(`  ✓ ${allUsers.length} user-organization memberships (backfilled, primary)`)
 
   console.log('\nSeed complete.')
   process.exit(0)

--- a/apps/govea/tests/integration/membership.test.ts
+++ b/apps/govea/tests/integration/membership.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Integration tests: user_organization_memberships (#693 slice 1 / #703)
+ *
+ * Slice 1 is behavior-neutral — nothing reads memberships yet (auth resolution
+ * is slice 2). These tests pin the membership model itself:
+ *   - one membership per (user, organization) — the unique guard
+ *   - the same user can hold memberships in different orgs (the whole point)
+ *   - role is per-membership (not per user row)
+ * See docs/design/multi-org-membership.md.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { createTestOrg, createTestUser, cleanupOrg } from './helpers/db'
+
+describe('user_organization_memberships (#693 slice 1)', () => {
+  let orgAId: string
+  let orgBId: string
+  let userId: string
+
+  beforeAll(async () => {
+    const orgA = await createTestOrg()
+    const orgB = await createTestOrg()
+    orgAId = orgA.id
+    orgBId = orgB.id
+    const user = await createTestUser(orgAId, 'admin')
+    userId = user.id
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgAId)
+    await cleanupOrg(orgBId)
+  })
+
+  it('accepts one membership per (user, organization)', async () => {
+    await db.insert(userOrganizationMemberships).values({
+      userId, organizationId: orgAId, role: 'admin', isPrimary: true,
+    })
+    const rows = await db.select().from(userOrganizationMemberships)
+      .where(and(eq(userOrganizationMemberships.userId, userId), eq(userOrganizationMemberships.organizationId, orgAId)))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].role).toBe('admin')
+    expect(rows[0].isPrimary).toBe(true)
+    expect(rows[0].isActive).toBe(true) // defaults to active
+  })
+
+  it('rejects a duplicate membership for the same (user, organization)', async () => {
+    await expect(db.insert(userOrganizationMemberships).values({
+      userId, organizationId: orgAId, role: 'viewer',
+    })).rejects.toThrow()
+  })
+
+  it('allows the same user to be a member of a different org, with a different role', async () => {
+    await db.insert(userOrganizationMemberships).values({
+      userId, organizationId: orgBId, role: 'viewer', isPrimary: false,
+    })
+    const rows = await db.select().from(userOrganizationMemberships)
+      .where(eq(userOrganizationMemberships.userId, userId))
+    expect(rows).toHaveLength(2)
+    const byOrg = Object.fromEntries(rows.map(r => [r.organizationId, r.role]))
+    expect(byOrg[orgAId]).toBe('admin')   // per-membership role
+    expect(byOrg[orgBId]).toBe('viewer')  // different role, same identity
+  })
+})


### PR DESCRIPTION
Closes #703 · Refs #693

## What

First, **behavior-neutral** slice of multi-org membership (#693), per `docs/design/multi-org-membership.md`. Adds the membership model and backfills it — but nothing reads it yet (auth resolution of the active org/role is slice 2).

| Piece | Detail |
|---|---|
| **Schema** (`users.ts`) | `user_organization_memberships` — `user_id`, `organization_id`, `role` (reuses `user_role` enum), `is_active`, `is_primary`, timestamps; unique `(user_id, organization_id)` |
| **Backfill** (`seeds/run.ts`) | One pass over *all* users (every org) → one primary membership each, mirroring current org/role; idempotent via the unique index |
| **Test** | uniqueness per `(user, org)`; same user in two orgs with distinct per-membership roles; `is_active`/`is_primary` defaults |

## Deliberately unchanged
`users.organization_id` / `users.role` stay as the denormalized active/home pointers — the insulation decision from the design doc. That's what lets the ~95+47 downstream session-readers keep working untouched, now and through slice 2.

## Out of scope (later slices of #693)
Auth resolution / session (slice 2) · org switcher (slice 3) · management UIs (slice 4) · removing the denormalized user columns.

## Verification
- `tsc --noEmit` clean; eslint clean on changed files.
- DB-backed: CI runs `db:push --force` + `db:apply-triggers` + the new integration test on fresh Postgres (authoritative — no local DB used).

## Acceptance criteria (#703)
- [x] `user_organization_memberships` with columns + unique `(user_id, organization_id)`
- [x] Seed backfills exactly one membership per user, mirroring org/role
- [x] Re-running the seed is a no-op (idempotent)
- [x] No existing behavior changes (no reads of the new table)
- [x] Integration test covers uniqueness + multi-org + per-membership role

Capability: iam-user-management

🤖 Generated with [Claude Code](https://claude.com/claude-code)