### PR TITLE
feat(taxonomy): value-chain capability taxonomy — v1 of #694

### DIFF
--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -814,6 +814,60 @@ async function seed() {
   }).onConflictDoNothing()
   console.log('  ✓ Capability Priority taxonomy type + entity definition')
 
+  // Value Chain taxonomy + entity definition (#694). v1 of value chains is a
+  // capabilities-only, taxonomy-backed grouping — the recognized gov reference-
+  // architecture pattern (value chain → capabilities), reversible and built on
+  // the existing entity-taxonomy mechanism, not a new entity. See
+  // docs/design/value-chains.md.
+  let valueChainTermId: string
+  const existingValueChain = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and, isNull }) =>
+      and(e(t.organizationId, devOrgId), isNull(t.parentId), e(t.slug, 'value-chain')),
+  })
+  if (existingValueChain) {
+    valueChainTermId = existingValueChain.id
+  } else {
+    const [inserted] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId,
+      name: 'Value Chain',
+      slug: 'value-chain',
+      description: 'The end-to-end public-value stream a capability contributes to — the top-level grouping of the capability map.',
+      sortOrder: '70',
+    }).returning()
+    valueChainTermId = inserted.id
+  }
+  const VALUE_CHAIN_VALUES = [
+    'Public Safety & Justice',
+    'Health & Human Services',
+    'Infrastructure & Environment',
+    'Economic & Community Development',
+    'Administration & Support',
+  ]
+  for (const name of VALUE_CHAIN_VALUES) {
+    const slug = toSlug(name)
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and }) =>
+        and(e(t.organizationId, devOrgId), e(t.parentId, valueChainTermId), e(t.slug, slug)),
+    })
+    if (!existing) {
+      await db.insert(taxonomyTerms).values({
+        organizationId: devOrgId,
+        parentId: valueChainTermId,
+        name,
+        slug,
+      })
+    }
+  }
+  await db.insert(entityTaxonomyDefinitions).values({
+    organizationId: devOrgId,
+    entityType: 'capability',
+    taxonomyTypeId: valueChainTermId,
+    selectionMode: 'single',
+    required: false,
+    sortOrder: 1,
+  }).onConflictDoNothing()
+  console.log('  ✓ Value Chain taxonomy type + entity definition')
+
   // Objective Category taxonomy + entity definition
   let objCategoryTermId: string
   const existingObjCategory = await db.query.taxonomyTerms.findFirst({

--- a/docs/design/value-chains.md
+++ b/docs/design/value-chains.md
@@ -1,6 +1,6 @@
 # Design: Value Chains in GovEA
 
-**Status:** Proposed — design decision for ARB; no implementation
+**Status:** Accepted — v1 spine shipped (capability value-chain taxonomy); read view + richer scope still gated on #668
 **Issue:** [#694](https://github.com/roballred/GovEA/issues/694)
 **Capabilities:** `po-value-streams`, `fd-traceability-views`, `rm-end-to-end-traceability`
 **Personas:** Enterprise Architect (Central IT), Agency EA Coordinator, Department Director
@@ -12,7 +12,9 @@
 
 #694 asks us to decide **whether "Value Chain" should be a distinct content type, a curated view over existing records, or a taxonomy-backed grouping** — without duplicating value-stream authoring or adding a diagramming burden. This doc makes the product distinction, evaluates the three options against GovEA's existing model and the market evidence, recommends one, and lists the inputs that gate finalizing it.
 
-> **Bottom line:** Recommend **Option C (taxonomy-backed grouping) as the spine + Option B (curated read view) as the presentation** — *not* a new staged-authoring entity. A value chain becomes a lightweight named grouping that capabilities (and optionally value streams/services) belong to, rendered as a read-oriented traceability view that composes records GovEA already links. This matches how government reference architectures actually model value chains (top-level grouping of capabilities), reuses the exact capabilities tagged on this issue, and keeps the concept people-centered. **Gate the build on #668 validation.**
+> **Bottom line:** Recommend **Option C (taxonomy-backed grouping) as the spine + Option B (curated read view) as the presentation** — *not* a new staged-authoring entity. A value chain becomes a lightweight named grouping that capabilities (and optionally value streams/services) belong to, rendered as a read-oriented traceability view that composes records GovEA already links. This matches how government reference architectures actually model value chains (top-level grouping of capabilities), reuses the exact capabilities tagged on this issue, and keeps the concept people-centered. **Gate the *richer* build on #668 validation.**
+
+> **Decision update (owner-directed):** Proceed now with the **Option C spine, capabilities-only** — a "Value Chain" taxonomy on the `capability` entity, exactly like the existing Domain / Capability Priority taxonomies. It needs no new code (the entity-taxonomy mechanism already supports it) and is trivially reversible, so it doesn't wait on #668. **Shipped:** seeded "Value Chain" taxonomy type + `entity_taxonomy_definition` for capabilities (`db/seeds/run.ts`). **Still gated on #668:** the curated read view (Option B), value-stream/service membership, and any first-class-entity upgrade (§6 deferred list).
 
 ---
 


### PR DESCRIPTION
Refs #694 (ships the v1 spine; broader scope stays on the issue)

## What

The **Option C spine** from `docs/design/value-chains.md`, **capabilities-only**, per owner direction: a "Value Chain" taxonomy on the `capability` entity — the recognized government reference-architecture pattern (value chain → capabilities). Built on the existing entity-taxonomy mechanism, so it's **no new entity/schema and trivially reversible** — which is why it proceeds now rather than waiting on #668.

- **seed (`run.ts`)** — "Value Chain" taxonomy type + five public-sector value chains (Public Safety & Justice; Health & Human Services; Infrastructure & Environment; Economic & Community Development; Administration & Support) + an `entity_taxonomy_definition` binding it to `capability` (single-select, optional). Mirrors the existing Capability Priority taxonomy; idempotent.
- **`docs/design/value-chains.md`** — status → **Accepted (v1 spine shipped)**; records the owner-directed decision to proceed with capabilities-only now, with the curated read view (Option B), value-stream/service membership, and any first-class-entity upgrade **still gated on #668**.

## Why no app code
Value-chain assignments render on capability forms/filters and round-trip through capability CSV export **for free** (the entity-taxonomy system + taxonomy-aware export already handle it). Admins edit/extend the values via Taxonomy management. So v1 is purely seed + decision record.

## Verification
- `tsc --noEmit` clean; eslint clean (one pre-existing unrelated warning).
- Ran `db:seed` locally against Postgres → `✓ Value Chain taxonomy type + entity definition`, seed completes. CI re-runs `db:push` + seed on fresh Postgres.

## Scope / what's deferred (on #694, gated on #668)
Curated value-chain read view (outcome → streams → capabilities → apps); value-stream/service membership; gap/risk scoring; any first-class Value Chain entity + many-to-many membership.

Capability: po-value-streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)