### PR TITLE
feat(iam): organization members management UI (slice 4b of #693)

### DIFF
--- a/apps/govea/src/actions/memberships.ts
+++ b/apps/govea/src/actions/memberships.ts
@@ -1,0 +1,186 @@
+'use server'
+
+import { db } from '@/db/client'
+import { users, userOrganizationMemberships } from '@/db/schema'
+import { and, count, eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { isAdmin, type Role } from '@/lib/rbac'
+import { writeAuditLog } from '@/lib/audit'
+import { redirect } from 'next/navigation'
+
+const MEMBERSHIP_ENTITY = 'user_organization_membership'
+
+async function requireAdmin() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!isAdmin(session.user)) throw new Error('Forbidden')
+  return session
+}
+
+/**
+ * Number of active **admin memberships** in an org — the per-org last-admin
+ * guard's basis (#693 slice 4a). This is the membership-level equivalent of the
+ * users.ts guard, which counted users.role; with multi-org, org admin coverage
+ * lives in memberships.
+ */
+async function activeAdminCount(orgId: string): Promise<number> {
+  const [row] = await db
+    .select({ c: count() })
+    .from(userOrganizationMemberships)
+    .where(and(
+      eq(userOrganizationMemberships.organizationId, orgId),
+      eq(userOrganizationMemberships.role, 'admin'),
+      eq(userOrganizationMemberships.isActive, true),
+    ))
+  return row?.c ?? 0
+}
+
+async function findMembership(userId: string, orgId: string) {
+  const [row] = await db
+    .select({
+      userId: userOrganizationMemberships.userId,
+      role: userOrganizationMemberships.role,
+      isActive: userOrganizationMemberships.isActive,
+    })
+    .from(userOrganizationMemberships)
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, orgId),
+    ))
+    .limit(1)
+  return row ?? null
+}
+
+export interface OrgMembershipRow {
+  userId: string
+  name: string | null
+  email: string
+  role: Role
+  isActive: boolean
+  isPrimary: boolean
+}
+
+/** Lists the active org's memberships (Admin only). */
+export async function getOrgMemberships(): Promise<OrgMembershipRow[]> {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const rows = await db
+    .select({
+      userId: userOrganizationMemberships.userId,
+      role: userOrganizationMemberships.role,
+      isActive: userOrganizationMemberships.isActive,
+      isPrimary: userOrganizationMemberships.isPrimary,
+      name: users.name,
+      email: users.email,
+    })
+    .from(userOrganizationMemberships)
+    .innerJoin(users, eq(users.id, userOrganizationMemberships.userId))
+    .where(eq(userOrganizationMemberships.organizationId, orgId))
+
+  return rows
+    .map(r => ({ ...r, role: r.role as Role }))
+    .sort((a, b) => (a.name ?? a.email).localeCompare(b.name ?? b.email))
+}
+
+/**
+ * Adds an existing identity as a member of the active org. If a (soft-
+ * deactivated) membership already exists it is reactivated and its role updated.
+ * Identity creation stays in createUser / the instance console.
+ */
+export async function addOrgMembership(email: string, role: Role) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const [user] = await db.select({ id: users.id }).from(users).where(eq(users.email, email.trim())).limit(1)
+  if (!user) throw new Error('No user with that email exists. Create the user first.')
+
+  const existing = await findMembership(user.id, orgId)
+
+  await db.transaction(async (tx) => {
+    if (existing) {
+      await tx.update(userOrganizationMemberships)
+        .set({ role, isActive: true, updatedAt: new Date() })
+        .where(and(
+          eq(userOrganizationMemberships.userId, user.id),
+          eq(userOrganizationMemberships.organizationId, orgId),
+        ))
+    } else {
+      await tx.insert(userOrganizationMemberships).values({
+        userId: user.id, organizationId: orgId, role, isActive: true,
+      })
+    }
+    await writeAuditLog(tx, {
+      action: existing ? 'membership.reactivate' : 'membership.add',
+      entityType: MEMBERSHIP_ENTITY,
+      entityId: user.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { email: email.trim(), role },
+    })
+  })
+}
+
+/** Changes a member's role in the active org. Guards the last active admin. */
+export async function updateOrgMembershipRole(userId: string, role: Role) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const before = await findMembership(userId, orgId)
+  if (!before) throw new Error('No membership for that user in this organization.')
+
+  if (before.role === 'admin' && role !== 'admin' && before.isActive) {
+    if (await activeAdminCount(orgId) <= 1) {
+      throw new Error('Cannot demote the last admin of this organization.')
+    }
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.update(userOrganizationMemberships)
+      .set({ role, updatedAt: new Date() })
+      .where(and(
+        eq(userOrganizationMemberships.userId, userId),
+        eq(userOrganizationMemberships.organizationId, orgId),
+      ))
+    await writeAuditLog(tx, {
+      action: 'membership.role_changed',
+      entityType: MEMBERSHIP_ENTITY,
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { role: before.role },
+      after: { role },
+    })
+  })
+}
+
+/** Deactivates (revokes) or reactivates a membership. Guards the last active admin on deactivate. */
+export async function setOrgMembershipActive(userId: string, active: boolean) {
+  const session = await requireAdmin()
+  const orgId = session.user.organizationId!
+
+  const before = await findMembership(userId, orgId)
+  if (!before) throw new Error('No membership for that user in this organization.')
+
+  if (!active && before.isActive && before.role === 'admin') {
+    if (await activeAdminCount(orgId) <= 1) {
+      throw new Error('Cannot remove the last admin of this organization.')
+    }
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.update(userOrganizationMemberships)
+      .set({ isActive: active, updatedAt: new Date() })
+      .where(and(
+        eq(userOrganizationMemberships.userId, userId),
+        eq(userOrganizationMemberships.organizationId, orgId),
+      ))
+    await writeAuditLog(tx, {
+      action: active ? 'membership.reactivate' : 'membership.deactivate',
+      entityType: MEMBERSHIP_ENTITY,
+      entityId: userId,
+      userId: session.user.id,
+      organizationId: orgId,
+    })
+  })
+}

--- a/apps/govea/src/app/(admin)/users/membership-table.tsx
+++ b/apps/govea/src/app/(admin)/users/membership-table.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  addOrgMembership, updateOrgMembershipRole, setOrgMembershipActive,
+  type OrgMembershipRow,
+} from '@/actions/memberships'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import type { Role } from '@/lib/rbac'
+
+const ROLE_STYLES: Record<string, string> = {
+  admin: 'bg-violet-100 text-violet-800 border-violet-200',
+  contributor: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  viewer: 'bg-slate-100 text-slate-700 border-slate-200',
+}
+
+const ROLES: Role[] = ['admin', 'contributor', 'viewer']
+
+interface Props {
+  members: OrgMembershipRow[]
+  currentUserId: string
+}
+
+/**
+ * #693 slice 4b — surfaces the org-scoped membership actions (slice 4a). Admins
+ * add an existing identity as a member of the active org, change a member's
+ * role, and revoke/restore membership. The last-admin guard is enforced
+ * server-side; here we also disable the controls for the sole active admin so
+ * the failure is visible before the click.
+ */
+export function MembershipTable({ members, currentUserId }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [addEmail, setAddEmail] = useState('')
+  const [addRole, setAddRole] = useState<Role>('viewer')
+
+  const activeAdmins = members.filter(m => m.role === 'admin' && m.isActive).length
+  const isLastAdmin = (m: OrgMembershipRow) => m.role === 'admin' && m.isActive && activeAdmins <= 1
+
+  function run(fn: () => Promise<void>) {
+    setError(null)
+    startTransition(async () => {
+      try {
+        await fn()
+        router.refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Something went wrong')
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold text-gray-900">Organization members</h2>
+      <p className="text-sm text-gray-500">
+        People with a membership in this organization. Add an existing user by email; changing the
+        active organization is done from the header switcher.
+      </p>
+
+      {/* Add member */}
+      <form
+        className="flex flex-wrap items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (!addEmail.trim()) return
+          run(async () => { await addOrgMembership(addEmail.trim(), addRole); setAddEmail('') })
+        }}
+      >
+        <div className="grid gap-1">
+          <Label htmlFor="add-member-email">Add member (email)</Label>
+          <Input
+            id="add-member-email"
+            type="email"
+            placeholder="person@example.gov"
+            value={addEmail}
+            onChange={(e) => setAddEmail(e.target.value)}
+            className="w-64"
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="add-member-role">Role</Label>
+          <select
+            id="add-member-role"
+            value={addRole}
+            onChange={(e) => setAddRole(e.target.value as Role)}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            {ROLES.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </div>
+        <Button type="submit" size="sm" disabled={isPending || !addEmail.trim()}>Add</Button>
+      </form>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600">{error}</p>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {members.map(m => {
+            const lastAdmin = isLastAdmin(m)
+            return (
+              <TableRow key={m.userId} className={cn(!m.isActive && 'opacity-60')}>
+                <TableCell>{m.name ?? '—'}{m.userId === currentUserId && ' (you)'}</TableCell>
+                <TableCell className="text-sm text-gray-600">{m.email}</TableCell>
+                <TableCell>
+                  <select
+                    aria-label={`Role for ${m.email}`}
+                    value={m.role}
+                    disabled={isPending || !m.isActive || lastAdmin}
+                    onChange={(e) => run(() => updateOrgMembershipRole(m.userId, e.target.value as Role))}
+                    className={cn(
+                      'rounded-md border px-2 py-0.5 text-xs font-medium disabled:cursor-not-allowed',
+                      ROLE_STYLES[m.role],
+                    )}
+                    title={lastAdmin ? 'Cannot demote the last admin' : undefined}
+                  >
+                    {ROLES.map(r => <option key={r} value={r}>{r}</option>)}
+                  </select>
+                </TableCell>
+                <TableCell className="text-sm">{m.isActive ? 'Active' : 'Revoked'}</TableCell>
+                <TableCell className="text-right">
+                  {m.isActive ? (
+                    <Button
+                      variant="ghost" size="sm" className="h-7 px-2 text-xs"
+                      disabled={isPending || lastAdmin}
+                      title={lastAdmin ? 'Cannot remove the last admin' : undefined}
+                      onClick={() => run(() => setOrgMembershipActive(m.userId, false))}
+                    >
+                      Revoke
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="ghost" size="sm" className="h-7 px-2 text-xs"
+                      disabled={isPending}
+                      onClick={() => run(() => setOrgMembershipActive(m.userId, true))}
+                    >
+                      Restore
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+          {members.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} className="text-center text-sm text-gray-500">No members yet.</TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/users/page.tsx
+++ b/apps/govea/src/app/(admin)/users/page.tsx
@@ -2,21 +2,26 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { isAdmin } from '@/lib/rbac'
 import { getUsers } from '@/actions/users'
+import { getOrgMemberships } from '@/actions/memberships'
 import { UserTable } from './user-table'
+import { MembershipTable } from './membership-table'
 
 export default async function UsersPage() {
   const session = await auth()
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) redirect('/dashboard')
 
-  const userList = await getUsers()
+  const [userList, members] = await Promise.all([getUsers(), getOrgMemberships()])
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+        </div>
+        <UserTable users={userList} currentUserId={session.user.id} />
       </div>
-      <UserTable users={userList} currentUserId={session.user.id} />
+      <MembershipTable members={members} currentUserId={session.user.id} />
     </div>
   )
 }

--- a/apps/govea/tests/integration/membership-management.test.ts
+++ b/apps/govea/tests/integration/membership-management.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration tests: org-scoped membership management (#693 slice 4a / #711)
+ *
+ * Admin-only management of user_organization_memberships for the active org,
+ * with a per-org last-admin guard and audit. See docs/design/multi-org-membership.md.
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  getOrgMemberships, addOrgMembership, updateOrgMembershipRole, setOrgMembershipActive,
+} from '@/actions/memberships'
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { createTestOrg, createTestUser, cleanupOrg, makeSession, getAuditLogs } from './helpers/db'
+import type { TestOrg, TestUser } from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+let org: TestOrg
+let admin: TestUser
+
+async function membership(userId: string) {
+  const [m] = await db.select().from(userOrganizationMemberships)
+    .where(and(eq(userOrganizationMemberships.userId, userId), eq(userOrganizationMemberships.organizationId, org.id)))
+  return m
+}
+
+beforeEach(async () => {
+  org = await createTestOrg()
+  admin = await createTestUser(org.id, 'admin')
+  // The actor's own admin membership in the active org.
+  await db.insert(userOrganizationMemberships).values({
+    userId: admin.id, organizationId: org.id, role: 'admin', isPrimary: true,
+  })
+  mockAuth.mockResolvedValue(makeSession(admin))
+})
+
+afterEach(async () => {
+  await cleanupOrg(org.id)
+})
+
+describe('membership management (#693 slice 4a)', () => {
+  it('lists the active org memberships', async () => {
+    const rows = await getOrgMemberships()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ userId: admin.id, role: 'admin', isActive: true })
+  })
+
+  it('adds an existing user as a member and audits it', async () => {
+    const bob = await createTestUser(org.id, 'viewer')
+    await addOrgMembership(bob.email, 'contributor')
+    expect(await membership(bob.id)).toMatchObject({ role: 'contributor', isActive: true })
+    expect((await getAuditLogs(org.id, 'membership.add')).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('rejects adding an unknown email', async () => {
+    await expect(addOrgMembership('nobody@nowhere.example', 'viewer'))
+      .rejects.toThrow(/no user with that email/i)
+  })
+
+  it('reactivates a soft-deactivated membership instead of duplicating', async () => {
+    const bob = await createTestUser(org.id, 'viewer')
+    await addOrgMembership(bob.email, 'viewer')
+    await setOrgMembershipActive(bob.id, false)
+    expect((await membership(bob.id)).isActive).toBe(false)
+    await addOrgMembership(bob.email, 'admin')
+    const m = await membership(bob.id)
+    expect(m).toMatchObject({ role: 'admin', isActive: true })
+    // still exactly one row for (bob, org)
+    const all = await db.select().from(userOrganizationMemberships)
+      .where(and(eq(userOrganizationMemberships.userId, bob.id), eq(userOrganizationMemberships.organizationId, org.id)))
+    expect(all).toHaveLength(1)
+  })
+
+  it('changes a member role', async () => {
+    const bob = await createTestUser(org.id, 'viewer')
+    await addOrgMembership(bob.email, 'viewer')
+    await updateOrgMembershipRole(bob.id, 'contributor')
+    expect((await membership(bob.id)).role).toBe('contributor')
+  })
+
+  it('last-admin guard: refuses to demote the only active admin', async () => {
+    await expect(updateOrgMembershipRole(admin.id, 'viewer'))
+      .rejects.toThrow(/last admin/i)
+    expect((await membership(admin.id)).role).toBe('admin') // unchanged
+  })
+
+  it('last-admin guard: refuses to deactivate the only active admin', async () => {
+    await expect(setOrgMembershipActive(admin.id, false))
+      .rejects.toThrow(/last admin/i)
+    expect((await membership(admin.id)).isActive).toBe(true) // unchanged
+  })
+
+  it('allows demoting an admin once a second admin exists', async () => {
+    const bob = await createTestUser(org.id, 'viewer')
+    await addOrgMembership(bob.email, 'admin') // now two active admins
+    await updateOrgMembershipRole(admin.id, 'contributor') // permitted
+    expect((await membership(admin.id)).role).toBe('contributor')
+  })
+})


### PR DESCRIPTION
Closes #714 · Refs #693

> **Stacks on #712 (slice 4a).** This branch is based on the 4a branch, so until #712 merges the diff here also shows 4a's `memberships.ts` + its test. Merge #712 first; this PR's diff then resolves to 4b only.

## What

UI for slice 4 of #693 — surfaces the slice-4a membership actions in the `/users` admin page. **Verified by running the app** (`/verify`).

- `(admin)/users/membership-table.tsx` — an **"Organization members"** section: list the active org's memberships, **add an existing identity by email**, change a member's **role**, and **revoke/restore**. Action errors (unknown email, last-admin guard) surface inline. The sole active admin's role select + Revoke are disabled client-side; the server guard stays authoritative.
- `(admin)/users/page.tsx` — loads `getOrgMemberships()` alongside `getUsers()`, renders the members section below the existing Users table. **Additive** — existing user CRUD untouched.

## Verification (running app, screenshots in thread)
- ✅ Members section lists Riverdale's memberships (alice/carol/victor)
- ✅ **Last-admin guard in UI**: sole admin Alice has role select + Revoke **disabled**; promoting Carol to admin **re-enables** Alice's controls (guard recomputes)
- ✅ Role change persists (Carol contributor→admin)
- 🔍 Add unknown email → inline error *"No user with that email exists…"*
- ✅ Cross-org add: `sam@state.govea.dev` (home = State org) added as Riverdale member
- ✅ Revoke → status **Revoked** + Restore button; Restore → **Active**

## Acceptance criteria (#713)
- [x] Org members listed in `/users`
- [x] Add existing identity by email (+ unknown-email error)
- [x] Change role (last-admin guard enforced + reflected in UI)
- [x] Revoke / restore membership
- [x] Verified by running the app

Capability: iam-role-based-access-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)
