### PR TITLE
fix(import): create Domain taxonomy value on capability CSV import (#717)

### DIFF
--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -14,6 +14,7 @@ import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { ensureDomainOwnerOverwriteAck, assertUserInOrg } from '@/lib/domain-owner-gate'
 import { ensurePublishReady } from '@/lib/publish-readiness-gate'
 import { parseCsv, splitSemicolonList } from '@/lib/csv'
+import { ensureDomainValue } from '@/lib/ensure-domain-value'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 import { flagLinksForVisibilityDrop, clearLinksFlag } from '@/lib/cross-org-link-helpers'
@@ -571,6 +572,21 @@ export async function importCapabilities(formData: FormData, dryRun = false): Pr
 
   if (!dryRun && (created > 0 || updated > 0)) {
     await db.transaction(async (tx) => {
+      // #717 — ensure each imported domain exists as a "Domain" taxonomy value
+      // (created if absent, deduped case-insensitively) the same way the form
+      // combobox does, and normalize each row's domain to the canonical name so
+      // the stored text matches the taxonomy value. Without this the domain
+      // showed on the capability but was orphaned (not in the dropdown/filter).
+      const canonicalDomain = new Map<string, string>()
+      for (const r of validRows) {
+        if (r.domain && !canonicalDomain.has(r.domain)) {
+          canonicalDomain.set(r.domain, await ensureDomainValue(tx, orgId, r.domain, session.user.id))
+        }
+      }
+      for (const r of validRows) {
+        if (r.domain) r.domain = canonicalDomain.get(r.domain) ?? r.domain
+      }
+
       for (const r of validRows) {
         let capId = r.existingId
         if (capId) {

--- a/apps/govea/src/actions/taxonomy.ts
+++ b/apps/govea/src/actions/taxonomy.ts
@@ -7,6 +7,7 @@ import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { assertOwnership } from '@/lib/federation'
 import { writeAuditLog } from '@/lib/audit'
+import { ensureDomainValue } from '@/lib/ensure-domain-value'
 import { redirect } from 'next/navigation'
 
 async function requireContributor() {
@@ -463,53 +464,8 @@ export async function createDomainValue(name: string): Promise<string> {
   const session = await requireContributor()
   const orgId = session.user.organizationId!
 
-  const trimmed = name.trim()
-
-  // Find or create the "Domain" type, then add the value, all in one transaction
-  // so the audit row is consistent with the inserted value (#416).
-  return db.transaction(async (tx) => {
-    let domainType = await tx.query.taxonomyTerms.findFirst({
-      where: (t, { eq, isNull, and }) =>
-        and(eq(t.organizationId, orgId), isNull(t.parentId), eq(t.slug, 'domain')),
-    })
-
-    if (!domainType) {
-      const [created] = await tx.insert(taxonomyTerms).values({
-        organizationId: orgId,
-        name: 'Domain',
-        slug: 'domain',
-        parentId: null,
-      }).returning()
-      domainType = created
-    }
-
-    // Avoid duplicates (case-insensitive)
-    const existing = await tx.query.taxonomyTerms.findFirst({
-      where: (t, { eq, and, sql }) =>
-        and(
-          eq(t.organizationId, orgId),
-          eq(t.parentId, domainType!.id),
-          sql`lower(${t.name}) = lower(${trimmed})`
-        ),
-    })
-    if (existing) return existing.name
-
-    const [entry] = await tx.insert(taxonomyTerms).values({
-      organizationId: orgId,
-      name: trimmed,
-      slug: toSlug(trimmed),
-      parentId: domainType.id,
-    }).returning()
-
-    await writeAuditLog(tx, {
-      action: 'taxonomy.create',
-      entityType: 'taxonomy_term',
-      entityId: entry.id,
-      userId: session.user.id,
-      organizationId: orgId,
-      after: { name: trimmed, parentId: domainType.id },
-    })
-
-    return entry.name
-  })
+  // Find or create the "Domain" type + value in one transaction so the audit
+  // row is consistent with the inserted value (#416). Shared with the CSV
+  // import path (#717) via ensureDomainValue.
+  return db.transaction(async (tx) => ensureDomainValue(tx, orgId, name, session.user.id))
 }

--- a/apps/govea/src/lib/ensure-domain-value.ts
+++ b/apps/govea/src/lib/ensure-domain-value.ts
@@ -1,0 +1,66 @@
+import { db } from '@/db/client'
+import { taxonomyTerms } from '@/db/schema'
+import { writeAuditLog } from '@/lib/audit'
+
+// Transaction handle type (same shape db.transaction hands its callback).
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+function toSlug(name: string): string {
+  return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+/**
+ * Idempotently ensures `name` exists as a value under the org's "Domain"
+ * taxonomy type, creating the type first if needed. Case-insensitive dedupe.
+ * Returns the **canonical** value name (the existing row's name on a match, so
+ * callers can normalize their stored `domain` text to it).
+ *
+ * Auth-free and transaction-scoped on purpose: shared by `createDomainValue`
+ * (the form combobox path) and `importCapabilities` (the CSV path) so both
+ * create the taxonomy value identically. Lives in lib/ — not actions/ — because
+ * it takes a `tx` and must not be exposed as an RPC server action (#427).
+ */
+export async function ensureDomainValue(
+  tx: Tx,
+  orgId: string,
+  name: string,
+  actorUserId?: string | null,
+): Promise<string> {
+  const trimmed = name.trim()
+
+  let domainType = await tx.query.taxonomyTerms.findFirst({
+    where: (t, { eq, isNull, and }) =>
+      and(eq(t.organizationId, orgId), isNull(t.parentId), eq(t.slug, 'domain')),
+  })
+  if (!domainType) {
+    const [created] = await tx.insert(taxonomyTerms).values({
+      organizationId: orgId, name: 'Domain', slug: 'domain', parentId: null,
+    }).returning()
+    domainType = created
+  }
+
+  const existing = await tx.query.taxonomyTerms.findFirst({
+    where: (t, { eq, and, sql }) =>
+      and(
+        eq(t.organizationId, orgId),
+        eq(t.parentId, domainType!.id),
+        sql`lower(${t.name}) = lower(${trimmed})`,
+      ),
+  })
+  if (existing) return existing.name
+
+  const [entry] = await tx.insert(taxonomyTerms).values({
+    organizationId: orgId, name: trimmed, slug: toSlug(trimmed), parentId: domainType.id,
+  }).returning()
+
+  await writeAuditLog(tx, {
+    action: 'taxonomy.create',
+    entityType: 'taxonomy_term',
+    entityId: entry.id,
+    userId: actorUserId ?? null,
+    organizationId: orgId,
+    after: { name: trimmed, parentId: domainType.id },
+  })
+
+  return entry.name
+}

--- a/apps/govea/tests/integration/capabilities-import.test.ts
+++ b/apps/govea/tests/integration/capabilities-import.test.ts
@@ -14,8 +14,8 @@
  */
 import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { db } from '@/db/client'
-import { capabilities, capabilityPersonas, personas } from '@/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { capabilities, capabilityPersonas, personas, taxonomyTerms } from '@/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import { importCapabilities } from '@/actions/capabilities'
 import {
@@ -56,6 +56,49 @@ describe('importCapabilities (#596)', () => {
   })
 
   afterAll(() => cleanupOrg(orgId))
+
+  // #717 — importing a domain must create the "Domain" taxonomy value, the same
+  // way the form combobox does, instead of leaving an orphaned text value.
+  async function domainValues() {
+    const [type] = await db.select({ id: taxonomyTerms.id }).from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), isNull(taxonomyTerms.parentId), eq(taxonomyTerms.slug, 'domain')))
+    if (!type) return []
+    return db.select({ name: taxonomyTerms.name }).from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.parentId, type.id)))
+  }
+
+  it('creates the Domain taxonomy value for an imported domain (#717)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      'name,description,domain,behaviors,rules,capability_type,status,visibility,personas',
+      'Elections Mgmt,Run elections,Elections,,,business,draft,org,',
+    ].join('\n')
+    const result = await importCapabilities(csvForm(csv), false)
+    expect(result.created).toBe(1)
+
+    // The taxonomy value now exists...
+    expect((await domainValues()).map(d => d.name)).toContain('Elections')
+    // ...and the capability's domain matches the canonical value.
+    const [cap] = await db.select({ domain: capabilities.domain }).from(capabilities)
+      .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Elections Mgmt')))
+    expect(cap.domain).toBe('Elections')
+  })
+
+  it('does not duplicate an existing domain value on case-variant import (#717)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const before = (await domainValues()).filter(d => d.name.toLowerCase() === 'elections').length
+    const csv = [
+      'name,description,domain,behaviors,rules,capability_type,status,visibility,personas',
+      'Voter Reg,Register voters,elections,,,business,draft,org,', // lower-case variant
+    ].join('\n')
+    await importCapabilities(csvForm(csv), false)
+    const after = (await domainValues()).filter(d => d.name.toLowerCase() === 'elections')
+    expect(after.length).toBe(before) // no new value created
+    // capability normalized to the canonical existing casing
+    const [cap] = await db.select({ domain: capabilities.domain }).from(capabilities)
+      .where(and(eq(capabilities.organizationId, orgId), eq(capabilities.name, 'Voter Reg')))
+    expect(cap.domain).toBe('Elections')
+  })
 
   it('rejects viewer role', async () => {
     mockAuth.mockResolvedValue(makeSession(viewer))


### PR DESCRIPTION
Closes #717

## Bug

Importing capabilities from CSV wrote the `domain` column to `capabilities.domain` but **never created the "Domain" taxonomy value**. The domain appeared on the capability record yet was orphaned — missing from the Domain dropdown, the capability filter, and Taxonomy management.

## Root cause

The **form** path creates the term via `createDomainValue()` (called by `DomainCombobox` when you type a new domain). `importCapabilities` bypassed that and stored the raw text only.

## Fix

- **`lib/ensure-domain-value.ts`** — extract `ensureDomainValue(tx, orgId, name)`: idempotent find-or-create under the org's "Domain" type, case-insensitive dedupe, returns the **canonical** value name. In `lib/` (not `actions/`) because it takes a `tx` and must not be exposed as an RPC server action (#427).
- **`actions/taxonomy.ts`** — `createDomainValue` now wraps the helper (single source of truth; form behavior unchanged).
- **`actions/capabilities.ts`** — `importCapabilities` ensures each distinct imported domain via the helper *inside its existing transaction*, and normalizes each row's `domain` to the canonical value (so casing matches the taxonomy value).

## Verification

Ran the import integration suite against Postgres — **14/14 pass** (12 existing + 2 new):
- importing a new domain creates the "Domain" taxonomy value and sets the capability's domain to the canonical name;
- a case-variant re-import (`elections` vs `Elections`) creates **no** duplicate and normalizes to the existing casing.

## Acceptance criteria (#717)
- [x] Importing a new domain creates the "Domain" taxonomy value (deduped case-insensitively)
- [x] Capability's `domain` matches the canonical taxonomy value
- [x] No duplicates on re-import / existing domains
- [x] Form behavior unchanged (`createDomainValue` still works, now shared)
- [x] Integration test covering import-creates-domain

Capability: ac-backup-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)