### PR TITLE
test(theming): guard org themes against drifting from globals.css a11y tokens

### DIFF
--- a/apps/govea/tests/unit/theme-globals-sync.test.ts
+++ b/apps/govea/tests/unit/theme-globals-sync.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Drift guard: org themes vs globals.css base tokens (#771)
+ *
+ * Org theme vars from themes.ts are injected as an inline :root <style> by
+ * app-shell.tsx, so they win the cascade over the :root block in globals.css
+ * at runtime. During WCAG AA work (#766 / #770) a contrast fix to
+ * --destructive in globals.css was silently negated by stale copies in
+ * themes.ts.
+ *
+ * For accessibility-critical vars, a theme must either omit the var (letting
+ * globals.css cascade through) or define exactly the globals.css value.
+ * An intentional deviation needs its own contrast review — change globals.css
+ * first, or consciously amend ACCESSIBILITY_CRITICAL_VARS in the same PR.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { themes } from '@/lib/themes'
+
+// Tokens whose values have been contrast-reviewed in globals.css. Extend as
+// more tokens get an accessibility pass.
+const ACCESSIBILITY_CRITICAL_VARS = ['--destructive']
+
+const globalsPath = fileURLToPath(new URL('../../src/app/globals.css', import.meta.url))
+
+/** Extract the custom properties declared in the (single) :root block. */
+function parseRootVars(css: string): Record<string, string> {
+  const noComments = css.replace(/\/\*[\s\S]*?\*\//g, '')
+  const rootBlock = noComments.match(/:root\s*\{([^}]*)\}/)
+  if (!rootBlock) throw new Error('Could not find a :root block in globals.css')
+  const vars: Record<string, string> = {}
+  for (const decl of rootBlock[1].matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    vars[decl[1]] = decl[2].trim()
+  }
+  return vars
+}
+
+const rootVars = parseRootVars(readFileSync(globalsPath, 'utf-8'))
+
+describe('theme drift guard (themes.ts vs globals.css)', () => {
+  it('parses custom properties out of the globals.css :root block', () => {
+    expect(Object.keys(rootVars).length).toBeGreaterThan(0)
+  })
+
+  // Parser-rot guard: if globals.css is restructured (var renamed, :root
+  // split up) this fails before the omit-or-match assertions go vacuous.
+  it.each(ACCESSIBILITY_CRITICAL_VARS)('globals.css :root defines %s', varName => {
+    expect(
+      rootVars[varName],
+      `${varName} not found in the :root block of globals.css — renamed or moved? ` +
+        'Update ACCESSIBILITY_CRITICAL_VARS in this test to follow it.',
+    ).toBeDefined()
+  })
+
+  describe.each(themes.map(t => [t.id, t] as const))('theme "%s"', (_id, theme) => {
+    it.each(ACCESSIBILITY_CRITICAL_VARS)('omits %s or matches the globals.css value', varName => {
+      const themeValue = theme.vars[varName]
+      if (themeValue === undefined) return // omitted — globals.css cascades through
+
+      expect(
+        themeValue,
+        `Theme "${theme.id}" overrides ${varName} with a value that differs from ` +
+          'globals.css. The inline theme style wins the cascade, so this silently ' +
+          'negates the contrast-reviewed value (see #766/#770). Sync it with ' +
+          'globals.css, or remove it from the theme so the base value applies.',
+      ).toBe(rootVars[varName])
+    })
+  })
+})


### PR DESCRIPTION
Closes #771
Capability: fd-theming
Persona: CMS Administrator

## What

Adds `apps/govea/tests/unit/theme-globals-sync.test.ts` — a plain vitest unit test (no DB) that parses the `:root` block of `globals.css` and asserts that for each accessibility-critical var (currently `--destructive`), every theme in `themes.ts` either **omits** the var or **matches** the globals.css value exactly.

## Why

Org theme vars are injected as an inline `:root` `<style>` by `app-shell.tsx`, so they win the cascade over `globals.css`. During the WCAG work (#766) the contrast fix to `--destructive` in globals.css was silently negated by stale copies in themes.ts until #770 synced them by hand. This guard turns the next occurrence of that drift into a CI failure with an actionable message instead of a shipped regression.

## Notes

- **Merge-order independent of #770**: the test passes on current `main` (both files still have the old `0 84% 60%`, consistently) and on the #770 branch (both updated). It only fails when the two files *disagree*.
- Includes a parser-rot guard: if globals.css is restructured so a critical var can't be found in `:root`, the test fails loudly rather than going vacuous.
- Follow-up #772 (blocked by #770) removes the duplication itself so globals.css becomes the single source for non-overridden tokens.

## Testing

- `pnpm --filter govea exec vitest run tests/unit` — 179 tests pass, including the 4 new ones
- Negative check: re-applied the #766 scenario locally (changed `--destructive` in globals.css only) → both themes fail with the expected message; reverted
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)