### PR TITLE
feat(reports): generic group-by-taxonomy-type report engine (#673 S3a)

### DIFF
--- a/apps/govea/src/lib/reports/group-by-taxonomy.ts
+++ b/apps/govea/src/lib/reports/group-by-taxonomy.ts
@@ -1,0 +1,93 @@
+import { db } from '@/db/client'
+import { taxonomyTerms } from '@/db/schema'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import { getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+
+/**
+ * Generic group-by-taxonomy-type report engine (#673 / #665 S3).
+ *
+ * Buckets a caller-supplied set of entities (id + display name) into the values
+ * of one taxonomy type, via `entity_taxonomy_values`, and surfaces an explicit
+ * "unmapped" gap set. Framework-agnostic: TOGAF Application Landscape / ADM
+ * coverage are just presets that call this with specific slugs.
+ *
+ * The caller fetches + visibility-filters the entities (this stays pure over the
+ * input set) and decides whether to render a `audience: 'framework'` type for
+ * the current role — the result exposes `type.audience` so the page can enforce
+ * ADR-0001/0002 (hide framework types from viewers / stakeholder views).
+ *
+ * Multi-select types: an entity tagged with N values appears in N groups; it is
+ * counted once in `total`. Entities with no value for this type are `unmapped`.
+ */
+export interface EntityRef {
+  id: string
+  name: string
+}
+
+export interface TaxonomyGroup {
+  termId: string
+  termName: string
+  termSlug: string
+  members: EntityRef[]
+}
+
+export interface GroupByTaxonomyResult {
+  type: { id: string; name: string; slug: string; audience: string | null }
+  groups: TaxonomyGroup[]
+  unmapped: EntityRef[]
+  total: number
+}
+
+export async function groupByTaxonomyType(
+  orgId: string,
+  entityType: string,
+  taxonomyTypeSlug: string,
+  entities: EntityRef[],
+): Promise<GroupByTaxonomyResult | null> {
+  // Resolve the taxonomy *type* (top-level term) by stable slug.
+  const [type] = await db
+    .select({
+      id: taxonomyTerms.id,
+      name: taxonomyTerms.name,
+      slug: taxonomyTerms.slug,
+      audience: taxonomyTerms.audience,
+    })
+    .from(taxonomyTerms)
+    .where(and(
+      eq(taxonomyTerms.organizationId, orgId),
+      isNull(taxonomyTerms.parentId),
+      eq(taxonomyTerms.slug, taxonomyTypeSlug),
+    ))
+    .limit(1)
+  if (!type) return null
+
+  // Its child terms are the groups, in display order.
+  const terms = await db
+    .select({ id: taxonomyTerms.id, name: taxonomyTerms.name, slug: taxonomyTerms.slug })
+    .from(taxonomyTerms)
+    .where(and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.parentId, type.id)))
+    .orderBy(asc(taxonomyTerms.sortOrder), asc(taxonomyTerms.name))
+
+  const termIds = new Set(terms.map(t => t.id))
+  const buckets = new Map<string, EntityRef[]>(terms.map(t => [t.id, []]))
+  const unmapped: EntityRef[] = []
+
+  const valueMap = await getEntityTaxonomyValuesForMany(orgId, entityType, entities.map(e => e.id))
+  for (const entity of entities) {
+    const tagged = (valueMap[entity.id] ?? [])
+      .map(v => v.taxonomyTermId)
+      .filter(id => termIds.has(id))
+    if (tagged.length === 0) {
+      unmapped.push(entity)
+      continue
+    }
+    for (const termId of tagged) buckets.get(termId)!.push(entity)
+  }
+
+  return {
+    type: { id: type.id, name: type.name, slug: type.slug, audience: type.audience ?? null },
+    groups: terms.map(t => ({ termId: t.id, termName: t.name, termSlug: t.slug, members: buckets.get(t.id)! })),
+    unmapped,
+    total: entities.length,
+  }
+}

--- a/apps/govea/tests/integration/group-by-taxonomy.test.ts
+++ b/apps/govea/tests/integration/group-by-taxonomy.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration tests: generic group-by-taxonomy report engine (#673 / #665 S3)
+ *
+ * Buckets entities into a taxonomy type's values via entity_taxonomy_values,
+ * with an explicit unmapped gap set; supports multi-select; exposes the type's
+ * audience so callers can hide framework types from viewers (ADR-0001/0002).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/db/client'
+import { taxonomyTerms, capabilities, entityTaxonomyValues } from '@/db/schema'
+import { groupByTaxonomyType, type EntityRef } from '@/lib/reports/group-by-taxonomy'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+describe('groupByTaxonomyType (#673)', () => {
+  let orgId: string
+  let termAId: string
+  let termBId: string
+  let caps: EntityRef[]
+
+  beforeAll(async () => {
+    orgId = (await createTestOrg()).id
+
+    const [type] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Report Type', slug: 'report-type', audience: 'framework',
+    }).returning()
+    const [a] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: type.id, name: 'Group A', slug: 'group-a', sortOrder: '0',
+    }).returning()
+    const [b] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: type.id, name: 'Group B', slug: 'group-b', sortOrder: '1',
+    }).returning()
+    termAId = a.id; termBId = b.id
+
+    const rows = await db.insert(capabilities).values([
+      { id: randomUUID(), organizationId: orgId, name: 'Cap One' },
+      { id: randomUUID(), organizationId: orgId, name: 'Cap Two' },
+      { id: randomUUID(), organizationId: orgId, name: 'Cap Three' },
+    ]).returning()
+    caps = rows.map(r => ({ id: r.id, name: r.name }))
+
+    // Cap One -> A; Cap Two -> A and B (multi); Cap Three -> none (unmapped)
+    await db.insert(entityTaxonomyValues).values([
+      { organizationId: orgId, entityType: 'capability', entityId: caps[0].id, taxonomyTermId: termAId },
+      { organizationId: orgId, entityType: 'capability', entityId: caps[1].id, taxonomyTermId: termAId },
+      { organizationId: orgId, entityType: 'capability', entityId: caps[1].id, taxonomyTermId: termBId },
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('returns null for an unknown taxonomy type slug', async () => {
+    expect(await groupByTaxonomyType(orgId, 'capability', 'does-not-exist', caps)).toBeNull()
+  })
+
+  it('groups entities by value, supports multi-select, and surfaces unmapped', async () => {
+    const r = await groupByTaxonomyType(orgId, 'capability', 'report-type', caps)
+    expect(r).not.toBeNull()
+    expect(r!.type.audience).toBe('framework')
+    expect(r!.total).toBe(3)
+
+    const a = r!.groups.find(g => g.termId === termAId)!
+    const b = r!.groups.find(g => g.termId === termBId)!
+    expect(a.members.map(m => m.name).sort()).toEqual(['Cap One', 'Cap Two'])
+    expect(b.members.map(m => m.name)).toEqual(['Cap Two']) // multi-select: Cap Two in both
+    expect(r!.unmapped.map(m => m.name)).toEqual(['Cap Three'])
+  })
+
+  it('preserves child-term order as the group order', async () => {
+    const r = await groupByTaxonomyType(orgId, 'capability', 'report-type', caps)
+    expect(r!.groups.map(g => g.termSlug)).toEqual(['group-a', 'group-b'])
+  })
+})


### PR DESCRIPTION
Refs #673 · #665 — the framework-agnostic core of the report engine (engine slice; presets + repoint follow).

## What

`groupByTaxonomyType(orgId, entityType, typeSlug, entities)` buckets a caller-supplied entity set into one taxonomy type's values via `entity_taxonomy_values`, returning groups (each with members), an explicit **unmapped** gap set, and `total`.

- **Framework-agnostic** — TOGAF Application Landscape / ADM coverage become *presets* that call this with specific slugs.
- **Pure over the input set** — the caller fetches + visibility-filters entities; the engine just groups. It exposes `type.audience` so pages hide `framework` types from viewers/stakeholder views (ADR-0001/0002).
- **Multi-select aware** — an entity tagged with N values appears in N groups, counted once in `total`. No value for the type → `unmapped`.

## Verification
- Integration test (3/3 local): grouping, multi-select (one cap in two groups), unmapped gap, `audience` surfaced, group order = child-term order, `null` for an unknown type slug.
- `tsc` + eslint clean.

## Deferred (rest of #673, next slice)
- **TOGAF presets** — Application Landscape (apps by `togaf-architecture-domain`, with capability-derived inference + mapped/derived/unmapped sections) and ADM coverage (by `togaf-adm-phase`).
- **Repoint** `reports/togaf/application-landscape` off `framework_mappings` onto `entity_taxonomy_values` (coordinates with #674).
- The report **UI** rendering (needs `/verify`).

Capability: ea/framework-alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)