### PR TITLE
feat(recipe): framework-agnostic recipe-install engine core (S1a of #671)

### DIFF
--- a/apps/govea/src/db/schema/taxonomy.ts
+++ b/apps/govea/src/db/schema/taxonomy.ts
@@ -9,6 +9,12 @@ export const taxonomyTerms = pgTable('taxonomy_terms', {
   slug: text('slug').notNull(),
   description: text('description'),
   domain: text('domain'), // top-level domain grouping
+  // #671 — audience marker on taxonomy *types*. 'framework' types (e.g. an
+  // installed TOGAF domain scheme) are hidden from viewer-role users and
+  // stakeholder reports by default, preserving ADR-0001 jargon-hiding without a
+  // module toggle. null = general (visible to everyone). General feature, not
+  // framework-specific.
+  audience: text('audience'),
   sortOrder: text('sort_order'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/apps/govea/src/lib/recipes/install.ts
+++ b/apps/govea/src/lib/recipes/install.ts
@@ -1,0 +1,150 @@
+import { db } from '@/db/client'
+import { taxonomyTerms, entityTaxonomyDefinitions, glossaryTerms, principles } from '@/db/schema'
+import { and, eq, isNull } from 'drizzle-orm'
+import { writeAuditLog } from '@/lib/audit'
+import type { Recipe, InstallResult } from './types'
+
+/**
+ * Installs a recipe into an org, **idempotently** (#671). Re-running adds
+ * nothing duplicate and updates curated fields in place. Everything happens in
+ * one transaction. The engine is framework-agnostic — it only knows how to
+ * upsert the generic content types a recipe carries.
+ *
+ * Keys (matching the existing seed pattern, since taxonomy uniqueness is
+ * enforced by an apply-triggers index rather than a schema constraint):
+ *   - taxonomy type:  (org, parentId=null, slug)
+ *   - taxonomy term:  (org, parentId=typeId, slug)
+ *   - binding:        (org, entityType, taxonomyTypeId)  [etd_org_entity_type_uniq]
+ *   - glossary term:  (org, term)
+ *   - principle:      (org, name)
+ *
+ * Installed glossary/principles are created `published` — a recipe is curated
+ * starter content meant to be usable immediately (admins can unpublish/edit).
+ */
+export async function installRecipe(
+  orgId: string,
+  recipe: Recipe,
+  actorUserId?: string | null,
+): Promise<InstallResult> {
+  const result: InstallResult = {
+    taxonomyTypes: 0, taxonomyTerms: 0, bindings: 0, glossaryTerms: 0, principles: 0,
+  }
+
+  await db.transaction(async (tx) => {
+    for (const type of recipe.taxonomyTypes ?? []) {
+      // Upsert the type (a parent term with parentId = null).
+      const [existingType] = await tx
+        .select({ id: taxonomyTerms.id })
+        .from(taxonomyTerms)
+        .where(and(
+          eq(taxonomyTerms.organizationId, orgId),
+          isNull(taxonomyTerms.parentId),
+          eq(taxonomyTerms.slug, type.slug),
+        ))
+        .limit(1)
+
+      let typeId: string
+      if (existingType) {
+        typeId = existingType.id
+        await tx.update(taxonomyTerms)
+          .set({ name: type.name, description: type.description ?? null, audience: type.audience ?? null, updatedAt: new Date() })
+          .where(eq(taxonomyTerms.id, typeId))
+      } else {
+        const [ins] = await tx.insert(taxonomyTerms).values({
+          organizationId: orgId, parentId: null, name: type.name, slug: type.slug,
+          description: type.description ?? null, audience: type.audience ?? null,
+        }).returning({ id: taxonomyTerms.id })
+        typeId = ins.id
+        result.taxonomyTypes++
+      }
+
+      // Upsert each term under the type.
+      for (const term of type.terms ?? []) {
+        const [existingTerm] = await tx
+          .select({ id: taxonomyTerms.id })
+          .from(taxonomyTerms)
+          .where(and(
+            eq(taxonomyTerms.organizationId, orgId),
+            eq(taxonomyTerms.parentId, typeId),
+            eq(taxonomyTerms.slug, term.slug),
+          ))
+          .limit(1)
+        if (existingTerm) {
+          await tx.update(taxonomyTerms)
+            .set({ name: term.name, description: term.description ?? null, updatedAt: new Date() })
+            .where(eq(taxonomyTerms.id, existingTerm.id))
+        } else {
+          await tx.insert(taxonomyTerms).values({
+            organizationId: orgId, parentId: typeId, name: term.name, slug: term.slug,
+            description: term.description ?? null,
+          })
+          result.taxonomyTerms++
+        }
+      }
+
+      // Bind the type to entity types (idempotent via etd_org_entity_type_uniq).
+      for (const b of type.bindings ?? []) {
+        const before = await tx
+          .select({ id: entityTaxonomyDefinitions.id })
+          .from(entityTaxonomyDefinitions)
+          .where(and(
+            eq(entityTaxonomyDefinitions.organizationId, orgId),
+            eq(entityTaxonomyDefinitions.entityType, b.entityType),
+            eq(entityTaxonomyDefinitions.taxonomyTypeId, typeId),
+          ))
+          .limit(1)
+        await tx.insert(entityTaxonomyDefinitions).values({
+          organizationId: orgId, entityType: b.entityType, taxonomyTypeId: typeId,
+          selectionMode: b.selectionMode ?? 'single', required: b.required ?? false, sortOrder: 0,
+        }).onConflictDoNothing()
+        if (before.length === 0) result.bindings++
+      }
+    }
+
+    // Glossary terms — keyed by (org, term).
+    for (const g of recipe.glossaryTerms ?? []) {
+      const [ex] = await tx.select({ id: glossaryTerms.id }).from(glossaryTerms)
+        .where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.term, g.term))).limit(1)
+      if (ex) {
+        await tx.update(glossaryTerms)
+          .set({ definition: g.definition, domain: g.domain ?? null, updatedAt: new Date() })
+          .where(eq(glossaryTerms.id, ex.id))
+      } else {
+        await tx.insert(glossaryTerms).values({
+          organizationId: orgId, term: g.term, definition: g.definition, domain: g.domain ?? null,
+          status: 'published', visibility: 'org', createdBy: actorUserId ?? null, updatedBy: actorUserId ?? null,
+        })
+        result.glossaryTerms++
+      }
+    }
+
+    // Principles — keyed by (org, name).
+    for (const p of recipe.principles ?? []) {
+      const [ex] = await tx.select({ id: principles.id }).from(principles)
+        .where(and(eq(principles.organizationId, orgId), eq(principles.name, p.name))).limit(1)
+      const fields = {
+        title: p.title ?? null, description: p.description ?? null, rationale: p.rationale ?? null,
+        implications: p.implications ?? null, principleType: p.principleType ?? 'architecture',
+      }
+      if (ex) {
+        await tx.update(principles).set({ ...fields, updatedAt: new Date() }).where(eq(principles.id, ex.id))
+      } else {
+        await tx.insert(principles).values({
+          organizationId: orgId, name: p.name, ...fields,
+          status: 'published', visibility: 'org', createdBy: actorUserId ?? null, updatedBy: actorUserId ?? null,
+        })
+        result.principles++
+      }
+    }
+
+    await writeAuditLog(tx, {
+      action: 'recipe.install',
+      entityType: 'recipe',
+      userId: actorUserId ?? null,
+      organizationId: orgId,
+      after: { recipe: recipe.slug, version: recipe.version, ...result },
+    })
+  })
+
+  return result
+}

--- a/apps/govea/src/lib/recipes/types.ts
+++ b/apps/govea/src/lib/recipes/types.ts
@@ -1,0 +1,71 @@
+// Recipe-install engine types (#671 / #665 S1).
+//
+// A *recipe* is a curated, framework-agnostic bundle of configuration + starter
+// content that an admin installs into their org. The engine (install.ts) knows
+// nothing about TOGAF or any specific framework — TOGAF is just recipe #1,
+// defined as data (S2). See docs/design/togaf-recipe-reconciliation.md §9–§10.
+
+export interface RecipeTaxonomyTerm {
+  name: string
+  slug: string
+  description?: string
+}
+
+export interface RecipeTaxonomyBinding {
+  /** Entity type the taxonomy applies to, e.g. 'capability', 'application'. */
+  entityType: string
+  selectionMode?: 'single' | 'multi'
+  required?: boolean
+}
+
+export interface RecipeTaxonomyType {
+  name: string
+  /** Stable machine key; the install upserts by (org, parentId=null, slug). */
+  slug: string
+  description?: string
+  /**
+   * 'framework' marks a jargon-bearing type to hide from viewer-role users and
+   * stakeholder reports (ADR-0001). Omit / null for general types.
+   */
+  audience?: 'framework' | null
+  terms?: RecipeTaxonomyTerm[]
+  /** Bind this type to entity types (the entity_taxonomy_definitions rows). */
+  bindings?: RecipeTaxonomyBinding[]
+}
+
+export interface RecipeGlossaryTerm {
+  term: string
+  definition: string
+  domain?: string
+}
+
+export interface RecipePrinciple {
+  name: string
+  title?: string
+  description?: string
+  rationale?: string
+  implications?: string
+  /** Slug of the principle-type taxonomy term; defaults to 'architecture'. */
+  principleType?: string
+}
+
+export interface Recipe {
+  /** Stable identifier, e.g. 'togaf'. */
+  slug: string
+  name: string
+  version: string
+  description?: string
+  taxonomyTypes?: RecipeTaxonomyType[]
+  glossaryTerms?: RecipeGlossaryTerm[]
+  principles?: RecipePrinciple[]
+  // Report presets are deferred until the report engine (S3 / #673) exists.
+}
+
+/** Counts of rows newly created by an install (updates-in-place are not counted). */
+export interface InstallResult {
+  taxonomyTypes: number
+  taxonomyTerms: number
+  bindings: number
+  glossaryTerms: number
+  principles: number
+}

--- a/apps/govea/tests/integration/recipe-install.test.ts
+++ b/apps/govea/tests/integration/recipe-install.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration tests: recipe-install engine (#671 / #665 S1)
+ *
+ * Pins the framework-agnostic engine: idempotent upsert of taxonomy
+ * types/terms/bindings + glossary + principles, and the `audience` marker.
+ * See docs/design/togaf-recipe-reconciliation.md §9–§10.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { taxonomyTerms, entityTaxonomyDefinitions, glossaryTerms, principles } from '@/db/schema'
+import { and, eq, isNull } from 'drizzle-orm'
+import { installRecipe } from '@/lib/recipes/install'
+import type { Recipe } from '@/lib/recipes/types'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+const RECIPE: Recipe = {
+  slug: 'test-recipe', name: 'Test Recipe', version: '1.0.0',
+  taxonomyTypes: [{
+    name: 'Test Domain', slug: 'test-domain', audience: 'framework',
+    terms: [{ name: 'Alpha', slug: 'alpha' }, { name: 'Beta', slug: 'beta' }],
+    bindings: [{ entityType: 'capability', selectionMode: 'single' }],
+  }],
+  glossaryTerms: [{ term: 'Test Term', definition: 'A term installed by a recipe.' }],
+  principles: [{ name: 'Test Principle', title: 'Prefer tests', principleType: 'architecture' }],
+}
+
+describe('recipe-install engine (#671)', () => {
+  let orgId: string
+  beforeAll(async () => { orgId = (await createTestOrg()).id })
+  afterAll(() => cleanupOrg(orgId))
+
+  async function counts() {
+    const tax = await db.select().from(taxonomyTerms).where(eq(taxonomyTerms.organizationId, orgId))
+    const defs = await db.select().from(entityTaxonomyDefinitions).where(eq(entityTaxonomyDefinitions.organizationId, orgId))
+    const gloss = await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))
+    const princ = await db.select().from(principles).where(eq(principles.organizationId, orgId))
+    return { tax: tax.length, defs: defs.length, gloss: gloss.length, princ: princ.length }
+  }
+
+  it('installs taxonomy types/terms/bindings, glossary, and principles', async () => {
+    const r = await installRecipe(orgId, RECIPE)
+    expect(r).toMatchObject({ taxonomyTypes: 1, taxonomyTerms: 2, bindings: 1, glossaryTerms: 1, principles: 1 })
+    expect(await counts()).toEqual({ tax: 3, defs: 1, gloss: 1, princ: 1 }) // 1 type + 2 terms
+  })
+
+  it('sets the audience marker on the type', async () => {
+    const [type] = await db.select().from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), isNull(taxonomyTerms.parentId), eq(taxonomyTerms.slug, 'test-domain')))
+    expect(type.audience).toBe('framework')
+  })
+
+  it('binds the type to the capability entity', async () => {
+    const [def] = await db.select().from(entityTaxonomyDefinitions)
+      .where(and(eq(entityTaxonomyDefinitions.organizationId, orgId), eq(entityTaxonomyDefinitions.entityType, 'capability')))
+    expect(def).toBeTruthy()
+    expect(def.selectionMode).toBe('single')
+  })
+
+  it('is idempotent — re-running creates nothing new', async () => {
+    const before = await counts()
+    const r = await installRecipe(orgId, RECIPE)
+    expect(r).toMatchObject({ taxonomyTypes: 0, taxonomyTerms: 0, bindings: 0, glossaryTerms: 0, principles: 0 })
+    expect(await counts()).toEqual(before)
+  })
+
+  it('updates curated fields in place on re-install', async () => {
+    const updated: Recipe = {
+      ...RECIPE,
+      glossaryTerms: [{ term: 'Test Term', definition: 'An updated definition.' }],
+    }
+    await installRecipe(orgId, updated)
+    const [g] = await db.select().from(glossaryTerms)
+      .where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.term, 'Test Term')))
+    expect(g.definition).toBe('An updated definition.')
+    // still exactly one glossary row (updated, not duplicated)
+    const all = await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))
+    expect(all).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Refs #671 (ships the engine core; admin UI + audience-hiding + presets are follow-ups)

## What

The idempotent **recipe-install engine** from `docs/design/togaf-recipe-reconciliation.md` §9–§10 — framework-agnostic, no TOGAF anything (that's S2 content). An admin-installable curated bundle writes generic content types into an org, safe to re-run.

| Piece | Detail |
|---|---|
| **schema** | `audience` column on `taxonomy_terms` — general marker; `'framework'` types will be hidden from viewers/stakeholder reports (the principled replacement for the removed overlay toggle, ADR-0001) |
| **`lib/recipes/types.ts`** | `Recipe` shape: taxonomy types/terms/bindings, glossary, principles + `InstallResult` |
| **`lib/recipes/install.ts`** | `installRecipe(orgId, recipe, actor)` — one transaction, **idempotent** check-then-upsert: `(org,parentId,slug)` for taxonomy, `etd_org_entity_type_uniq` for bindings, `(org,term)`/`(org,name)` for glossary/principles; updates curated fields in place; counts only new rows; audited |

## Idempotency (the core AC)
Verified locally against Postgres (5/5 tests): first install creates the expected rows; **re-install creates zero new rows and leaves totals identical**; curated fields (e.g. a glossary definition) update in place rather than duplicating.

## Scope boundaries
- **No TOGAF content** — engine has zero framework-specific code paths (S2 / #672 is the content).
- **Report presets deferred** — no presets table yet; that's the report engine (S3 / #673).
- **Admin Install UI + viewer-hiding of `audience:'framework'`** — next slice (needs `/verify`); this PR lands the column + sets it on install.

## Acceptance criteria (#671) — progress
- [x] Engine writes taxonomy types/terms/bindings + glossary + principles in one idempotent operation
- [x] Re-running installs nothing duplicate / updates in place
- [x] Taxonomy types support an `audience` marker (column + set on install)
- [x] Engine has no TOGAF-specific code paths
- [ ] Admin Install surface (follow-up, needs verify)
- [ ] Viewers/stakeholder reports hide `audience:'framework'` types (follow-up — consumption side)
- [ ] Report presets (deferred to S3)

Capability: ea/framework-alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)