### PR TITLE
refactor(theming): single-source base tokens — drop globals.css duplicates from themes.ts

### DIFF
--- a/apps/govea/src/lib/themes.ts
+++ b/apps/govea/src/lib/themes.ts
@@ -10,6 +10,14 @@ export interface ThemeDefinition {
     primary: string
     background: string
   }
+  /**
+   * CSS custom properties this theme intentionally overrides relative to
+   * globals.css. Anything omitted cascades from the base tokens in
+   * globals.css — :root (light) / .dark (dark). Do not mirror globals.css
+   * values here: the inline theme <style> wins the cascade at runtime, so a
+   * stale copy silently negates later fixes to the base tokens (#766/#770;
+   * drift guard in tests/unit/theme-globals-sync.test.ts).
+   */
   vars: Record<string, string>
 }
 
@@ -24,28 +32,9 @@ export const themes: ThemeDefinition[] = [
       primary: '#1a4fba',
       background: '#f8f9fb',
     },
+    // GovEA is the default brand — its content tokens ARE the globals.css
+    // base values, so only the header/brand vars are declared here (#772).
     vars: {
-      '--background': '0 0% 100%',
-      '--foreground': '222 47% 11%',
-      '--card': '0 0% 100%',
-      '--card-foreground': '222 47% 11%',
-      '--popover': '0 0% 100%',
-      '--popover-foreground': '222 47% 11%',
-      '--primary': '221 83% 40%',
-      '--primary-foreground': '210 40% 98%',
-      '--secondary': '214 32% 95%',
-      '--secondary-foreground': '222 47% 11%',
-      '--muted': '214 32% 95%',
-      '--muted-foreground': '215 16% 47%',
-      '--accent': '214 32% 95%',
-      '--accent-foreground': '222 47% 11%',
-      // WCAG AA (#766): keep in sync with globals.css --destructive
-      '--destructive': '0 72% 45%',
-      '--destructive-foreground': '210 40% 98%',
-      '--border': '214 32% 91%',
-      '--input': '214 32% 91%',
-      '--ring': '221 83% 40%',
-      '--radius': '0.375rem',
       '--header-bg': '221 56% 22%',
       '--header-fg': '214 40% 93%',
       '--header-border': '221 56% 30%',
@@ -76,8 +65,9 @@ export const themes: ThemeDefinition[] = [
       '--muted-foreground': '220 9% 46%',
       '--accent': '270 44% 94%',
       '--accent-foreground': '270 44% 30%',
-      // WCAG AA (#766): keep in sync with globals.css --destructive
-      '--destructive': '0 72% 45%',
+      // Intentional override (unlike --destructive, which cascades from
+      // globals.css): 0 0% 98% matches this theme's neutral palette and
+      // passes AA on the base --destructive background.
       '--destructive-foreground': '0 0% 98%',
       '--border': '220 13% 87%',
       '--input': '220 13% 87%',

--- a/apps/govea/tests/unit/themes.test.ts
+++ b/apps/govea/tests/unit/themes.test.ts
@@ -69,7 +69,9 @@ describe('themeToStyleString', () => {
   })
 
   it('places --background in the :root:not(.dark) block only', () => {
-    const [rootBlock, darkBlock] = css.split(':root:not(.dark)')
+    // Uses servicenow: govea no longer declares content vars (#772).
+    const snCss = themeToStyleString(getTheme('servicenow'))
+    const [rootBlock, darkBlock] = snCss.split(':root:not(.dark)')
     expect(rootBlock).not.toContain('--background')
     expect(darkBlock).toContain('--background')
   })
@@ -91,6 +93,28 @@ describe('themeToStyleString', () => {
   it('every var in the theme appears somewhere in the output', () => {
     for (const key of Object.keys(govea.vars)) {
       expect(css).toContain(key)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// theme definitions
+// ---------------------------------------------------------------------------
+
+describe('theme definitions', () => {
+  it('govea (the default brand) declares only the header/brand vars (#772)', () => {
+    // Everything else must cascade from globals.css — see the vars contract
+    // in themes.ts and tests/unit/theme-globals-sync.test.ts.
+    expect(Object.keys(getTheme('govea').vars).sort()).toEqual([
+      '--header-bg',
+      '--header-border',
+      '--header-fg',
+    ])
+  })
+
+  it('no theme re-declares --destructive (cascades from globals.css)', () => {
+    for (const theme of themes) {
+      expect(theme.vars).not.toHaveProperty('--destructive')
     }
   })
 })


### PR DESCRIPTION
Closes #772
Capability: fd-theming
Persona: CMS Administrator

## What changed

`themes.ts` re-declared CSS custom properties that `globals.css` already defines, and the inline org-theme `<style>` injected by `app-shell.tsx` wins the cascade — so every duplicated var was a future drift hazard (#766/#770).

- **govea**: removed all content vars — each was value-identical to the `globals.css` `:root` block (it *is* the default brand). Only `--header-bg`, `--header-fg`, `--header-border` remain.
- **servicenow**: removed `--destructive` (a sync copy per its inline comment). Kept all intentional overrides, including `--destructive-foreground` (`0 0% 98%` deliberately matches its neutral palette and passes AA on the base destructive background).
- **Contract documented** on `ThemeDefinition.vars`: it holds only values a theme intentionally overrides relative to `globals.css`; omitted vars cascade from `:root` (light) / `.dark` (dark). `themeToStyleString` scoping is unchanged.
- **Tests**: the `--background` scoping assertion now uses the servicenow theme (govea no longer declares content vars); new tests pin govea to exactly the three header vars and assert no theme re-declares `--destructive`.

No visual change: every removed var matches what `globals.css` already supplies in the scope where the inline style applies.

## How it was tested

- `pnpm --filter govea exec vitest run tests/unit --config vitest.config.ts` — 181 tests pass, including the #773 drift guard
- `tsc --noEmit` — clean
- `eslint` on both touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)