### PR TITLE
docs(framework-alignment): align capability docs and README with the shipped recipe model

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Use the README as the starting point, not the full manual. Detailed material bel
 
 GovEA is EasyEA-first. External frameworks such as TOGAF should support government teams without replacing the core workflow.
 
-Current framework-alignment detail is tracked in [capabilities.md](./capabilities.md) and [ADR-0001: TOGAF and ADM Scope Boundary](./docs/decisions/0001-togaf-adm-scope.md). The intended product direction is to move framework support toward taxonomy-backed recipes rather than hard-coded overlays.
+Framework support is taxonomy-and-recipe-backed ([ADR-0002: ADM as Classification](./docs/decisions/0002-adm-as-classification.md)): installing the TOGAF recipe gives an organization Architecture Domain and ADM Phase classifications, and the TOGAF reports read from that taxonomy — there is no hard-coded overlay. Current framework-alignment detail is tracked in [capabilities.md](./capabilities.md) and [ADR-0001: TOGAF and ADM Scope Boundary](./docs/decisions/0001-togaf-adm-scope.md).
 
 ## Deployment Notes
 

--- a/business-architecture/capabilities/ea/framework-alignment/fa-adm-phase-alignment.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-adm-phase-alignment.md
@@ -14,7 +14,7 @@ ADM phase alignment is a view over existing GovEA content. It is not a mandatory
 
 ## Behaviors
 
-- Tag GovEA records to one or more ADM phases when a TOGAF overlay is enabled
+- Tag GovEA records to one or more ADM phases when the TOGAF recipe's taxonomy is installed
 - View records grouped by ADM phase for architecture review or planning
 - Identify missing evidence for an ADM phase without blocking ordinary GovEA use
 - Use ADM phase tags in reports and governance summaries
@@ -28,7 +28,18 @@ ADM phase alignment is a view over existing GovEA content. It is not a mandatory
 
 ## Implementation Status
 
-Not implemented.
+Partially implemented — taxonomy-backed per ADR-0002 (#665/#671 arc).
+
+Current shipped slice:
+
+- ADM Phase ships as an optional taxonomy type installed by the TOGAF recipe; capabilities and initiatives can be tagged through the ordinary taxonomy UI
+- The ADM Coverage report groups tagged records by phase and discloses untagged gaps rather than hiding them
+- ADM Phase carries `audience: 'framework'`, so phase labels stay out of viewer-role and stakeholder-facing views by default (ADR-0001's no-jargon guarantee)
+
+Not yet shipped:
+
+- Phase gates or any workflow behavior (deliberately out of scope — ADM phases are a classification lens, not a process engine)
+- Governance summaries driven by phase tags beyond the ADM Coverage report
 
 ## Links
 

--- a/business-architecture/capabilities/ea/framework-alignment/fa-framework-mapping.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-framework-mapping.md
@@ -2,7 +2,7 @@
 
 ## What It Does
 
-The system must allow users to map GovEA records to concepts from an enabled framework overlay. For TOGAF, mappings may include architecture domains, content categories, architecture building block concepts, governance concerns, or other reference categories.
+The system must allow users to map GovEA records to concepts from an installed framework vocabulary. For TOGAF, mappings may include architecture domains, content categories, architecture building block concepts, governance concerns, or other reference categories.
 
 Mappings explain how existing GovEA content relates to external architecture practice without changing the GovEA content model.
 
@@ -29,16 +29,17 @@ Mappings explain how existing GovEA content relates to external architecture pra
 
 ## Implementation Status
 
-Partially implemented.
+Partially implemented — taxonomy-backed per ADR-0002 (#665/#671 arc).
 
 Current shipped slice:
 
-- Capability and application detail pages support TOGAF Architecture Domain mappings
-- Mappings can carry an optional rationale
-- Mappings are organization-scoped and only visible when the TOGAF overlay is enabled
+- TOGAF Architecture Domain ships as a taxonomy type installed by the TOGAF recipe; capability and application records are classified through the generic entity-taxonomy UI
+- Mappings are organization-scoped and the framework vocabulary only exists where the recipe has been installed (recipe presence replaced the old overlay toggle)
+- Framework taxonomy types carry `audience: 'framework'`, keeping framework labels out of stakeholder-facing views by default
 
 Not yet shipped:
 
+- Per-mapping rationale (the decommissioned `framework_mappings` table supported one; the taxonomy migration dropped it — restore as a taxonomy-value annotation if practitioners ask for it)
 - Mapping additional entity types
 - Supporting multiple frameworks or richer concept taxonomies
 - Reporting and filtering across arbitrary framework concepts beyond the current TOGAF domain slice

--- a/business-architecture/capabilities/ea/framework-alignment/fa-togaf-reporting.md
+++ b/business-architecture/capabilities/ea/framework-alignment/fa-togaf-reporting.md
@@ -27,19 +27,19 @@ The system must generate TOGAF-friendly reports from GovEA content for organizat
 
 ## Implementation Status
 
-Partially implemented.
+Partially implemented — reports read recipe-installed taxonomy (ADR-0002; #665/#671 arc).
 
 Current shipped slice:
 
-- `Architecture Vision` report generates a plain-language architecture summary from existing GovEA records
-- `Application Landscape` report is available under Reports when the TOGAF overlay is enabled
+- `Architecture Vision` report generates a plain-language architecture summary from existing GovEA records for all orgs
+- `Application Landscape` and `ADM Coverage` reports appear under Reports when the TOGAF recipe's taxonomy is present (recipe-presence detection — no toggle), built on the generic group-by-taxonomy report engine
 - Reports disclose repository gaps rather than hiding them
 - Reports link back to the underlying GovEA records
 
 Not yet shipped:
 
-- Additional TOGAF-style outputs beyond the current Architecture Vision and Application Landscape reports
-- Reporting driven by richer framework mappings or ADM phase labels
+- Additional TOGAF-style outputs beyond Architecture Vision, Application Landscape, and ADM Coverage
+- Reporting driven by richer framework mappings beyond domain and phase classifications
 - A broader configurable reporting surface for multiple frameworks
 
 ## Links

--- a/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
+++ b/business-architecture/capabilities/ea/framework-alignment/framework-alignment.md
@@ -21,7 +21,7 @@ The system must allow organizations to align GovEA content to external architect
 |---|---|---|---|
 | Framework Reference Management | [fa-framework-reference-management.md](./fa-framework-reference-management.md) | Not implemented | Store external framework references separately from GovEA's authoritative capability definitions |
 | Framework Mapping | [fa-framework-mapping.md](./fa-framework-mapping.md) | Partially implemented | Map capability and application records to TOGAF Architecture Domains; broader framework concept mapping remains future work |
-| ADM Phase Alignment | [fa-adm-phase-alignment.md](./fa-adm-phase-alignment.md) | Not implemented | Optionally tag architecture work to TOGAF ADM phases for TOGAF-aware teams |
+| ADM Phase Alignment | [fa-adm-phase-alignment.md](./fa-adm-phase-alignment.md) | Partially implemented | Optionally tag architecture work to TOGAF ADM phases for TOGAF-aware teams; ADM Phase taxonomy + ADM Coverage report ship via the TOGAF recipe |
 | TOGAF-Aligned Reporting | [fa-togaf-reporting.md](./fa-togaf-reporting.md) | Partially implemented | Generate TOGAF-friendly reports from existing GovEA content |
 | Framework Overlay Configuration | [fa-framework-overlay-configuration.md](./fa-framework-overlay-configuration.md) | Partially implemented | Allow admins to enable, disable, and configure optional framework overlays per organization |
 
@@ -40,8 +40,8 @@ Framework reference sources are inputs to capability design, not GovEA capabilit
 ## Success Criteria
 
 - A TOGAF-aware enterprise architect can find Architecture Domain and ADM-phase mapping affordances on capability and application detail pages without leaving the standard authoring surface
-- A non-architect Department Director can browse the same repository without encountering TOGAF jargon by default — framework overlay is invisible to them
-- Enabling or disabling the framework overlay is a per-org admin action with no downstream content destruction
+- A non-architect Department Director can browse the same repository without encountering TOGAF jargon by default — framework-audience taxonomy is invisible to them
+- Installing the framework recipe is a per-org admin action; removing its taxonomy hides framework affordances with no downstream content destruction
 - The Architecture Vision and TOGAF Application Landscape reports reflect current published content automatically; no separate data-entry surface is required
 
 ## Out of Scope
@@ -59,21 +59,21 @@ Framework support should increase credibility without increasing friction. A TOG
 
 ## Implementation Status
 
-GovEA now ships the first framework-alignment slice:
+Framework alignment is taxonomy-and-recipe-backed (ADR-0002; #665/#671 arc). The earlier hard-coded `framework-overlay` module, its settings toggle, and the `framework_mappings` table have been removed:
 
-- The `framework-overlay` module is org-scoped, opt-in, and off by default
-- Capability and application detail pages support TOGAF Architecture Domain mappings with optional rationale
-- The Reports area includes a TOGAF Application Landscape report when the overlay is enabled
-- The generic Architecture Vision report also now provides a framework-friendly summary built from existing repository content
+- TOGAF is enabled per organization by installing the taxonomy-backed recipe, which creates the Architecture Domain and ADM Phase taxonomy types (org-scoped, opt-in, idempotent re-install)
+- Capability and application records are classified against those types through the ordinary entity-taxonomy UI
+- The Reports area derives TOGAF Application Landscape and ADM Coverage from the taxonomy when the recipe is present; the generic Architecture Vision report provides a framework-friendly summary for all orgs
+- Framework taxonomy types carry `audience: 'framework'`, keeping framework jargon out of viewer-role and stakeholder views by default
 
 Still not shipped:
 
-- ADM phase tagging
 - Admin-managed framework reference records
-- Broader framework mappings beyond the current TOGAF domain slice
-- Per-framework configuration deeper than a single overlay toggle
+- Broader framework mappings beyond the current TOGAF domain/phase slice (including per-mapping rationale, dropped with the legacy table)
+- A standalone Recipes admin surface (install currently rides the TOGAF Starter pack flow; #780)
+- Frameworks other than TOGAF
 
 ## Links
 
 - Depends on: Content Management — Content Relationships, IAM — Role-Based Access Control
-- Related: Portfolio (Capabilities, Applications), Repository & Modelling (TOGAF reports), Admin Configuration (overlay toggle)
+- Related: Portfolio (Capabilities, Applications), Repository & Modelling (TOGAF reports), Admin Configuration (recipe install via starter content)


### PR DESCRIPTION
Closes #779
Closes #665
Capability group: ea/framework-alignment
Persona: Enterprise Architect (Central IT), Agency EA Coordinator

## What

Brings the four remaining stale docs in line with the shipped recipe/taxonomy model (#755 already updated `fa-framework-overlay-configuration.md` and `capabilities.md`):

- **fa-adm-phase-alignment.md** — was `Not implemented`; now records the shipped slice (ADM Phase taxonomy via the TOGAF recipe, ADM Coverage report, framework-audience hiding) and the deliberate non-goals (no phase gates)
- **fa-framework-mapping.md** — no longer describes the deleted `framework_mappings` mechanism; records that per-mapping rationale was dropped with the legacy table and is explicit future work
- **framework-alignment.md** (group) — status no longer presents the removed `framework-overlay` module as current; sub-capability table, success criteria, and links updated to recipe phrasing; the standalone Recipes surface gap points at #780
- **fa-togaf-reporting.md** — recipe-presence detection instead of 'overlay enabled'; adds the shipped ADM Coverage report and the group-by-taxonomy engine
- **README.md** — framework support described as shipped reality (ADR-0002 linked), not an 'intended direction'

## Why

This was the last unmet acceptance criterion on #665 ('Documentation is updated so GovEA describes framework support as recipe/taxonomy-driven') — merging this closes the umbrella. It is also exactly the 'docs match reality' debt that v0.9 — Foundation Cleanup exists to clear. Full closure-review evidence map for #665 is posted on the issue.

## Validation

- `node scripts/lint-business-architecture.mjs` — OK (107 files checked)
- Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)