### PR TITLE
feat(reports): TOGAF presets + repoint Application Landscape to taxonomy (#673 S3b)

### DIFF
--- a/apps/govea/src/app/(admin)/reports/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/page.tsx
@@ -87,6 +87,16 @@ export default async function ReportsPage() {
               </div>
               <span className="text-muted-foreground text-sm">→</span>
             </Link>
+            <Link
+              href="/reports/togaf/adm-coverage"
+              className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors group"
+            >
+              <div>
+                <p className="text-sm font-medium group-hover:text-primary transition-colors">ADM Coverage</p>
+                <p className="text-xs text-muted-foreground mt-0.5">Capabilities &amp; initiatives grouped by TOGAF ADM Phase (classification only)</p>
+              </div>
+              <span className="text-muted-foreground text-sm">→</span>
+            </Link>
           </div>
         </section>
       )}

--- a/apps/govea/src/app/(admin)/reports/togaf/adm-coverage/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/togaf/adm-coverage/page.tsx
@@ -1,0 +1,93 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
+import { db } from '@/db/client'
+import { capabilities, initiatives } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import Link from 'next/link'
+import { groupByTaxonomyType, type GroupByTaxonomyResult, type TaxonomyGroup, type EntityRef } from '@/lib/reports/group-by-taxonomy'
+
+function CoverageSection({ label, hrefBase, result }: { label: string; hrefBase: string; result: GroupByTaxonomyResult | null }) {
+  if (!result) {
+    return (
+      <section className="space-y-2">
+        <h2 className="text-base font-semibold">{label}</h2>
+        <p className="text-sm text-muted-foreground">The ADM Phase taxonomy is not installed for this organization.</p>
+      </section>
+    )
+  }
+  const taggedGroups = result.groups.filter((g: TaxonomyGroup) => g.members.length > 0)
+  return (
+    <section className="space-y-4">
+      <div className="flex items-baseline gap-3">
+        <h2 className="text-base font-semibold">{label}</h2>
+        <span className="text-xs text-muted-foreground">
+          {result.total - result.unmapped.length} of {result.total} tagged
+        </span>
+      </div>
+      {taggedGroups.map((g: TaxonomyGroup) => (
+        <div key={g.termId}>
+          <div className="flex items-center gap-3 mb-2">
+            <span className="inline-flex items-center rounded border bg-slate-100 text-slate-700 border-slate-200 px-2 py-0.5 text-xs font-semibold">{g.termName}</span>
+            <span className="text-xs text-muted-foreground">{g.members.length}</span>
+          </div>
+          <div className="rounded-lg border bg-card divide-y">
+            {g.members.map((m: EntityRef) => (
+              <Link key={m.id} href={`${hrefBase}/${m.id}`} className="block px-4 py-2 text-sm hover:bg-muted/40">{m.name}</Link>
+            ))}
+          </div>
+        </div>
+      ))}
+      {result.unmapped.length > 0 && (
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <span className="inline-flex items-center rounded border bg-amber-50 text-amber-700 border-amber-200 px-2 py-0.5 text-xs font-semibold">No ADM phase</span>
+            <span className="text-xs text-muted-foreground">{result.unmapped.length}</span>
+          </div>
+          <div className="rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/20 divide-y divide-amber-200 dark:divide-amber-900">
+            {result.unmapped.map((m: EntityRef) => (
+              <Link key={m.id} href={`${hrefBase}/${m.id}`} className="block px-4 py-2 text-sm hover:bg-amber-100/40">{m.name}</Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default async function AdmCoveragePage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const enabledModules = await getEnabledModules()
+  if (!isModuleEnabled(enabledModules, 'framework-overlay')) notFound()
+
+  const orgId = session.user.organizationId!
+  // ADM Phase is a framework-audience classification (ADR-0001/0002): hidden
+  // from viewer-role / stakeholder-facing output.
+  if (session.user.role === 'viewer') notFound()
+
+  const [caps, inits] = await Promise.all([
+    db.select({ id: capabilities.id, name: capabilities.name }).from(capabilities).where(eq(capabilities.organizationId, orgId)),
+    db.select({ id: initiatives.id, name: initiatives.name }).from(initiatives).where(eq(initiatives.organizationId, orgId)),
+  ])
+  const [capResult, initResult] = await Promise.all([
+    groupByTaxonomyType(orgId, 'capability', 'togaf-adm-phase', caps),
+    groupByTaxonomyType(orgId, 'initiative', 'togaf-adm-phase', inits),
+  ])
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <div className="space-y-1">
+        <Link href="/reports" className="text-sm text-muted-foreground hover:text-foreground transition-colors">← Reports</Link>
+        <h1 className="text-2xl font-bold tracking-tight">ADM Coverage</h1>
+        <p className="text-sm text-muted-foreground">
+          Capabilities and initiatives grouped by their TOGAF ADM Phase classification. This is read-only classification reporting — it asserts no conformance and gates nothing (ADR-0002).
+        </p>
+      </div>
+      <CoverageSection label="Capabilities by ADM Phase" hrefBase="/capabilities" result={capResult} />
+      <CoverageSection label="Initiatives by ADM Phase" hrefBase="/initiatives" result={initResult} />
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/reports/togaf/application-landscape/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/togaf/application-landscape/page.tsx
@@ -3,11 +3,21 @@ import { redirect, notFound } from 'next/navigation'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { db } from '@/db/client'
-import { applications, frameworkMappings } from '@/db/schema'
-import { and, eq, inArray } from 'drizzle-orm'
+import { applications } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
-import { TOGAF_DOMAINS, type TogafDomain } from '@/db/schema'
+
+// #673 — domain order/labels are now read from the "TOGAF Architecture Domain"
+// taxonomy (slug togaf-architecture-domain); this local list only fixes display
+// order. The report no longer depends on framework_mappings.
+const TOGAF_DOMAIN_ORDER = [
+  'Business Architecture',
+  'Application Architecture',
+  'Technology Architecture',
+  'Data Architecture',
+] as const
+type TogafDomain = string
 
 // ── Styles ────────────────────────────────────────────────────────────────────
 
@@ -75,6 +85,10 @@ export default async function ApplicationLandscapePage() {
   const enabledModules = await getEnabledModules()
   if (!isModuleEnabled(enabledModules, 'framework-overlay')) notFound()
 
+  // TOGAF Architecture Domain is a framework-audience classification
+  // (ADR-0001/0002): hidden from viewer-role / stakeholder-facing output.
+  if (session.user.role === 'viewer') notFound()
+
   const orgId = session.user.organizationId!
 
   // Fetch all published applications with their capability links
@@ -91,20 +105,32 @@ export default async function ApplicationLandscapePage() {
     orderBy: (t, { asc }) => [asc(t.name)],
   })
 
-  // Fetch all framework mappings for this org (capabilities + applications)
-  const allMappings = await db.query.frameworkMappings.findMany({
-    where: and(
-      eq(frameworkMappings.organizationId, orgId),
-      eq(frameworkMappings.framework, 'togaf'),
-    ),
-  })
-
-  // Index: entityId → concept labels
+  // Domain assignments from the "TOGAF Architecture Domain" taxonomy (#673),
+  // for capabilities + applications. Replaces the framework_mappings read.
   const mappingsByEntity = new Map<string, TogafDomain[]>()
-  for (const m of allMappings) {
-    const existing = mappingsByEntity.get(m.entityId) ?? []
-    existing.push(m.conceptLabel as TogafDomain)
-    mappingsByEntity.set(m.entityId, existing)
+  const domainType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and: a, isNull: n }) =>
+      a(e(t.organizationId, orgId), n(t.parentId), e(t.slug, 'togaf-architecture-domain')),
+  })
+  if (domainType) {
+    const terms = await db.query.taxonomyTerms.findMany({
+      where: (t, { eq: e, and: a }) => a(e(t.organizationId, orgId), e(t.parentId, domainType.id)),
+    })
+    if (terms.length > 0) {
+      const domainNameByTermId = new Map(terms.map(t => [t.id, t.name]))
+      const termIds = terms.map(t => t.id)
+      const values = await db.query.entityTaxonomyValues.findMany({
+        where: (v, { eq: e, and: a, inArray }) =>
+          a(e(v.organizationId, orgId), inArray(v.entityType, ['capability', 'application']), inArray(v.taxonomyTermId, termIds)),
+      })
+      for (const v of values) {
+        const domain = domainNameByTermId.get(v.taxonomyTermId)
+        if (!domain) continue
+        const existing = mappingsByEntity.get(v.entityId) ?? []
+        if (!existing.includes(domain)) existing.push(domain)
+        mappingsByEntity.set(v.entityId, existing)
+      }
+    }
   }
 
   // Normalise apps into a shape the report can use
@@ -147,7 +173,7 @@ export default async function ApplicationLandscapePage() {
 
   // Group direct-mapped by domain (an app can appear under multiple domains)
   const byDomain = new Map<TogafDomain, ReportApp[]>()
-  for (const domain of TOGAF_DOMAINS) {
+  for (const domain of TOGAF_DOMAIN_ORDER) {
     const appsForDomain = directMapped.filter(a => a.directDomains.includes(domain))
     if (appsForDomain.length > 0) byDomain.set(domain, appsForDomain)
   }
@@ -178,7 +204,7 @@ export default async function ApplicationLandscapePage() {
       {/* ── Direct mappings ── */}
       {byDomain.size > 0 && (
         <section className="space-y-6">
-          {TOGAF_DOMAINS.filter(d => byDomain.has(d)).map(domain => (
+          {TOGAF_DOMAIN_ORDER.filter(d => byDomain.has(d)).map(domain => (
             <div key={domain}>
               <SectionHeading domain={domain} count={byDomain.get(domain)!.length} />
               <div className="rounded-lg border border-border bg-card divide-y">

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -41,7 +41,7 @@ import {
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
   principles, principleAdrs, principleCapabilities,
   glossaryTerms, glossaryTermSources,
-  taxonomyTerms, entityTaxonomyDefinitions,
+  taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues,
   services, serviceCapabilities, servicePersonas, serviceValueStreams,
   orgConnections, crossOrgLinks,
   frameworkMappings,
@@ -284,6 +284,116 @@ async function seed() {
     }
   }
   console.log(`  ✓ ${togafMappingCount} TOGAF domain mappings (capabilities)`)
+
+  // #673 — TOGAF Architecture Domain as a taxonomy type + capability
+  // assignments via entity_taxonomy_values, so the (repointed) Application
+  // Landscape report reads from taxonomy. Mirrors the TOGAF recipe's domain
+  // type (slug/audience). framework_mappings above is retained until #674
+  // decommissions it. audience:'framework' hides it from viewers (ADR-0001/0002).
+  let togafDomainTypeId: string
+  const existingTogafDomainType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and: a, isNull: n }) =>
+      a(e(t.organizationId, devOrgId), n(t.parentId), e(t.slug, 'togaf-architecture-domain')),
+  })
+  if (existingTogafDomainType) {
+    togafDomainTypeId = existingTogafDomainType.id
+  } else {
+    const [ins] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId, name: 'TOGAF Architecture Domain', slug: 'togaf-architecture-domain',
+      audience: 'framework', description: 'The four TOGAF architecture domains (optional classification).', sortOrder: '80',
+    }).returning()
+    togafDomainTypeId = ins.id
+  }
+  const TOGAF_DOMAIN_TERMS: Record<string, string> = {
+    'Business Architecture': 'business-architecture',
+    'Application Architecture': 'application-architecture',
+    'Data Architecture': 'data-architecture',
+    'Technology Architecture': 'technology-architecture',
+  }
+  const togafDomainTermIdByName: Record<string, string> = {}
+  for (const [name, slug] of Object.entries(TOGAF_DOMAIN_TERMS)) {
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and: a }) => a(e(t.organizationId, devOrgId), e(t.parentId, togafDomainTypeId), e(t.slug, slug)),
+    })
+    togafDomainTermIdByName[name] = existing
+      ? existing.id
+      : (await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: togafDomainTypeId, name, slug }).returning())[0].id
+  }
+  for (const entityType of ['capability', 'application'] as const) {
+    await db.insert(entityTaxonomyDefinitions).values({
+      organizationId: devOrgId, entityType, taxonomyTypeId: togafDomainTypeId, selectionMode: 'multi', required: false, sortOrder: 2,
+    }).onConflictDoNothing()
+  }
+  let togafDomainValueCount = 0
+  for (const [capName, domainLabel] of Object.entries(DEV_CAPABILITY_TOGAF_DOMAINS)) {
+    const capId = devCapabilityIds[capName]
+    const termId = togafDomainTermIdByName[domainLabel]
+    if (!capId || !termId) continue
+    await db.insert(entityTaxonomyValues).values({
+      organizationId: devOrgId, entityType: 'capability', entityId: capId, taxonomyTermId: termId,
+    }).onConflictDoNothing()
+    togafDomainValueCount++
+  }
+  console.log(`  ✓ TOGAF domain taxonomy + ${togafDomainValueCount} capability assignments (entity_taxonomy_values)`)
+
+  // #673 — ADM Phase taxonomy (classification only, ADR-0002) + a few capability
+  // tags so the ADM-coverage report demos. audience:'framework'.
+  let admPhaseTypeId: string
+  const existingAdmType = await db.query.taxonomyTerms.findFirst({
+    where: (t, { eq: e, and: a, isNull: n }) =>
+      a(e(t.organizationId, devOrgId), n(t.parentId), e(t.slug, 'togaf-adm-phase')),
+  })
+  if (existingAdmType) {
+    admPhaseTypeId = existingAdmType.id
+  } else {
+    const [ins] = await db.insert(taxonomyTerms).values({
+      organizationId: devOrgId, name: 'ADM Phase', slug: 'togaf-adm-phase', audience: 'framework',
+      description: 'TOGAF ADM phases as an optional classification label (no workflow).', sortOrder: '81',
+    }).returning()
+    admPhaseTypeId = ins.id
+  }
+  const ADM_PHASES: [string, string][] = [
+    ['Preliminary', 'adm-preliminary'],
+    ['A: Architecture Vision', 'adm-a-architecture-vision'],
+    ['B: Business Architecture', 'adm-b-business-architecture'],
+    ['C: Information Systems Architectures', 'adm-c-information-systems-architectures'],
+    ['D: Technology Architecture', 'adm-d-technology-architecture'],
+    ['E: Opportunities & Solutions', 'adm-e-opportunities-and-solutions'],
+    ['F: Migration Planning', 'adm-f-migration-planning'],
+    ['G: Implementation Governance', 'adm-g-implementation-governance'],
+    ['H: Architecture Change Management', 'adm-h-architecture-change-management'],
+    ['Requirements Management', 'adm-requirements-management'],
+  ]
+  const admTermIdBySlug: Record<string, string> = {}
+  for (const [name, slug] of ADM_PHASES) {
+    const existing = await db.query.taxonomyTerms.findFirst({
+      where: (t, { eq: e, and: a }) => a(e(t.organizationId, devOrgId), e(t.parentId, admPhaseTypeId), e(t.slug, slug)),
+    })
+    admTermIdBySlug[slug] = existing
+      ? existing.id
+      : (await db.insert(taxonomyTerms).values({ organizationId: devOrgId, parentId: admPhaseTypeId, name, slug }).returning())[0].id
+  }
+  for (const entityType of ['capability', 'initiative'] as const) {
+    await db.insert(entityTaxonomyDefinitions).values({
+      organizationId: devOrgId, entityType, taxonomyTypeId: admPhaseTypeId, selectionMode: 'single', required: false, sortOrder: 3,
+    }).onConflictDoNothing()
+  }
+  const DEV_CAPABILITY_ADM: Record<string, string> = {
+    'Online Permitting': 'adm-b-business-architecture',
+    'GIS Mapping': 'adm-c-information-systems-architectures',
+    'Cross-Agency Data Sharing': 'adm-c-information-systems-architectures',
+    'Print & Mail Services': 'adm-d-technology-architecture',
+  }
+  let admTagCount = 0
+  for (const [capName, slug] of Object.entries(DEV_CAPABILITY_ADM)) {
+    const capId = devCapabilityIds[capName]; const termId = admTermIdBySlug[slug]
+    if (!capId || !termId) continue
+    await db.insert(entityTaxonomyValues).values({
+      organizationId: devOrgId, entityType: 'capability', entityId: capId, taxonomyTermId: termId,
+    }).onConflictDoNothing()
+    admTagCount++
+  }
+  console.log(`  ✓ ADM Phase taxonomy + ${admTagCount} capability tags (entity_taxonomy_values)`)
 
   // Applications + capability links
   const devApplicationIds: Record<string, string> = {}

--- a/apps/govea/src/lib/reports/group-by-taxonomy.ts
+++ b/apps/govea/src/lib/reports/group-by-taxonomy.ts
@@ -1,0 +1,93 @@
+import { db } from '@/db/client'
+import { taxonomyTerms } from '@/db/schema'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import { getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
+
+/**
+ * Generic group-by-taxonomy-type report engine (#673 / #665 S3).
+ *
+ * Buckets a caller-supplied set of entities (id + display name) into the values
+ * of one taxonomy type, via `entity_taxonomy_values`, and surfaces an explicit
+ * "unmapped" gap set. Framework-agnostic: TOGAF Application Landscape / ADM
+ * coverage are just presets that call this with specific slugs.
+ *
+ * The caller fetches + visibility-filters the entities (this stays pure over the
+ * input set) and decides whether to render a `audience: 'framework'` type for
+ * the current role — the result exposes `type.audience` so the page can enforce
+ * ADR-0001/0002 (hide framework types from viewers / stakeholder views).
+ *
+ * Multi-select types: an entity tagged with N values appears in N groups; it is
+ * counted once in `total`. Entities with no value for this type are `unmapped`.
+ */
+export interface EntityRef {
+  id: string
+  name: string
+}
+
+export interface TaxonomyGroup {
+  termId: string
+  termName: string
+  termSlug: string
+  members: EntityRef[]
+}
+
+export interface GroupByTaxonomyResult {
+  type: { id: string; name: string; slug: string; audience: string | null }
+  groups: TaxonomyGroup[]
+  unmapped: EntityRef[]
+  total: number
+}
+
+export async function groupByTaxonomyType(
+  orgId: string,
+  entityType: string,
+  taxonomyTypeSlug: string,
+  entities: EntityRef[],
+): Promise<GroupByTaxonomyResult | null> {
+  // Resolve the taxonomy *type* (top-level term) by stable slug.
+  const [type] = await db
+    .select({
+      id: taxonomyTerms.id,
+      name: taxonomyTerms.name,
+      slug: taxonomyTerms.slug,
+      audience: taxonomyTerms.audience,
+    })
+    .from(taxonomyTerms)
+    .where(and(
+      eq(taxonomyTerms.organizationId, orgId),
+      isNull(taxonomyTerms.parentId),
+      eq(taxonomyTerms.slug, taxonomyTypeSlug),
+    ))
+    .limit(1)
+  if (!type) return null
+
+  // Its child terms are the groups, in display order.
+  const terms = await db
+    .select({ id: taxonomyTerms.id, name: taxonomyTerms.name, slug: taxonomyTerms.slug })
+    .from(taxonomyTerms)
+    .where(and(eq(taxonomyTerms.organizationId, orgId), eq(taxonomyTerms.parentId, type.id)))
+    .orderBy(asc(taxonomyTerms.sortOrder), asc(taxonomyTerms.name))
+
+  const termIds = new Set(terms.map(t => t.id))
+  const buckets = new Map<string, EntityRef[]>(terms.map(t => [t.id, []]))
+  const unmapped: EntityRef[] = []
+
+  const valueMap = await getEntityTaxonomyValuesForMany(orgId, entityType, entities.map(e => e.id))
+  for (const entity of entities) {
+    const tagged = (valueMap[entity.id] ?? [])
+      .map(v => v.taxonomyTermId)
+      .filter(id => termIds.has(id))
+    if (tagged.length === 0) {
+      unmapped.push(entity)
+      continue
+    }
+    for (const termId of tagged) buckets.get(termId)!.push(entity)
+  }
+
+  return {
+    type: { id: type.id, name: type.name, slug: type.slug, audience: type.audience ?? null },
+    groups: terms.map(t => ({ termId: t.id, termName: t.name, termSlug: t.slug, members: buckets.get(t.id)! })),
+    unmapped,
+    total: entities.length,
+  }
+}

--- a/apps/govea/tests/integration/group-by-taxonomy.test.ts
+++ b/apps/govea/tests/integration/group-by-taxonomy.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration tests: generic group-by-taxonomy report engine (#673 / #665 S3)
+ *
+ * Buckets entities into a taxonomy type's values via entity_taxonomy_values,
+ * with an explicit unmapped gap set; supports multi-select; exposes the type's
+ * audience so callers can hide framework types from viewers (ADR-0001/0002).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/db/client'
+import { taxonomyTerms, capabilities, entityTaxonomyValues } from '@/db/schema'
+import { groupByTaxonomyType, type EntityRef } from '@/lib/reports/group-by-taxonomy'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+
+describe('groupByTaxonomyType (#673)', () => {
+  let orgId: string
+  let termAId: string
+  let termBId: string
+  let caps: EntityRef[]
+
+  beforeAll(async () => {
+    orgId = (await createTestOrg()).id
+
+    const [type] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, name: 'Report Type', slug: 'report-type', audience: 'framework',
+    }).returning()
+    const [a] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: type.id, name: 'Group A', slug: 'group-a', sortOrder: '0',
+    }).returning()
+    const [b] = await db.insert(taxonomyTerms).values({
+      id: randomUUID(), organizationId: orgId, parentId: type.id, name: 'Group B', slug: 'group-b', sortOrder: '1',
+    }).returning()
+    termAId = a.id; termBId = b.id
+
+    const rows = await db.insert(capabilities).values([
+      { id: randomUUID(), organizationId: orgId, name: 'Cap One' },
+      { id: randomUUID(), organizationId: orgId, name: 'Cap Two' },
+      { id: randomUUID(), organizationId: orgId, name: 'Cap Three' },
+    ]).returning()
+    caps = rows.map(r => ({ id: r.id, name: r.name }))
+
+    // Cap One -> A; Cap Two -> A and B (multi); Cap Three -> none (unmapped)
+    await db.insert(entityTaxonomyValues).values([
+      { organizationId: orgId, entityType: 'capability', entityId: caps[0].id, taxonomyTermId: termAId },
+      { organizationId: orgId, entityType: 'capability', entityId: caps[1].id, taxonomyTermId: termAId },
+      { organizationId: orgId, entityType: 'capability', entityId: caps[1].id, taxonomyTermId: termBId },
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('returns null for an unknown taxonomy type slug', async () => {
+    expect(await groupByTaxonomyType(orgId, 'capability', 'does-not-exist', caps)).toBeNull()
+  })
+
+  it('groups entities by value, supports multi-select, and surfaces unmapped', async () => {
+    const r = await groupByTaxonomyType(orgId, 'capability', 'report-type', caps)
+    expect(r).not.toBeNull()
+    expect(r!.type.audience).toBe('framework')
+    expect(r!.total).toBe(3)
+
+    const a = r!.groups.find(g => g.termId === termAId)!
+    const b = r!.groups.find(g => g.termId === termBId)!
+    expect(a.members.map(m => m.name).sort()).toEqual(['Cap One', 'Cap Two'])
+    expect(b.members.map(m => m.name)).toEqual(['Cap Two']) // multi-select: Cap Two in both
+    expect(r!.unmapped.map(m => m.name)).toEqual(['Cap Three'])
+  })
+
+  it('preserves child-term order as the group order', async () => {
+    const r = await groupByTaxonomyType(orgId, 'capability', 'report-type', caps)
+    expect(r!.groups.map(g => g.termSlug)).toEqual(['group-a', 'group-b'])
+  })
+})


### PR DESCRIPTION
Closes #673 · Refs #665 · **Stacks on #747** (the generic engine, S3a) — merge #747 first; diff resolves to S3b-only after.

## What

Completes #673: the TOGAF report **presets** on the generic engine, reading `entity_taxonomy_values` instead of `framework_mappings`.

- **Application Landscape** — repointed off `framework_mappings` onto the **TOGAF Architecture Domain** taxonomy (apps + capabilities); preserves the direct / derived / unmapped sections. No remaining `framework_mappings` dependency.
- **ADM coverage** *(new)* — capabilities + initiatives grouped by the **ADM Phase** taxonomy via `groupByTaxonomyType`; read-only classification, no conformance/governance (ADR-0002). Linked from the reports index.
- **Viewer gating** — both reports `notFound()` for viewer-role (framework `audience`, ADR-0001/0002).
- **Seed** — TOGAF Architecture Domain + ADM Phase taxonomy types (`audience: 'framework'`) + capability assignments so the reports render with data. The `framework_mappings` seed stays until **#674** decommissions it (this PR keeps the old data intact; it just stops reading it).

## Verification (live, running app)
- **alice (admin / Riverdale):** Application Landscape → 7 apps, all **7 derived** from capability domain tags; "Inferred from capability mappings" present. ADM coverage → B/C/D phases populated, **"4 of 13 tagged"**, "No ADM phase" gap (9). *(screenshot captured)*
- **victor (viewer):** both reports → **404** (framework audience hidden).
- `tsc` + eslint clean; the engine's grouping is unit-tested in #747.

## Acceptance criteria (#673)
- [x] Group-by report for any taxonomy type (engine, #747)
- [x] Application Landscape renders from `entity_taxonomy_values`, no `framework_mappings` dependency
- [x] ADM-coverage renders; asserts no conformance/governance
- [x] Framework-audience types excluded from viewer output

## Next
**#674** — migrate/decommission `framework_mappings` (schema + the capability-detail writes + remaining seed), now that nothing reads it.

Capability: ea/framework-alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)