### PR TITLE
feat(reports): repository duplicates report across all entities and taxonomy

### DIFF
--- a/apps/govea/src/app/(admin)/reports/duplicates/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/duplicates/page.tsx
@@ -1,0 +1,119 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getRepositoryDuplicateReport } from '@/lib/duplicate-report-data'
+import type { DuplicateGroup } from '@/lib/duplicate-report'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+/**
+ * Repository Duplicates report (#718). Same-org duplicate candidates across
+ * every repository entity type, plus taxonomy types, values, and conflicting
+ * entity-taxonomy assignments. Complements the cross-agency Capability
+ * Duplicates report (#538), which deliberately excludes same-org pairs.
+ *
+ * Detection only — candidates are surfaced for human review; nothing is
+ * merged, deleted, or mutated.
+ */
+export default async function RepositoryDuplicatesReport() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const orgId = session.user.organizationId!
+
+  const sections = await getRepositoryDuplicateReport(orgId)
+  const totalGroups = sections.reduce((n, s) => n + s.groups.length, 0)
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+          <Link href="/reports" className="hover:underline">Reports</Link>
+          <span>/</span>
+          <span>Repository Duplicates</span>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">Repository Duplicates</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Candidate duplicate records across your organization&apos;s repository — naming drift makes the
+          same capability, term, or taxonomy value look like separate work. <strong>Exact</strong> groups
+          match after normalizing case, punctuation, and whitespace; <strong>near</strong> groups share
+          most meaningful name tokens within the same grouping (domain or taxonomy type). Review each
+          group and decide — nothing is merged or deleted automatically.
+        </p>
+      </div>
+
+      {totalGroups === 0 && (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          No duplicate candidates found anywhere in the repository. As records are added — especially
+          via CSV import, starter content, or framework recipes — re-check this report periodically.
+        </div>
+      )}
+
+      {sections.map(section => (
+        <section key={section.key}>
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+            {section.label}{' '}
+            <span className="font-normal">
+              — {section.groups.length === 0
+                ? `no candidates (${section.scanned} scanned)`
+                : `${section.groups.length} candidate group${section.groups.length === 1 ? '' : 's'}`}
+            </span>
+          </h2>
+          {section.groups.length > 0 && (
+            <div className="space-y-3 mb-6">
+              {section.groups.map((group, i) => (
+                <DuplicateGroupCard key={`${section.key}-${i}`} group={group} />
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function DuplicateGroupCard({ group }: { group: DuplicateGroup }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <CardTitle className="text-sm font-semibold">
+            {group.records.length} records with {group.tier === 'exact' ? 'the same name' : 'similar names'}
+          </CardTitle>
+          <span
+            className={cn(
+              'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+              group.tier === 'exact'
+                ? 'bg-destructive/10 text-destructive'
+                : 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+            )}
+          >
+            {group.tier === 'exact' ? 'Exact match' : `Near match · ${Math.round(group.similarity * 100)}%`}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ul className="divide-y">
+          {group.records.map(r => (
+            <li key={r.id} className="flex items-center justify-between gap-3 py-2 text-sm">
+              <div className="min-w-0">
+                {r.href ? (
+                  <Link href={r.href} className="font-medium hover:underline">{r.name}</Link>
+                ) : (
+                  <span className="font-medium">{r.name}</span>
+                )}
+                {r.context && (
+                  <span className="ml-2 text-xs text-muted-foreground">{r.context}</span>
+                )}
+              </div>
+              {r.status && (
+                <span className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {r.status}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/govea/src/app/(admin)/reports/page.tsx
+++ b/apps/govea/src/app/(admin)/reports/page.tsx
@@ -46,6 +46,16 @@ export default async function ReportsPage() {
             </div>
             <span className="text-muted-foreground text-sm">→</span>
           </Link>
+          <Link
+            href="/reports/duplicates"
+            className="flex items-center justify-between px-4 py-3 hover:bg-muted/40 transition-colors group"
+          >
+            <div>
+              <p className="text-sm font-medium group-hover:text-primary transition-colors">Repository Duplicates</p>
+              <p className="text-xs text-muted-foreground mt-0.5">Candidate duplicate records across every entity type in your repository, including taxonomy types, values, and conflicting assignments. Exact and near matches, grouped for review.</p>
+            </div>
+            <span className="text-muted-foreground text-sm">→</span>
+          </Link>
         </div>
       </section>
 

--- a/apps/govea/src/lib/duplicate-report-data.ts
+++ b/apps/govea/src/lib/duplicate-report-data.ts
@@ -1,0 +1,265 @@
+/**
+ * Data assembly for the Repository Duplicates report (#718).
+ *
+ * Fetches minimal name/context rows for every repository entity type in ONE
+ * organization, runs the pure duplicate grouping from duplicate-report.ts,
+ * and returns per-entity-type sections plus taxonomy coverage:
+ *
+ *  - standard entities (capabilities … data business keys): exact + near
+ *    name matches, near-tier scoped to the natural grouping (capability
+ *    domain, glossary domain) where one exists
+ *  - taxonomy types (root terms) and taxonomy values (scoped to their type)
+ *  - conflicting entity-taxonomy assignments: one entity tagged with two or
+ *    more same-type values whose names are duplicates of each other
+ *
+ * Read-only: detection never merges, deletes, or mutates records.
+ */
+
+import { db } from '@/db/client'
+import {
+  capabilities, applications, personas, adrs, initiatives, strategicObjectives,
+  goals, services, valueStreams, principles, glossaryTerms,
+  dataEntities, dataAttributes, dataLinks, dataBusinessKeys,
+  taxonomyTerms, entityTaxonomyValues,
+} from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { findDuplicateGroups, type DuplicateGroup, type DuplicateRecord } from '@/lib/duplicate-report'
+
+export type DuplicateReportSection = {
+  key: string
+  label: string
+  /** How many records were scanned (drives the empty-state copy). */
+  scanned: number
+  groups: DuplicateGroup[]
+}
+
+type StandardSource = {
+  key: string
+  label: string
+  /** entityType literal used by entity_taxonomy_values rows, where applicable. */
+  assignmentKey?: string
+  hrefBase: string
+  /** True when the route has no per-record detail page. */
+  listOnly?: boolean
+  fetch: (orgId: string) => Promise<{
+    id: string
+    name: string
+    status?: string | null
+    context?: string | null
+    nearGroupKey?: string | null
+  }[]>
+}
+
+const STANDARD_SOURCES: StandardSource[] = [
+  {
+    key: 'capabilities', label: 'Capabilities', assignmentKey: 'capability', hrefBase: '/capabilities',
+    fetch: async orgId => (await db.select({
+      id: capabilities.id, name: capabilities.name, status: capabilities.status, domain: capabilities.domain,
+    }).from(capabilities).where(eq(capabilities.organizationId, orgId)))
+      .map(r => ({ ...r, context: r.domain, nearGroupKey: r.domain ?? '' })),
+  },
+  {
+    key: 'applications', label: 'Applications', assignmentKey: 'application', hrefBase: '/applications',
+    fetch: async orgId => db.select({
+      id: applications.id, name: applications.name, status: applications.status,
+    }).from(applications).where(eq(applications.organizationId, orgId)),
+  },
+  {
+    key: 'personas', label: 'Personas', assignmentKey: 'persona', hrefBase: '/personas',
+    fetch: async orgId => db.select({
+      id: personas.id, name: personas.name, status: personas.status,
+    }).from(personas).where(eq(personas.organizationId, orgId)),
+  },
+  {
+    key: 'adrs', label: 'Decisions (ADRs)', assignmentKey: 'adr', hrefBase: '/adrs',
+    fetch: async orgId => db.select({
+      id: adrs.id, name: adrs.title, status: adrs.status,
+    }).from(adrs).where(eq(adrs.organizationId, orgId)),
+  },
+  {
+    key: 'initiatives', label: 'Initiatives', assignmentKey: 'initiative', hrefBase: '/initiatives',
+    fetch: async orgId => db.select({
+      id: initiatives.id, name: initiatives.name, status: initiatives.status,
+    }).from(initiatives).where(eq(initiatives.organizationId, orgId)),
+  },
+  {
+    key: 'objectives', label: 'Objectives', assignmentKey: 'objective', hrefBase: '/objectives',
+    fetch: async orgId => db.select({
+      id: strategicObjectives.id, name: strategicObjectives.name, status: strategicObjectives.status,
+    }).from(strategicObjectives).where(eq(strategicObjectives.organizationId, orgId)),
+  },
+  {
+    key: 'goals', label: 'Goals', assignmentKey: 'goal', hrefBase: '/goals',
+    fetch: async orgId => db.select({
+      id: goals.id, name: goals.name, status: goals.status,
+    }).from(goals).where(eq(goals.organizationId, orgId)),
+  },
+  {
+    key: 'services', label: 'Services', assignmentKey: 'service', hrefBase: '/services',
+    fetch: async orgId => db.select({
+      id: services.id, name: services.name, status: services.status,
+    }).from(services).where(eq(services.organizationId, orgId)),
+  },
+  {
+    key: 'value-streams', label: 'Value Streams', assignmentKey: 'value-stream', hrefBase: '/value-streams',
+    fetch: async orgId => db.select({
+      id: valueStreams.id, name: valueStreams.name, status: valueStreams.status,
+    }).from(valueStreams).where(eq(valueStreams.organizationId, orgId)),
+  },
+  {
+    key: 'principles', label: 'Principles', assignmentKey: 'principle', hrefBase: '/principles',
+    fetch: async orgId => (await db.select({
+      id: principles.id, name: principles.name, status: principles.status, principleType: principles.principleType,
+    }).from(principles).where(eq(principles.organizationId, orgId)))
+      .map(r => ({ ...r, context: r.principleType })),
+  },
+  {
+    key: 'glossary', label: 'Glossary Terms', assignmentKey: 'glossary', hrefBase: '/glossary',
+    fetch: async orgId => (await db.select({
+      id: glossaryTerms.id, name: glossaryTerms.term, status: glossaryTerms.status, domain: glossaryTerms.domain,
+    }).from(glossaryTerms).where(eq(glossaryTerms.organizationId, orgId)))
+      .map(r => ({ ...r, context: r.domain, nearGroupKey: r.domain ?? '' })),
+  },
+  {
+    key: 'data-entities', label: 'Data Entities', assignmentKey: 'data_entity', hrefBase: '/data', listOnly: true,
+    fetch: async orgId => db.select({
+      id: dataEntities.id, name: dataEntities.name, status: dataEntities.status,
+    }).from(dataEntities).where(eq(dataEntities.organizationId, orgId)),
+  },
+  {
+    key: 'data-attributes', label: 'Data Attributes', hrefBase: '/data', listOnly: true,
+    fetch: async orgId => db.select({
+      id: dataAttributes.id, name: dataAttributes.name, status: dataAttributes.status,
+    }).from(dataAttributes).where(eq(dataAttributes.organizationId, orgId)),
+  },
+  {
+    key: 'data-relationships', label: 'Data Relationships', hrefBase: '/data', listOnly: true,
+    fetch: async orgId => db.select({
+      id: dataLinks.id, name: dataLinks.name, status: dataLinks.status,
+    }).from(dataLinks).where(eq(dataLinks.organizationId, orgId)),
+  },
+  {
+    key: 'data-business-keys', label: 'Data Business Keys', hrefBase: '/data', listOnly: true,
+    fetch: async orgId => db.select({
+      id: dataBusinessKeys.id, name: dataBusinessKeys.name, status: dataBusinessKeys.status,
+    }).from(dataBusinessKeys).where(eq(dataBusinessKeys.organizationId, orgId)),
+  },
+]
+
+export async function getRepositoryDuplicateReport(orgId: string): Promise<DuplicateReportSection[]> {
+  const sections: DuplicateReportSection[] = []
+
+  // entityType:entityId → display name, for assignment-conflict context.
+  const entityNames = new Map<string, string>()
+
+  // ── Standard entity sections ────────────────────────────────────────────
+  for (const source of STANDARD_SOURCES) {
+    const rows = await source.fetch(orgId)
+    if (source.assignmentKey) {
+      for (const r of rows) entityNames.set(`${source.assignmentKey}:${r.id}`, r.name)
+    }
+    const records: DuplicateRecord[] = rows.map(r => ({
+      id: r.id,
+      name: r.name,
+      status: r.status ?? null,
+      context: r.context ?? null,
+      nearGroupKey: r.nearGroupKey ?? '',
+      href: source.listOnly ? source.hrefBase : `${source.hrefBase}/${r.id}`,
+    }))
+    sections.push({
+      key: source.key,
+      label: source.label,
+      scanned: rows.length,
+      groups: findDuplicateGroups(records),
+    })
+  }
+
+  // ── Taxonomy types and values ───────────────────────────────────────────
+  const terms = await db.select({
+    id: taxonomyTerms.id, name: taxonomyTerms.name, parentId: taxonomyTerms.parentId,
+  }).from(taxonomyTerms).where(eq(taxonomyTerms.organizationId, orgId))
+
+  const termById = new Map(terms.map(t => [t.id, t]))
+  const types = terms.filter(t => t.parentId === null)
+  const values = terms.filter(t => t.parentId !== null)
+  const typeName = (id: string | null) =>
+    (id !== null ? termById.get(id)?.name : null) ?? '(unknown type)'
+
+  sections.push({
+    key: 'taxonomy-types',
+    label: 'Taxonomy Types',
+    scanned: types.length,
+    groups: findDuplicateGroups(types.map(t => ({
+      id: t.id, name: t.name, href: '/taxonomy', nearGroupKey: '',
+    }))),
+  })
+
+  sections.push({
+    key: 'taxonomy-values',
+    label: 'Taxonomy Values',
+    scanned: values.length,
+    // Scoped to the parent type: duplicate names across different types are
+    // legitimate (e.g. "Other" under several types).
+    groups: findDuplicateGroups(values.map(v => ({
+      id: v.id, name: v.name, href: '/taxonomy',
+      context: typeName(v.parentId), nearGroupKey: v.parentId,
+    }))),
+  })
+
+  // ── Conflicting entity-taxonomy assignments ─────────────────────────────
+  // Exact duplicate assignment rows are blocked by the etv_entity_term_uniq
+  // index; the reviewable problem is one entity tagged with two or more
+  // values OF THE SAME TYPE whose names duplicate each other (e.g. both
+  // "Public Safety" and "public-safety" after an import).
+  const assignments = await db.select({
+    id: entityTaxonomyValues.id,
+    entityType: entityTaxonomyValues.entityType,
+    entityId: entityTaxonomyValues.entityId,
+    taxonomyTermId: entityTaxonomyValues.taxonomyTermId,
+  }).from(entityTaxonomyValues).where(eq(entityTaxonomyValues.organizationId, orgId))
+
+  const assignmentGroups: DuplicateGroup[] = []
+  const byEntity = new Map<string, typeof assignments>()
+  for (const a of assignments) {
+    const key = `${a.entityType}:${a.entityId}`
+    const list = byEntity.get(key) ?? []
+    list.push(a)
+    byEntity.set(key, list)
+  }
+
+  const sourceByAssignmentKey = new Map(
+    STANDARD_SOURCES.filter(s => s.assignmentKey).map(s => [s.assignmentKey!, s]),
+  )
+
+  for (const [entityKey, list] of byEntity) {
+    if (list.length < 2) continue
+    const [entityType, entityId] = entityKey.split(':')
+    const entityLabel = entityNames.get(entityKey) ?? entityId
+    const source = sourceByAssignmentKey.get(entityType)
+    const href = source ? (source.listOnly ? source.hrefBase : `${source.hrefBase}/${entityId}`) : null
+
+    // Group this entity's assigned values by their taxonomy type.
+    const records: DuplicateRecord[] = list.flatMap(a => {
+      const term = termById.get(a.taxonomyTermId)
+      if (!term) return []
+      return [{
+        id: a.id,
+        name: term.name,
+        context: `${typeName(term.parentId)} on ${entityType} “${entityLabel}”`,
+        href,
+        nearGroupKey: term.parentId, // same-type values only
+      }]
+    })
+
+    assignmentGroups.push(...findDuplicateGroups(records))
+  }
+
+  sections.push({
+    key: 'taxonomy-assignments',
+    label: 'Entity-Taxonomy Assignments',
+    scanned: assignments.length,
+    groups: assignmentGroups,
+  })
+
+  return sections
+}

--- a/apps/govea/src/lib/duplicate-report.ts
+++ b/apps/govea/src/lib/duplicate-report.ts
@@ -1,0 +1,147 @@
+/**
+ * Same-org duplicate-candidate detection (#718).
+ *
+ * Pure grouping logic for the Repository Duplicates report: callers supply
+ * the records for ONE organization and ONE entity type; this module finds
+ * candidate groups in two tiers:
+ *
+ *  - `exact` — names equal after normalization (case, punctuation, and
+ *    whitespace insensitive). The highest-confidence signal.
+ *  - `near`  — meaningful-name-token Jaccard similarity at or above
+ *    NEAR_THRESHOLD, compared only within the same `nearGroupKey` (e.g.
+ *    capability domain or taxonomy type) so unrelated areas don't cross-flag.
+ *
+ * Detection only — no merging, no deletion, no mutation of inputs. The
+ * report surfaces candidates for human review.
+ *
+ * Related, deliberately different normalizers:
+ *  - duplicate-name-gate.ts `normaliseName` keeps punctuation (create-time
+ *    soft-warn gate where "Permitting & Licensing" ≠ "Permitting Licensing").
+ *    This report strips it — punctuation drift is exactly what it looks for.
+ *  - enterprise-view.ts compares cross-org capability pairs at a looser
+ *    threshold (0.33); same-org naming drift clusters tighter, so this
+ *    report uses 0.5 to keep 13 entity-type sections reviewable.
+ */
+
+import { tokenize, jaccard } from '@/lib/name-similarity'
+
+export type DuplicateRecord = {
+  id: string
+  name: string
+  /** Human context shown next to the name (e.g. domain, parent type, status). */
+  context?: string | null
+  /** Status/visibility chip, when the entity has one. */
+  status?: string | null
+  /** Link to the source record (list or detail page). */
+  href?: string | null
+  /** Near-tier comparisons happen only within the same key. Default: one shared group. */
+  nearGroupKey?: string | null
+}
+
+export type DuplicateGroup = {
+  tier: 'exact' | 'near'
+  /** 1 for exact groups; max pairwise Jaccard for near groups. */
+  similarity: number
+  records: DuplicateRecord[]
+}
+
+// Majority-token overlap. See module doc for why this is tighter than the
+// cross-org report's 0.33.
+export const NEAR_THRESHOLD = 0.5
+
+/**
+ * Case, punctuation, and whitespace insensitive name key.
+ * "Case-Management!" → "case management".
+ */
+export function normalizeName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/**
+ * Find duplicate-candidate groups among `records`.
+ *
+ * Exact groups come first (alphabetical by normalized name); near groups
+ * follow, ordered by similarity descending. Records already in an exact
+ * group are excluded from near-tier comparison — the exact signal subsumes
+ * the weaker one.
+ */
+export function findDuplicateGroups(records: DuplicateRecord[]): DuplicateGroup[] {
+  // ── Exact tier ──────────────────────────────────────────────────────────
+  const byNormalized = new Map<string, DuplicateRecord[]>()
+  for (const r of records) {
+    const key = normalizeName(r.name)
+    if (key === '') continue
+    const list = byNormalized.get(key) ?? []
+    list.push(r)
+    byNormalized.set(key, list)
+  }
+
+  const exactGroups: DuplicateGroup[] = [...byNormalized.entries()]
+    .filter(([, list]) => list.length >= 2)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, list]) => ({ tier: 'exact' as const, similarity: 1, records: list }))
+
+  const inExactGroup = new Set(exactGroups.flatMap(g => g.records.map(r => r.id)))
+
+  // ── Near tier ───────────────────────────────────────────────────────────
+  // Pairwise Jaccard within each nearGroupKey, merged into connected groups
+  // (A~B and B~C puts all three in one group for a single review pass).
+  const candidates = records.filter(r => !inExactGroup.has(r.id) && normalizeName(r.name) !== '')
+  const byKey = new Map<string, DuplicateRecord[]>()
+  for (const r of candidates) {
+    const key = r.nearGroupKey ?? ''
+    const list = byKey.get(key) ?? []
+    list.push(r)
+    byKey.set(key, list)
+  }
+
+  const nearGroups: DuplicateGroup[] = []
+  for (const group of byKey.values()) {
+    if (group.length < 2) continue
+    const tokens = group.map(r => tokenize(r.name))
+
+    // Union-find over above-threshold pairs; similarity is resolved per
+    // final root after all unions, so chained merges can't strand a value.
+    const parent = group.map((_, i) => i)
+    const find = (i: number): number => (parent[i] === i ? i : (parent[i] = find(parent[i])))
+    const hits: { i: number; sim: number }[] = []
+
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const sim = jaccard(tokens[i], tokens[j])
+        if (sim < NEAR_THRESHOLD) continue
+        parent[find(j)] = find(i)
+        hits.push({ i, sim })
+      }
+    }
+
+    const members = new Map<number, DuplicateRecord[]>()
+    for (let i = 0; i < group.length; i++) {
+      const root = find(i)
+      const list = members.get(root) ?? []
+      list.push(group[i])
+      members.set(root, list)
+    }
+
+    const rootSim = new Map<number, number>()
+    for (const h of hits) {
+      const root = find(h.i)
+      rootSim.set(root, Math.max(rootSim.get(root) ?? 0, h.sim))
+    }
+
+    for (const [root, list] of members) {
+      if (list.length < 2) continue
+      nearGroups.push({ tier: 'near', similarity: rootSim.get(root) ?? NEAR_THRESHOLD, records: list })
+    }
+  }
+
+  nearGroups.sort(
+    (a, b) => b.similarity - a.similarity
+      || normalizeName(a.records[0].name).localeCompare(normalizeName(b.records[0].name)),
+  )
+
+  return [...exactGroups, ...nearGroups]
+}

--- a/apps/govea/src/lib/enterprise-view.ts
+++ b/apps/govea/src/lib/enterprise-view.ts
@@ -21,6 +21,7 @@ import { db } from '@/db/client'
 import { capabilities, crossOrgLinks, organizations } from '@/db/schema'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getConnectedOrgIds } from '@/lib/federation'
+import { tokenize, jaccard, NAME_STOPWORDS } from '@/lib/name-similarity'
 
 type LinkType = 'implements' | 'extends' | 'maps_to'
 type LinkStatus = 'pending' | 'active' | 'rejected'
@@ -154,39 +155,15 @@ export type DuplicateCandidate = {
   b: { id: string; name: string; description: string | null; orgId: string; orgName: string }
 }
 
-// Stopwords that carry no meaningful overlap signal. Tuned for government IT
-// capability names; conservative — we'd rather flag a false positive than
-// hide a real overlap. Filtered out before Jaccard.
-const NAME_STOPWORDS = new Set([
-  'a', 'an', 'and', 'the', 'of', 'for', 'to', 'in', 'on', 'with', 'by',
-  'system', 'systems', 'service', 'services', 'platform', 'platforms',
-  'management', 'application', 'applications', 'integration', 'integrations',
-  'capability', 'capabilities',
-])
+// Tokenize/Jaccard primitives moved to name-similarity.ts so the same-org
+// Repository Duplicates report (#718) shares them. Re-exported via _testing
+// below to keep the existing unit-test surface.
 
 // 0.33 catches the realistic "one of three meaningful tokens shared" case
 // (e.g. "Online Permitting" vs "Permitting & Licensing System" → {permitting}
 // shared, {online, permitting, licensing} union → 1/3). Tightening above this
 // silently hides real candidate pairs in the data the audit walked.
 const JACCARD_THRESHOLD = 0.33
-const MIN_TOKEN_LENGTH = 3
-
-function tokenize(name: string): Set<string> {
-  return new Set(
-    name
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter(t => t.length >= MIN_TOKEN_LENGTH && !NAME_STOPWORDS.has(t)),
-  )
-}
-
-function jaccard(a: Set<string>, b: Set<string>): number {
-  if (a.size === 0 || b.size === 0) return 0
-  let intersection = 0
-  for (const x of a) if (b.has(x)) intersection++
-  const union = a.size + b.size - intersection
-  return union === 0 ? 0 : intersection / union
-}
 
 /**
  * Find candidate duplicate pairs across the caller's visible capabilities.

--- a/apps/govea/src/lib/name-similarity.ts
+++ b/apps/govea/src/lib/name-similarity.ts
@@ -1,0 +1,38 @@
+/**
+ * Name-similarity primitives shared by duplicate-detection features:
+ * the cross-agency Capability Duplicates report (enterprise-view.ts, #538)
+ * and the same-org Repository Duplicates report (duplicate-report.ts, #718).
+ *
+ * Pure functions — no DB, no framework imports.
+ */
+
+// Stopwords that carry no meaningful overlap signal. Tuned for government IT
+// capability names; conservative — we'd rather flag a false positive than
+// hide a real overlap. Filtered out before Jaccard.
+export const NAME_STOPWORDS = new Set([
+  'a', 'an', 'and', 'the', 'of', 'for', 'to', 'in', 'on', 'with', 'by',
+  'system', 'systems', 'service', 'services', 'platform', 'platforms',
+  'management', 'application', 'applications', 'integration', 'integrations',
+  'capability', 'capabilities',
+])
+
+export const MIN_TOKEN_LENGTH = 3
+
+/** Meaningful name tokens: lowercased, alphanumeric, stopwords removed. */
+export function tokenize(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(t => t.length >= MIN_TOKEN_LENGTH && !NAME_STOPWORDS.has(t)),
+  )
+}
+
+/** Jaccard similarity (0..1) between two token sets. */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let intersection = 0
+  for (const x of a) if (b.has(x)) intersection++
+  const union = a.size + b.size - intersection
+  return union === 0 ? 0 : intersection / union
+}

--- a/apps/govea/tests/integration/duplicate-report.test.ts
+++ b/apps/govea/tests/integration/duplicate-report.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration tests for the Repository Duplicates report assembly (#718).
+ *
+ * Covers the acceptance-criteria matrix against real tables: capabilities
+ * (exact + near), one non-capability entity (services), taxonomy values
+ * scoped to their type, and conflicting same-type entity-taxonomy
+ * assignments. Grouping math itself is unit-tested in
+ * tests/unit/duplicate-report.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { capabilities, services, taxonomyTerms, entityTaxonomyValues } from '@/db/schema'
+import { randomUUID } from 'node:crypto'
+import { createTestOrg, cleanupOrg } from './helpers/db'
+import { getRepositoryDuplicateReport, type DuplicateReportSection } from '@/lib/duplicate-report-data'
+
+describe('repository duplicates report (#718)', () => {
+  let orgId: string
+  let otherOrgId: string
+  let sections: DuplicateReportSection[]
+
+  const capExactA = randomUUID()
+  const capExactB = randomUUID()
+  const capNearA = randomUUID()
+  const capNearB = randomUUID()
+  const svcA = randomUUID()
+  const svcB = randomUUID()
+  const otherOrgCapId = randomUUID()
+  const typeId = randomUUID()
+  const valueA = randomUUID()
+  const valueB = randomUUID()
+  const taggedCapability = capNearA
+
+  const section = (key: string) => {
+    const s = sections.find(x => x.key === key)
+    if (!s) throw new Error(`missing section ${key}`)
+    return s
+  }
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    const other = await createTestOrg()
+    orgId = org.id
+    otherOrgId = other.id
+
+    await db.insert(capabilities).values([
+      // Exact pair (case + punctuation drift), same domain
+      { id: capExactA, organizationId: orgId, name: 'Case Management', domain: 'Health', status: 'draft', visibility: 'org' },
+      { id: capExactB, organizationId: orgId, name: 'case-management', domain: 'Health', status: 'published', visibility: 'org' },
+      // Near pair within one domain
+      { id: capNearA, organizationId: orgId, name: 'Online Permitting', domain: 'Licensing', status: 'draft', visibility: 'org' },
+      { id: capNearB, organizationId: orgId, name: 'Permitting Online Portal', domain: 'Licensing', status: 'draft', visibility: 'org' },
+      // Same name in ANOTHER org — must never appear in this org's report
+      { id: otherOrgCapId, organizationId: otherOrgId, name: 'Case Management', domain: 'Health', status: 'draft', visibility: 'org' },
+    ])
+
+    await db.insert(services).values([
+      { id: svcA, organizationId: orgId, name: 'Benefits Enrollment', status: 'draft', visibility: 'org' },
+      { id: svcB, organizationId: orgId, name: 'Benefits  Enrollment!', status: 'draft', visibility: 'org' },
+    ])
+
+    await db.insert(taxonomyTerms).values([
+      { id: typeId, organizationId: orgId, parentId: null, name: 'Service Area', slug: 'service-area' },
+      // Duplicate value names within the same type
+      { id: valueA, organizationId: orgId, parentId: typeId, name: 'Public Safety', slug: 'public-safety' },
+      { id: valueB, organizationId: orgId, parentId: typeId, name: 'public safety', slug: 'public-safety-2' },
+    ])
+
+    // One capability tagged with BOTH same-type values whose names duplicate
+    // each other — the conflicting-assignment case.
+    await db.insert(entityTaxonomyValues).values([
+      { id: randomUUID(), organizationId: orgId, entityType: 'capability', entityId: taggedCapability, taxonomyTermId: valueA },
+      { id: randomUUID(), organizationId: orgId, entityType: 'capability', entityId: taggedCapability, taxonomyTermId: valueB },
+    ])
+
+    sections = await getRepositoryDuplicateReport(orgId)
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgId)
+    await cleanupOrg(otherOrgId)
+  })
+
+  it('reports a section for every supported entity type', () => {
+    const keys = sections.map(s => s.key)
+    for (const expected of [
+      'capabilities', 'applications', 'personas', 'adrs', 'initiatives', 'objectives',
+      'goals', 'services', 'value-streams', 'principles', 'glossary',
+      'data-entities', 'data-attributes', 'data-relationships', 'data-business-keys',
+      'taxonomy-types', 'taxonomy-values', 'taxonomy-assignments',
+    ]) {
+      expect(keys, `section ${expected} should exist`).toContain(expected)
+    }
+  })
+
+  it('capabilities: finds the exact group and the near group, tiered', () => {
+    const caps = section('capabilities')
+    expect(caps.scanned).toBe(4) // other org's rows are not scanned
+
+    const exact = caps.groups.find(g => g.tier === 'exact')
+    expect(exact, 'exact group should exist').toBeDefined()
+    expect(exact!.records.map(r => r.id).sort()).toEqual([capExactA, capExactB].sort())
+    // Enough context to review: status chip and source link
+    expect(exact!.records.every(r => r.status)).toBe(true)
+    expect(exact!.records.every(r => r.href?.startsWith('/capabilities/'))).toBe(true)
+
+    const near = caps.groups.find(g => g.tier === 'near')
+    expect(near, 'near group should exist').toBeDefined()
+    expect(near!.records.map(r => r.id).sort()).toEqual([capNearA, capNearB].sort())
+    expect(near!.similarity).toBeLessThan(1)
+  })
+
+  it('never includes another organization’s records', () => {
+    for (const s of sections) {
+      for (const g of s.groups) {
+        for (const r of g.records) {
+          expect(r.id, `record ${r.name} in ${s.key}`).not.toBe(otherOrgCapId)
+        }
+      }
+    }
+    const exact = section('capabilities').groups.find(g => g.tier === 'exact')!
+    expect(exact.records).toHaveLength(2) // not 3 — the other org's copy is excluded
+  })
+
+  it('services (non-capability entity): finds the exact group', () => {
+    const svc = section('services')
+    const exact = svc.groups.find(g => g.tier === 'exact')
+    expect(exact).toBeDefined()
+    expect(exact!.records.map(r => r.id).sort()).toEqual([svcA, svcB].sort())
+  })
+
+  it('taxonomy values: duplicate names within the same type are flagged with type context', () => {
+    const vals = section('taxonomy-values')
+    const exact = vals.groups.find(g => g.tier === 'exact')
+    expect(exact).toBeDefined()
+    expect(exact!.records.map(r => r.id).sort()).toEqual([valueA, valueB].sort())
+    expect(exact!.records[0].context).toBe('Service Area')
+  })
+
+  it('assignments: one entity tagged with duplicate same-type values is flagged', () => {
+    const assigns = section('taxonomy-assignments')
+    expect(assigns.groups.length).toBeGreaterThanOrEqual(1)
+    const group = assigns.groups[0]
+    expect(group.records).toHaveLength(2)
+    expect(group.records.map(r => r.name).sort()).toEqual(['Public Safety', 'public safety'])
+    // Context names the type and the tagged entity
+    expect(group.records[0].context).toContain('Service Area')
+    expect(group.records[0].context).toContain('Online Permitting')
+  })
+
+  it('empty states: sections with no candidates report zero groups', () => {
+    const apps = section('applications')
+    expect(apps.groups).toEqual([])
+  })
+
+  it('detection is read-only — no records were mutated or removed', async () => {
+    const caps = await db.query.capabilities.findMany({
+      where: (c, { eq: e }) => e(c.organizationId, orgId),
+    })
+    expect(caps).toHaveLength(4)
+    expect(caps.map(c => c.name).sort()).toEqual(
+      ['Case Management', 'Online Permitting', 'Permitting Online Portal', 'case-management'].sort(),
+    )
+  })
+})

--- a/apps/govea/tests/unit/duplicate-report.test.ts
+++ b/apps/govea/tests/unit/duplicate-report.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the same-org duplicate-candidate grouping (#718).
+ *
+ * Pure logic — no DB. Data assembly over real tables is covered by
+ * tests/integration/duplicate-report.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeName,
+  findDuplicateGroups,
+  NEAR_THRESHOLD,
+  type DuplicateRecord,
+} from '@/lib/duplicate-report'
+
+const rec = (id: string, name: string, extra: Partial<DuplicateRecord> = {}): DuplicateRecord =>
+  ({ id, name, ...extra })
+
+describe('normalizeName', () => {
+  it('lowercases, strips punctuation, collapses whitespace', () => {
+    expect(normalizeName('Case-Management!')).toBe('case management')
+    expect(normalizeName('  Case   Management ')).toBe('case management')
+    expect(normalizeName('Permitting & Licensing')).toBe('permitting licensing')
+    expect(normalizeName('CASE MANAGEMENT')).toBe('case management')
+  })
+
+  it('returns empty string for punctuation-only names', () => {
+    expect(normalizeName('—')).toBe('')
+    expect(normalizeName('')).toBe('')
+  })
+})
+
+describe('findDuplicateGroups — exact tier', () => {
+  it('groups case/punctuation/whitespace variants of the same name', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Case Management'),
+      rec('b', 'case-management'),
+      rec('c', 'CASE  MANAGEMENT!'),
+      rec('d', 'Permitting'),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tier).toBe('exact')
+    expect(groups[0].similarity).toBe(1)
+    expect(groups[0].records.map(r => r.id).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns no groups when all names are distinct', () => {
+    expect(findDuplicateGroups([rec('a', 'Permits'), rec('b', 'Licensing')])).toEqual([])
+  })
+
+  it('exact matching ignores nearGroupKey — same name across domains still flags', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Case Management', { nearGroupKey: 'health' }),
+      rec('b', 'Case Management', { nearGroupKey: 'justice' }),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tier).toBe('exact')
+  })
+
+  it('skips records whose names normalize to empty', () => {
+    expect(findDuplicateGroups([rec('a', '—'), rec('b', '!!')])).toEqual([])
+  })
+})
+
+describe('findDuplicateGroups — near tier', () => {
+  it('groups names sharing most meaningful tokens', () => {
+    // tokens: {online, permitting} vs {permitting, licensing} → 1/3 — below 0.5.
+    // {online, permitting} vs {permitting, online, portal}: 2/3 ≥ 0.5 ✓
+    const groups = findDuplicateGroups([
+      rec('a', 'Online Permitting'),
+      rec('b', 'Permitting Online Portal'),
+      rec('c', 'Fleet Maintenance'),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tier).toBe('near')
+    expect(groups[0].records.map(r => r.id).sort()).toEqual(['a', 'b'])
+    expect(groups[0].similarity).toBeGreaterThanOrEqual(NEAR_THRESHOLD)
+    expect(groups[0].similarity).toBeLessThan(1)
+  })
+
+  it('near comparison is scoped to nearGroupKey', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Online Permitting', { nearGroupKey: 'health' }),
+      rec('b', 'Permitting Online Portal', { nearGroupKey: 'justice' }),
+    ])
+    expect(groups).toEqual([])
+  })
+
+  it('records in an exact group are excluded from near comparison', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Online Permitting'),
+      rec('b', 'online permitting'),       // exact with a
+      rec('c', 'Online Permitting Portal'), // near a/b — but they're consumed by exact
+      rec('d', 'Fleet Maintenance'),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tier).toBe('exact')
+    expect(groups[0].records.map(r => r.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('chains transitively: A~B and B~C land in one group', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Permit Intake Review'),
+      rec('b', 'Permit Intake Review Board'),   // ~a (3/4)
+      rec('c', 'Permit Intake Review Board Appeals'), // ~b (4/5)
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].records).toHaveLength(3)
+  })
+})
+
+describe('findDuplicateGroups — ordering and safety', () => {
+  it('exact groups come before near groups', () => {
+    const groups = findDuplicateGroups([
+      rec('a', 'Records Retention'),
+      rec('b', 'records retention'),
+      rec('c', 'Online Permitting'),
+      rec('d', 'Permitting Online Portal'),
+    ])
+    expect(groups.map(g => g.tier)).toEqual(['exact', 'near'])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [rec('a', 'X Ray Services'), rec('b', 'x-ray services')]
+    const copy = structuredClone(input)
+    findDuplicateGroups(input)
+    expect(input).toEqual(copy)
+  })
+
+  it('handles empty input', () => {
+    expect(findDuplicateGroups([])).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #718
Capability: rm-repository-completeness
Capability: cm-taxonomy-management
Persona: Enterprise Architect, Agency EA Coordinator, CMS Administrator
Related: #538

## What

**/reports/duplicates** — a same-org duplicate-candidates report covering every repository entity type: capabilities, applications, personas, ADRs, initiatives, objectives, goals, services, value streams, principles, glossary terms, data entities/attributes/relationships/business keys — plus taxonomy types, taxonomy values (scoped to their parent type, so "Other" under two types doesn't false-flag), and **conflicting entity-taxonomy assignments** (one entity tagged with two same-type values whose names duplicate each other; exact duplicate rows are already DB-blocked by `etv_entity_term_uniq`).

Two tiers, visually distinguished so reviewers can prioritize:
- **Exact** — names equal after case/punctuation/whitespace normalization
- **Near** — majority meaningful-token overlap (Jaccard ≥ 0.5), compared only within the natural grouping (capability/glossary domain, taxonomy type), with transitive chaining so A~B~C is one review pass

Each group shows name, status chip, grouping context, and links to the source records. Per-section empty states show the scanned count. **Detection only** — nothing is merged, deleted, or mutated.

## Design notes

- Pure grouping logic lives in [duplicate-report.ts](apps/govea/src/lib/duplicate-report.ts); DB assembly in [duplicate-report-data.ts](apps/govea/src/lib/duplicate-report-data.ts) is a table-driven source list, so adding an entity type is one config entry.
- Tokenize/Jaccard primitives are extracted to `name-similarity.ts` and shared with the cross-agency Capability Duplicates report (#538), which deliberately excludes same-org pairs — the two reports now reference each other. Its `_testing` surface and threshold are unchanged.
- The same-org near threshold (0.5) is deliberately tighter than the cross-org 0.33 — rationale in the module doc. `duplicate-name-gate.ts`'s punctuation-preserving normalizer is deliberately NOT reused; the difference is documented.

## Testing

- **Unit (13 new)**: normalizer, exact tier (incl. cross-domain), near tier (threshold, grouping-key scoping, exact-subsumes-near, transitive chaining), ordering, input immutability.
- **Integration (8 new)**: against real tables — capabilities (exact + near, with status/href context), services as the non-capability entity, taxonomy values within a type, the conflicting-assignment case with entity+type context, org isolation (another org's identical name never leaks in), per-section coverage of all 18 sections, empty states, and a read-only check that no records were mutated.
- `eslint`, `tsc --noEmit`, 207 unit tests pass locally; integration + production build run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)