### PR TITLE
feat(audit): capture client IP/user-agent on auth events (slice 1 of #720)

### DIFF
--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -12,6 +12,7 @@ import { authConfig } from '@/lib/auth.config'
 import { checkSsoProvisioning } from '@/lib/sso-guard'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
 import { resolveActiveMembership } from '@/lib/active-membership'
+import { getRequestContext } from '@/lib/request-context'
 
 // Identity model: users.email is globally unique across all organizations (#269).
 // Auth lookups by bare email (credentials provider, jwt callback) are therefore
@@ -47,15 +48,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) return null
         const email = credentials.email as string
+        // #720 — proxy-aware client telemetry for auth audit events.
+        const ctx = await getRequestContext()
+        const authMeta = { ip: ctx.ip, userAgent: ctx.userAgent, provider: 'local' as const }
         const user = await db.query.users.findFirst({
           where: eq(users.email, email),
         })
         if (!user || !user.passwordHash || user.isActive !== 'true') {
+          // Unknown / unusable / inactive account — recorded for investigation,
+          // but the requester gets the same generic failure (no enumeration).
           await writeAuditLog(db, {
             action: 'auth.login_failed',
             entityType: 'user',
             organizationId: user?.organizationId,
-            metadata: { email },
+            metadata: { ...authMeta, email, reason: 'invalid_credentials' },
           })
           return null
         }
@@ -72,7 +78,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             entityType: 'user',
             entityId: user.id,
             organizationId: user.organizationId,
-            metadata: { email, lockoutUntil: user.lockoutUntil.toISOString() },
+            metadata: { ...authMeta, email, reason: 'locked_account', lockoutUntil: user.lockoutUntil.toISOString() },
           })
           return null
         }
@@ -97,7 +103,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             entityType: 'user',
             entityId: user.id,
             organizationId: user.organizationId,
-            metadata: { email, attempts: newCount, lockedUntil: lockoutUntil?.toISOString() ?? null },
+            metadata: { ...authMeta, email, reason: 'invalid_credentials', attempts: newCount, lockedUntil: lockoutUntil?.toISOString() ?? null },
           })
           return null
         }
@@ -274,23 +280,27 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         })
       }
     },
-    async signIn({ user }) {
+    async signIn({ user, account }) {
+      const ctx = await getRequestContext()
       await writeAuditLog(db, {
         action: 'auth.login',
         entityType: 'user',
         entityId: user.id,
         userId: user.id,
         organizationId: (user as unknown as AppUser).organizationId,
+        metadata: { ip: ctx.ip, userAgent: ctx.userAgent, provider: account?.provider ?? 'credentials' },
       })
     },
     async signOut(message) {
       const token = 'token' in message ? message.token : null
+      const ctx = await getRequestContext()
       await writeAuditLog(db, {
         action: 'auth.logout',
         entityType: 'user',
         entityId: token?.id as string | undefined,
         userId: token?.id as string | undefined,
         organizationId: token?.organizationId as string | undefined,
+        metadata: { ip: ctx.ip, userAgent: ctx.userAgent },
       })
     },
   },

--- a/apps/govea/src/lib/request-context.ts
+++ b/apps/govea/src/lib/request-context.ts
@@ -1,0 +1,55 @@
+import { headers } from 'next/headers'
+
+export interface RequestContext {
+  ip: string | null
+  userAgent: string | null
+}
+
+const DEFAULT_TRUSTED_HOPS = 1
+
+/**
+ * Number of trusted proxy hops in front of the app, from
+ * `GOVEA_TRUSTED_PROXY_HOPS` (default 1 — Azure Container Apps ingress).
+ * Operator-specific (public-repo policy: kept in env, not hardcoded).
+ */
+export function trustedProxyHops(): number {
+  const raw = process.env.GOVEA_TRUSTED_PROXY_HOPS
+  const n = raw ? Number.parseInt(raw, 10) : NaN
+  return Number.isFinite(n) && n >= 1 ? n : DEFAULT_TRUSTED_HOPS
+}
+
+/**
+ * Resolves the real client IP from an `X-Forwarded-For` value, trusting only
+ * the rightmost `hops` entries (those appended by our own proxies). #720.
+ *
+ * XFF is `client, proxy1, …` — proxies *append* on the right, so the entry our
+ * outermost trusted proxy added sits at index `len - hops`. A malicious client
+ * can only *prepend* fake entries (to the left of `len - hops`), which this
+ * ignores. Returns null for empty/missing input.
+ *
+ * Exported for unit testing — this is the security-critical, anti-spoofing bit.
+ */
+export function clientIpFromForwarded(xff: string | null | undefined, hops: number): string | null {
+  if (!xff) return null
+  const parts = xff.split(',').map(s => s.trim()).filter(Boolean)
+  if (parts.length === 0) return null
+  const idx = Math.max(0, parts.length - hops)
+  return parts[idx] ?? null
+}
+
+/**
+ * Proxy-aware client context (IP + user-agent) for audit telemetry (#720).
+ * Safe to call outside a request scope — returns nulls if `headers()` throws.
+ * Never records raw headers; only the derived IP and the user-agent string.
+ */
+export async function getRequestContext(): Promise<RequestContext> {
+  try {
+    const h = await headers()
+    const ip = clientIpFromForwarded(h.get('x-forwarded-for'), trustedProxyHops())
+      ?? h.get('x-real-ip')
+      ?? null
+    return { ip, userAgent: h.get('user-agent') }
+  } catch {
+    return { ip: null, userAgent: null }
+  }
+}

--- a/apps/govea/tests/unit/request-context.test.ts
+++ b/apps/govea/tests/unit/request-context.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests: proxy-aware client-IP resolution (#720 slice 1 / #725)
+ *
+ * The anti-spoofing core: trust only the rightmost `hops` X-Forwarded-For
+ * entries (added by our own proxies); ignore client-prepended fakes.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { clientIpFromForwarded, trustedProxyHops } from '@/lib/request-context'
+
+describe('clientIpFromForwarded (#720)', () => {
+  it('returns null for missing/empty input', () => {
+    expect(clientIpFromForwarded(null, 1)).toBeNull()
+    expect(clientIpFromForwarded(undefined, 1)).toBeNull()
+    expect(clientIpFromForwarded('', 1)).toBeNull()
+    expect(clientIpFromForwarded('   ', 1)).toBeNull()
+  })
+
+  it('single trusted hop (Azure): rightmost entry is the real client', () => {
+    // ACA ingress appends the real client IP as the sole entry.
+    expect(clientIpFromForwarded('203.0.113.7', 1)).toBe('203.0.113.7')
+  })
+
+  it('ignores client-prepended spoofed entries beyond the trusted hop', () => {
+    // Attacker sends "X-Forwarded-For: 1.2.3.4" hoping to be logged as 1.2.3.4;
+    // the trusted proxy appends the *real* peer on the right.
+    expect(clientIpFromForwarded('1.2.3.4, 203.0.113.7', 1)).toBe('203.0.113.7')
+    expect(clientIpFromForwarded('9.9.9.9, 8.8.8.8, 203.0.113.7', 1)).toBe('203.0.113.7')
+  })
+
+  it('two trusted hops: client is two from the right', () => {
+    // client, proxy1 (proxy2 is the socket peer, not in XFF)
+    expect(clientIpFromForwarded('203.0.113.7, 10.0.0.2', 2)).toBe('203.0.113.7')
+    // with a prepended fake, still resolves the real client
+    expect(clientIpFromForwarded('1.2.3.4, 203.0.113.7, 10.0.0.2', 2)).toBe('203.0.113.7')
+  })
+
+  it('clamps when hops exceeds the list length (best-effort leftmost)', () => {
+    expect(clientIpFromForwarded('203.0.113.7', 5)).toBe('203.0.113.7')
+  })
+
+  it('trims whitespace around entries', () => {
+    expect(clientIpFromForwarded('  1.2.3.4 ,  203.0.113.7  ', 1)).toBe('203.0.113.7')
+  })
+})
+
+describe('trustedProxyHops (#720)', () => {
+  const original = process.env.GOVEA_TRUSTED_PROXY_HOPS
+  afterEach(() => {
+    if (original === undefined) delete process.env.GOVEA_TRUSTED_PROXY_HOPS
+    else process.env.GOVEA_TRUSTED_PROXY_HOPS = original
+  })
+
+  it('defaults to 1 when unset or invalid', () => {
+    delete process.env.GOVEA_TRUSTED_PROXY_HOPS
+    expect(trustedProxyHops()).toBe(1)
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = 'nonsense'
+    expect(trustedProxyHops()).toBe(1)
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = '0'
+    expect(trustedProxyHops()).toBe(1) // min 1
+  })
+
+  it('honors a valid configured value', () => {
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = '2'
+    expect(trustedProxyHops()).toBe(2)
+  })
+})


### PR DESCRIPTION
Closes #725 · Refs #720 (slice 1 of 3)

## What

The capture spine for richer auth/access audit telemetry (#720). Aggregation review (slice 2) and the instance-audit UI + audit CSV export (slice 3) follow.

- **`lib/request-context.ts`** — `getRequestContext()` → `{ ip, userAgent }`. Client IP from `X-Forwarded-For` honoring **`GOVEA_TRUSTED_PROXY_HOPS`** (default **1**, Azure Container Apps ingress): trusts only the rightmost N entries, so a client-prepended XFF can't spoof the logged IP. Falls back to `x-real-ip`, then null; safe outside a request scope. Operator-specific hop count stays in env (public-repo policy).
- **`lib/auth.ts`** — threads `ip` + `userAgent` + `provider` into `auth.login`, `auth.logout`, and the failed/locked-login events; adds a safe **reason category** (`invalid_credentials` / `locked_account`) with no account-enumeration leak to the requester.

## Security constraints held
No passwords / tokens / secrets / raw headers logged. Audit immutability unchanged. Failed logins for unknown accounts still recorded (generic failure to the requester). IP-spoofing resistance is the unit-tested core.

## Verification
- 8 unit tests for the XFF/trusted-hops parsing (single/multi hop, prepended-spoof rejection, clamping, env default/override).
- **Live**: logout → bad-password login → good login produced these `audit_log` rows (queried directly):
  - `auth.login` → `{ip, userAgent, provider: "credentials"}`
  - `auth.login_failed` → `{ip, userAgent, provider: "local", reason: "invalid_credentials", attempts, email}`
  - `auth.logout` → `{ip, userAgent}`
  - (a pre-change `auth.login` row showed `null` metadata — confirms the new code is the source)
- `tsc` + eslint clean.

## Acceptance criteria (#725)
- [x] Proxy-aware client IP + user-agent; honors `GOVEA_TRUSTED_PROXY_HOPS`; ignores client-prepended XFF
- [x] Auth events carry `ip`, `userAgent`, `provider`, safe `reason`
- [x] Unknown-account failures logged; no enumeration leak
- [x] No sensitive data logged; audit immutability preserved
- [x] Unit tests incl. spoofing scenarios

## Operator note
Set `GOVEA_TRUSTED_PROXY_HOPS` to the number of trusted proxies in front of the app (default 1 = Azure Container Apps). Behind an extra operator proxy, set 2, etc.

Capability: iam-audit-trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)