### PR TITLE
feat(audit): repeated failed-login aggregation for instance review (slice 2 of #720)

### DIFF
--- a/apps/govea/src/lib/audit-view.ts
+++ b/apps/govea/src/lib/audit-view.ts
@@ -155,3 +155,77 @@ export async function getAuditActionNamespaces(orgId: string, role: AuditViewRol
     .orderBy(sql`split_part(${auditLog.action}, '.', 1)`)
   return rows.map(r => r.ns).filter(Boolean)
 }
+
+// ── Failed-login aggregation (#720 slice 2) ────────────────────────────────
+// Instance-admin security review: surface repeated failed-login patterns across
+// ALL orgs (credential stuffing, attacks on privileged accounts), grouped by
+// attempted email and by source IP. Reads the telemetry captured in slice 1
+// (metadata.email / metadata.ip). Caller gates with requireInstanceAdmin (same
+// pattern as getAuditEntries). Pure read; audit immutability untouched.
+
+export const FAILED_LOGIN_ACTIONS = [
+  'auth.login_failed',
+  'auth.login_failed_locked',
+  'auth.login_blocked_locked',
+] as const
+
+export interface FailedLoginByEmail {
+  email: string
+  attempts: number
+  lastAttempt: Date
+  distinctIps: number
+}
+export interface FailedLoginByIp {
+  ip: string
+  attempts: number
+  lastAttempt: Date
+  distinctEmails: number
+}
+export interface FailedLoginSummary {
+  since: Date
+  byEmail: FailedLoginByEmail[]
+  byIp: FailedLoginByIp[]
+}
+
+export async function getFailedLoginSummary(
+  opts?: { sinceDays?: number; limit?: number },
+): Promise<FailedLoginSummary> {
+  const sinceDays = opts?.sinceDays ?? 7
+  const limit = opts?.limit ?? 20
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+  const emailExpr = sql<string>`${auditLog.metadata} ->> 'email'`
+  const ipExpr = sql<string>`${auditLog.metadata} ->> 'ip'`
+  const inWindow = and(
+    inArray(auditLog.action, FAILED_LOGIN_ACTIONS as unknown as string[]),
+    gte(auditLog.createdAt, since),
+  )
+
+  const byEmail = await db
+    .select({
+      email: emailExpr,
+      attempts: sql<number>`count(*)::int`,
+      lastAttempt: sql<Date>`max(${auditLog.createdAt})`,
+      distinctIps: sql<number>`count(distinct ${ipExpr})::int`,
+    })
+    .from(auditLog)
+    .where(and(inWindow, sql`${emailExpr} is not null`))
+    .groupBy(emailExpr)
+    .orderBy(desc(sql`count(*)`))
+    .limit(limit)
+
+  const byIp = await db
+    .select({
+      ip: ipExpr,
+      attempts: sql<number>`count(*)::int`,
+      lastAttempt: sql<Date>`max(${auditLog.createdAt})`,
+      distinctEmails: sql<number>`count(distinct ${emailExpr})::int`,
+    })
+    .from(auditLog)
+    .where(and(inWindow, sql`${ipExpr} is not null`))
+    .groupBy(ipExpr)
+    .orderBy(desc(sql`count(*)`))
+    .limit(limit)
+
+  return { since, byEmail, byIp }
+}

--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -12,6 +12,7 @@ import { authConfig } from '@/lib/auth.config'
 import { checkSsoProvisioning } from '@/lib/sso-guard'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
 import { resolveActiveMembership } from '@/lib/active-membership'
+import { getRequestContext } from '@/lib/request-context'
 
 // Identity model: users.email is globally unique across all organizations (#269).
 // Auth lookups by bare email (credentials provider, jwt callback) are therefore
@@ -47,15 +48,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) return null
         const email = credentials.email as string
+        // #720 — proxy-aware client telemetry for auth audit events.
+        const ctx = await getRequestContext()
+        const authMeta = { ip: ctx.ip, userAgent: ctx.userAgent, provider: 'local' as const }
         const user = await db.query.users.findFirst({
           where: eq(users.email, email),
         })
         if (!user || !user.passwordHash || user.isActive !== 'true') {
+          // Unknown / unusable / inactive account — recorded for investigation,
+          // but the requester gets the same generic failure (no enumeration).
           await writeAuditLog(db, {
             action: 'auth.login_failed',
             entityType: 'user',
             organizationId: user?.organizationId,
-            metadata: { email },
+            metadata: { ...authMeta, email, reason: 'invalid_credentials' },
           })
           return null
         }
@@ -72,7 +78,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             entityType: 'user',
             entityId: user.id,
             organizationId: user.organizationId,
-            metadata: { email, lockoutUntil: user.lockoutUntil.toISOString() },
+            metadata: { ...authMeta, email, reason: 'locked_account', lockoutUntil: user.lockoutUntil.toISOString() },
           })
           return null
         }
@@ -97,7 +103,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             entityType: 'user',
             entityId: user.id,
             organizationId: user.organizationId,
-            metadata: { email, attempts: newCount, lockedUntil: lockoutUntil?.toISOString() ?? null },
+            metadata: { ...authMeta, email, reason: 'invalid_credentials', attempts: newCount, lockedUntil: lockoutUntil?.toISOString() ?? null },
           })
           return null
         }
@@ -274,23 +280,27 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         })
       }
     },
-    async signIn({ user }) {
+    async signIn({ user, account }) {
+      const ctx = await getRequestContext()
       await writeAuditLog(db, {
         action: 'auth.login',
         entityType: 'user',
         entityId: user.id,
         userId: user.id,
         organizationId: (user as unknown as AppUser).organizationId,
+        metadata: { ip: ctx.ip, userAgent: ctx.userAgent, provider: account?.provider ?? 'credentials' },
       })
     },
     async signOut(message) {
       const token = 'token' in message ? message.token : null
+      const ctx = await getRequestContext()
       await writeAuditLog(db, {
         action: 'auth.logout',
         entityType: 'user',
         entityId: token?.id as string | undefined,
         userId: token?.id as string | undefined,
         organizationId: token?.organizationId as string | undefined,
+        metadata: { ip: ctx.ip, userAgent: ctx.userAgent },
       })
     },
   },

--- a/apps/govea/src/lib/request-context.ts
+++ b/apps/govea/src/lib/request-context.ts
@@ -1,0 +1,55 @@
+import { headers } from 'next/headers'
+
+export interface RequestContext {
+  ip: string | null
+  userAgent: string | null
+}
+
+const DEFAULT_TRUSTED_HOPS = 1
+
+/**
+ * Number of trusted proxy hops in front of the app, from
+ * `GOVEA_TRUSTED_PROXY_HOPS` (default 1 — Azure Container Apps ingress).
+ * Operator-specific (public-repo policy: kept in env, not hardcoded).
+ */
+export function trustedProxyHops(): number {
+  const raw = process.env.GOVEA_TRUSTED_PROXY_HOPS
+  const n = raw ? Number.parseInt(raw, 10) : NaN
+  return Number.isFinite(n) && n >= 1 ? n : DEFAULT_TRUSTED_HOPS
+}
+
+/**
+ * Resolves the real client IP from an `X-Forwarded-For` value, trusting only
+ * the rightmost `hops` entries (those appended by our own proxies). #720.
+ *
+ * XFF is `client, proxy1, …` — proxies *append* on the right, so the entry our
+ * outermost trusted proxy added sits at index `len - hops`. A malicious client
+ * can only *prepend* fake entries (to the left of `len - hops`), which this
+ * ignores. Returns null for empty/missing input.
+ *
+ * Exported for unit testing — this is the security-critical, anti-spoofing bit.
+ */
+export function clientIpFromForwarded(xff: string | null | undefined, hops: number): string | null {
+  if (!xff) return null
+  const parts = xff.split(',').map(s => s.trim()).filter(Boolean)
+  if (parts.length === 0) return null
+  const idx = Math.max(0, parts.length - hops)
+  return parts[idx] ?? null
+}
+
+/**
+ * Proxy-aware client context (IP + user-agent) for audit telemetry (#720).
+ * Safe to call outside a request scope — returns nulls if `headers()` throws.
+ * Never records raw headers; only the derived IP and the user-agent string.
+ */
+export async function getRequestContext(): Promise<RequestContext> {
+  try {
+    const h = await headers()
+    const ip = clientIpFromForwarded(h.get('x-forwarded-for'), trustedProxyHops())
+      ?? h.get('x-real-ip')
+      ?? null
+    return { ip, userAgent: h.get('user-agent') }
+  } catch {
+    return { ip: null, userAgent: null }
+  }
+}

--- a/apps/govea/tests/integration/failed-login-summary.test.ts
+++ b/apps/govea/tests/integration/failed-login-summary.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests: getFailedLoginSummary (#720 slice 2 / #726)
+ *
+ * Aggregates failed-login telemetry (slice 1) by attempted email and by source
+ * IP for instance-admin security review. Uses unique email/IP markers per run
+ * so assertions target only this test's rows — audit_log is append-only
+ * (immutability triggers block DELETE), so inserted rows aren't cleaned up.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/db/client'
+import { auditLog } from '@/db/schema'
+import { getFailedLoginSummary } from '@/lib/audit-view'
+
+const tag = randomUUID().slice(0, 8)
+const E1 = `e1-${tag}@attack.example`
+const E2 = `e2-${tag}@attack.example`
+const I1 = `198.51.100.${(parseInt(tag, 16) % 200) + 1}`
+const I2 = `203.0.113.${(parseInt(tag.slice(1), 16) % 200) + 1}`
+
+async function failRow(email: string, ip: string, createdAt?: Date) {
+  await db.insert(auditLog).values({
+    action: 'auth.login_failed',
+    entityType: 'user',
+    organizationId: null,
+    metadata: { email, ip, reason: 'invalid_credentials', provider: 'local' },
+    ...(createdAt ? { createdAt } : {}),
+  })
+}
+
+describe('getFailedLoginSummary (#720 slice 2)', () => {
+  beforeAll(async () => {
+    // E1: 3 recent attempts from 2 IPs (I1 x2, I2 x1)
+    await failRow(E1, I1)
+    await failRow(E1, I1)
+    await failRow(E1, I2)
+    // E2: 1 recent attempt from I1
+    await failRow(E2, I1)
+    // An old E1/I1 attempt outside a 1-day window (must be excluded)
+    await failRow(E1, I1, new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
+  })
+
+  it('groups by attempted email with attempt count + distinct IPs (windowed)', async () => {
+    const { byEmail } = await getFailedLoginSummary({ sinceDays: 1, limit: 500 })
+    const e1 = byEmail.find(r => r.email === E1)
+    const e2 = byEmail.find(r => r.email === E2)
+    expect(e1).toBeDefined()
+    expect(e1!.attempts).toBe(3)        // old 30-day row excluded by the window
+    expect(e1!.distinctIps).toBe(2)
+    expect(e1!.lastAttempt).toBeTruthy()
+    expect(e2!.attempts).toBe(1)
+    expect(e2!.distinctIps).toBe(1)
+  })
+
+  it('groups by source IP with attempt count + distinct emails', async () => {
+    const { byIp } = await getFailedLoginSummary({ sinceDays: 1, limit: 500 })
+    const i1 = byIp.find(r => r.ip === I1)
+    expect(i1).toBeDefined()
+    expect(i1!.attempts).toBe(3)        // E1 x2 + E2 x1 within window
+    expect(i1!.distinctEmails).toBe(2)  // E1 and E2
+  })
+
+  it('respects the time window (wide window includes the old attempt)', async () => {
+    // 1-day window saw 3 (test above); a 60-day window also includes the
+    // 30-day-old E1/I1 attempt → 4. Proves the window boundary actually filters.
+    const { byEmail } = await getFailedLoginSummary({ sinceDays: 60, limit: 500 })
+    const e1 = byEmail.find(r => r.email === E1)
+    expect(e1).toBeDefined()
+    expect(e1!.attempts).toBe(4)
+  })
+})

--- a/apps/govea/tests/unit/request-context.test.ts
+++ b/apps/govea/tests/unit/request-context.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests: proxy-aware client-IP resolution (#720 slice 1 / #725)
+ *
+ * The anti-spoofing core: trust only the rightmost `hops` X-Forwarded-For
+ * entries (added by our own proxies); ignore client-prepended fakes.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { clientIpFromForwarded, trustedProxyHops } from '@/lib/request-context'
+
+describe('clientIpFromForwarded (#720)', () => {
+  it('returns null for missing/empty input', () => {
+    expect(clientIpFromForwarded(null, 1)).toBeNull()
+    expect(clientIpFromForwarded(undefined, 1)).toBeNull()
+    expect(clientIpFromForwarded('', 1)).toBeNull()
+    expect(clientIpFromForwarded('   ', 1)).toBeNull()
+  })
+
+  it('single trusted hop (Azure): rightmost entry is the real client', () => {
+    // ACA ingress appends the real client IP as the sole entry.
+    expect(clientIpFromForwarded('203.0.113.7', 1)).toBe('203.0.113.7')
+  })
+
+  it('ignores client-prepended spoofed entries beyond the trusted hop', () => {
+    // Attacker sends "X-Forwarded-For: 1.2.3.4" hoping to be logged as 1.2.3.4;
+    // the trusted proxy appends the *real* peer on the right.
+    expect(clientIpFromForwarded('1.2.3.4, 203.0.113.7', 1)).toBe('203.0.113.7')
+    expect(clientIpFromForwarded('9.9.9.9, 8.8.8.8, 203.0.113.7', 1)).toBe('203.0.113.7')
+  })
+
+  it('two trusted hops: client is two from the right', () => {
+    // client, proxy1 (proxy2 is the socket peer, not in XFF)
+    expect(clientIpFromForwarded('203.0.113.7, 10.0.0.2', 2)).toBe('203.0.113.7')
+    // with a prepended fake, still resolves the real client
+    expect(clientIpFromForwarded('1.2.3.4, 203.0.113.7, 10.0.0.2', 2)).toBe('203.0.113.7')
+  })
+
+  it('clamps when hops exceeds the list length (best-effort leftmost)', () => {
+    expect(clientIpFromForwarded('203.0.113.7', 5)).toBe('203.0.113.7')
+  })
+
+  it('trims whitespace around entries', () => {
+    expect(clientIpFromForwarded('  1.2.3.4 ,  203.0.113.7  ', 1)).toBe('203.0.113.7')
+  })
+})
+
+describe('trustedProxyHops (#720)', () => {
+  const original = process.env.GOVEA_TRUSTED_PROXY_HOPS
+  afterEach(() => {
+    if (original === undefined) delete process.env.GOVEA_TRUSTED_PROXY_HOPS
+    else process.env.GOVEA_TRUSTED_PROXY_HOPS = original
+  })
+
+  it('defaults to 1 when unset or invalid', () => {
+    delete process.env.GOVEA_TRUSTED_PROXY_HOPS
+    expect(trustedProxyHops()).toBe(1)
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = 'nonsense'
+    expect(trustedProxyHops()).toBe(1)
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = '0'
+    expect(trustedProxyHops()).toBe(1) // min 1
+  })
+
+  it('honors a valid configured value', () => {
+    process.env.GOVEA_TRUSTED_PROXY_HOPS = '2'
+    expect(trustedProxyHops()).toBe(2)
+  })
+})


### PR DESCRIPTION
Closes #729 · Refs #720 (slice 2 of 3) · **Stacks on #727** (slice 1) — merge #727 first; diff resolves to slice-2-only after.

## What

Builds on slice 1's telemetry: `getFailedLoginSummary()` aggregates failed-login events **across all orgs**, grouped by attempted email and by source IP — the instance-admin signal for credential stuffing / attacks on privileged accounts.

- **`lib/audit-view.ts`** — `getFailedLoginSummary({ sinceDays=7, limit=20 })` →
  `{ since, byEmail[{email, attempts, lastAttempt, distinctIps}], byIp[{ip, attempts, lastAttempt, distinctEmails}] }`. Reads `metadata->>'email'` / `->>'ip'` from `FAILED_LOGIN_ACTIONS`. Pure read; caller gates with `requireInstanceAdmin` (same pattern as `getAuditEntries`). Audit immutability untouched.

## Verification
- Integration test (ran locally, 3/3): email grouping (attempts + distinct IPs), IP grouping (attempts + distinct emails), and the time window — a 1-day window sees 3 attempts, a 60-day window includes a 30-day-old attempt (=4), proving the boundary filters. Unique per-run markers keep it isolation-safe on the append-only `audit_log`.
- `tsc` + eslint clean.

## Acceptance criteria (#729)
- [x] Group by attempted email + by source IP, with counts/last-seen/distinct
- [x] Configurable window; out-of-window events excluded
- [x] Reads slice-1 telemetry; spans all orgs
- [x] Pure read; audit immutability preserved
- [x] Integration test for both groupings + window

## Next
- **Slice 3** — surface this in the instance audit UI + add an audit CSV export (needs `/verify`).

Capability: iam-audit-trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)