### PR TITLE
fix(impact): enforce auth and tenant scoping on impact actions (#738)

### DIFF
--- a/apps/govea/src/actions/impact.ts
+++ b/apps/govea/src/actions/impact.ts
@@ -1,8 +1,11 @@
 'use server'
 
 import { db } from '@/db/client'
-import { applicationCapabilities, capabilityPersonas, initiativeCapabilities, initiativeApplications } from '@/db/schema'
+import { applications, capabilities, applicationCapabilities, capabilityPersonas, initiativeCapabilities, initiativeApplications } from '@/db/schema'
 import { eq, inArray } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { canReadFederatedEntity } from '@/lib/federation'
 
 export type RiskLevel = 'high' | 'medium' | 'none'
 
@@ -39,7 +42,31 @@ export type CapabilityImpact = {
   riskLevel: RiskLevel
 }
 
+const EMPTY_APPLICATION_IMPACT: ApplicationImpact = {
+  orphanedCapabilities: [], affectedPersonas: [], activeInitiatives: [], riskLevel: 'none',
+}
+const EMPTY_CAPABILITY_IMPACT: CapabilityImpact = {
+  dependentPersonas: [], soleCoveragePersonaIds: [], activeInitiatives: [], riskLevel: 'none',
+}
+
 export async function getApplicationImpact(applicationId: string): Promise<ApplicationImpact> {
+  // Access control (#738): these are `'use server'` endpoints addressable
+  // directly, so they must enforce auth + tenant scoping themselves — the
+  // page-level guard does not protect a direct action invocation. Mirror the
+  // pattern in impact-analysis.ts: authenticate, then confirm the caller may
+  // read this entity under federated-visibility rules before returning any
+  // dependency data. Unreadable → empty result, never another org's data.
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const application = await db.query.applications.findFirst({
+    where: eq(applications.id, applicationId),
+    columns: { organizationId: true, visibility: true },
+  })
+  if (!application) return EMPTY_APPLICATION_IMPACT
+  const visible = await canReadFederatedEntity(application.organizationId, application.visibility, session.user.organizationId!)
+  if (!visible) return EMPTY_APPLICATION_IMPACT
+
   // Capabilities this application supports
   const linkedCapRows = await db.query.applicationCapabilities.findMany({
     where: eq(applicationCapabilities.applicationId, applicationId),
@@ -111,6 +138,18 @@ export async function getApplicationImpact(applicationId: string): Promise<Appli
 }
 
 export async function getCapabilityImpact(capabilityId: string): Promise<CapabilityImpact> {
+  // Access control (#738) — see getApplicationImpact above.
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const capability = await db.query.capabilities.findFirst({
+    where: eq(capabilities.id, capabilityId),
+    columns: { organizationId: true, visibility: true },
+  })
+  if (!capability) return EMPTY_CAPABILITY_IMPACT
+  const visible = await canReadFederatedEntity(capability.organizationId, capability.visibility, session.user.organizationId!)
+  if (!visible) return EMPTY_CAPABILITY_IMPACT
+
   // Personas that rely on this capability
   const personaRows = await db.query.capabilityPersonas.findMany({
     where: eq(capabilityPersonas.capabilityId, capabilityId),

--- a/apps/govea/tests/integration/impact-authz.test.ts
+++ b/apps/govea/tests/integration/impact-authz.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration tests: access control for getApplicationImpact /
+ * getCapabilityImpact (#738).
+ *
+ * These `'use server'` actions previously ran with no auth and no tenant
+ * scoping, so a caller could read another org's dependency/impact data by
+ * passing an arbitrary id (cross-tenant IDOR). These tests lock in the fix:
+ *
+ *   - No session → redirect('/login') (modelled here as a thrown sentinel).
+ *   - An org-private entity in another org → empty result, never its data.
+ *   - The owning org's caller → real data (guard doesn't over-block).
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  applications, capabilities, applicationCapabilities, capabilityPersonas, personas,
+} from '@/db/schema'
+import { randomUUID } from 'node:crypto'
+import { getApplicationImpact, getCapabilityImpact } from '@/actions/impact'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+// redirect() throws in Next's real implementation; model that here so a
+// guard that redirects is observable as a throw rather than a silent return.
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => { throw new Error(`REDIRECT:${url}`) },
+}))
+
+let orgA: string
+let orgB: string
+let userA: TestUser
+let appB: string
+let capB: string
+
+beforeAll(async () => {
+  orgA = (await createTestOrg()).id
+  orgB = (await createTestOrg()).id
+  userA = await createTestUser(orgA, 'admin')
+
+  // An org-private application + capability owned by org B, with a linked
+  // persona so a successful read would return non-empty data.
+  appB = randomUUID()
+  capB = randomUUID()
+  const personaB = randomUUID()
+  await db.insert(applications).values({
+    id: appB, organizationId: orgB, name: 'Org B App',
+    lifecycleStatus: 'active', status: 'published', visibility: 'org',
+  })
+  await db.insert(capabilities).values({
+    id: capB, organizationId: orgB, name: 'Org B Capability',
+    status: 'published', visibility: 'org',
+  })
+  await db.insert(personas).values({
+    id: personaB, organizationId: orgB, name: 'Org B Persona',
+    status: 'published', visibility: 'org',
+  })
+  await db.insert(applicationCapabilities).values({ applicationId: appB, capabilityId: capB })
+  await db.insert(capabilityPersonas).values({ capabilityId: capB, personaId: personaB })
+})
+
+afterAll(async () => {
+  await cleanupOrg(orgA)
+  await cleanupOrg(orgB)
+})
+
+describe('getApplicationImpact access control (#738)', () => {
+  it('redirects to /login when there is no session', async () => {
+    mockAuth.mockResolvedValueOnce(null)
+    await expect(getApplicationImpact(appB)).rejects.toThrow('REDIRECT:/login')
+  })
+
+  it('does not leak another org\'s org-private application', async () => {
+    mockAuth.mockResolvedValueOnce(makeSession(userA))
+    const result = await getApplicationImpact(appB)
+    expect(result).toEqual({
+      orphanedCapabilities: [], affectedPersonas: [], activeInitiatives: [], riskLevel: 'none',
+    })
+  })
+
+  it('returns real data for the owning org', async () => {
+    const userB = await createTestUser(orgB, 'admin')
+    mockAuth.mockResolvedValueOnce(makeSession(userB))
+    const result = await getApplicationImpact(appB)
+    // capB is sole-supported by appB and has a persona → orphan + high risk.
+    expect(result.orphanedCapabilities.map(c => c.id)).toContain(capB)
+    expect(result.affectedPersonas.length).toBeGreaterThan(0)
+    expect(result.riskLevel).toBe('high')
+  })
+})
+
+describe('getCapabilityImpact access control (#738)', () => {
+  it('redirects to /login when there is no session', async () => {
+    mockAuth.mockResolvedValueOnce(null)
+    await expect(getCapabilityImpact(capB)).rejects.toThrow('REDIRECT:/login')
+  })
+
+  it('does not leak another org\'s org-private capability', async () => {
+    mockAuth.mockResolvedValueOnce(makeSession(userA))
+    const result = await getCapabilityImpact(capB)
+    expect(result).toEqual({
+      dependentPersonas: [], soleCoveragePersonaIds: [], activeInitiatives: [], riskLevel: 'none',
+    })
+  })
+
+  it('returns real data for the owning org', async () => {
+    const userB = await createTestUser(orgB, 'admin')
+    mockAuth.mockResolvedValueOnce(makeSession(userB))
+    const result = await getCapabilityImpact(capB)
+    expect(result.dependentPersonas.length).toBeGreaterThan(0)
+    expect(result.soleCoveragePersonaIds.length).toBeGreaterThan(0)
+    expect(result.riskLevel).toBe('high')
+  })
+})


### PR DESCRIPTION
## What & why
`getApplicationImpact` and `getCapabilityImpact` in `src/actions/impact.ts` are `'use server'` actions that ran with **no authentication and no tenant scoping** — the only data-returning action module missing the standard guard. Because server actions are directly addressable endpoints (page-level/middleware auth gates navigation, not action invocation), a caller could pass an arbitrary `applicationId`/`capabilityId` from another org and read its linked personas, applications, active initiatives, and orphan/sole-coverage risk signals. This is a cross-tenant IDOR that bypasses the federated-visibility mechanism the product relies on.

## Change
- Both actions now `auth()` + `redirect('/login')` when unauthenticated.
- Each loads the root entity's `organizationId` + `visibility` and gates the read through `canReadFederatedEntity(entityOrg, visibility, callerOrg)`, exactly mirroring `impact-analysis.ts` and `traceability.ts`.
- Unreadable entity → empty impact result (no leak), never another org's data.

## Tests
New `tests/integration/impact-authz.test.ts`:
- no session → `redirect('/login')`
- org A caller against an org-B org-private app/capability → empty result
- owning-org caller → real data (guard doesn't over-block)

## Verification
- `tsc --noEmit` ✓
- `lint` ✓ (0 errors)
- `build` ✓
- Integration/e2e run in CI (no local Postgres in the authoring environment).

Closes #738
Capability: iam-role-based-access-control
Persona: instance-administrator, agency-ea-coordinator

🤖 Generated with [Claude Code](https://claude.com/claude-code)