### PR TITLE
feat(value-streams): support direct business capability mappings on value streams

### DIFF
--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -19,6 +19,7 @@ import {
   personas,
   valueStreams,
   valueStreamPersonas,
+  valueStreamCapabilities,
   strategicObjectives,
   objectiveCapabilities,
   objectiveValueStreams,
@@ -282,6 +283,27 @@ export async function unlinkValueStreamPersona(valueStreamId: string, personaId:
   assertOwnership(vs?.organizationId, user.organizationId!)
   await db.delete(valueStreamPersonas).where(
     and(eq(valueStreamPersonas.valueStreamId, valueStreamId), eq(valueStreamPersonas.personaId, personaId))
+  )
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+
+// ── Value Stream ↔ Capability (direct, stream-level — #734) ──────────────────
+
+export async function linkValueStreamCapability(valueStreamId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const vs = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
+  assertOwnership(vs?.organizationId, user.organizationId!)
+  await assertEntityInOrg('capability', capabilityId, user.organizationId!)
+  await db.insert(valueStreamCapabilities).values({ valueStreamId, capabilityId }).onConflictDoNothing()
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+
+export async function unlinkValueStreamCapability(valueStreamId: string, capabilityId: string) {
+  const { user } = await requireContributor()
+  const vs = await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, valueStreamId) })
+  assertOwnership(vs?.organizationId, user.organizationId!)
+  await db.delete(valueStreamCapabilities).where(
+    and(eq(valueStreamCapabilities.valueStreamId, valueStreamId), eq(valueStreamCapabilities.capabilityId, capabilityId))
   )
   revalidatePath(`/value-streams/${valueStreamId}`)
 }

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -74,6 +74,7 @@ export async function getValueStream(id: string) {
         },
       },
       valueStreamPersonas: { with: { persona: true } },
+      valueStreamCapabilities: { with: { capability: true } },
       objectiveValueStreams: { with: { objective: true } },
     },
   })

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkValueStreamPersona, unlinkValueStreamPersona,
+  linkValueStreamCapability, unlinkValueStreamCapability,
 } from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
@@ -54,6 +55,11 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
 
   const addPersona = linkValueStreamPersona.bind(null, id)
   const removePersona = unlinkValueStreamPersona.bind(null, id)
+  const addCapability = linkValueStreamCapability.bind(null, id)
+  const removeCapability = unlinkValueStreamCapability.bind(null, id)
+
+  // IDs already linked directly to the stream, so the picker excludes them.
+  const directCapIds = new Set(vs.valueStreamCapabilities.map(({ capability }) => capability.id))
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -164,6 +170,28 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
           />
         )}
       </div>
+
+      {isModuleEnabled(enabledModules, 'capabilities') && (
+        <div className="space-y-1.5">
+          <RelationshipPanel
+            title="Business Capabilities"
+            items={vs.valueStreamCapabilities.map(({ capability }) => ({
+              id: capability.id, name: capability.name,
+              href: `/capabilities/${capability.id}`,
+            }))}
+            canEdit={canMutate}
+            available={capabilityList
+              .filter(c => c.organizationId === orgId && !directCapIds.has(c.id))
+              .map(c => ({ id: c.id, name: c.name }))}
+            addAction={addCapability}
+            removeAction={removeCapability}
+            emptyMessage="No stream-level capabilities linked yet."
+          />
+          <p className="text-xs text-muted-foreground">
+            These capabilities apply to the whole value stream. Capabilities tied to a single step appear as tags on each stage above.
+          </p>
+        </div>
+      )}
 
       {isModuleEnabled(enabledModules, 'personas') && (
         <RelationshipPanel

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -4,7 +4,7 @@ import { applications, applicationCapabilities } from './applications'
 import { personas, personaTags } from './personas'
 import { taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues } from './taxonomy'
 import { organizations } from './organizations'
-import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas } from './value-streams'
+import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities } from './value-streams'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from './objectives'
 import { goals, goalObjectives } from './goals'
 import { initiatives, initiativeCapabilities, initiativeObjectives, initiativeApplications } from './initiatives'
@@ -22,6 +22,7 @@ export const capabilitiesRelations = relations(capabilities, ({ one, many }) => 
   }),
   capabilityPersonas: many(capabilityPersonas),
   valueStreamStageCapabilities: many(valueStreamStageCapabilities),
+  valueStreamCapabilities: many(valueStreamCapabilities),
   objectiveCapabilities: many(objectiveCapabilities),
   initiativeCapabilities: many(initiativeCapabilities),
   applicationCapabilities: many(applicationCapabilities),
@@ -89,7 +90,19 @@ export const valueStreamsRelations = relations(valueStreams, ({ one, many }) => 
   }),
   stages: many(valueStreamStages),
   valueStreamPersonas: many(valueStreamPersonas),
+  valueStreamCapabilities: many(valueStreamCapabilities),
   objectiveValueStreams: many(objectiveValueStreams),
+}))
+
+export const valueStreamCapabilitiesRelations = relations(valueStreamCapabilities, ({ one }) => ({
+  valueStream: one(valueStreams, {
+    fields: [valueStreamCapabilities.valueStreamId],
+    references: [valueStreams.id],
+  }),
+  capability: one(capabilities, {
+    fields: [valueStreamCapabilities.capabilityId],
+    references: [capabilities.id],
+  }),
 }))
 
 export const valueStreamPersonasRelations = relations(valueStreamPersonas, ({ one }) => ({

--- a/apps/govea/src/db/schema/value-streams.ts
+++ b/apps/govea/src/db/schema/value-streams.ts
@@ -1,4 +1,4 @@
-import { index, integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { index, integer, pgTable, primaryKey, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 import { workflowStatusEnum } from './personas'
@@ -41,6 +41,18 @@ export const valueStreamStageCapabilities = pgTable('value_stream_stage_capabili
 })
 
 export type ValueStreamStageCapability = typeof valueStreamStageCapabilities.$inferSelect
+
+// Junction: value stream ↔ business capability (#734).
+// Direct, stream-level capability mapping — distinct from the stage-level
+// `value_stream_stage_capabilities` above. A capability mapped here applies to
+// the whole value stream rather than a specific stage. Both FKs cascade on
+// delete so removing either side cleans up the junction row.
+export const valueStreamCapabilities = pgTable('value_stream_capabilities', {
+  valueStreamId: uuid('value_stream_id').notNull().references(() => valueStreams.id, { onDelete: 'cascade' }),
+  capabilityId: uuid('capability_id').notNull().references(() => capabilities.id, { onDelete: 'cascade' }),
+}, (t) => [primaryKey({ columns: [t.valueStreamId, t.capabilityId] })])
+
+export type ValueStreamCapability = typeof valueStreamCapabilities.$inferSelect
 
 // Junction: value stream ↔ persona (many-to-many, replaces single stakeholderPersonaId FK)
 export const valueStreamPersonas = pgTable('value_stream_personas', {

--- a/apps/govea/src/lib/backup-export.ts
+++ b/apps/govea/src/lib/backup-export.ts
@@ -140,7 +140,7 @@ async function collectContent(orgId: string) {
   // primary rows are restored.
   const [
     personaRows, capabilityRows, applicationRows, serviceRows,
-    valueStreamRows, valueStreamStageRows, valueStreamStageCapRows, valueStreamPersonaRows,
+    valueStreamRows, valueStreamStageRows, valueStreamStageCapRows, valueStreamPersonaRows, valueStreamCapRows,
     objectiveRows, objectiveCapRows, objectiveVsRows,
     goalRows, goalObjectiveRows,
     initiativeRows, initiativeCapRows, initiativeAppRows, initiativeObjRows,
@@ -160,6 +160,7 @@ async function collectContent(orgId: string) {
     db.query.valueStreamStages.findMany({}),
     db.query.valueStreamStageCapabilities.findMany({}),
     db.query.valueStreamPersonas.findMany({}),
+    db.query.valueStreamCapabilities.findMany({}),
     db.query.strategicObjectives.findMany({ where: eq(strategicObjectives.organizationId, orgId) }),
     db.query.objectiveCapabilities.findMany({}),
     db.query.objectiveValueStreams.findMany({}),
@@ -234,6 +235,7 @@ async function collectContent(orgId: string) {
       valueStreamStages: (valueStreamStageRows as Array<{ valueStreamId: string }>).filter(r => vsIds.has(r.valueStreamId)),
       valueStreamStageCapabilities: (valueStreamStageCapRows as Array<{ capabilityId: string }>).filter(r => capIds.has(r.capabilityId)),
       valueStreamPersonas: (valueStreamPersonaRows as Array<{ valueStreamId: string; personaId: string }>).filter(r => vsIds.has(r.valueStreamId) && personaIds.has(r.personaId)),
+      valueStreamCapabilities: (valueStreamCapRows as Array<{ valueStreamId: string; capabilityId: string }>).filter(r => vsIds.has(r.valueStreamId) && capIds.has(r.capabilityId)),
       objectiveCapabilities: (objectiveCapRows as Array<{ objectiveId: string; capabilityId: string }>).filter(r => objIds.has(r.objectiveId) && capIds.has(r.capabilityId)),
       objectiveValueStreams: (objectiveVsRows as Array<{ objectiveId: string; valueStreamId: string }>).filter(r => objIds.has(r.objectiveId) && vsIds.has(r.valueStreamId)),
       goalObjectives: (goalObjectiveRows as Array<{ goalId: string; objectiveId: string }>).filter(r => goalIds.has(r.goalId) && objIds.has(r.objectiveId)),

--- a/apps/govea/src/lib/backup-import.ts
+++ b/apps/govea/src/lib/backup-import.ts
@@ -38,7 +38,7 @@ import { db } from '@/db/client'
 import {
   organizations,
   personas, capabilities, applications, services,
-  valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
+  valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
   goals, goalObjectives,
   initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
@@ -363,6 +363,7 @@ export async function importArchive(
     await replayJunction(valueStreamStages, 'valueStreamStages', false)
     await replayJunction(valueStreamStageCapabilities, 'valueStreamStageCapabilities', false)
     await replayJunction(valueStreamPersonas, 'valueStreamPersonas', false)
+    await replayJunction(valueStreamCapabilities, 'valueStreamCapabilities', false)
     await replayJunction(objectiveCapabilities, 'objectiveCapabilities', false)
     await replayJunction(objectiveValueStreams, 'objectiveValueStreams', false)
     await replayJunction(goalObjectives, 'goalObjectives', false)

--- a/apps/govea/tests/integration/value-stream-capabilities.test.ts
+++ b/apps/govea/tests/integration/value-stream-capabilities.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration tests: direct value-stream ↔ business-capability links (#734).
+ *
+ * Covers:
+ *  - Contributor can link/unlink a stream-level capability on their own org.
+ *  - Cross-org enforcement: foreign capability (target) and foreign value
+ *    stream (source) are both rejected — the link can never reference another
+ *    org's row through the local junction.
+ *  - getValueStream surfaces direct (stream-level) links distinctly from
+ *    stage-level links, so the UI can tell them apart.
+ *  - FK cascade: deleting the value stream or the capability removes the
+ *    junction rows.
+ *  - Backup export → import round-trips the new junction.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  valueStreams, valueStreamCapabilities, valueStreamStages, valueStreamStageCapabilities,
+  capabilities,
+} from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { linkValueStreamCapability, unlinkValueStreamCapability } from '@/actions/links'
+import { getValueStream, deleteValueStream } from '@/actions/value-streams'
+import { buildArchiveExport } from '@/lib/backup-export'
+import { importArchive } from '@/lib/backup-import'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  insertCapability, insertValueStream,
+  type TestOrg, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+async function directLink(vsId: string, capId: string) {
+  return db.query.valueStreamCapabilities.findFirst({
+    where: and(
+      eq(valueStreamCapabilities.valueStreamId, vsId),
+      eq(valueStreamCapabilities.capabilityId, capId),
+    ),
+  })
+}
+
+describe('value stream ↔ capability direct links (#734)', () => {
+  let orgA: TestOrg
+  let orgB: TestOrg
+  let contributorA: TestUser
+  let capA: { id: string }
+  let capA2: { id: string }
+  let vsA: { id: string }
+  let capB: { id: string }
+  let vsB: { id: string }
+
+  beforeAll(async () => {
+    ;[orgA, orgB] = await Promise.all([createTestOrg(), createTestOrg()])
+    contributorA = await createTestUser(orgA.id, 'contributor')
+    ;[capA, capA2, vsA] = await Promise.all([
+      insertCapability(orgA.id), insertCapability(orgA.id), insertValueStream(orgA.id),
+    ])
+    ;[capB, vsB] = await Promise.all([insertCapability(orgB.id), insertValueStream(orgB.id)])
+    mockAuth.mockResolvedValue(makeSession(contributorA))
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgA.id)
+    await cleanupOrg(orgB.id)
+  })
+
+  it('links a stream-level capability and is idempotent', async () => {
+    await linkValueStreamCapability(vsA.id, capA.id)
+    expect(await directLink(vsA.id, capA.id)).toBeDefined()
+
+    // onConflictDoNothing → re-linking does not create a duplicate row.
+    await linkValueStreamCapability(vsA.id, capA.id)
+    const rows = await db.select().from(valueStreamCapabilities)
+      .where(and(eq(valueStreamCapabilities.valueStreamId, vsA.id), eq(valueStreamCapabilities.capabilityId, capA.id)))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('rejects a foreign capability (target ownership)', async () => {
+    await expect(linkValueStreamCapability(vsA.id, capB.id)).rejects.toThrow(/Forbidden/)
+    expect(await directLink(vsA.id, capB.id)).toBeUndefined()
+  })
+
+  it('rejects a foreign value stream (source ownership)', async () => {
+    await expect(linkValueStreamCapability(vsB.id, capA.id)).rejects.toThrow(/Forbidden/)
+  })
+
+  it('surfaces direct links distinctly from stage-level links', async () => {
+    // Scaffold a stage with a stage-level capability (capA2) directly.
+    const [stage] = await db.insert(valueStreamStages)
+      .values({ valueStreamId: vsA.id, name: 'Stage 1', order: 0 }).returning()
+    await db.insert(valueStreamStageCapabilities).values({ stageId: stage.id, capabilityId: capA2.id })
+
+    const vs = await getValueStream(vsA.id)
+    expect(vs).not.toBeNull()
+
+    const directIds = vs!.valueStreamCapabilities.map(c => c.capability.id)
+    const stageIds = vs!.stages.flatMap(s => s.stageCapabilities.map(sc => sc.capability.id))
+
+    // capA is a whole-stream link; capA2 is a stage link. They are reported
+    // through different fields and do not bleed into each other.
+    expect(directIds).toContain(capA.id)
+    expect(directIds).not.toContain(capA2.id)
+    expect(stageIds).toContain(capA2.id)
+    expect(stageIds).not.toContain(capA.id)
+  })
+
+  it('unlinks a stream-level capability', async () => {
+    await unlinkValueStreamCapability(vsA.id, capA.id)
+    expect(await directLink(vsA.id, capA.id)).toBeUndefined()
+  })
+
+  it('cascades when the capability is deleted', async () => {
+    const org = await createTestOrg()
+    const cap = await insertCapability(org.id)
+    const vs = await insertValueStream(org.id)
+    await db.insert(valueStreamCapabilities).values({ valueStreamId: vs.id, capabilityId: cap.id })
+
+    await db.delete(capabilities).where(eq(capabilities.id, cap.id))
+    expect(await directLink(vs.id, cap.id)).toBeUndefined()
+    await cleanupOrg(org.id)
+  })
+
+  it('cascades when the value stream is deleted', async () => {
+    const org = await createTestOrg()
+    const admin = await createTestUser(org.id, 'admin')
+    const cap = await insertCapability(org.id)
+    const vs = await insertValueStream(org.id)
+    await db.insert(valueStreamCapabilities).values({ valueStreamId: vs.id, capabilityId: cap.id })
+
+    mockAuth.mockResolvedValue(makeSession(admin))
+    await deleteValueStream(vs.id)
+    mockAuth.mockResolvedValue(makeSession(contributorA))
+
+    expect(await directLink(vs.id, cap.id)).toBeUndefined()
+    // The capability itself is untouched by the value-stream delete.
+    expect(await db.query.capabilities.findFirst({ where: eq(capabilities.id, cap.id) })).toBeDefined()
+    await cleanupOrg(org.id)
+  })
+
+  it('round-trips the direct link through backup export → import', async () => {
+    const org = await createTestOrg()
+    const admin = await createTestUser(org.id, 'admin')
+    const cap = await insertCapability(org.id, { status: 'published' })
+    const vs = await insertValueStream(org.id, { status: 'published' })
+    await db.insert(valueStreamCapabilities).values({ valueStreamId: vs.id, capabilityId: cap.id })
+
+    const archive = await buildArchiveExport(org.id)
+    // Import wipes the destination org's content, then restores from the archive.
+    await importArchive(org.id, admin.id, archive.body)
+
+    expect(await directLink(vs.id, cap.id)).toBeDefined()
+    await cleanupOrg(org.id)
+  })
+})

--- a/business-architecture/capabilities/cms/portfolio/po-value-streams.md
+++ b/business-architecture/capabilities/cms/portfolio/po-value-streams.md
@@ -8,13 +8,13 @@ Value streams are authoring records, not just display artefacts. Creating and ma
 
 ## Implementation Status
 
-**Implemented.** Full CRUD for value streams and stages. Stage ordering, capability assignment per stage, persona linkage, and objective linkage are all shipped.
+**Implemented.** Full CRUD for value streams and stages. Stage ordering, stage-level capability assignment, direct (stream-level) capability mapping, persona linkage, and objective linkage are all shipped.
 
-Schema: `value_streams`, `value_stream_stages`, `value_stream_stage_capabilities`, `value_stream_personas` (`apps/govea/src/db/schema/value-streams.ts`)
+Schema: `value_streams`, `value_stream_stages`, `value_stream_stage_capabilities`, `value_stream_capabilities` (direct stream-level links, #734), `value_stream_personas` (`apps/govea/src/db/schema/value-streams.ts`)
 
-Server actions: create, edit, delete, add/edit/delete/reorder stages, add/remove capability per stage (`apps/govea/src/actions/value-streams.ts`)
+Server actions: create, edit, delete, add/edit/delete/reorder stages, add/remove capability per stage (`apps/govea/src/actions/value-streams.ts`); `linkValueStreamCapability` / `unlinkValueStreamCapability` for direct stream-level links (`apps/govea/src/actions/links.ts`)
 
-Admin UI: list view, detail view with inline stage and persona management (`apps/govea/src/app/(admin)/value-streams/`)
+Admin UI: list view, detail view with inline stage management, a stream-level Business Capabilities panel, and persona management (`apps/govea/src/app/(admin)/value-streams/`)
 
 ## Personas
 
@@ -52,11 +52,17 @@ A stage may link to zero or more capabilities. The same capability may appear in
 | Relationship | Direction | Junction Table | Notes |
 |---|---|---|---|
 | Personas | Many-to-many | `value_stream_personas` | The stakeholder personas this stream serves; shown on the detail page |
-| Capabilities (via stages) | Many-to-many | `value_stream_stage_capabilities` | Capabilities assigned at each stage; not a direct value_stream → capability link |
+| Capabilities (direct) | Many-to-many | `value_stream_capabilities` | Capabilities that apply to the **whole** value stream (#734); shown in the stream-level Business Capabilities panel |
+| Capabilities (via stages) | Many-to-many | `value_stream_stage_capabilities` | Capabilities active at a **specific stage**; shown as badges on each stage |
 | Strategic Objectives | Many-to-many | `objective_value_streams` | Objectives that this value stream supports; linked from the Objective record |
 | Services | Many-to-many | `service_value_streams` | Services that deliver through this value stream; linked from the Service record |
 
-**Important:** Capabilities are linked to stages, not directly to the value stream. To see which capabilities a value stream involves, a reader must look at the stage-level links. This reflects the fact that different capabilities are active at different points in the delivery sequence — the stage structure makes that visible.
+**Two kinds of capability link (#734).** A value stream can map to capabilities in two distinct ways, and the two are reported separately so a reader can always tell which is which:
+
+- **Direct (stream-level)** — `value_stream_capabilities`. The capability applies to the entire stream, without forcing the author to repeat it on every stage. Use this for stream-wide concerns and stream-level coverage summaries.
+- **Stage-level** — `value_stream_stage_capabilities`. The capability is active at a specific step. This remains the right model when different capabilities are active at different points in the delivery sequence.
+
+Both are first-class. Stage-level mapping is unchanged by #734; the direct link is additive. (Prior to #734 the model supported stage-level links only — this document intentionally changed that.)
 
 ## Behaviors
 
@@ -68,13 +74,15 @@ A stage may link to zero or more capabilities. The same capability may appear in
 - Delete a stage (removes all capability assignments on that stage)
 - Move a stage up or down in the ordered sequence
 - Assign a capability to a stage; remove a capability from a stage
+- Link and unlink a capability directly to the whole value stream (stream-level), shown in a Business Capabilities panel distinct from per-stage badges
 - Add and remove persona links on the value stream
 - View the full value stream with ordered stages and capability badges on the detail page
 - Viewers see only published value streams; Contributors and Admins see all statuses
 
 ## Rules
 
-- Creating, editing stages, and assigning capabilities to stages requires Contributor or Admin role
+- Creating, editing stages, and assigning capabilities (per stage or directly to the stream) requires Contributor or Admin role
+- Direct stream-level capability links are organization-scoped: the value stream and the capability must belong to the caller's organization, enforced by the local junction — a stream can never link to another org's capability (consistent with #415 junction-ownership rules)
 - Deleting a value stream requires Admin role
 - Deleting a stage does not require Admin — Contributors may delete stages they added
 - Visibility defaults to `org`; Contributors may set `connections` or `instance`


### PR DESCRIPTION
## Summary

Adds a **direct value-stream → business-capability** link alongside the existing stage-level mapping. Some capabilities apply to an entire value stream rather than one step; today the model forces all capability mapping through stages. This adds the stream-level link while leaving stage-level mapping fully intact.

The two are first-class and reported distinctly:
- **Direct (stream-level)** — `value_stream_capabilities`, shown in a new "Business Capabilities" panel on the detail page.
- **Stage-level** — `value_stream_stage_capabilities` (unchanged), shown as badges on each stage.

## Changes

- **Schema** (`db/schema/value-streams.ts`): new `value_stream_capabilities` junction with a **composite PK** `(value_stream_id, capability_id)` and `onDelete: cascade` on both FKs — idempotent, and rows are cleaned up when either side is deleted.
- **Relations**: junction wired to `valueStreams` and `capabilities`.
- **Actions** (`actions/links.ts`): `linkValueStreamCapability` / `unlinkValueStreamCapability`, org-scoped via `assertOwnership` + `assertEntityInOrg('capability')` — the same #415 junction-ownership pattern as every other local junction, so a stream can never link to a foreign org's capability.
- **Query** (`getValueStream`): includes the direct capabilities, surfaced separately from stage capabilities.
- **UI** (`value-streams/[id]/page.tsx`): a stream-level "Business Capabilities" `RelationshipPanel`, visually distinct from per-stage badges, with helper text explaining whole-stream vs. per-stage.
- **Backup** (`backup-export.ts` / `backup-import.ts`): collect + replay the new junction so restore preserves direct links.
- **Docs** (`po-value-streams.md`): describes the two kinds of capability link, correcting the prior "capabilities are linked to stages, not directly" note (the issue explicitly changes this product model).

## Acceptance criteria
- [x] A value stream can be directly linked to zero or more business capabilities.
- [x] Existing stage-level capability mapping remains supported and unchanged.
- [x] Stream-level vs. stage-level links displayed distinctly (separate panel + helper text; reported through different fields by `getValueStream`).
- [x] Contributors/Admins can add and remove direct links in the value-stream edit experience.
- [x] Direct links are org-scoped and cannot reference another org's capability (local junction + `assertEntityInOrg`).
- [x] Deleting a value stream or capability cleans up junction rows (FK cascade — tested both sides).
- [x] Traceability/coverage reporting accounts for both — the value-stream detail page is the only surface that reports VS capability coverage, and it now covers both link kinds. (No separate coverage report exists today; not adding one is intentional scope control.)
- [x] Backup/export/import includes the new rows (round-trip test).
- [x] Existing stage-only value streams keep working with no data migration (additive table; pre-prod `db:push`).
- [x] Focused tests: create/remove, ownership enforcement (source + target), display distinction, cascade, backup round-trip.

## Testing
- `tsc --noEmit` clean · `lint` 0 errors · docs-lint OK
- Integration suite **985/985**, including the new `value-stream-capabilities.test.ts` (8 tests)
- Production `build` passed
- Schema applied locally via `db:push` + `db:apply-triggers`; CI applies via `db:push --force`

## Notes for the maintainer
- **Process gap:** #734 had no `track:*` label and no milestone (the session-start doc says every open issue should have exactly one of each). I left classification to you rather than guess — likely `track:core` given it's a portfolio CRUD capability.
- I deliberately did **not** add "used in these value streams" to the capability detail page — no such surface exists today, so it would be scope creep beyond this issue.

Capability: po-value-streams
Persona: Enterprise Architect (Central IT), Agency EA Coordinator, Department Director

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)