### PR TITLE
fix(iam): instance user creation crashes when email belongs to existing instance admin

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { organizations, users, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
+import { organizations, users, userOrganizationMemberships, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
 import { eq, and, isNull, gt, like, desc, ne, count } from 'drizzle-orm'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { writeAuditLog } from '@/lib/audit'
@@ -465,12 +465,23 @@ export async function getActiveBreakGlass(adminId: string, orgId: string) {
   })
 }
 
-export async function createInstanceUser(formData: FormData) {
+/**
+ * Outcome of {@link createInstanceUser}. The action never throws for the
+ * "email already exists" case any more (#756) — an existing identity is
+ * attached to the selected org via a membership, and the caller is told what
+ * happened so the UI can show a handled message instead of a server crash.
+ */
+export type CreateInstanceUserResult = {
+  status: 'identity_created' | 'membership_added' | 'membership_reactivated' | 'already_member'
+  message: string
+}
+
+export async function createInstanceUser(formData: FormData): Promise<CreateInstanceUserResult> {
   const session = await requireInstanceAdmin()
 
   const organizationId = formData.get('organizationId') as string
   const name = formData.get('name') as string
-  const email = formData.get('email') as string
+  const email = ((formData.get('email') as string) ?? '').trim()
   const password = formData.get('password') as string
   const role = formData.get('role') as 'admin' | 'contributor' | 'viewer'
   const grantPlatformAdmin = formData.get('instanceAdmin') === 'on'
@@ -483,8 +494,68 @@ export async function createInstanceUser(formData: FormData) {
   if (!organization) throw new Error('Organization not found')
 
   const existing = await db.query.users.findFirst({ where: eq(users.email, email) })
-  if (existing) throw new Error('A user with that email address already exists.')
 
+  // ── Existing identity → grant org access via membership (#756) ────────────
+  // The email already belongs to an identity (e.g. an instance admin). Rather
+  // than the old global-duplicate crash, attach that identity to the selected
+  // org by creating or reactivating a membership. The `users` row is left
+  // untouched: instanceRole, password, and other identity fields are preserved.
+  // (Promoting an existing identity to platform admin has its own dedicated
+  // control — `promoteInstanceAdmin` — so the create form's checkbox is not
+  // applied here.)
+  if (existing) {
+    const [membership] = await db
+      .select({
+        role: userOrganizationMemberships.role,
+        isActive: userOrganizationMemberships.isActive,
+      })
+      .from(userOrganizationMemberships)
+      .where(and(
+        eq(userOrganizationMemberships.userId, existing.id),
+        eq(userOrganizationMemberships.organizationId, organizationId),
+      ))
+      .limit(1)
+
+    if (membership?.isActive) {
+      return {
+        status: 'already_member',
+        message: `${email} is already an active ${membership.role} in ${organization.name}.`,
+      }
+    }
+
+    const reactivated = Boolean(membership)
+    await db.transaction(async (tx) => {
+      if (reactivated) {
+        await tx.update(userOrganizationMemberships)
+          .set({ role, isActive: true, updatedAt: new Date() })
+          .where(and(
+            eq(userOrganizationMemberships.userId, existing.id),
+            eq(userOrganizationMemberships.organizationId, organizationId),
+          ))
+      } else {
+        await tx.insert(userOrganizationMemberships).values({
+          userId: existing.id, organizationId, role, isActive: true,
+        })
+      }
+
+      await writeAuditLog(tx, {
+        action: reactivated ? 'instance.user.membership_reactivate' : 'instance.user.membership_add',
+        entityType: 'user_organization_membership',
+        entityId: existing.id,
+        userId: session.user.id,
+        organizationId: null,
+        before: reactivated ? { role: membership!.role, isActive: membership!.isActive } : undefined,
+        after: { email, role, organizationId, organizationName: organization.name },
+      })
+    })
+
+    revalidatePath('/instance/users')
+    return reactivated
+      ? { status: 'membership_reactivated', message: `Reactivated ${email}’s membership in ${organization.name} as ${role}.` }
+      : { status: 'membership_added', message: `Added ${email} to ${organization.name} as ${role}.` }
+  }
+
+  // ── New identity → create the user row (original path) ─────────────────────
   const pwValidation = validatePassword(password)
   if (!pwValidation.valid) throw new Error(pwValidation.message)
 
@@ -518,6 +589,7 @@ export async function createInstanceUser(formData: FormData) {
   })
 
   revalidatePath('/instance/users')
+  return { status: 'identity_created', message: `Created ${email} in ${organization.name} as ${role}.` }
 }
 
 export async function updateOrgGovernance(

--- a/apps/govea/src/app/(instance)/instance/users/instance-user-table.tsx
+++ b/apps/govea/src/app/(instance)/instance/users/instance-user-table.tsx
@@ -45,16 +45,33 @@ export function InstanceUserTable({ users, organizations, currentUserId, hiddenU
   const router = useRouter()
   const [createOpen, setCreateOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
+  const [createMessage, setCreateMessage] = useState<{ kind: 'error' | 'info'; text: string } | null>(null)
 
   function refresh() {
     router.refresh()
   }
 
+  function openCreate() {
+    setCreateMessage(null)
+    setCreateOpen(true)
+  }
+
   async function handleCreate(formData: FormData) {
+    setCreateMessage(null)
     startTransition(async () => {
-      await createInstanceUser(formData)
-      setCreateOpen(false)
-      refresh()
+      try {
+        const result = await createInstanceUser(formData)
+        if (result.status === 'already_member') {
+          // Handled, non-crashing: keep the dialog open so the operator sees why.
+          setCreateMessage({ kind: 'info', text: result.message })
+          refresh()
+          return
+        }
+        setCreateOpen(false)
+        refresh()
+      } catch (e) {
+        setCreateMessage({ kind: 'error', text: e instanceof Error ? e.message : 'Could not create the account.' })
+      }
     })
   }
 
@@ -65,7 +82,7 @@ export function InstanceUserTable({ users, organizations, currentUserId, hiddenU
           <h1 className="text-2xl font-bold tracking-tight">Users</h1>
           <p className="text-muted-foreground mt-1">Platform admins are always visible. Tenant users are only visible for organisations you currently hold break-glass access to.</p>
         </div>
-        <Button size="sm" onClick={() => setCreateOpen(true)}>
+        <Button size="sm" onClick={openCreate}>
           + Create account
         </Button>
       </div>
@@ -198,6 +215,21 @@ export function InstanceUserTable({ users, organizations, currentUserId, hiddenU
             <DialogTitle>Create account</DialogTitle>
           </DialogHeader>
           <form action={handleCreate} className="space-y-3">
+            {createMessage && (
+              <div
+                className={cn(
+                  'rounded-md border p-2.5 text-sm',
+                  createMessage.kind === 'error'
+                    ? 'border-destructive/40 bg-destructive/5 text-destructive'
+                    : 'border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950/20 dark:text-blue-300',
+                )}
+              >
+                {createMessage.text}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              If the email already belongs to an existing account, that account is added to the selected organization instead — its password and platform role are left unchanged.
+            </p>
             <div className="space-y-1.5">
               <Label htmlFor="create-org">Organization</Label>
               <select

--- a/apps/govea/tests/integration/instance-actions.test.ts
+++ b/apps/govea/tests/integration/instance-actions.test.ts
@@ -19,7 +19,7 @@ import {
   suspendUserAccount, reactivateUserAccount,
 } from '@/actions/instance'
 import { db } from '@/db/client'
-import { breakGlassSessions, auditLog, instanceSettings, organizations, users } from '@/db/schema'
+import { breakGlassSessions, auditLog, instanceSettings, organizations, users, userOrganizationMemberships } from '@/db/schema'
 import { eq, and, isNull, or } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import {
@@ -321,6 +321,92 @@ describe('createInstanceUser', () => {
     formData.set('role', 'viewer')
 
     await expect(createInstanceUser(formData)).rejects.toThrow('Forbidden')
+  })
+})
+
+describe('createInstanceUser — existing email → org membership (#756)', () => {
+  function fd(email: string, role: 'admin' | 'contributor' | 'viewer') {
+    const f = new FormData()
+    f.set('organizationId', targetOrgId)
+    f.set('name', 'Ignored For Existing Identity')
+    f.set('email', email)
+    // Password is required by the form but must be ignored for an existing
+    // identity — deliberately weak here to prove it is never validated/applied.
+    f.set('password', 'x')
+    f.set('role', role)
+    return f
+  }
+
+  async function membership(userId: string) {
+    const [m] = await db.select().from(userOrganizationMemberships).where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, targetOrgId),
+    ))
+    return m ?? null
+  }
+
+  it('adds an existing identity to the selected org without crashing or duplicating the user', async () => {
+    asInstanceAdmin()
+    const existing = await createTestUser(orgId, 'admin')
+    // Mark as a platform admin to prove instanceRole is preserved.
+    await db.update(users).set({ instanceRole: 'instance_admin' }).where(eq(users.id, existing.id))
+    const hashBefore = (await db.query.users.findFirst({ where: eq(users.id, existing.id) }))!.passwordHash
+
+    const result = await createInstanceUser(fd(existing.email, 'contributor'))
+    expect(result.status).toBe('membership_added')
+
+    // No duplicate users row.
+    const rows = await db.select().from(users).where(eq(users.email, existing.email))
+    expect(rows).toHaveLength(1)
+    // Identity fields preserved: instanceRole + password hash untouched.
+    expect(rows[0].instanceRole).toBe('instance_admin')
+    expect(rows[0].passwordHash).toBe(hashBefore)
+
+    // Active membership in the target org with the requested role.
+    const m = await membership(existing.id)
+    expect(m).not.toBeNull()
+    expect(m!.role).toBe('contributor')
+    expect(m!.isActive).toBe(true)
+  })
+
+  it('returns a handled already_member result for an already-active membership (no role change)', async () => {
+    asInstanceAdmin()
+    const existing = await createTestUser(orgId, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: existing.id, organizationId: targetOrgId, role: 'admin', isActive: true,
+    })
+
+    const result = await createInstanceUser(fd(existing.email, 'viewer'))
+    expect(result.status).toBe('already_member')
+    // Existing active role is not downgraded by the create attempt.
+    expect((await membership(existing.id))!.role).toBe('admin')
+  })
+
+  it('reactivates an inactive membership and updates its role', async () => {
+    asInstanceAdmin()
+    const existing = await createTestUser(orgId, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: existing.id, organizationId: targetOrgId, role: 'viewer', isActive: false,
+    })
+
+    const result = await createInstanceUser(fd(existing.email, 'admin'))
+    expect(result.status).toBe('membership_reactivated')
+    const m = await membership(existing.id)
+    expect(m!.isActive).toBe(true)
+    expect(m!.role).toBe('admin')
+  })
+
+  it('writes an instance-level audit event for the membership add', async () => {
+    asInstanceAdmin()
+    const existing = await createTestUser(orgId, 'viewer')
+    await createInstanceUser(fd(existing.email, 'viewer'))
+
+    const [evt] = await db.select().from(auditLog).where(and(
+      eq(auditLog.action, 'instance.user.membership_add'),
+      eq(auditLog.entityId, existing.id),
+    ))
+    expect(evt).toBeDefined()
+    expect(evt.organizationId).toBeNull() // instance-level
   })
 })
 


### PR DESCRIPTION
## Summary

`createInstanceUser` threw `A user with that email address already exists.` whenever the email already belonged to an identity (commonly an instance admin), surfacing a Next.js digest crash on `/instance/users`. The instance create-user path predated the multi-org membership model (#693) and still ran a global duplicate-email guard.

This fix makes the existing-email case attach the identity to the selected org via a membership, mirroring the org-admin `addOrgMembership` flow.

## Behavior

When the email already exists, instead of crashing:
- **No membership yet** → create an active `user_organization_memberships` row with the chosen role.
- **Inactive membership** → reactivate it and update the role.
- **Already-active membership** → return a handled result (no crash, no change), surfaced as a message in the dialog.

The `users` row is left untouched — `instanceRole`, password hash, and identity fields are preserved. The new-identity create path is unchanged.

## Changes

- `actions/instance.ts`: `createInstanceUser` branches on existing identity; creates/reactivates a membership and audits it as an instance-level event (`instance.user.membership_add` / `_reactivate`, `organizationId: null`). Returns a structured `CreateInstanceUserResult`.
- `instance-user-table.tsx`: the create handler consumes the result, shows a handled message for the already-member case, and **catches errors** instead of letting them become a server digest crash. Adds a one-line note that an existing email is added to the org with its password/platform role unchanged.
- `instance-actions.test.ts`: 4 regression tests.

## Acceptance criteria
- [x] Instance Admin can add an existing instance-admin identity to a tenant org from `/instance/users` without a server error.
- [x] Creates or reactivates an org membership instead of inserting a duplicate `users` row.
- [x] Existing `instanceRole` preserved (asserted).
- [x] Existing password/local auth state preserved (password hash asserted unchanged; typed password is ignored for existing identities).
- [x] Already-active membership returns a clear handled message.
- [x] Writes an instance-level audit event for membership add/reactivate.
- [x] Regression test: existing instance-admin email → selected-org membership.
- [x] Regression test: existing active membership → handled non-crashing result.

## Testing
- `tsc --noEmit` clean · `lint` 0 errors
- Integration suite **981/981**, incl. 4 new cases under `createInstanceUser — existing email → org membership (#756)`
- Production `build` passed

## Design notes for the maintainer
- **Membership-only for existing identities.** I deliberately do *not* apply the form's "grant platform admin" checkbox to an existing identity — promotion has its own dedicated `promoteInstanceAdmin` control and table button, and the AC says preserve `instanceRole`. Applying it here would be a surprising side effect of an "add to org" action.
- **Already-active = no role change.** An already-active membership returns the handled message without altering the existing role (so the create form can't silently downgrade an admin). Role changes go through `updateOrgMembershipRole`.
- **First-membership resolution caveat (pre-existing, not introduced here):** per `resolveActiveMembership`, once a user has *any* active membership, their active context resolves from memberships rather than the denormalized `users.organization_id`. Adding a first membership to a previously membership-less identity therefore shifts their default active org. This is existing #693 behavior shared with `addOrgMembership`, not new to this fix — flagging it in case you want a follow-up to also represent home orgs as memberships.

Capability: iam-user-management
Capability: iam-instance-administration
Persona: Instance Administrator, CMS Administrator

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)