### PR TITLE
feat(a11y): automated WCAG 2.1 AA gates — jsx-a11y lint + axe e2e checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,9 +215,11 @@ jobs:
       - name: Run E2E smoke tests
         # smoke.spec.ts is the route-health sweep; overview.spec.ts (#614)
         # adds role-aware /overview CTA-gating + Coming-next-tile coverage.
+        # a11y.spec.ts (#766) runs axe-core WCAG 2.1 A/AA checks over the
+        # same routes — serious/critical violations fail the build.
         # Other specs (iam.spec.ts, auth-security.spec.ts) intentionally
         # stay out of CI for now — they mutate state and are run locally.
-        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts
+        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts tests/e2e/specs/a11y.spec.ts
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/apps/govea/eslint.config.mjs
+++ b/apps/govea/eslint.config.mjs
@@ -1,10 +1,28 @@
 import coreWebVitals from 'eslint-config-next/core-web-vitals'
 import nextTypescript from 'eslint-config-next/typescript'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 
 const config = [
   { ignores: ['.next/**'] },
   ...coreWebVitals,
   ...nextTypescript,
+  // #766 — WCAG 2.1 AA (Washington Policy 188). eslint-config-next wires only
+  // a subset of jsx-a11y rules; this enables the full recommended rule set as
+  // errors so violations fail the CI lint gate. Rules only — the plugin itself
+  // is already registered by eslint-config-next and cannot be redefined.
+  { rules: jsxA11y.flatConfigs.recommended.rules },
+  {
+    rules: {
+      // Focus moves in this app are user-initiated (opening an inline editor,
+      // a rename field, a search page the user navigated to) — WCAG 3.2.1
+      // permits focus set in response to a user action; the rule targets
+      // unsolicited focus steals on page load.
+      'jsx-a11y/no-autofocus': 'off',
+      // Label text in settings forms sits inside a div+span wrapper next to
+      // the checkbox; raise the search depth so the rule sees it.
+      'jsx-a11y/label-has-associated-control': ['error', { depth: 3 }],
+    },
+  },
   {
     rules: {
       '@typescript-eslint/no-unused-vars': [

--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -50,6 +50,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.48.0",
     "@types/bcryptjs": "^2.4.6",
@@ -61,6 +62,7 @@
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.4",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",

--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -184,6 +184,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
         {!canEdit && null /* viewers see pre-filtered results — no status filter needed */}
         {canEdit && (
           <select
+            aria-label="Filter by status"
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value)}
             className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -425,6 +425,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           className="w-56"
         />
         <select
+          aria-label="Filter by lifecycle"
           value={lifecycleFilter}
           onChange={e => setLifecycleFilter(e.target.value)}
           className={selectClass}
@@ -438,6 +439,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         {/* Status filter hidden in portfolio view — less relevant for leadership */}
         {viewMode === 'table' && (
           <select
+            aria-label="Filter by status"
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value)}
             className={selectClass}
@@ -450,6 +452,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         )}
         {domainOptions.length > 0 && (
           <select
+            aria-label="Filter by domain"
             value={domainFilter}
             onChange={e => setDomainFilter(e.target.value)}
             className={selectClass}
@@ -460,6 +463,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         )}
         {hostingOptions.length > 0 && (
           <select
+            aria-label="Filter by hosting model"
             value={hostingFilter}
             onChange={e => setHostingFilter(e.target.value)}
             className={selectClass}
@@ -476,7 +480,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           onFilterChange={(defId, value) => setTaxonomyFilters(prev => ({ ...prev, [defId]: value }))}
         />
         {orgOptions.length > 1 && (
-          <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className={selectClass}>
+          <select aria-label="Filter by organization" value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className={selectClass}>
             <option value="all">All organizations</option>
             <option value="own">My organization</option>
             {orgOptions.filter(([id]) => id !== currentOrgId).map(([id, name]) => (

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -261,6 +261,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           className="w-56"
         />
         <select
+          aria-label="Filter by status"
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -271,6 +272,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           <option value="archived">Archived</option>
         </select>
         <select
+          aria-label="Filter by type"
           value={typeFilter}
           onChange={e => setTypeFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -281,6 +283,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
         </select>
         {domainOptions.length > 0 && (
           <select
+            aria-label="Filter by domain"
             value={domainFilter}
             onChange={e => setDomainFilter(e.target.value)}
             className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -290,7 +293,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           </select>
         )}
         {orgOptions.length > 1 && (
-          <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+          <select aria-label="Filter by organization" value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
             <option value="all">All organizations</option>
             <option value="own">My organization</option>
             {orgOptions.filter(([id]) => id !== currentOrgId).map(([id, name]) => (

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -30,7 +30,7 @@ import { ViewerDashboard } from './viewer-dashboard'
 
 const RAG_TEXT_CLASS: Record<RagBucket, string> = {
   green:   'text-green-700 dark:text-green-400',
-  amber:   'text-amber-600 dark:text-amber-400',
+  amber:   'text-amber-700 dark:text-amber-400',
   red:     'text-red-600 dark:text-red-400',
   neutral: 'text-foreground',
 }
@@ -343,7 +343,7 @@ export default async function DashboardPage() {
                     <CardContent className="pb-4 px-4">
                       <p className="text-2xl font-bold">{s.total}</p>
                       {draftCount > 0 && (
-                        <p className="text-xs text-amber-600 mt-0.5">{draftCount} draft</p>
+                        <p className="text-xs text-amber-700 mt-0.5">{draftCount} draft</p>
                       )}
                     </CardContent>
                   </Card>
@@ -362,7 +362,7 @@ export default async function DashboardPage() {
             <CardContent className="pt-4 pb-4 space-y-3">
               {federation.inboundPending.length > 0 && (
                 <div className="space-y-2">
-                  <p className="text-xs font-medium text-amber-600">
+                  <p className="text-xs font-medium text-amber-700">
                     {federation.inboundPending.length} link request{federation.inboundPending.length !== 1 ? 's' : ''} awaiting your approval
                   </p>
                   <ul className="space-y-1">
@@ -401,7 +401,7 @@ export default async function DashboardPage() {
               )}
               {federation.flaggedCount > 0 && (
                 <div className="space-y-1 border-t pt-3">
-                  <p className="text-xs text-amber-600 font-medium">
+                  <p className="text-xs text-amber-700 font-medium">
                     {federation.flaggedCount} link{federation.flaggedCount !== 1 ? 's' : ''} flagged for review
                   </p>
                   <p className="text-xs text-muted-foreground">
@@ -436,13 +436,13 @@ export default async function DashboardPage() {
                     <div className="flex-1 flex items-center gap-6 text-sm">
                       <span className="text-muted-foreground">
                         Modified:{' '}
-                        <span className={modifiedPct !== null && modifiedPct < 50 ? 'text-amber-600 font-medium' : 'font-medium'}>
+                        <span className={modifiedPct !== null && modifiedPct < 50 ? 'text-amber-700 font-medium' : 'font-medium'}>
                           {modifiedPct !== null ? `${modifiedPct}%` : '—'}
                         </span>
                       </span>
                       <span className="text-muted-foreground">
                         Reviewed:{' '}
-                        <span className={reviewedPct !== null && reviewedPct < 50 ? 'text-amber-600 font-medium' : 'font-medium'}>
+                        <span className={reviewedPct !== null && reviewedPct < 50 ? 'text-amber-700 font-medium' : 'font-medium'}>
                           {reviewedPct !== null ? `${reviewedPct}%` : '—'}
                         </span>
                       </span>
@@ -509,13 +509,13 @@ export default async function DashboardPage() {
                   <span>
                     Stale <span className="text-xs text-muted-foreground">(past staleness window)</span>
                   </span>
-                  <span className={`font-medium ${signals.stale > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                  <span className={`font-medium ${signals.stale > 0 ? 'text-amber-700' : 'text-muted-foreground'}`}>
                     {signals.stale}
                   </span>
                 </li>
                 <li className="flex items-center justify-between text-sm">
                   <span>Unpublished <span className="text-xs text-muted-foreground">(drafts)</span></span>
-                  <span className={`font-medium ${signals.unpublished > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                  <span className={`font-medium ${signals.unpublished > 0 ? 'text-amber-700' : 'text-muted-foreground'}`}>
                     {signals.unpublished}
                   </span>
                 </li>
@@ -523,7 +523,7 @@ export default async function DashboardPage() {
                   <span>
                     Incomplete relationships <span className="text-xs text-muted-foreground">(capability ↔ application / persona)</span>
                   </span>
-                  <span className={`font-medium ${signals.incompleteRelationships > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                  <span className={`font-medium ${signals.incompleteRelationships > 0 ? 'text-amber-700' : 'text-muted-foreground'}`}>
                     {signals.incompleteRelationships}
                   </span>
                 </li>
@@ -531,7 +531,7 @@ export default async function DashboardPage() {
                   <Link href="/debt" className="hover:underline">
                     Open debt <span className="text-xs text-muted-foreground">(draft / published / in-progress)</span>
                   </Link>
-                  <span className={`font-medium ${signals.openDebt > 0 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                  <span className={`font-medium ${signals.openDebt > 0 ? 'text-amber-700' : 'text-muted-foreground'}`}>
                     {signals.openDebt}
                   </span>
                 </li>

--- a/apps/govea/src/app/(admin)/notifications/notification-row-item.tsx
+++ b/apps/govea/src/app/(admin)/notifications/notification-row-item.tsx
@@ -16,7 +16,10 @@ export function NotificationRowItem({ item }: { item: NotificationRow }) {
 
   // Layered click: the row is clickable to mark-read; the link inside is
   // a real navigation. The mark-read fires in parallel with the link click.
+  // The row click is a pointer-only convenience — keyboard users have full
+  // parity through the focusable "mark read" button and the link below.
   return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
     <li
       onClick={handleClick}
       className={cn(

--- a/apps/govea/src/app/(admin)/overview/page.tsx
+++ b/apps/govea/src/app/(admin)/overview/page.tsx
@@ -476,7 +476,7 @@ export default async function OverviewPage() {
         </div>
         <p className="text-sm text-muted-foreground">
           The current shortlist of next product moves. Mirrors{' '}
-          <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+          <code className="rounded bg-muted px-1 py-0.5 text-[11px] text-foreground">
             docs/product-priorities.md
           </code>
           , which is the source of truth.
@@ -542,7 +542,7 @@ export default async function OverviewPage() {
         <p className="text-xs text-muted-foreground leading-relaxed">
           This overview reflects what is in the product today. For the
           authoritative capability inventory see{' '}
-          <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+          <code className="rounded bg-muted px-1 py-0.5 text-[11px] text-foreground">
             capabilities.md
           </code>{' '}
           in the repository.

--- a/apps/govea/src/app/(admin)/personas/persona-table.tsx
+++ b/apps/govea/src/app/(admin)/personas/persona-table.tsx
@@ -168,6 +168,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           className="w-56"
         />
         <select
+          aria-label="Filter by type"
           value={typeFilter}
           onChange={e => setTypeFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -178,6 +179,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           ))}
         </select>
         <select
+          aria-label="Filter by tag"
           value={tagFilter}
           onChange={e => setTagFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -188,6 +190,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           ))}
         </select>
         <select
+          aria-label="Filter by status"
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -198,7 +201,7 @@ export function PersonaTable({ personas, personaTypes, allTags, role, currentOrg
           <option value="archived">Archived</option>
         </select>
         {orgOptions.length > 1 && (
-          <select value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+          <select aria-label="Filter by organization" value={orgFilter} onChange={e => setOrgFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
             <option value="all">All organizations</option>
             <option value="own">My organization</option>
             {orgOptions.filter(([id]) => id !== currentOrgId).map(([id, name]) => (

--- a/apps/govea/src/app/(admin)/users/user-table.tsx
+++ b/apps/govea/src/app/(admin)/users/user-table.tsx
@@ -107,6 +107,7 @@ export function UserTable({ users, currentUserId }: Props) {
           className="w-64"
         />
         <select
+          aria-label="Filter by role"
           value={roleFilter}
           onChange={e => setRoleFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -117,6 +118,7 @@ export function UserTable({ users, currentUserId }: Props) {
           <option value="viewer">Viewer</option>
         </select>
         <select
+          aria-label="Filter by status"
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value)}
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -194,7 +196,7 @@ export function UserTable({ users, currentUserId }: Props) {
                               onClick={() => handleDeactivate(u)}
                               disabled={isPending || lastAdmin}
                               title={lastAdmin ? 'Cannot deactivate the last admin' : undefined}
-                              className="h-7 px-2 text-xs text-amber-600 hover:text-amber-700 hover:bg-amber-50"
+                              className="h-7 px-2 text-xs text-amber-700 hover:text-amber-800 hover:bg-amber-50"
                             >
                               Deactivate
                             </Button>

--- a/apps/govea/src/app/globals.css
+++ b/apps/govea/src/app/globals.css
@@ -25,7 +25,9 @@
     --accent: 214 32% 95%;
     --accent-foreground: 222 47% 11%;
 
-    --destructive: 0 84% 60%;
+    /* WCAG AA (#766): 0 84% 60% was 3.8:1 as text on white — darkened so
+       text-destructive passes 4.5:1 and white-on-destructive improves too. */
+    --destructive: 0 72% 45%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 214 32% 91%;

--- a/apps/govea/src/components/taxonomy-ui.tsx
+++ b/apps/govea/src/components/taxonomy-ui.tsx
@@ -95,6 +95,7 @@ export function TaxonomyFilters({
       {defs.map(def => def.values.length > 0 && (
         <select
           key={def.id}
+          aria-label={`Filter by ${def.typeName}`}
           value={filters[def.id] ?? 'all'}
           onChange={e => onFilterChange(def.id, e.target.value)}
           className={SELECT_CLASS}

--- a/apps/govea/src/components/ui/card.tsx
+++ b/apps/govea/src/components/ui/card.tsx
@@ -17,6 +17,9 @@ CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
+    // Heading content arrives via the spread props' children; the rule can't
+    // see through the generic wrapper. Callers always pass visible text.
+    // eslint-disable-next-line jsx-a11y/heading-has-content
     <h3 ref={ref} className={cn("font-semibold leading-none tracking-tight", className)} {...props} />
   )
 )

--- a/apps/govea/src/lib/themes.ts
+++ b/apps/govea/src/lib/themes.ts
@@ -39,7 +39,8 @@ export const themes: ThemeDefinition[] = [
       '--muted-foreground': '215 16% 47%',
       '--accent': '214 32% 95%',
       '--accent-foreground': '222 47% 11%',
-      '--destructive': '0 84% 60%',
+      // WCAG AA (#766): keep in sync with globals.css --destructive
+      '--destructive': '0 72% 45%',
       '--destructive-foreground': '210 40% 98%',
       '--border': '214 32% 91%',
       '--input': '214 32% 91%',
@@ -75,7 +76,8 @@ export const themes: ThemeDefinition[] = [
       '--muted-foreground': '220 9% 46%',
       '--accent': '270 44% 94%',
       '--accent-foreground': '270 44% 30%',
-      '--destructive': '0 84% 60%',
+      // WCAG AA (#766): keep in sync with globals.css --destructive
+      '--destructive': '0 72% 45%',
       '--destructive-foreground': '0 0% 98%',
       '--border': '220 13% 87%',
       '--input': '220 13% 87%',

--- a/apps/govea/tests/e2e/specs/a11y.spec.ts
+++ b/apps/govea/tests/e2e/specs/a11y.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Automated accessibility checks — #766 (WCAG 2.1 AA, Washington Policy 188).
+ *
+ * Runs axe-core against the key authenticated routes (the smoke-test set)
+ * plus the login page, scoped to the WCAG 2.0/2.1 A and AA rule tags.
+ *
+ * Gate policy: serious and critical violations fail the build. Moderate and
+ * minor violations are logged to the test output for triage but do not fail —
+ * tighten this once the backlog is clear. Waivers belong here, as rule
+ * exclusions with a comment, not as silent config.
+ */
+
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+const AUTHED_ROUTES = [
+  '/dashboard',
+  '/overview',
+  '/capabilities',
+  '/applications',
+  '/adrs',
+  '/personas',
+  '/users',
+] as const
+
+async function runAxe(page: import('@playwright/test').Page, route: string) {
+  const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze()
+
+  const blocking = results.violations.filter(
+    v => v.impact === 'serious' || v.impact === 'critical',
+  )
+  const advisory = results.violations.filter(
+    v => v.impact !== 'serious' && v.impact !== 'critical',
+  )
+
+  for (const v of advisory) {
+    console.log(
+      `[a11y advisory] ${route}: ${v.id} (${v.impact}) — ${v.help} — ${v.nodes.length} node(s)`,
+    )
+  }
+
+  expect(
+    blocking.map(v => ({
+      id: v.id,
+      impact: v.impact,
+      help: v.help,
+      nodes: v.nodes.map(n => n.target.join(' ')).slice(0, 5),
+    })),
+    `${route}: no serious/critical WCAG A/AA violations`,
+  ).toEqual([])
+}
+
+test.describe('accessibility — login', () => {
+  test('login page has no serious/critical WCAG violations', async ({ page }) => {
+    await page.goto('/login')
+    await page.waitForLoadState('networkidle')
+    await runAxe(page, '/login')
+  })
+})
+
+test.describe('accessibility — authenticated routes', () => {
+  test.use({ storageState: 'tests/e2e/.auth/admin.json' })
+
+  for (const route of AUTHED_ROUTES) {
+    test(`${route} has no serious/critical WCAG violations`, async ({ page }) => {
+      await page.goto(route)
+      await page.waitForLoadState('networkidle')
+      await runAxe(page, route)
+    })
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.59.1)
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -123,6 +126,9 @@ importers:
       eslint-config-next:
         specifier: ^16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -191,6 +197,11 @@ packages:
 
   '@auth/drizzle-adapter@1.11.1':
     resolution: {integrity: sha512-cQTvDZqsyF7RPhDm/B6SvqdVP9EzQhy3oM4Muu7fjjmSYFLbSR203E6dH631ZHSKDn2b4WZkfMnjPDzRsPSAeA==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2180,6 +2191,10 @@ packages:
 
   axe-core@4.11.2:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
+    engines: {node: '>=4'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -4475,6 +4490,11 @@ snapshots:
       - '@simplewebauthn/server'
       - nodemailer
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -6123,6 +6143,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.2: {}
+
+  axe-core@4.11.4: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
Closes #766
Capability group: cms/frontend-display
Persona: CMS Viewer

## What changed
- **Static gate**: enables the full `eslint-plugin-jsx-a11y` recommended rule set as errors in the lint gate (eslint-config-next only wires a subset). One documented waiver: `no-autofocus` is off because all focus moves in the app are user-initiated (WCAG 3.2.1-permitted); `label-has-associated-control` depth raised to 3 for the settings-form wrapper markup.
- **Fixes surfaced by the new gate**: notification row's pointer-only row-click documented + waived inline (keyboard parity exists via the "mark read" button and link); `CardTitle` heading rule waived at the generic-wrapper level (content arrives via children).
- **Runtime gate**: new `tests/e2e/specs/a11y.spec.ts` runs axe-core (`@axe-core/playwright`) with WCAG 2.0/2.1 A+AA tags over the smoke-test routes plus `/login`. Serious/critical violations fail the build; moderate/minor are logged for triage.
- **CI**: the e2e step now runs the a11y spec alongside smoke and overview.

## Why
Washington Policy 188 mandates WCAG 2.1 AA for state-used IT (#766, from the security/standards deep dive). This adds the automated enforcement half; the VPAT/ACR document remains tracked in #766's follow-up.

## How it was validated
- `pnpm lint` — 0 errors (10 a11y errors found and resolved during rollout)
- `pnpm exec tsc --noEmit` — passes
- `pnpm build` — passes
- axe e2e spec runs in CI against the Postgres-backed app (no local DB on this machine)

Per Standards.md, a human reviews and merges this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)