### PR TITLE
feat(instance-admin): enrich audit telemetry for access & security events (#720)

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -5,6 +5,7 @@ import { organizations, users, breakGlassSessions, instanceSettings, platformCon
 import { eq, and, isNull, gt, like, desc, ne, count } from 'drizzle-orm'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { writeAuditLog } from '@/lib/audit'
+import { getRequestContext } from '@/lib/request-context'
 import { revalidatePath } from 'next/cache'
 import { MODULE_DEFS, type ModuleKey, type ModuleGroup } from '@/lib/modules'
 import { validatePassword } from '@/lib/password'
@@ -16,6 +17,18 @@ import {
   isValidBreakGlassTtl,
 } from '@/lib/break-glass'
 import { notifyBreakGlassEvent } from '@/lib/notifications/break-glass'
+
+/**
+ * Proxy-aware request telemetry (source IP + user agent) for an instance-admin
+ * audit entry's `metadata` (#720). Security-relevant platform-administration
+ * events need this context for incident review. Never records raw headers —
+ * only the derived IP and user-agent string. Returns nulls outside a request
+ * scope (e.g. background jobs), so callers can use it unconditionally.
+ */
+async function auditMeta(extra?: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const ctx = await getRequestContext()
+  return { ip: ctx.ip, userAgent: ctx.userAgent, ...(extra ?? {}) }
+}
 
 export async function createOrg(formData: FormData): Promise<{ id: string }> {
   const session = await requireInstanceAdmin()
@@ -49,6 +62,7 @@ export async function createOrg(formData: FormData): Promise<{ id: string }> {
 
     await writeAuditLog(tx, {
       action: 'instance.org.create',
+      metadata: await auditMeta(),
       entityType: 'organization',
       entityId: org.id,
       userId: session.user.id,
@@ -94,6 +108,7 @@ export async function grantBreakGlass(
 
     await writeAuditLog(tx, {
       action: 'instance.break_glass.grant',
+      metadata: await auditMeta(),
       entityType: 'organization',
       entityId: orgId,
       userId: session.user.id,
@@ -146,6 +161,7 @@ export async function approveBreakGlass(sessionId: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.break_glass.approve',
+      metadata: await auditMeta(),
       entityType: 'break_glass_session',
       entityId: sessionId,
       userId: session.user.id,
@@ -185,6 +201,7 @@ export async function revokeBreakGlass(sessionId: string, orgId: string) {
     if (row) {
       await writeAuditLog(tx, {
         action: 'instance.break_glass.revoke',
+        metadata: await auditMeta(),
         entityType: 'break_glass_session',
         entityId: sessionId,
         userId: session.user.id,
@@ -241,6 +258,7 @@ export async function suspendOrg(orgId: string, reason: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.org.suspend',
+      metadata: await auditMeta(),
       entityType: 'organization',
       entityId: orgId,
       userId: session.user.id,
@@ -264,6 +282,7 @@ export async function unsuspendOrg(orgId: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.org.unsuspend',
+      metadata: await auditMeta(),
       entityType: 'organization',
       entityId: orgId,
       userId: session.user.id,
@@ -285,6 +304,7 @@ export async function promoteInstanceAdmin(userId: string, reason?: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.user.promote',
+      metadata: await auditMeta(),
       entityType: 'user',
       entityId: userId,
       userId: session.user.id,
@@ -307,6 +327,7 @@ export async function demoteInstanceAdmin(userId: string, reason?: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.user.demote',
+      metadata: await auditMeta(),
       entityType: 'user',
       entityId: userId,
       userId: session.user.id,
@@ -342,6 +363,7 @@ export async function suspendUserAccount(userId: string, reason: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.user.suspend',
+      metadata: await auditMeta(),
       entityType: 'user',
       entityId: userId,
       userId: session.user.id,
@@ -367,6 +389,7 @@ export async function reactivateUserAccount(userId: string, reason: string) {
 
     await writeAuditLog(tx, {
       action: 'instance.user.reactivate',
+      metadata: await auditMeta(),
       entityType: 'user',
       entityId: userId,
       userId: session.user.id,
@@ -428,6 +451,7 @@ export async function updatePlatformConfig(data: {
 
     await writeAuditLog(tx, {
       action: 'instance.config.update',
+      metadata: await auditMeta(),
       entityType: 'platform_config',
       entityId: 'singleton',
       userId: session.user.id,
@@ -539,6 +563,7 @@ export async function updateOrgGovernance(
 
     await writeAuditLog(tx, {
       action: 'instance.org.governance.update',
+      metadata: await auditMeta(),
       entityType: 'organization',
       entityId: orgId,
       userId: session.user.id,
@@ -592,6 +617,7 @@ export async function setInstanceModuleAvailability(key: ModuleKey, available: b
 
     await writeAuditLog(tx, {
       action: 'instance.settings.module_availability',
+      metadata: await auditMeta(),
       entityType: 'instance_settings',
       entityId: row.id,
       userId: session.user.id,
@@ -637,6 +663,7 @@ export async function setInstanceGroupAvailability(group: ModuleGroup, available
 
     await writeAuditLog(tx, {
       action: 'instance.settings.group_availability',
+      metadata: await auditMeta(),
       entityType: 'instance_settings',
       entityId: row.id,
       userId: session.user.id,

--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -564,6 +564,7 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
 
       await writeAuditLog(tx, {
         action: reactivated ? 'instance.user.membership_reactivate' : 'instance.user.membership_add',
+        metadata: await auditMeta(),
         entityType: 'user_organization_membership',
         entityId: existing.id,
         userId: session.user.id,
@@ -597,6 +598,7 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
 
     await writeAuditLog(tx, {
       action: 'instance.user.create',
+      metadata: await auditMeta(),
       entityType: 'user',
       entityId: user.id,
       userId: session.user.id,

--- a/apps/govea/src/app/(instance)/instance/audit/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/audit/page.tsx
@@ -167,9 +167,17 @@ export default async function InstanceAuditPage({
 
       {/* Instance events */}
       <section>
-        <h2 className="text-base font-semibold mb-3">
-          Platform Events <span className="text-muted-foreground text-sm font-normal">({instanceEvents.length})</span>
-        </h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold">
+            Platform Events <span className="text-muted-foreground text-sm font-normal">({instanceEvents.length})</span>
+          </h2>
+          <a
+            href="/api/instance/audit/export?scope=platform"
+            className="text-sm text-primary underline underline-offset-2 hover:no-underline"
+          >
+            Export CSV (30d)
+          </a>
+        </div>
         <div className="rounded-lg border bg-card">
           <Table>
             <TableHeader>

--- a/apps/govea/src/app/(instance)/instance/audit/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/audit/page.tsx
@@ -178,24 +178,32 @@ export default async function InstanceAuditPage({
                 <TableHead>Action</TableHead>
                 <TableHead>Entity</TableHead>
                 <TableHead>Actor</TableHead>
+                <TableHead>Source IP</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {instanceEvents.map(({ log, actor }) => (
-                <TableRow key={log.id}>
-                  <TableCell className="text-muted-foreground whitespace-nowrap text-xs">
-                    {log.createdAt.toLocaleString()}
-                  </TableCell>
-                  <TableCell className="font-mono text-xs">{log.action}</TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {log.entityType}{log.entityId ? ` · ${log.entityId.slice(0, 8)}` : ''}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">{actor?.email ?? 'system'}</TableCell>
-                </TableRow>
-              ))}
+              {instanceEvents.map(({ log, actor }) => {
+                // #720 — proxy-aware client telemetry captured on the event.
+                const meta = (log.metadata ?? null) as { ip?: string | null; userAgent?: string | null } | null
+                return (
+                  <TableRow key={log.id}>
+                    <TableCell className="text-muted-foreground whitespace-nowrap text-xs">
+                      {log.createdAt.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{log.action}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {log.entityType}{log.entityId ? ` · ${log.entityId.slice(0, 8)}` : ''}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{actor?.email ?? 'system'}</TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground" title={meta?.userAgent ?? undefined}>
+                      {meta?.ip ?? '—'}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
               {instanceEvents.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
                     No platform events match these filters
                   </TableCell>
                 </TableRow>

--- a/apps/govea/src/app/api/instance/audit/export/route.ts
+++ b/apps/govea/src/app/api/instance/audit/export/route.ts
@@ -1,20 +1,47 @@
 import { auth } from '@/lib/auth'
 import { isInstanceAdmin } from '@/lib/rbac'
 import { escapeCsv } from '@/lib/csv'
-import { getFailedLoginEvents } from '@/lib/audit-view'
+import { getFailedLoginEvents, getPlatformAuditEvents } from '@/lib/audit-view'
 
 /**
- * Failed-login telemetry CSV export — #720 slice 3. Instance-admin only; spans
- * all orgs (instance security review). Includes the slice-1 telemetry fields
- * (ip, user_agent, reason) on each failed-login event. No secrets exported.
+ * Instance audit telemetry CSV export — #720. Instance-admin only; spans all
+ * orgs (instance security review). No secrets exported — only derived IP, user
+ * agent, and safe categorical fields.
+ *
+ * Two scopes via the `scope` query param:
+ *   - default / `failed-logins` — failed-login events (email, ip, user_agent, reason)
+ *   - `platform` — platform-administration events (action, entity, actor, ip, user_agent)
  */
-export async function GET() {
+export async function GET(req: Request) {
   const session = await auth()
   if (!session?.user) return new Response('Unauthorized', { status: 401 })
   if (!isInstanceAdmin(session.user)) return new Response('Forbidden', { status: 403 })
 
-  const events = await getFailedLoginEvents({ sinceDays: 30 })
+  const scope = new URL(req.url).searchParams.get('scope')
+  const date = new Date().toISOString().slice(0, 10)
 
+  if (scope === 'platform') {
+    const events = await getPlatformAuditEvents({ sinceDays: 30 })
+    const headers = ['when', 'action', 'entity_type', 'entity_id', 'actor_email', 'ip', 'user_agent']
+    const lines = events.map(e => [
+      e.createdAt.toISOString(),
+      e.action,
+      e.entityType ?? '',
+      e.entityId ?? '',
+      e.actorEmail ?? '',
+      e.ip ?? '',
+      e.userAgent ?? '',
+    ].map(escapeCsv).join(','))
+    const csv = [headers.map(escapeCsv).join(','), ...lines].join('\n')
+    return new Response(csv, {
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="platform-events-${date}.csv"`,
+      },
+    })
+  }
+
+  const events = await getFailedLoginEvents({ sinceDays: 30 })
   const headers = ['when', 'action', 'email', 'ip', 'user_agent', 'reason', 'organization_id']
   const lines = events.map(e => [
     e.createdAt.toISOString(),
@@ -27,7 +54,6 @@ export async function GET() {
   ].map(escapeCsv).join(','))
   const csv = [headers.map(escapeCsv).join(','), ...lines].join('\n')
 
-  const date = new Date().toISOString().slice(0, 10)
   return new Response(csv, {
     headers: {
       'Content-Type': 'text/csv',

--- a/apps/govea/src/lib/audit-view.ts
+++ b/apps/govea/src/lib/audit-view.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/client'
 import { auditLog, users } from '@/db/schema'
-import { and, eq, desc, gte, inArray, like, sql, type SQL } from 'drizzle-orm'
+import { and, eq, desc, gte, inArray, isNull, like, sql, type SQL } from 'drizzle-orm'
 
 /**
  * Entity types whose audit events are visible to Contributors (#597).
@@ -264,6 +264,50 @@ export async function getFailedLoginEvents(
     .from(auditLog)
     .where(and(
       inArray(auditLog.action, FAILED_LOGIN_ACTIONS as unknown as string[]),
+      gte(auditLog.createdAt, since),
+    ))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit)
+}
+
+/**
+ * Instance-scoped (platform-administration) audit events with telemetry, for
+ * the platform-events CSV export (#720). Instance-admin only; events have
+ * `organizationId IS NULL`. Includes the source IP + user agent captured on
+ * each event plus the acting admin's email, so an incident reviewer can export
+ * the full platform-admin trail — not just failed logins.
+ */
+export interface PlatformAuditEvent {
+  createdAt: Date
+  action: string
+  entityType: string | null
+  entityId: string | null
+  actorEmail: string | null
+  ip: string | null
+  userAgent: string | null
+}
+
+export async function getPlatformAuditEvents(
+  opts?: { sinceDays?: number; limit?: number },
+): Promise<PlatformAuditEvent[]> {
+  const sinceDays = opts?.sinceDays ?? 30
+  const limit = opts?.limit ?? 5000
+  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+  return db
+    .select({
+      createdAt: auditLog.createdAt,
+      action: auditLog.action,
+      entityType: auditLog.entityType,
+      entityId: auditLog.entityId,
+      actorEmail: users.email,
+      ip: sql<string | null>`${auditLog.metadata} ->> 'ip'`,
+      userAgent: sql<string | null>`${auditLog.metadata} ->> 'userAgent'`,
+    })
+    .from(auditLog)
+    .leftJoin(users, eq(auditLog.userId, users.id))
+    .where(and(
+      isNull(auditLog.organizationId),
       gte(auditLog.createdAt, since),
     ))
     .orderBy(desc(auditLog.createdAt))

--- a/apps/govea/tests/integration/instance-actions.test.ts
+++ b/apps/govea/tests/integration/instance-actions.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@/actions/instance'
 import { db } from '@/db/client'
 import { breakGlassSessions, auditLog, instanceSettings, organizations, users } from '@/db/schema'
-import { eq, and, isNull, or } from 'drizzle-orm'
+import { eq, and, isNull, or, desc } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import {
   createTestOrg, createTestUser, cleanupOrg, makeSession, findOrg, findUser,
@@ -34,6 +34,14 @@ vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
 
 const mockRevalidate = vi.hoisted(() => vi.fn())
 vi.mock('next/cache', () => ({ revalidatePath: mockRevalidate }))
+
+// #720 — proxy-aware request telemetry. Default to nulls (no request scope) so
+// every action runs; individual tests override to assert IP/UA capture.
+const mockRequestContext = vi.hoisted(() => vi.fn(async () => ({ ip: null as string | null, userAgent: null as string | null })))
+vi.mock('@/lib/request-context', async (orig) => ({
+  ...(await orig<typeof import('@/lib/request-context')>()),
+  getRequestContext: mockRequestContext,
+}))
 
 // ── Test state ────────────────────────────────────────────────────────────────
 
@@ -414,5 +422,66 @@ describe('reactivateUserAccount', () => {
   it('throws Forbidden for non-instance-admin', async () => {
     asRegularAdmin()
     await expect(reactivateUserAccount(regularUser.id, 'x')).rejects.toThrow('Forbidden')
+  })
+})
+
+// ── Audit telemetry: source IP + user agent on instance-admin events (#720) ───
+
+describe('instance-admin audit telemetry (#720)', () => {
+  const IP = '203.0.113.7'
+  const UA = 'Vitest/1.0 (audit-telemetry)'
+
+  beforeAll(() => {
+    mockRequestContext.mockResolvedValue({ ip: IP, userAgent: UA })
+  })
+
+  afterAll(() => {
+    mockRequestContext.mockResolvedValue({ ip: null, userAgent: null })
+  })
+
+  async function latestMeta(action: string, entityId: string) {
+    const [row] = await db.select().from(auditLog)
+      .where(and(eq(auditLog.action, action), eq(auditLog.entityId, entityId)))
+      .orderBy(desc(auditLog.createdAt))
+      .limit(1)
+    return (row?.metadata ?? null) as { ip?: string; userAgent?: string } | null
+  }
+
+  it('captures IP + user agent on a break-glass grant', async () => {
+    asInstanceAdmin()
+    await grantBreakGlass(targetOrgId, 'Telemetry test grant')
+    const meta = await latestMeta('instance.break_glass.grant', targetOrgId)
+    expect(meta?.ip).toBe(IP)
+    expect(meta?.userAgent).toBe(UA)
+  })
+
+  it('captures IP + user agent on org suspend', async () => {
+    asInstanceAdmin()
+    await suspendOrg(targetOrgId, 'Telemetry test suspend')
+    const meta = await latestMeta('instance.org.suspend', targetOrgId)
+    expect(meta?.ip).toBe(IP)
+    expect(meta?.userAgent).toBe(UA)
+    await unsuspendOrg(targetOrgId) // restore state for any later assertions
+  })
+
+  it('captures IP + user agent on a platform-admin promotion', async () => {
+    asInstanceAdmin()
+    await promoteInstanceAdmin(regularUser.id, 'Telemetry test promote')
+    const meta = await latestMeta('instance.user.promote', regularUser.id)
+    expect(meta?.ip).toBe(IP)
+    expect(meta?.userAgent).toBe(UA)
+    await demoteInstanceAdmin(regularUser.id, 'Telemetry test cleanup')
+  })
+
+  it('records null IP/UA gracefully outside a request scope (no crash)', async () => {
+    asInstanceAdmin()
+    mockRequestContext.mockResolvedValueOnce({ ip: null, userAgent: null })
+    await grantBreakGlass(targetOrgId, 'No-context grant')
+    // The action still succeeds and writes an entry; telemetry is simply null.
+    const [row] = await db.select().from(auditLog)
+      .where(and(eq(auditLog.action, 'instance.break_glass.grant'), eq(auditLog.entityId, targetOrgId)))
+      .orderBy(desc(auditLog.createdAt)).limit(1)
+    expect(row).toBeDefined()
+    expect((row.metadata as { ip: string | null }).ip).toBeNull()
   })
 })

--- a/apps/govea/tests/integration/instance-actions.test.ts
+++ b/apps/govea/tests/integration/instance-actions.test.ts
@@ -20,8 +20,9 @@ import {
 } from '@/actions/instance'
 import { db } from '@/db/client'
 import { breakGlassSessions, auditLog, instanceSettings, organizations, users, userOrganizationMemberships } from '@/db/schema'
-import { eq, and, isNull, or } from 'drizzle-orm'
+import { eq, and, isNull, or, desc } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { getPlatformAuditEvents } from '@/lib/audit-view'
 import {
   createTestOrg, createTestUser, cleanupOrg, makeSession, findOrg, findUser,
   type TestUser,
@@ -569,5 +570,18 @@ describe('instance-admin audit telemetry (#720)', () => {
       .orderBy(desc(auditLog.createdAt)).limit(1)
     expect(row).toBeDefined()
     expect((row.metadata as { ip: string | null }).ip).toBeNull()
+  })
+
+  it('surfaces platform events with telemetry + actor for the CSV export', async () => {
+    asInstanceAdmin()
+    await suspendOrg(targetOrgId, 'Platform-events export test')
+    await unsuspendOrg(targetOrgId)
+
+    const events = await getPlatformAuditEvents({ sinceDays: 1 })
+    const suspendEvt = events.find(e => e.action === 'instance.org.suspend' && e.entityId === targetOrgId)
+    expect(suspendEvt).toBeDefined()
+    expect(suspendEvt!.ip).toBe(IP)
+    expect(suspendEvt!.userAgent).toBe(UA)
+    expect(suspendEvt!.actorEmail).toBe(instanceAdmin.email)
   })
 })


### PR DESCRIPTION
## Summary

Completes **#720** — instance-admin and authentication audit events now carry the operational telemetry needed for access reviews and incident response. This PR finishes the remaining gap (instance-admin events + platform CSV) on top of the auth-telemetry and failed-login work already in `main`.

## What this PR adds

- **Source IP + user agent on every instance-admin audit event** (`actions/instance.ts`): a small `auditMeta()` helper wraps the proxy-aware `getRequestContext()` and is attached to all 16 platform audit writes — break-glass grant/approve/revoke, org create/suspend/unsuspend/governance, platform-admin promote/demote, user suspend/reactivate, **user create + org-membership add/reactivate** (the #758 paths), and module/group availability. No raw headers stored; telemetry is null outside a request scope.
- **Platform Events get a Source IP column** in the instance audit UI (user agent on hover).
- **Platform-administration CSV export**: `getPlatformAuditEvents()` + a `scope=platform` mode on the audit export route (action, entity, actor, ip, user_agent), with an "Export CSV (30d)" link on the Platform Events section. The existing failed-login CSV is unchanged.
- Tests: instance-admin events capture IP/UA (grant, suspend, promote), a graceful null-context case, and the platform-events export query surfacing telemetry + actor.

## Already in `main` (earlier #720 slices)
- Proxy-aware IP capture with anti-spoofing (`lib/request-context.ts`) + unit tests
- Auth telemetry: `auth.login` / `login_failed` / `login_blocked_locked` / `logout` with IP, user agent, provider, and safe failure-reason categories
- Failed-login summary (by email + by IP) and failed-login CSV export

## Acceptance criteria — all met
- [x] Auth events capture source IP + user agent.
- [x] Failed logins logged without account enumeration (safe `invalid_credentials` reason for unknown accounts).
- [x] Repeated failed-login telemetry reviewable by email and by source IP.
- [x] Instance-admin events carry target org / user / break-glass session / reason / before-after context **plus** source IP + user agent.
- [x] Instance audit UI exposes the telemetry readably (Source IP column + failed-login tables) without bloating the default list.
- [x] CSV export includes the new telemetry — both failed-login and platform-admin scopes.
- [x] No sensitive data logged — derived IP + UA only; never raw headers, passwords, tokens, or SSO assertions.
- [x] Audit-log immutability preserved.
- [x] Tests cover successful login, failed login, and instance-admin events with target context + telemetry.

## Testing
- `tsc --noEmit` clean · `lint` 0 errors
- Integration suite **994/994** (instance-actions at 40 tests across #720 telemetry + #756 membership)
- Production `build` passed
- Rebased onto current `main` (picks up #756/#758 — its new `createInstanceUser` membership writes are covered here)

Capability: iam-audit-trail
Capability: iam-instance-administration
Persona: Instance Administrator

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)