### PR TITLE
feat(audit): instance audit telemetry UI + CSV export (slice 3 of #720)

### DIFF
--- a/apps/govea/src/app/(instance)/instance/audit/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/audit/page.tsx
@@ -6,6 +6,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
 import { AuditFilters } from './audit-filters'
+import { getFailedLoginSummary } from '@/lib/audit-view'
 
 function cutoffForSince(since: string | undefined): Date | null {
   switch (since) {
@@ -42,6 +43,9 @@ export default async function InstanceAuditPage({
     actor ? eq(breakGlassSessions.instanceAdminId, actor) : undefined,
     cutoff ? gte(breakGlassSessions.grantedAt, cutoff) : undefined,
   )
+
+  // #720 — repeated failed-login telemetry (across all orgs), last 7 days.
+  const failedLogins = await getFailedLoginSummary({ sinceDays: 7, limit: 10 })
 
   const [instanceEvents, bgSessions, adminRows, actionRows] = await Promise.all([
     db
@@ -85,6 +89,81 @@ export default async function InstanceAuditPage({
         actions={knownActions}
         current={{ actor, action: actionFilter, since }}
       />
+
+      {/* Failed-login telemetry (#720) — repeated-failure review across orgs */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold">
+            Failed Logins <span className="text-muted-foreground text-sm font-normal">(last 7 days)</span>
+          </h2>
+          <a
+            href="/api/instance/audit/export"
+            className="text-sm text-primary underline underline-offset-2 hover:no-underline"
+          >
+            Export CSV (30d)
+          </a>
+        </div>
+        {failedLogins.byEmail.length === 0 && failedLogins.byIp.length === 0 ? (
+          <p className="text-sm text-muted-foreground rounded-lg border bg-card p-4">
+            No failed logins in the last 7 days.
+          </p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border bg-card">
+              <div className="px-3 py-2 text-xs font-medium text-muted-foreground border-b">By attempted email</div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead className="text-right">Attempts</TableHead>
+                    <TableHead className="text-right">IPs</TableHead>
+                    <TableHead>Last</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {failedLogins.byEmail.map(r => (
+                    <TableRow key={r.email}>
+                      <TableCell className="text-sm">{r.email}</TableCell>
+                      <TableCell className="text-right font-medium">{r.attempts}</TableCell>
+                      <TableCell className="text-right text-muted-foreground">{r.distinctIps}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">{new Date(r.lastAttempt).toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                  {failedLogins.byEmail.length === 0 && (
+                    <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground py-4 text-sm">None</TableCell></TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+            <div className="rounded-lg border bg-card">
+              <div className="px-3 py-2 text-xs font-medium text-muted-foreground border-b">By source IP</div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>IP</TableHead>
+                    <TableHead className="text-right">Attempts</TableHead>
+                    <TableHead className="text-right">Emails</TableHead>
+                    <TableHead>Last</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {failedLogins.byIp.map(r => (
+                    <TableRow key={r.ip}>
+                      <TableCell className="font-mono text-xs">{r.ip}</TableCell>
+                      <TableCell className="text-right font-medium">{r.attempts}</TableCell>
+                      <TableCell className="text-right text-muted-foreground">{r.distinctEmails}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">{new Date(r.lastAttempt).toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                  {failedLogins.byIp.length === 0 && (
+                    <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground py-4 text-sm">None</TableCell></TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+      </section>
 
       {/* Instance events */}
       <section>

--- a/apps/govea/src/app/api/instance/audit/export/route.ts
+++ b/apps/govea/src/app/api/instance/audit/export/route.ts
@@ -1,0 +1,37 @@
+import { auth } from '@/lib/auth'
+import { isInstanceAdmin } from '@/lib/rbac'
+import { escapeCsv } from '@/lib/csv'
+import { getFailedLoginEvents } from '@/lib/audit-view'
+
+/**
+ * Failed-login telemetry CSV export — #720 slice 3. Instance-admin only; spans
+ * all orgs (instance security review). Includes the slice-1 telemetry fields
+ * (ip, user_agent, reason) on each failed-login event. No secrets exported.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return new Response('Unauthorized', { status: 401 })
+  if (!isInstanceAdmin(session.user)) return new Response('Forbidden', { status: 403 })
+
+  const events = await getFailedLoginEvents({ sinceDays: 30 })
+
+  const headers = ['when', 'action', 'email', 'ip', 'user_agent', 'reason', 'organization_id']
+  const lines = events.map(e => [
+    e.createdAt.toISOString(),
+    e.action,
+    e.email ?? '',
+    e.ip ?? '',
+    e.userAgent ?? '',
+    e.reason ?? '',
+    e.organizationId ?? '',
+  ].map(escapeCsv).join(','))
+  const csv = [headers.map(escapeCsv).join(','), ...lines].join('\n')
+
+  const date = new Date().toISOString().slice(0, 10)
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="failed-logins-${date}.csv"`,
+    },
+  })
+}

--- a/apps/govea/src/lib/audit-view.ts
+++ b/apps/govea/src/lib/audit-view.ts
@@ -229,3 +229,43 @@ export async function getFailedLoginSummary(
 
   return { since, byEmail, byIp }
 }
+
+/**
+ * Raw failed-login events with telemetry, for the instance audit CSV export
+ * (#720 slice 3). Caller gates with instance-admin. Spans all orgs.
+ */
+export interface FailedLoginEvent {
+  createdAt: Date
+  action: string
+  email: string | null
+  ip: string | null
+  userAgent: string | null
+  reason: string | null
+  organizationId: string | null
+}
+
+export async function getFailedLoginEvents(
+  opts?: { sinceDays?: number; limit?: number },
+): Promise<FailedLoginEvent[]> {
+  const sinceDays = opts?.sinceDays ?? 30
+  const limit = opts?.limit ?? 5000
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+  return db
+    .select({
+      createdAt: auditLog.createdAt,
+      action: auditLog.action,
+      email: sql<string | null>`${auditLog.metadata} ->> 'email'`,
+      ip: sql<string | null>`${auditLog.metadata} ->> 'ip'`,
+      userAgent: sql<string | null>`${auditLog.metadata} ->> 'userAgent'`,
+      reason: sql<string | null>`${auditLog.metadata} ->> 'reason'`,
+      organizationId: auditLog.organizationId,
+    })
+    .from(auditLog)
+    .where(and(
+      inArray(auditLog.action, FAILED_LOGIN_ACTIONS as unknown as string[]),
+      gte(auditLog.createdAt, since),
+    ))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit)
+}


### PR DESCRIPTION
Closes #732 · Refs #720 — **completes #720** (slices 1+2 merged).

## What

Makes the captured auth telemetry (slice 1) and aggregation (slice 2) reviewable by instance admins.

- **Instance audit page** — a "Failed Logins (last 7 days)" panel: top offenders **by attempted email** (attempts · distinct IPs · last seen) and **by source IP** (attempts · distinct emails · last seen), from `getFailedLoginSummary`. Placed above the event list so the default view isn't overwhelmed; empty-state when clean.
- **`/api/instance/audit/export`** — failed-login CSV export (30d), instance-admin gated (401/403), columns `when, action, email, ip, user_agent, reason, organization_id`. No secrets exported.
- **`lib/audit-view.ts`** — `getFailedLoginEvents()` raw-event query backing the export.

## Verification (live, as instance admin `ivan@govea.dev`)
- Panel renders with real aggregated data (by email + by IP, with attempts/distinct/last); "platform admin" badge confirms instance-admin gating.
- `GET /api/instance/audit/export` → **200**, `text/csv`, `attachment; filename="failed-logins-YYYY-MM-DD.csv"`, header `when,action,email,ip,user_agent,reason,organization_id`, rows with `ip`/`reason` populated.
- `tsc` + eslint clean.

## Acceptance criteria (#732 / #720)
- [x] Instance audit surfaces repeated failed-login telemetry (email + source IP) readably; default list not overwhelmed
- [x] IP / reason exposed (export columns; panel shows IP groupings)
- [x] CSV export includes the new telemetry fields
- [x] Instance-admin gated; no secrets leaked
- [x] Verified by running the app

## #720 complete
Slice 1 (capture, #727) + slice 2 (aggregation, #730) + slice 3 (this) — telemetry is captured proxy-aware, aggregated for review, and surfaced + exportable.

Capability: iam-audit-trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)