### PR TITLE
feat(hardening): add security response headers and report-only CSP (#739)

### DIFF
--- a/apps/govea/next.config.ts
+++ b/apps/govea/next.config.ts
@@ -13,6 +13,40 @@ if (process.env.NEXT_PUBLIC_APP_URL) {
   }
 }
 
+// #739 — baseline security response headers.
+//
+// The enforced headers below are safe for an app of this shape. The CSP is
+// intentionally shipped in *report-only* mode first: the app injects an inline
+// `<style>` for org theming (app-shell.tsx) and mermaid renders inline SVG, so
+// an enforcing `style-src`/`script-src` needs a nonce or hash rollout. Starting
+// report-only surfaces violations (via the browser console / a report endpoint)
+// without breaking the UI; a follow-up tightens to an enforcing policy.
+//
+// `frame-ancestors 'none'` (clickjacking) is also expressed via the enforced
+// `X-Frame-Options: DENY` header, which older browsers honour.
+const cspReportOnly = [
+  "default-src 'self'",
+  // 'unsafe-inline' is what we want to *remove* via nonces in the enforcing
+  // follow-up; documented here so the report-only baseline matches today's app.
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join('; ')
+
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+  { key: 'Content-Security-Policy-Report-Only', value: cspReportOnly },
+]
+
 const nextConfig: NextConfig = {
   output: 'standalone',
   // #34: the @govea/core workspace package is the canonical source for RBAC
@@ -25,6 +59,9 @@ const nextConfig: NextConfig = {
     serverActions: {
       allowedOrigins,
     },
+  },
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }]
   },
 }
 

--- a/apps/govea/tests/e2e/specs/smoke.spec.ts
+++ b/apps/govea/tests/e2e/specs/smoke.spec.ts
@@ -48,3 +48,17 @@ for (const route of ROUTES) {
     expect(page.url(), `${route}: should not redirect to /login`).not.toContain('/login')
   })
 }
+
+// #739 — baseline security response headers are present.
+test('security response headers are set', async ({ page }) => {
+  const response = await page.goto('/overview')
+  const headers = response?.headers() ?? {}
+  expect(headers['x-frame-options']).toBe('DENY')
+  expect(headers['x-content-type-options']).toBe('nosniff')
+  expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin')
+  expect(headers['strict-transport-security']).toContain('max-age=')
+  expect(
+    headers['content-security-policy-report-only'],
+    'CSP should ship report-only first (see next.config.ts)',
+  ).toContain("frame-ancestors 'none'")
+})


### PR DESCRIPTION
## What & why
The app sent no security response headers. With three `dangerouslySetInnerHTML` sinks and one mermaid `innerHTML` sink in the tree, a CSP is the defense-in-depth layer that contains an XSS sink if one is reached, and `X-Frame-Options`/`frame-ancestors` prevents clickjacking of the admin surface.

## Change
`next.config.ts` adds an `async headers()` applied to `/:path*`:
- **Enforced:** `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`.
- **Report-only:** `Content-Security-Policy-Report-Only` with a sane baseline (`default-src 'self'`, `frame-ancestors 'none'`, `object-src 'none'`, …).

CSP is report-only *deliberately*: the inline `<style>` theme injection (app-shell) and mermaid's inline SVG mean an enforcing `style-src`/`script-src` needs a nonce/hash rollout. Report-only surfaces violations now without breaking the UI; the nonce work is the tracked follow-up.

## Verification
- `tsc --noEmit` ✓, `lint` ✓ (0 errors), `build` ✓
- Ran the built standalone server and confirmed all five headers emit (curl).
- Added a smoke e2e assertion (`tests/e2e/specs/smoke.spec.ts`) — runs in CI.

## Follow-up (not in this PR)
Tighten CSP to enforcing with per-request nonces for the theme `<style>` and any inline scripts.

Closes #739
Capability: ac-site-settings
Persona: instance-administrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)