### PR TITLE
feat(iam): resolve active org/role from memberships in auth (slice 2 of #693)

### DIFF
--- a/apps/govea/src/lib/active-membership.ts
+++ b/apps/govea/src/lib/active-membership.ts
@@ -1,0 +1,49 @@
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import type { Role } from '@/lib/rbac'
+
+export interface ActiveContext {
+  organizationId: string
+  role: Role
+}
+
+/**
+ * Resolves a user's *active* organization context from their memberships.
+ *
+ * Slice 2 of #693 (see docs/design/multi-org-membership.md). With no org
+ * switcher yet (that's slice 3), the active org is the user's **primary** active
+ * membership, falling back to the oldest active membership for determinism.
+ * Returns `null` when the user has no active membership, in which case the
+ * caller falls back to the denormalized `users.organization_id` / `role`.
+ *
+ * This is the single server-side resolution point for "which org am I acting in
+ * right now" — the value that ends up in the JWT and session. Only `is_active`
+ * memberships are eligible; revoked (soft-deactivated) memberships never grant
+ * an active context.
+ */
+export async function resolveActiveMembership(userId: string): Promise<ActiveContext | null> {
+  const memberships = await db
+    .select({
+      organizationId: userOrganizationMemberships.organizationId,
+      role: userOrganizationMemberships.role,
+      isPrimary: userOrganizationMemberships.isPrimary,
+      createdAt: userOrganizationMemberships.createdAt,
+    })
+    .from(userOrganizationMemberships)
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.isActive, true),
+    ))
+
+  if (memberships.length === 0) return null
+
+  // Primary first; then oldest, so selection is deterministic when there is no
+  // primary (or — defensively — more than one).
+  const chosen = [...memberships].sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1
+    return a.createdAt.getTime() - b.createdAt.getTime()
+  })[0]
+
+  return { organizationId: chosen.organizationId, role: chosen.role as Role }
+}

--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -11,6 +11,7 @@ import type { Role } from '@/lib/rbac'
 import { authConfig } from '@/lib/auth.config'
 import { checkSsoProvisioning } from '@/lib/sso-guard'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
+import { resolveActiveMembership } from '@/lib/active-membership'
 
 // Identity model: users.email is globally unique across all organizations (#269).
 // Auth lookups by bare email (credentials provider, jwt callback) are therefore
@@ -143,9 +144,17 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const dbUser = await db.query.users.findFirst({
           where: eq(users.id, user.id!),
         })
+        // #693 slice 2 — the *active* org/role come from the user's membership
+        // (primary, then oldest active), with the denormalized users columns as
+        // a fallback when no membership exists. For today's single-membership
+        // users this resolves to exactly their backfilled primary membership,
+        // so the session is unchanged. Slice 3 adds switching the active org.
+        const active = await resolveActiveMembership(user.id!)
+        const activeOrgId = active?.organizationId ?? dbUser?.organizationId ?? null
+        const activeRole = active?.role ?? dbUser?.role ?? 'viewer'
         token.id = user.id
-        token.role = dbUser?.role ?? 'viewer'
-        token.organizationId = dbUser?.organizationId ?? null
+        token.role = activeRole
+        token.organizationId = activeOrgId
         token.instanceRole = (dbUser?.instanceRole as 'instance_admin' | null) ?? null
         token.checkedAt = Date.now()
         // #527 — record session-issued-at + last-password-changed-at so the
@@ -160,8 +169,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // a redirect decision. The middleware can't query the DB (edge
         // runtime / no `net`), so we mirror the policy into the token and
         // refresh it on the same 5-minute cadence as the active-user check.
-        if (dbUser?.organizationId) {
-          const policy = await getOrgSecuritySettings(dbUser.organizationId)
+        if (activeOrgId) {
+          const policy = await getOrgSecuritySettings(activeOrgId)
           token.sessionTimeoutMinutes = policy.sessionTimeoutMinutes
           token.passwordExpiryDays = policy.passwordExpiryDays
         }

--- a/apps/govea/tests/integration/active-membership.test.ts
+++ b/apps/govea/tests/integration/active-membership.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests: resolveActiveMembership (#693 slice 2 / #705)
+ *
+ * Pins the server-side resolution of a user's *active* org/role from
+ * user_organization_memberships — the value that flows into the JWT/session.
+ * Selection order: primary active → oldest active → null.
+ * See docs/design/multi-org-membership.md.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { resolveActiveMembership } from '@/lib/active-membership'
+import { createTestOrg, createTestUser, cleanupOrg } from './helpers/db'
+
+describe('resolveActiveMembership (#693 slice 2)', () => {
+  const orgIds: string[] = []
+
+  afterEach(async () => {
+    while (orgIds.length) await cleanupOrg(orgIds.pop()!)
+  })
+
+  async function org() {
+    const o = await createTestOrg()
+    orgIds.push(o.id)
+    return o.id
+  }
+
+  it('returns the primary active membership', async () => {
+    const a = await org(); const b = await org()
+    const user = await createTestUser(a, 'viewer')
+    await db.insert(userOrganizationMemberships).values([
+      { userId: user.id, organizationId: a, role: 'viewer', isPrimary: false },
+      { userId: user.id, organizationId: b, role: 'admin', isPrimary: true },
+    ])
+    const active = await resolveActiveMembership(user.id)
+    expect(active).toEqual({ organizationId: b, role: 'admin' })
+  })
+
+  it('falls back to the oldest active membership when none is primary', async () => {
+    const a = await org(); const b = await org()
+    const user = await createTestUser(a, 'viewer')
+    const older = new Date('2026-01-01T00:00:00Z')
+    const newer = new Date('2026-02-01T00:00:00Z')
+    await db.insert(userOrganizationMemberships).values([
+      { userId: user.id, organizationId: b, role: 'admin', isPrimary: false, createdAt: newer },
+      { userId: user.id, organizationId: a, role: 'contributor', isPrimary: false, createdAt: older },
+    ])
+    const active = await resolveActiveMembership(user.id)
+    expect(active).toEqual({ organizationId: a, role: 'contributor' })
+  })
+
+  it('ignores inactive memberships and returns null when none are active', async () => {
+    const a = await org()
+    const user = await createTestUser(a, 'admin')
+    await db.insert(userOrganizationMemberships).values({
+      userId: user.id, organizationId: a, role: 'admin', isPrimary: true, isActive: false,
+    })
+    const active = await resolveActiveMembership(user.id)
+    expect(active).toBeNull()
+  })
+
+  it('returns null when the user has no membership rows', async () => {
+    const a = await org()
+    const user = await createTestUser(a, 'admin')
+    const rows = await db.select().from(userOrganizationMemberships)
+      .where(eq(userOrganizationMemberships.userId, user.id))
+    expect(rows).toHaveLength(0)
+    expect(await resolveActiveMembership(user.id)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #705 · Refs #693

## What

Second slice of multi-org membership (#693), per `docs/design/multi-org-membership.md`. Makes `user_organization_memberships` **authoritative** for the session's active org/role — while staying **behavior-neutral** for today's single-membership users.

| Piece | Detail |
|---|---|
| **`lib/active-membership.ts`** | `resolveActiveMembership(userId)` → active org/role. Selection: **primary active → oldest active → null**. Only `is_active` memberships eligible. The single server-side "which org am I acting in" resolution point. |
| **`lib/auth.ts`** | JWT callback (initial sign-in) sets `token.organizationId`/`role` from the resolved membership, **falling back** to `users.organization_id`/`role`; security-policy snapshot now uses the **active** org. |
| **Test** | resolver: primary, multi-without-primary (oldest), inactive-only, no-membership. |

## Why it's behavior-neutral
Slice 1 backfilled one **primary** membership per user mirroring their org/role. So `resolveActiveMembership` returns exactly that → the session org/role are unchanged for every existing user. The fallback to the `users` columns covers any user without a membership row.

## Deliberately untouched
- The JWT **refresh branch** and the denormalized `users` columns (token.organizationId persists across refreshes; for slice 2 it equals the home org).
- No org switcher / last-selected persistence — that's **slice 3**, which is what makes the active org *change*.

## Verification
- `tsc --noEmit` clean; eslint clean on changed files.
- CI runs the resolver integration test on fresh Postgres (authoritative).

## Acceptance criteria (#705)
- [x] `resolveActiveMembership`: primary → oldest active → null
- [x] JWT callback uses it with fallback to `users` columns
- [x] Single-membership users get an identical session
- [x] Security-policy snapshot uses the active org
- [x] Integration test covers all resolver branches
- [x] Existing auth behavior unaffected (no auth-callback tests existed; behavior-neutral by construction)

Capability: iam-role-based-access-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)