### PR TITLE
feat(import): glossary CSV import with domain-value creation (closes #721)

### DIFF
--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -10,6 +10,8 @@ import { writeAuditLog } from '@/lib/audit'
 import { ensureNoDuplicateName } from '@/lib/duplicate-name-gate'
 import { redirect } from 'next/navigation'
 import { validateWebUrl } from '@/lib/url'
+import { parseCsv } from '@/lib/csv'
+import { ensureDomainValue } from '@/lib/ensure-domain-value'
 
 async function requireContributor() {
   const session = await auth()
@@ -192,4 +194,122 @@ export async function deleteGlossaryTerm(termId: string) {
       before: { term: before?.term },
     })
   })
+}
+
+// ── CSV import (#721) ──────────────────────────────────────────────────────
+// Mirrors importCapabilities (#596): `term` is the case-insensitive upsert key;
+// all rows are pre-validated before the transaction; `dryRun` returns counts +
+// errors without writing. An imported `domain` creates the "Domain" taxonomy
+// value (shared ensureDomainValue, #717) and is normalized to the canonical
+// name — no orphaned domains.
+
+export type GlossaryImportResult = {
+  created: number
+  updated: number
+  skipped: number
+  errors: string[]
+}
+
+const VALID_GLOSSARY_STATUS = new Set(['draft', 'published', 'archived'])
+const VALID_GLOSSARY_VISIBILITY = new Set(['org', 'connections', 'instance'])
+
+export async function importGlossary(formData: FormData, dryRun = false): Promise<GlossaryImportResult> {
+  const session = await requireContributor()
+  const orgId = session.user.organizationId!
+
+  const file = formData.get('csvFile') as File | null
+  if (!file) return { created: 0, updated: 0, skipped: 0, errors: ['No file provided'] }
+
+  const rows = parseCsv(await file.text())
+  if (rows.length === 0) return { created: 0, updated: 0, skipped: 0, errors: ['CSV has no data rows'] }
+
+  const existing = await db.query.glossaryTerms.findMany({
+    where: eq(glossaryTerms.organizationId, orgId),
+    columns: { id: true, term: true },
+  })
+  const existingByTerm = new Map(existing.map(t => [t.term.toLowerCase(), t.id]))
+
+  type ValidRow = {
+    term: string
+    definition: string
+    domain: string | null
+    notes: string | null
+    status: 'draft' | 'published' | 'archived'
+    visibility: 'org' | 'connections' | 'instance'
+    existingId: string | undefined
+  }
+  const validRows: ValidRow[] = []
+  let created = 0, updated = 0, skipped = 0
+  const errors: string[] = []
+
+  for (const [i, row] of rows.entries()) {
+    const rowNum = i + 2 // 1-indexed + header row
+    const term = row['term']?.trim()
+    if (!term) { errors.push(`Row ${rowNum}: missing required field "term"`); skipped++; continue }
+
+    const definition = row['definition']?.trim()
+    if (!definition) { errors.push(`Row ${rowNum}: missing required field "definition"`); skipped++; continue }
+
+    const status = (row['status'] || 'draft').trim().toLowerCase()
+    const visibility = (row['visibility'] || 'org').trim().toLowerCase()
+    if (!VALID_GLOSSARY_STATUS.has(status)) {
+      errors.push(`Row ${rowNum}: invalid status "${status}"`); skipped++; continue
+    }
+    if (!VALID_GLOSSARY_VISIBILITY.has(visibility)) {
+      errors.push(`Row ${rowNum}: invalid visibility "${visibility}"`); skipped++; continue
+    }
+
+    const existingId = existingByTerm.get(term.toLowerCase())
+    if (existingId) updated++; else created++
+
+    validRows.push({
+      term,
+      definition,
+      domain: row['domain']?.trim() || null,
+      notes: row['notes']?.trim() || null,
+      status: status as 'draft' | 'published' | 'archived',
+      visibility: visibility as 'org' | 'connections' | 'instance',
+      existingId,
+    })
+  }
+
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await db.transaction(async (tx) => {
+      // Ensure each imported domain is a "Domain" taxonomy value, then normalize
+      // each row's domain to the canonical name (#717).
+      const canonicalDomain = new Map<string, string>()
+      for (const r of validRows) {
+        if (r.domain && !canonicalDomain.has(r.domain)) {
+          canonicalDomain.set(r.domain, await ensureDomainValue(tx, orgId, r.domain, session.user.id))
+        }
+      }
+
+      for (const r of validRows) {
+        const domain = r.domain ? canonicalDomain.get(r.domain) ?? r.domain : null
+        if (r.existingId) {
+          await tx.update(glossaryTerms).set({
+            definition: r.definition, domain, notes: r.notes,
+            status: r.status, visibility: r.visibility,
+            updatedBy: session.user.id, updatedAt: new Date(),
+          }).where(and(eq(glossaryTerms.id, r.existingId), eq(glossaryTerms.organizationId, orgId)))
+        } else {
+          await tx.insert(glossaryTerms).values({
+            organizationId: orgId, term: r.term, definition: r.definition, domain, notes: r.notes,
+            status: r.status, visibility: r.visibility,
+            createdBy: session.user.id, updatedBy: session.user.id,
+          })
+        }
+      }
+
+      await writeAuditLog(tx, {
+        action: 'glossary.import',
+        entityType: 'glossary',
+        userId: session.user.id,
+        organizationId: orgId,
+        after: { created, updated, skipped, dryRun, errorCount: errors.length },
+      })
+    })
+  }
+
+  return { created, updated, skipped, errors }
 }

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createGlossaryTerm, editGlossaryTerm, deleteGlossaryTerm } from '@/actions/glossary'
+import { createGlossaryTerm, editGlossaryTerm, deleteGlossaryTerm, importGlossary, type GlossaryImportResult } from '@/actions/glossary'
 import type { GlossaryTerm, GlossaryTermSource } from '@/db/schema'
 import { DomainCombobox } from '@/components/domain-combobox'
 import { useRouter } from 'next/navigation'
@@ -64,9 +64,35 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
   const editDirty = useDirtyTracker()
   const [deleteTarget, setDeleteTarget] = useState<GlossaryRow | null>(null)
 
+  // CSV import dialog state (#721). Preview (dryRun) → confirm; same UX as the
+  // capability/application import.
+  const [importOpen, setImportOpen] = useState(false)
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [importPreview, setImportPreview] = useState<GlossaryImportResult | null>(null)
+  const [importResult, setImportResult] = useState<GlossaryImportResult | null>(null)
+
   const canEditRole = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
   const refresh = () => router.refresh()
+
+  function openImport() {
+    setImportOpen(true); setImportResult(null); setImportPreview(null); setImportFile(null)
+  }
+  function handleImportPreview() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData(); fd.append('csvFile', importFile)
+      setImportPreview(await importGlossary(fd, true))
+    })
+  }
+  function handleImportConfirm() {
+    if (!importFile) return
+    startTransition(async () => {
+      const fd = new FormData(); fd.append('csvFile', importFile)
+      setImportResult(await importGlossary(fd, false))
+      setImportPreview(null); setImportFile(null); refresh()
+    })
+  }
 
   const domains = Array.from(new Set(terms.map(t => t.domain).filter(Boolean))) as string[]
 
@@ -131,7 +157,12 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
           </select>
         )}
         {canEditRole && (
-          <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
+          <Button variant="outline" onClick={openImport} size="sm" className="ml-auto">
+            Import CSV
+          </Button>
+        )}
+        {canEditRole && (
+          <Button onClick={() => setCreateOpen(true)} size="sm">
             + New Glossary Term
           </Button>
         )}
@@ -285,6 +316,70 @@ export function GlossaryTable({ terms, domainTerms, role, currentOrgId }: Props)
             <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
               {isPending ? 'Deleting…' : 'Delete'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Import CSV Dialog (#721) */}
+      <Dialog open={importOpen} onOpenChange={open => { if (!open) setImportOpen(false) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>Import Glossary</DialogTitle></DialogHeader>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">
+              Upload a CSV with columns: <code className="bg-muted px-1 rounded">term</code>, <code className="bg-muted px-1 rounded">definition</code>, <code className="bg-muted px-1 rounded">domain</code>, <code className="bg-muted px-1 rounded">notes</code>, <code className="bg-muted px-1 rounded">status</code>, <code className="bg-muted px-1 rounded">visibility</code>.
+              Existing terms are matched by <code className="bg-muted px-1 rounded">term</code> (case-insensitive) and updated. A new domain is added to the Domain taxonomy automatically.
+            </p>
+
+            {!importResult && (
+              <div className="space-y-1.5">
+                <Label>CSV file</Label>
+                <Input
+                  type="file"
+                  accept=".csv,text/csv"
+                  onChange={e => { setImportFile(e.target.files?.[0] ?? null); setImportPreview(null) }}
+                />
+              </div>
+            )}
+
+            {importPreview && !importResult && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1">
+                <p className="font-medium">Preview</p>
+                <p>Will create <strong>{importPreview.created}</strong> · update <strong>{importPreview.updated}</strong> · skip <strong>{importPreview.skipped}</strong></p>
+                {importPreview.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importPreview.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-md border bg-emerald-50 border-emerald-200 p-3 space-y-1">
+                <p className="font-medium text-emerald-800">Import complete</p>
+                <p className="text-emerald-700">Created <strong>{importResult.created}</strong> · updated <strong>{importResult.updated}</strong> · skipped <strong>{importResult.skipped}</strong></p>
+                {importResult.errors.length > 0 && (
+                  <ul className="text-destructive space-y-0.5 mt-1">
+                    {importResult.errors.map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(false)}>
+              {importResult ? 'Close' : 'Cancel'}
+            </Button>
+            {!importResult && !importPreview && (
+              <Button onClick={handleImportPreview} disabled={!importFile || isPending}>
+                {isPending ? 'Checking…' : 'Preview'}
+              </Button>
+            )}
+            {importPreview && !importResult && (
+              <Button onClick={handleImportConfirm} disabled={isPending || importPreview.created + importPreview.updated === 0}>
+                {isPending ? 'Importing…' : `Import ${importPreview.created + importPreview.updated} terms`}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/govea/tests/integration/glossary-import.test.ts
+++ b/apps/govea/tests/integration/glossary-import.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests: importGlossary server action (#721)
+ *
+ * Mirrors the capability import suite: role enforcement, create, case-insensitive
+ * upsert by term, required-field + enum validation, dryRun writes nothing, and
+ * domain values are created via ensureDomainValue (#717).
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { glossaryTerms, taxonomyTerms } from '@/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { importGlossary } from '@/actions/glossary'
+import { createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser } from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function csvForm(content: string): FormData {
+  const fd = new FormData()
+  fd.append('csvFile', new File([new Blob([content], { type: 'text/csv' })], 'glossary.csv', { type: 'text/csv' }))
+  return fd
+}
+const HEADER = 'term,definition,domain,notes,status,visibility'
+
+describe('importGlossary (#721)', () => {
+  let orgId: string
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+  afterAll(() => cleanupOrg(orgId))
+
+  async function termRow(term: string) {
+    const [r] = await db.select().from(glossaryTerms)
+      .where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.term, term)))
+    return r
+  }
+  async function domainValues() {
+    const [type] = await db.select({ id: taxonomyTerms.id }).from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), isNull(taxonomyTerms.parentId), eq(taxonomyTerms.slug, 'domain')))
+    if (!type) return [] as string[]
+    const rows = await db.select({ name: taxonomyTerms.name }).from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.parentId, type.id)))
+    return rows.map(r => r.name)
+  }
+
+  it('rejects viewer role', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(importGlossary(csvForm(`${HEADER}\nTerm,Def,,,,`))).rejects.toThrow('Forbidden')
+  })
+
+  it('creates terms and creates the Domain taxonomy value', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [HEADER, 'API Gateway,A managed entry point,Integration,,published,org'].join('\n')
+    const r = await importGlossary(csvForm(csv), false)
+    expect(r.created).toBe(1)
+    const row = await termRow('API Gateway')
+    expect(row).toMatchObject({ definition: 'A managed entry point', domain: 'Integration', status: 'published' })
+    expect(await domainValues()).toContain('Integration')
+  })
+
+  it('upserts by term (case-insensitive) — updates, no duplicate', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [HEADER, 'api gateway,Updated definition,,,published,org'].join('\n')
+    const r = await importGlossary(csvForm(csv), false)
+    expect(r.updated).toBe(1); expect(r.created).toBe(0)
+    expect((await termRow('API Gateway')).definition).toBe('Updated definition')
+    const all = await db.select().from(glossaryTerms)
+      .where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.term, 'API Gateway')))
+    expect(all).toHaveLength(1)
+  })
+
+  it('skips rows missing required fields / invalid enums', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const csv = [
+      HEADER,
+      ',has def but no term,,,,',          // missing term
+      'No Def,,,,,',                        // missing definition
+      'Bad Status,def,,,nonsense,org',      // invalid status
+    ].join('\n')
+    const r = await importGlossary(csvForm(csv), false)
+    expect(r.skipped).toBe(3)
+    expect(r.errors.some(e => /term/.test(e))).toBe(true)
+    expect(r.errors.some(e => /definition/.test(e))).toBe(true)
+    expect(r.errors.some(e => /status/.test(e))).toBe(true)
+  })
+
+  it('dryRun writes nothing', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const before = (await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))).length
+    const r = await importGlossary(csvForm([HEADER, 'Ephemeral,Should not persist,,,published,org'].join('\n')), true)
+    expect(r.created).toBe(1) // counted in preview
+    const after = (await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))).length
+    expect(after).toBe(before) // but nothing written
+  })
+})


### PR DESCRIPTION
Closes #721

## What

CSV import for glossary terms, matching the capability/application import pattern (#596). Glossary had no importer before this.

- **`actions/glossary.ts` — `importGlossary(formData, dryRun)`**: `term` is the case-insensitive upsert key; `definition` required; `status`/`visibility` enum-validated; all rows pre-validated before the transaction; `dryRun` returns counts + errors without writing. An imported `domain` creates the "Domain" taxonomy value via the shared **`ensureDomainValue`** (#717) and is normalized to the canonical name — **no orphaned domains** (the bug we just fixed for capabilities). Audited; Contributor+ only.
- **`glossary-table.tsx`**: Import CSV button + preview→confirm dialog, same UX as the capability/application import.

## Verification
- Integration test **5/5** against Postgres: role enforcement; create + Domain-value creation; case-insensitive upsert (no duplicate); required-field/enum validation; `dryRun` writes nothing.
- Ran the app: the **Import Glossary dialog renders and opens** correctly (title, all 6 columns documented, file picker, Preview/Cancel) on the populated glossary page (screenshot taken). The file-pick→confirm flow isn't browser-drivable via the preview tools, but the import logic is integration-tested and the file→FormData wiring is identical to the shipped capability/application import.

## Acceptance criteria (#721)
- [x] Contributor/Admin import; viewer rejected
- [x] `term` upserts case-insensitively; `definition` required
- [x] Invalid `status`/`visibility` skip the row with a clear error
- [x] Imported `domain` creates the Domain taxonomy value (deduped) + canonical name stored
- [x] `dryRun` writes nothing; returns counts + errors
- [x] Integration test covers create/upsert/validation/dryRun/domain-creation
- [x] Import dialog renders/opens in the running app

## Out of scope
Glossary CSV **export** (separate; round-trip parity can follow, cf. #696) · reference-source attribution columns.

Capability: ac-backup-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)