### PR TITLE
fix(nav): remove Executive Summary from the top left navigation

### DIFF
--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -190,19 +190,9 @@ function SidebarContent({
         Overview
       </Link>
 
-      {/* Executive Summary */}
-      <Link
-        href="/executive"
-        onClick={onClose}
-        className={cn(
-          'rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          pathname === '/executive' || pathname.startsWith('/executive/')
-            ? 'bg-white/15 text-white'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
-        )}
-      >
-        Executive Summary
-      </Link>
+      {/* Executive Summary intentionally has no top-level slot (#731) — it
+          lives in the Reports group below, which auto-opens when the route
+          is active. Viewers still land on /executive via auth-redirect. */}
 
       {/* Notifications inbox (#581) */}
       <Link


### PR DESCRIPTION
Closes #731
Capability: fd-navigation
Persona: CMS Administrator

## What

Removes the standalone **Executive Summary** link that sat between Overview and Notifications in the left nav. It duplicated the entry in the **Reports** group, which remains the access path for every role — the Reports accordion auto-opens when `/executive` is the active route (the #662 containing-active-route behavior), and viewers still land on `/executive` directly via auth-redirect (#548). A comment in the removed slot records the intent so the link doesn't quietly come back.

## Scope check (per the issue's acceptance criteria)

- Overview and Notifications keep their order; only the slot between them is removed.
- No change to the `/executive` page, its permissions, or the viewer landing flow.
- No focused unit test added: the standalone top links are JSX in `app-shell.tsx` with no existing render-test infrastructure (the nav unit tests cover accordion state logic only, untouched). The preserved access path is already e2e-asserted for every role by `overview.spec.ts`'s Executive Summary CTA check, which runs in CI.

## Testing

- `eslint`, `tsc --noEmit`, and the unit suite pass locally (one pre-existing #662 lint warning, untouched).
- CI e2e (smoke/overview/a11y/logout) exercises the sidebar on gated routes and the per-role Executive Summary CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)