### PR TITLE
feat(iam): org switcher UI (slice 3b of #693)

### DIFF
--- a/apps/govea/src/actions/active-org.ts
+++ b/apps/govea/src/actions/active-org.ts
@@ -1,11 +1,52 @@
 'use server'
 
 import { db } from '@/db/client'
-import { users, userOrganizationMemberships } from '@/db/schema'
+import { users, userOrganizationMemberships, organizations } from '@/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { writeAuditLog } from '@/lib/audit'
+import type { Role } from '@/lib/rbac'
+
+export interface MyOrganization {
+  organizationId: string
+  name: string
+  role: Role
+  isCurrent: boolean
+}
+
+/**
+ * Lists the caller's active organization memberships (with org name + the role
+ * they hold there), flagging the currently-active one. Drives the org switcher
+ * (#693 slice 3b). Returns [] for an unauthenticated caller.
+ */
+export async function getMyActiveOrganizations(): Promise<MyOrganization[]> {
+  const session = await auth()
+  if (!session?.user) return []
+  const currentOrgId = session.user.organizationId
+
+  const rows = await db
+    .select({
+      organizationId: userOrganizationMemberships.organizationId,
+      role: userOrganizationMemberships.role,
+      name: organizations.name,
+    })
+    .from(userOrganizationMemberships)
+    .innerJoin(organizations, eq(organizations.id, userOrganizationMemberships.organizationId))
+    .where(and(
+      eq(userOrganizationMemberships.userId, session.user.id),
+      eq(userOrganizationMemberships.isActive, true),
+    ))
+
+  return rows
+    .map(r => ({
+      organizationId: r.organizationId,
+      name: r.name,
+      role: r.role as Role,
+      isCurrent: r.organizationId === currentOrgId,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
 
 /**
  * Switches the caller's active organization, persisting it as

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -12,6 +12,8 @@ import { AppShell } from '@/components/app-shell'
 import { AdminNoticeBanner } from '@/components/admin-notice-banner'
 import { getCurrentModuleSettings } from '@/lib/get-enabled-modules'
 import { getMyUnreadCount } from '@/actions/notifications'
+import { getMyActiveOrganizations } from '@/actions/active-org'
+import { OrgSwitcher } from '@/components/org-switcher'
 
 const ROLE_BADGE_CLASS: Record<Role, string> = {
   admin: 'bg-violet-100 text-violet-800 border-violet-200',
@@ -29,6 +31,10 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   // layout level so the badge is up-to-date on every navigation; the
   // /notifications page itself revalidates this path after mark-read.
   const unreadNotificationCount = await getMyUnreadCount()
+
+  // #693 slice 3b — active-org switcher data. Component self-hides for
+  // single-membership users, so this is a no-op cost for the common case.
+  const myOrganizations = await getMyActiveOrganizations()
 
   // Load org settings (theme + enabled modules)
   let themeStyle = ''
@@ -73,6 +79,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       isInstanceAdmin={isInstanceAdmin(session.user)}
       enabledModules={enabledModules}
       unreadNotificationCount={unreadNotificationCount}
+      orgSwitcherSlot={<OrgSwitcher orgs={myOrganizations} />}
       signOutSlot={signOutSlot}
     >
       {session.user.organizationId && (

--- a/apps/govea/src/app/layout.tsx
+++ b/apps/govea/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { ActAsBanner } from '@/components/act-as-banner'
+import { Providers } from '@/components/providers'
 
 export const metadata: Metadata = {
   title: 'GovEA',
@@ -19,8 +20,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body>
-        <ActAsBanner />
-        {children}
+        <Providers>
+          <ActAsBanner />
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -360,6 +360,8 @@ interface AppShellProps {
   enabledModules: Record<string, boolean>
   /** Caller's unread notification count — drives the nav badge (#581). */
   unreadNotificationCount?: number
+  /** Org switcher (#693 slice 3b) — self-hides for single-membership users. */
+  orgSwitcherSlot?: ReactNode
   signOutSlot: ReactNode
   children: ReactNode
 }
@@ -372,6 +374,7 @@ export function AppShell({
   isInstanceAdmin,
   enabledModules,
   unreadNotificationCount,
+  orgSwitcherSlot,
   signOutSlot,
   children,
 }: AppShellProps) {
@@ -537,6 +540,7 @@ export function AppShell({
                 Platform Admin
               </Link>
             )}
+            {orgSwitcherSlot}
             <span className="hidden sm:block text-sm text-white/70">{email}</span>
             <span
               data-tour="role-badge"

--- a/apps/govea/src/components/org-switcher.tsx
+++ b/apps/govea/src/components/org-switcher.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useTransition, useRef, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { switchActiveOrganization, type MyOrganization } from '@/actions/active-org'
+import { cn } from '@/lib/utils'
+
+/**
+ * Active-organization switcher (#693 slice 3b). Renders only when the user has
+ * more than one active membership. Selecting an org persists it server-side
+ * (switchActiveOrganization), then fires the NextAuth session update() so the
+ * JWT re-resolves the active org/role (see the `update` trigger in lib/auth.ts),
+ * then refreshes the server components.
+ */
+export function OrgSwitcher({ orgs }: { orgs: MyOrganization[] }) {
+  const { update } = useSession()
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [])
+
+  // Single-membership users get no switcher — unchanged UX.
+  if (orgs.length < 2) return null
+
+  const current = orgs.find(o => o.isCurrent) ?? orgs[0]
+
+  function choose(orgId: string) {
+    if (orgId === current.organizationId) { setOpen(false); return }
+    startTransition(async () => {
+      await switchActiveOrganization(orgId)
+      // Pass data so NextAuth POSTs to /api/auth/session and fires the jwt
+      // `update` trigger (a bare update() only refetches via GET and won't
+      // re-resolve the active org). The server re-reads last_active from the DB;
+      // this payload is just the signal to run the trigger.
+      await update({ activeOrganizationId: orgId })
+      router.refresh()
+      setOpen(false)
+    })
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        disabled={pending}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-md border border-white/20 bg-white/10 px-2.5 py-1 text-xs font-medium text-white hover:bg-white/20 transition-colors disabled:opacity-60"
+        title="Switch active organization"
+      >
+        <span className="max-w-[10rem] truncate">{pending ? 'Switching…' : current.name}</span>
+        <svg className="h-3 w-3 opacity-70" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+        </svg>
+      </button>
+      {open && (
+        <ul
+          role="listbox"
+          className="absolute right-0 z-50 mt-1 max-h-72 w-56 overflow-auto rounded-md border border-slate-200 bg-white py-1 text-sm text-slate-900 shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+        >
+          {orgs.map(o => (
+            <li key={o.organizationId}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={o.isCurrent}
+                onClick={() => choose(o.organizationId)}
+                className={cn(
+                  'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-slate-100 dark:hover:bg-slate-700',
+                  o.isCurrent && 'font-semibold',
+                )}
+              >
+                <span className="truncate">{o.name}</span>
+                <span className="ml-2 shrink-0 text-xs text-slate-500 dark:text-slate-400">
+                  {o.isCurrent ? '✓ ' : ''}{o.role}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/components/providers.tsx
+++ b/apps/govea/src/components/providers.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+
+/**
+ * App-wide client providers. Adds NextAuth's SessionProvider so client
+ * components can call `useSession().update()` — required by the org switcher
+ * (#693 slice 3b) to fire the JWT `update` trigger after switching active org.
+ *
+ * The app is otherwise server-session only (`auth()`); this provider does not
+ * change how server components read the session.
+ */
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -2192,6 +2192,21 @@ async function seed() {
   }
   console.log(`  ✓ ${allUsers.length} user-organization memberships (backfilled, primary)`)
 
+  // #693 slice 3b demo — make one dev user multi-org so the org switcher is
+  // exercisable in dev: Alice (City of Riverdale admin) also joins the State
+  // org as a contributor. Idempotent.
+  const [alice] = await db.select({ id: users.id }).from(users).where(eq(users.email, 'alice@govea.dev')).limit(1)
+  const [stateOrg] = await db.select({ id: organizations.id }).from(organizations).where(eq(organizations.slug, 'office-of-digital-services')).limit(1)
+  if (alice && stateOrg) {
+    await db.insert(userOrganizationMemberships).values({
+      userId: alice.id,
+      organizationId: stateOrg.id,
+      role: 'contributor',
+      isPrimary: false,
+    }).onConflictDoNothing()
+    console.log('  ✓ demo multi-org membership: alice@govea.dev → Office of Digital Services (contributor)')
+  }
+
   console.log('\nSeed complete.')
   process.exit(0)
 }


### PR DESCRIPTION
Closes #709 · Refs #693

## What

UI half of org switching (slice 3 of #693). Backend (slice 3a, #707) merged. **Verified by running the app** (`/verify`).

| Piece | Detail |
|---|---|
| `providers.tsx` + root layout | app-wide NextAuth `SessionProvider` (the app had none) so the switcher can fire the JWT `update` trigger via `useSession()` |
| `actions/active-org.ts` | `getMyActiveOrganizations()` — active memberships with org name + role, current flagged |
| `components/org-switcher.tsx` | header dropdown; **self-hides for single-membership users**; on select → `switchActiveOrganization` → `update({...})` → `router.refresh()` |
| `app-shell.tsx` + `(admin)/layout.tsx` | mount the switcher slot in the header |
| seed | `alice@govea.dev` is now multi-org (admin @ City of Riverdale + contributor @ Office of Digital Services) so the switcher is exercisable in dev |

## Bug caught during verification
A bare `update()` only **refetches** the session via GET — it does **not** fire the jwt `update` trigger, so the active org never changed. Fix: pass a payload (`update({ activeOrganizationId })`) so NextAuth **POSTs** and runs the trigger (which re-reads `last_active` server-side). Caught only by running the app; would have shipped a no-op switcher otherwise.

## Verification (running app, screenshots in thread)
- ✅ Login as Alice → header shows **"City of Riverdale ▾"** switcher + `admin` badge
- ✅ Dropdown lists both orgs, current marked `✓ admin`, other `contributor`
- ✅ Select "Office of Digital Services" → header flips to **contributor**, dashboard re-scopes (Caps 13→3, Apps 8→2) — whole app, **no re-login**
- ✅ `/api/auth/session` confirms `role: contributor` after switch
- 🔍 Login as Victor (single membership, viewer) → **no switcher rendered**
- 🔍 SessionProvider adds `/api/auth/session` fetches app-wide; sign-in/out unaffected

## Acceptance criteria (#709)
- [x] Single-membership users see no switcher
- [x] 2+ memberships → switcher lists orgs, current indicated
- [x] Selecting an org switches active context immediately (org + role), no re-login
- [x] Server-authoritative (reuses `switchActiveOrganization`)
- [x] Verified by running the app

Capability: iam-role-based-access-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)