### PR TITLE
feat(iam): active-org switch mechanism + last-selected resolution (slice 3a of #693)

### DIFF
--- a/apps/govea/src/actions/active-org.ts
+++ b/apps/govea/src/actions/active-org.ts
@@ -1,0 +1,52 @@
+'use server'
+
+import { db } from '@/db/client'
+import { users, userOrganizationMemberships } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { writeAuditLog } from '@/lib/audit'
+
+/**
+ * Switches the caller's active organization, persisting it as
+ * `users.last_active_organization_id`. #693 slice 3a.
+ *
+ * Server-authoritative: succeeds only if the caller has an *active* membership
+ * in the target org — the client's claim is never trusted. After this resolves,
+ * the client calls the NextAuth session `update()` so the JWT re-resolves the
+ * active org/role (see the `trigger === 'update'` branch in lib/auth.ts).
+ */
+export async function switchActiveOrganization(organizationId: string) {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const userId = session.user.id
+
+  const [membership] = await db
+    .select({ id: userOrganizationMemberships.id })
+    .from(userOrganizationMemberships)
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, organizationId),
+      eq(userOrganizationMemberships.isActive, true),
+    ))
+    .limit(1)
+
+  if (!membership) {
+    throw new Error('You are not an active member of that organization.')
+  }
+
+  const from = session.user.organizationId ?? null
+
+  await db.update(users)
+    .set({ lastActiveOrganizationId: organizationId, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+
+  await writeAuditLog(db, {
+    action: 'auth.switch_active_org',
+    entityType: 'user',
+    entityId: userId,
+    userId,
+    organizationId,
+    metadata: { from, to: organizationId },
+  })
+}

--- a/apps/govea/src/db/schema/users.ts
+++ b/apps/govea/src/db/schema/users.ts
@@ -6,6 +6,10 @@ export const userRoleEnum = pgEnum('user_role', ['admin', 'contributor', 'viewer
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  // #693 slice 3a: the user's last-selected active org, honored first by
+  // resolveActiveMembership when it's still an active membership. Nullable
+  // (most users never switch); `set null` so deleting an org doesn't orphan.
+  lastActiveOrganizationId: uuid('last_active_organization_id').references(() => organizations.id, { onDelete: 'set null' }),
   name: text('name'),
   email: text('email').notNull(),
   emailVerified: timestamp('email_verified'),

--- a/apps/govea/src/lib/active-membership.ts
+++ b/apps/govea/src/lib/active-membership.ts
@@ -11,18 +11,26 @@ export interface ActiveContext {
 /**
  * Resolves a user's *active* organization context from their memberships.
  *
- * Slice 2 of #693 (see docs/design/multi-org-membership.md). With no org
- * switcher yet (that's slice 3), the active org is the user's **primary** active
- * membership, falling back to the oldest active membership for determinism.
- * Returns `null` when the user has no active membership, in which case the
- * caller falls back to the denormalized `users.organization_id` / `role`.
+ * Slice 2/3a of #693 (see docs/design/multi-org-membership.md). This is the
+ * single server-side resolution point for "which org am I acting in right now" —
+ * the value that ends up in the JWT and session.
  *
- * This is the single server-side resolution point for "which org am I acting in
- * right now" — the value that ends up in the JWT and session. Only `is_active`
- * memberships are eligible; revoked (soft-deactivated) memberships never grant
- * an active context.
+ * Selection order (#693 Q2):
+ *   1. `preferredOrgId` (the user's last-selected org) — only if it is still an
+ *      active membership;
+ *   2. the **primary** active membership;
+ *   3. the oldest active membership (deterministic tie-break).
+ *
+ * Returns `null` when the user has no active membership, in which case the
+ * caller falls back to the denormalized `users.organization_id` / `role`. Only
+ * `is_active` memberships are eligible; revoked (soft-deactivated) memberships
+ * never grant an active context — so a stale last-selected pointing at a revoked
+ * membership is correctly ignored.
  */
-export async function resolveActiveMembership(userId: string): Promise<ActiveContext | null> {
+export async function resolveActiveMembership(
+  userId: string,
+  preferredOrgId?: string | null,
+): Promise<ActiveContext | null> {
   const memberships = await db
     .select({
       organizationId: userOrganizationMemberships.organizationId,
@@ -38,8 +46,14 @@ export async function resolveActiveMembership(userId: string): Promise<ActiveCon
 
   if (memberships.length === 0) return null
 
-  // Primary first; then oldest, so selection is deterministic when there is no
-  // primary (or — defensively — more than one).
+  // 1. Honor last-selected when it is still an active membership.
+  if (preferredOrgId) {
+    const preferred = memberships.find(m => m.organizationId === preferredOrgId)
+    if (preferred) return { organizationId: preferred.organizationId, role: preferred.role as Role }
+  }
+
+  // 2/3. Primary first; then oldest, so selection is deterministic when there is
+  // no primary (or — defensively — more than one).
   const chosen = [...memberships].sort((a, b) => {
     if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1
     return a.createdAt.getTime() - b.createdAt.getTime()

--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -133,7 +133,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
       return true
     },
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
       if (user) {
         // Initial sign-in — always fetch role and org from the DB regardless
         // of provider. The credentials provider returns these fields directly,
@@ -149,7 +149,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // a fallback when no membership exists. For today's single-membership
         // users this resolves to exactly their backfilled primary membership,
         // so the session is unchanged. Slice 3 adds switching the active org.
-        const active = await resolveActiveMembership(user.id!)
+        // #693 slice 3a — honor the user's last-selected org (if still an active
+        // membership) before primary/oldest.
+        const active = await resolveActiveMembership(user.id!, dbUser?.lastActiveOrganizationId)
         const activeOrgId = active?.organizationId ?? dbUser?.organizationId ?? null
         const activeRole = active?.role ?? dbUser?.role ?? 'viewer'
         token.id = user.id
@@ -175,6 +177,29 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token.passwordExpiryDays = policy.passwordExpiryDays
         }
       } else if (token.id) {
+        // #693 slice 3a — explicit active-org switch. The client calls the
+        // NextAuth session `update()` after switchActiveOrganization() has
+        // persisted the new last_active_organization_id; we re-resolve the
+        // active org/role (server-authoritative — we never trust a client-
+        // supplied org) and refresh the policy snapshot, then return early.
+        if (trigger === 'update') {
+          const dbUser = await db.query.users.findFirst({
+            where: eq(users.id, token.id as string),
+          })
+          if (dbUser) {
+            const active = await resolveActiveMembership(token.id as string, dbUser.lastActiveOrganizationId)
+            const activeOrgId = active?.organizationId ?? dbUser.organizationId ?? null
+            token.role = active?.role ?? dbUser.role ?? 'viewer'
+            token.organizationId = activeOrgId
+            if (activeOrgId) {
+              const policy = await getOrgSecuritySettings(activeOrgId)
+              token.sessionTimeoutMinutes = policy.sessionTimeoutMinutes
+              token.passwordExpiryDays = policy.passwordExpiryDays
+            }
+          }
+          return token
+        }
+
         // Subsequent requests — re-validate isActive every 5 minutes so that
         // deactivating a user takes effect without waiting for the 24h JWT to
         // expire. Returning null clears the session cookie and forces re-login.

--- a/apps/govea/tests/integration/active-membership.test.ts
+++ b/apps/govea/tests/integration/active-membership.test.ts
@@ -68,4 +68,27 @@ describe('resolveActiveMembership (#693 slice 2)', () => {
     expect(rows).toHaveLength(0)
     expect(await resolveActiveMembership(user.id)).toBeNull()
   })
+
+  // #693 slice 3a — last-selected (preferredOrgId) takes precedence.
+  it('honors a valid preferred org over the primary', async () => {
+    const a = await org(); const b = await org()
+    const user = await createTestUser(a, 'viewer')
+    await db.insert(userOrganizationMemberships).values([
+      { userId: user.id, organizationId: a, role: 'admin', isPrimary: true },
+      { userId: user.id, organizationId: b, role: 'contributor', isPrimary: false },
+    ])
+    const active = await resolveActiveMembership(user.id, b)
+    expect(active).toEqual({ organizationId: b, role: 'contributor' })
+  })
+
+  it('ignores a preferred org the user is no longer an active member of', async () => {
+    const a = await org(); const stale = await org()
+    const user = await createTestUser(a, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: user.id, organizationId: a, role: 'admin', isPrimary: true,
+    })
+    // preferred points at an org with no active membership → fall back to primary
+    const active = await resolveActiveMembership(user.id, stale)
+    expect(active).toEqual({ organizationId: a, role: 'admin' })
+  })
 })

--- a/apps/govea/tests/integration/active-org-switch.test.ts
+++ b/apps/govea/tests/integration/active-org-switch.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration tests: switchActiveOrganization (#693 slice 3a / #707)
+ *
+ * Server-authoritative active-org switch: persists last_active_organization_id
+ * only for an org where the caller has an active membership; rejects otherwise.
+ * See docs/design/multi-org-membership.md.
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { switchActiveOrganization } from '@/actions/active-org'
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { createTestOrg, createTestUser, cleanupOrg, makeSession, findUser, getAuditLogs } from './helpers/db'
+import type { TestOrg, TestUser } from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+let orgA: TestOrg
+let orgB: TestOrg
+let orgC: TestOrg
+let user: TestUser
+
+beforeEach(async () => {
+  orgA = await createTestOrg()
+  orgB = await createTestOrg()
+  orgC = await createTestOrg()
+  user = await createTestUser(orgA.id, 'admin')
+  // Active member of A (admin) and B (viewer); NOT a member of C.
+  await db.insert(userOrganizationMemberships).values([
+    { userId: user.id, organizationId: orgA.id, role: 'admin', isPrimary: true },
+    { userId: user.id, organizationId: orgB.id, role: 'viewer', isPrimary: false },
+  ])
+  mockAuth.mockResolvedValue(makeSession(user))
+})
+
+afterEach(async () => {
+  await cleanupOrg(orgA.id)
+  await cleanupOrg(orgB.id)
+  await cleanupOrg(orgC.id)
+})
+
+describe('switchActiveOrganization (#693 slice 3a)', () => {
+  it('persists last_active_organization_id for an org the user actively belongs to', async () => {
+    await switchActiveOrganization(orgB.id)
+    const updated = await findUser(user.id)
+    expect(updated?.lastActiveOrganizationId).toBe(orgB.id)
+
+    const audits = await getAuditLogs(orgB.id, 'auth.switch_active_org')
+    expect(audits.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('rejects switching to an org the user is not a member of', async () => {
+    await expect(switchActiveOrganization(orgC.id)).rejects.toThrow(/not an active member/i)
+    const updated = await findUser(user.id)
+    expect(updated?.lastActiveOrganizationId).toBeNull()
+  })
+
+  it('rejects switching to an org where the membership is inactive', async () => {
+    await db.insert(userOrganizationMemberships).values({
+      userId: user.id, organizationId: orgC.id, role: 'viewer', isActive: false,
+    })
+    await expect(switchActiveOrganization(orgC.id)).rejects.toThrow(/not an active member/i)
+    const updated = await findUser(user.id)
+    expect(updated?.lastActiveOrganizationId).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #707 · Refs #693

## What

Backend half of org switching (slice 3 of #693), per `docs/design/multi-org-membership.md`. Makes the active org **changeable and persisted**. The UI switcher control is **slice 3b** (separate PR — it needs runtime/E2E verification I can't do reliably here, so I'm not bundling unverifiable UI with this verifiable backend).

| Piece | Detail |
|---|---|
| **Schema** (`users.ts`) | `last_active_organization_id` (nullable FK → organizations, `on delete set null`) persists the chosen active org across sessions/devices |
| **Resolver** (`active-membership.ts`) | `resolveActiveMembership(userId, preferredOrgId?)` — selection: **last-selected (if still active) → primary → oldest active → null** |
| **`auth.ts`** | passes last-selected as preferred at sign-in; adds a JWT `update` trigger that re-resolves active org/role + policy snapshot |
| **Action** (`active-org.ts`) | `switchActiveOrganization(orgId)` — sets last-selected **only** for an org where the caller has an active membership; audits; rejects otherwise |

## Server-authoritative
The switch validates an active membership server-side and never trusts a client-supplied org. The JWT `update` trigger re-derives org/role from the DB. A stale last-selected pointing at a revoked membership is ignored by the resolver.

## Behavior-neutral for single-membership users
No preferred org set → resolution is unchanged (primary/backfilled membership). Existing sign-in untouched.

## Verification
- `tsc --noEmit` clean; eslint clean on all changed files.
- CI integration tests (fresh Postgres):
  - resolver: preferred honored; stale preferred ignored → fallback
  - switch: success persists + audits; rejects non-member; rejects inactive membership

## Acceptance criteria (#707)
- [x] Resolver honors valid preferred; ignores stale; falls back primary → oldest
- [x] `switchActiveOrganization` gated on active membership; rejects otherwise
- [x] JWT `update` trigger re-resolves active org/role + policy
- [x] Single-membership users unaffected
- [x] Audit event on switch
- [x] Integration tests for resolver + switch (success/both rejections)

## Next: slice 3b
The org switcher UI component (lists active memberships, calls `switchActiveOrganization` + NextAuth `update()`), shown when a user has >1 active membership.

Capability: iam-role-based-access-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)