### PR TITLE
feat(recipe): TOGAF recipe definition + built-in catalog (#672 / S2)

### DIFF
--- a/apps/govea/src/lib/recipes/catalog.ts
+++ b/apps/govea/src/lib/recipes/catalog.ts
@@ -1,0 +1,14 @@
+import type { Recipe } from './types'
+import { togafRecipe } from './togaf'
+
+/**
+ * The built-in recipe catalog (#671 / #665). Recipes are defined in-repo as
+ * data; the admin install surface (S1b) lists these and installs one via
+ * installRecipe(). File-based / uploaded recipes are a deferred follow-on.
+ */
+export const RECIPE_CATALOG: Recipe[] = [togafRecipe]
+
+/** Look up a built-in recipe by its stable slug. */
+export function getRecipe(slug: string): Recipe | undefined {
+  return RECIPE_CATALOG.find(r => r.slug === slug)
+}

--- a/apps/govea/src/lib/recipes/togaf.ts
+++ b/apps/govea/src/lib/recipes/togaf.ts
@@ -1,0 +1,80 @@
+import type { Recipe } from './types'
+
+/**
+ * TOGAF recipe — the recipe engine's first real consumer (#672 / #665 S2).
+ *
+ * Per ADR-0002, TOGAF concepts ship as ordinary taxonomy **classification**,
+ * not workflow: an "Architecture Domain" type and an "ADM Phase" type, both
+ * marked `audience: 'framework'` so they stay invisible to viewer-role users
+ * and stakeholder reports (ADR-0001's "no framework jargon for Department
+ * Directors"). ADM phases are labels only — no phase gates, approvals, or
+ * transitions (ADR-0002 §35-38).
+ *
+ * Report presets (Application Landscape by domain, ADM coverage by phase) are
+ * deferred to the report engine (S3 / #673) — the Recipe type doesn't carry
+ * presets yet.
+ */
+export const togafRecipe: Recipe = {
+  slug: 'togaf',
+  name: 'TOGAF',
+  version: '1.0.0',
+  description:
+    'Installs TOGAF as optional taxonomy: Architecture Domains and ADM Phases (classification only, per ADR-0002), plus core TOGAF glossary and principles. Framework types are hidden from viewers and stakeholder reports.',
+
+  taxonomyTypes: [
+    {
+      name: 'TOGAF Architecture Domain',
+      slug: 'togaf-architecture-domain',
+      audience: 'framework',
+      description: 'The four TOGAF architecture domains, as an optional classification.',
+      terms: [
+        { name: 'Business Architecture', slug: 'business-architecture' },
+        { name: 'Application Architecture', slug: 'application-architecture' },
+        { name: 'Data Architecture', slug: 'data-architecture' },
+        { name: 'Technology Architecture', slug: 'technology-architecture' },
+      ],
+      bindings: [
+        { entityType: 'capability', selectionMode: 'multi' },
+        { entityType: 'application', selectionMode: 'multi' },
+      ],
+    },
+    {
+      name: 'ADM Phase',
+      slug: 'togaf-adm-phase',
+      audience: 'framework',
+      description:
+        'TOGAF ADM phases as an optional classification label (ADR-0002). Tagging only — no phase gates, approvals, or required progression.',
+      terms: [
+        { name: 'Preliminary', slug: 'adm-preliminary' },
+        { name: 'A: Architecture Vision', slug: 'adm-a-architecture-vision' },
+        { name: 'B: Business Architecture', slug: 'adm-b-business-architecture' },
+        { name: 'C: Information Systems Architectures', slug: 'adm-c-information-systems-architectures' },
+        { name: 'D: Technology Architecture', slug: 'adm-d-technology-architecture' },
+        { name: 'E: Opportunities & Solutions', slug: 'adm-e-opportunities-and-solutions' },
+        { name: 'F: Migration Planning', slug: 'adm-f-migration-planning' },
+        { name: 'G: Implementation Governance', slug: 'adm-g-implementation-governance' },
+        { name: 'H: Architecture Change Management', slug: 'adm-h-architecture-change-management' },
+        { name: 'Requirements Management', slug: 'adm-requirements-management' },
+      ],
+      bindings: [
+        { entityType: 'capability', selectionMode: 'single' },
+        { entityType: 'initiative', selectionMode: 'single' },
+      ],
+    },
+  ],
+
+  glossaryTerms: [
+    { term: 'Architecture Development Method (ADM)', definition: 'TOGAF’s step-by-step approach to developing and managing an enterprise architecture, organised into phases (Preliminary, A–H, and Requirements Management).', domain: 'Framework' },
+    { term: 'Architecture Domain', definition: 'One of the four TOGAF architecture areas — Business, Data, Application, and Technology — used to organise architecture work.', domain: 'Framework' },
+    { term: 'Architecture Vision', definition: 'The high-level, aspirational view of the target architecture produced in ADM Phase A, used to gain stakeholder buy-in.', domain: 'Framework' },
+    { term: 'Building Block', definition: 'A reusable component of business, IT, or architectural capability that can be combined with others to deliver architectures and solutions.', domain: 'Framework' },
+    { term: 'Architecture Repository', definition: 'The holding area for all architecture assets — reference models, standards, completed architectures, and governance records.', domain: 'Framework' },
+  ],
+
+  principles: [
+    { name: 'Primacy of Principles', title: 'Primacy of Principles', description: 'All people and teams involved in the enterprise apply these principles.', rationale: 'Consistent, measurable progress depends on everyone working from the same principles.', implications: 'Initiatives are assessed for compliance; conflicts are reconciled against the principles.' },
+    { name: 'Business Continuity', title: 'Business Continuity', description: 'Operations are maintained in spite of system interruptions.', rationale: 'Public services must remain available through outages and change.', implications: 'Dependencies and recovery expectations are documented for critical capabilities.' },
+    { name: 'Data Is an Asset', title: 'Data Is an Asset', description: 'Data is an asset with value to the enterprise and is managed accordingly.', rationale: 'Decisions and services depend on accurate, governed data.', implications: 'Ownership, stewardship, and quality expectations are defined for key data.' },
+    { name: 'Common Use Applications', title: 'Common Use Applications', description: 'Prefer applications used across the enterprise over similar duplicates.', rationale: 'Duplicate applications raise cost and fragment data.', implications: 'New applications are evaluated against existing shared capabilities first.' },
+  ],
+}

--- a/apps/govea/tests/integration/togaf-recipe.test.ts
+++ b/apps/govea/tests/integration/togaf-recipe.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration tests: TOGAF recipe content (#672 / #665 S2)
+ *
+ * Pins the recipe *data* (not the engine — that's recipe-install.test.ts): the
+ * TOGAF recipe installs an Architecture Domain type and an ADM Phase type, both
+ * audience='framework' (ADR-0001/0002), with the right values + bindings, plus
+ * glossary and principles — and is idempotent on re-install.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { taxonomyTerms, entityTaxonomyDefinitions, glossaryTerms, principles } from '@/db/schema'
+import { and, eq, isNull } from 'drizzle-orm'
+import { installRecipe } from '@/lib/recipes/install'
+import { togafRecipe } from '@/lib/recipes/togaf'
+import { getRecipe, RECIPE_CATALOG } from '@/lib/recipes/catalog'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+describe('TOGAF recipe (#672)', () => {
+  let orgId: string
+  beforeAll(async () => { orgId = (await createTestOrg()).id })
+  afterAll(() => cleanupOrg(orgId))
+
+  async function typeBySlug(slug: string) {
+    const [t] = await db.select().from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), isNull(taxonomyTerms.parentId), eq(taxonomyTerms.slug, slug)))
+    return t
+  }
+  async function childCount(typeId: string) {
+    return (await db.select().from(taxonomyTerms)
+      .where(and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.parentId, typeId)))).length
+  }
+  async function bindingsFor(typeId: string) {
+    const rows = await db.select().from(entityTaxonomyDefinitions)
+      .where(and(eq(entityTaxonomyDefinitions.organizationId, orgId), eq(entityTaxonomyDefinitions.taxonomyTypeId, typeId)))
+    return rows.map(r => `${r.entityType}:${r.selectionMode}`).sort()
+  }
+
+  it('is registered in the catalog', () => {
+    expect(getRecipe('togaf')).toBe(togafRecipe)
+    expect(RECIPE_CATALOG).toContain(togafRecipe)
+  })
+
+  it('installs Architecture Domain + ADM Phase as framework-audience classifications', async () => {
+    const result = await installRecipe(orgId, togafRecipe, null)
+    expect(result.taxonomyTypes).toBe(2)
+
+    const domain = await typeBySlug('togaf-architecture-domain')
+    expect(domain.audience).toBe('framework')
+    expect(await childCount(domain.id)).toBe(4)
+    expect(await bindingsFor(domain.id)).toEqual(['application:multi', 'capability:multi'])
+
+    const adm = await typeBySlug('togaf-adm-phase')
+    expect(adm.audience).toBe('framework')
+    expect(await childCount(adm.id)).toBe(10) // Preliminary + A–H + Requirements Management
+    expect(await bindingsFor(adm.id)).toEqual(['capability:single', 'initiative:single'])
+  })
+
+  it('installs TOGAF glossary terms and principles', async () => {
+    const gloss = await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))
+    expect(gloss.some(g => g.term.startsWith('Architecture Development Method'))).toBe(true)
+    const princ = await db.select().from(principles).where(eq(principles.organizationId, orgId))
+    expect(princ.some(p => p.name === 'Data Is an Asset')).toBe(true)
+  })
+
+  it('is idempotent on re-install (no new rows, counts zero)', async () => {
+    const before = {
+      tax: (await db.select().from(taxonomyTerms).where(eq(taxonomyTerms.organizationId, orgId))).length,
+      gloss: (await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))).length,
+      princ: (await db.select().from(principles).where(eq(principles.organizationId, orgId))).length,
+    }
+    const result = await installRecipe(orgId, togafRecipe, null)
+    expect(result).toMatchObject({ taxonomyTypes: 0, taxonomyTerms: 0, bindings: 0, glossaryTerms: 0, principles: 0 })
+    const after = {
+      tax: (await db.select().from(taxonomyTerms).where(eq(taxonomyTerms.organizationId, orgId))).length,
+      gloss: (await db.select().from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId))).length,
+      princ: (await db.select().from(principles).where(eq(principles.organizationId, orgId))).length,
+    }
+    expect(after).toEqual(before)
+  })
+})


### PR DESCRIPTION
Closes #672 · Refs #665 — the recipe engine's (#716) first real consumer.

## What

TOGAF shipped as **data on the existing engine**, per ADR-0002 (classification, not workflow):

- **`lib/recipes/togaf.ts`** —
  - **TOGAF Architecture Domain** type (Business/Application/Data/Technology Architecture; bound to **capability + application**, multi)
  - **ADM Phase** type (Preliminary, A–H, Requirements Management = 10 values; bound to **capability + initiative**, single) — tagging only, **no** phase gates/approvals/transitions (ADR-0002)
  - both `audience: 'framework'` → hidden from viewers + stakeholder reports (ADR-0001)
  - core TOGAF **glossary** terms + a few architecture **principles**
- **`lib/recipes/catalog.ts`** — `RECIPE_CATALOG` + `getRecipe(slug)`, the built-in registry the admin install surface (S1b) will list from.

## Verification
- Integration test (ran locally, 4/4): catalog registration; both types install with `audience='framework'`, correct value counts + bindings; glossary + principles created; **idempotent** re-install (counts zero, no new rows).
- `tsc` + eslint clean.

## Scope notes / deferred
- **Report presets** → report engine (S3 / #673); the `Recipe` type doesn't carry presets yet.
- **Admin install UI (S1b)** deferred — there's an existing `applyStarterPack` flow (`actions/starter-content.ts`) wired into the UI, so a recipe install surface needs a **recipe-vs-starter-pack UX reconciliation** decision before adding a second "apply a pack" flow. Flagging rather than guessing.

Capability: ea/framework-alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)