### PR TITLE
feat(traceability): entry points from every participating entity detail page

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -5,11 +5,17 @@ import {
   strategicObjectives, capabilities, services, goals,
   goalObjectives, objectiveCapabilities, applicationCapabilities,
   initiativeObjectives, serviceCapabilities,
+  // #695 — trace-participation subjects and their one-hop root junctions
+  applications, initiatives, personas, valueStreams, adrs, principles,
+  initiativeCapabilities, capabilityPersonas, servicePersonas,
+  serviceValueStreams, valueStreamCapabilities, objectiveValueStreams,
+  adrCapabilities, adrObjectives, principleCapabilities,
 } from '@/db/schema'
 import { eq, inArray } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { canReadFederatedEntity } from '@/lib/federation'
+import type { TraceParticipantKind } from '@/lib/trace-participants'
 
 // ── Shared sub-types ──────────────────────────────────────────────────────────
 
@@ -369,5 +375,142 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
     capabilities: serviceCapRows
       .map(({ capabilityId }) => capabilityTraceRows.find((c) => c.id === capabilityId))
       .filter((c): c is TraceCapability => Boolean(c)),
+  }
+}
+
+// ── Trace participation (#695) ────────────────────────────────────────────────
+//
+// Non-root entities (applications, initiatives, personas, value streams,
+// ADRs, principles) appear inside trace chains but are not trace roots. Their
+// detail pages still need a working "View traceability →" entry point, so
+// /traceability?from=<kind>&id=<id> renders a participation panel: the
+// record's one-hop connections to the native trace roots (capabilities,
+// objectives, services), each linking into the existing root trace views.
+// No new diagram — this is discoverability plumbing.
+
+export interface TraceParticipation {
+  kind: TraceParticipantKind
+  id: string
+  name: string
+  /** One-hop connections to trace roots, viewer-visibility filtered. */
+  connections: {
+    capabilities: { id: string; name: string }[]
+    objectives: { id: string; name: string }[]
+    services: { id: string; name: string }[]
+  }
+}
+
+type RootRow = { id: string; name: string; organizationId: string; visibility: string; status: string }
+
+export async function getTraceParticipation(
+  kind: TraceParticipantKind,
+  id: string,
+): Promise<TraceParticipation | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const viewerOrgId = session.user.organizationId!
+  const isViewer = session.user.role === 'viewer'
+
+  // Subject record — same record-level gate the root trace loaders apply.
+  const subject =
+    kind === 'application' ? await db.query.applications.findFirst({ where: eq(applications.id, id) })
+    : kind === 'initiative' ? await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
+    : kind === 'persona' ? await db.query.personas.findFirst({ where: eq(personas.id, id) })
+    : kind === 'value-stream' ? await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, id) })
+    : kind === 'adr' ? await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
+    : await db.query.principles.findFirst({ where: eq(principles.id, id) })
+
+  if (!subject) return null
+  const visible = await canReadFederatedEntity(subject.organizationId, subject.visibility, viewerOrgId)
+  if (!visible) return null
+
+  // One-hop root connections per kind.
+  const capabilityIds: string[] = []
+  const objectiveIds: string[] = []
+  const serviceIds: string[] = []
+
+  if (kind === 'application') {
+    const rows = await db.select({ id: applicationCapabilities.capabilityId })
+      .from(applicationCapabilities).where(eq(applicationCapabilities.applicationId, id))
+    capabilityIds.push(...rows.map(r => r.id))
+  } else if (kind === 'initiative') {
+    const [caps, objs] = await Promise.all([
+      db.select({ id: initiativeCapabilities.capabilityId })
+        .from(initiativeCapabilities).where(eq(initiativeCapabilities.initiativeId, id)),
+      db.select({ id: initiativeObjectives.objectiveId })
+        .from(initiativeObjectives).where(eq(initiativeObjectives.initiativeId, id)),
+    ])
+    capabilityIds.push(...caps.map(r => r.id))
+    objectiveIds.push(...objs.map(r => r.id))
+  } else if (kind === 'persona') {
+    const [caps, svcs] = await Promise.all([
+      db.select({ id: capabilityPersonas.capabilityId })
+        .from(capabilityPersonas).where(eq(capabilityPersonas.personaId, id)),
+      db.select({ id: servicePersonas.serviceId })
+        .from(servicePersonas).where(eq(servicePersonas.personaId, id)),
+    ])
+    capabilityIds.push(...caps.map(r => r.id))
+    serviceIds.push(...svcs.map(r => r.id))
+  } else if (kind === 'value-stream') {
+    const [caps, svcs, objs] = await Promise.all([
+      db.select({ id: valueStreamCapabilities.capabilityId })
+        .from(valueStreamCapabilities).where(eq(valueStreamCapabilities.valueStreamId, id)),
+      db.select({ id: serviceValueStreams.serviceId })
+        .from(serviceValueStreams).where(eq(serviceValueStreams.valueStreamId, id)),
+      db.select({ id: objectiveValueStreams.objectiveId })
+        .from(objectiveValueStreams).where(eq(objectiveValueStreams.valueStreamId, id)),
+    ])
+    capabilityIds.push(...caps.map(r => r.id))
+    serviceIds.push(...svcs.map(r => r.id))
+    objectiveIds.push(...objs.map(r => r.id))
+  } else if (kind === 'adr') {
+    const [caps, objs] = await Promise.all([
+      db.select({ id: adrCapabilities.capabilityId })
+        .from(adrCapabilities).where(eq(adrCapabilities.adrId, id)),
+      db.select({ id: adrObjectives.objectiveId })
+        .from(adrObjectives).where(eq(adrObjectives.adrId, id)),
+    ])
+    capabilityIds.push(...caps.map(r => r.id))
+    objectiveIds.push(...objs.map(r => r.id))
+  } else {
+    const rows = await db.select({ id: principleCapabilities.capabilityId })
+      .from(principleCapabilities).where(eq(principleCapabilities.principleId, id))
+    capabilityIds.push(...rows.map(r => r.id))
+  }
+
+  // Connected roots a stakeholder may follow: same-org or instance-visible,
+  // and published-only for viewers — matching the trace pages' promise that
+  // relationships reflect published, visible records only.
+  const rootVisible = (r: RootRow) =>
+    (r.organizationId === viewerOrgId || r.visibility === 'instance') &&
+    (!isViewer || r.status === 'published')
+
+  const [capRows, objRows, svcRows] = await Promise.all([
+    capabilityIds.length > 0
+      ? db.select({ id: capabilities.id, name: capabilities.name, organizationId: capabilities.organizationId, visibility: capabilities.visibility, status: capabilities.status })
+          .from(capabilities).where(inArray(capabilities.id, capabilityIds))
+      : Promise.resolve([] as RootRow[]),
+    objectiveIds.length > 0
+      ? db.select({ id: strategicObjectives.id, name: strategicObjectives.name, organizationId: strategicObjectives.organizationId, visibility: strategicObjectives.visibility, status: strategicObjectives.status })
+          .from(strategicObjectives).where(inArray(strategicObjectives.id, objectiveIds))
+      : Promise.resolve([] as RootRow[]),
+    serviceIds.length > 0
+      ? db.select({ id: services.id, name: services.name, organizationId: services.organizationId, visibility: services.visibility, status: services.status })
+          .from(services).where(inArray(services.id, serviceIds))
+      : Promise.resolve([] as RootRow[]),
+  ])
+
+  const toRef = (r: RootRow) => ({ id: r.id, name: r.name })
+  const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name)
+
+  return {
+    kind,
+    id,
+    name: kind === 'adr' ? (subject as { title: string }).title : (subject as { name: string }).name,
+    connections: {
+      capabilities: capRows.filter(rootVisible).map(toRef).sort(byName),
+      objectives: objRows.filter(rootVisible).map(toRef).sort(byName),
+      services: svcRows.filter(rootVisible).map(toRef).sort(byName),
+    },
   }
 }

--- a/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/adrs/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getInitiatives } from '@/actions/initiatives'
 import { getObjectives } from '@/actions/objectives'
 import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import { LinkedDebt } from '@/components/linked-debt'
@@ -97,9 +98,12 @@ export default async function ADRDetailPage({ params }: { params: Promise<{ id: 
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/adrs" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Architecture Decision Records
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/adrs" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Architecture Decision Records
+        </Link>
+        <ViewTraceabilityLink from="adr" id={id} />
+      </div>
 
       {/* Header */}
       <div className="space-y-3">

--- a/apps/govea/src/app/(admin)/applications/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/applications/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getADRs } from '@/actions/adrs'
 import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import { LinkedDebt } from '@/components/linked-debt'
 import {
@@ -106,9 +107,12 @@ export default async function ApplicationDetailPage({ params }: { params: Promis
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/applications" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Applications
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/applications" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Applications
+        </Link>
+        <ViewTraceabilityLink from="application" id={id} />
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getObjectives } from '@/actions/objectives'
 import { getApplications } from '@/actions/applications'
 import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import type { RelationshipItem } from '@/components/relationship-panel'
@@ -103,9 +104,12 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/initiatives" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Initiatives
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/initiatives" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Initiatives
+        </Link>
+        <ViewTraceabilityLink from="initiative" id={id} />
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/personas/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/personas/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getValueStreams } from '@/actions/value-streams'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import { PersonaEditButton } from '@/components/persona-edit-button'
 import {
@@ -74,9 +75,12 @@ export default async function PersonaDetailPage({ params }: { params: Promise<{ 
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/personas" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Personas
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/personas" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Personas
+        </Link>
+        <ViewTraceabilityLink from="persona" id={id} />
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/principles/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/principles/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getADRs } from '@/actions/adrs'
 import { canEdit } from '@/lib/rbac'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkPrincipleCapability, unlinkPrincipleCapability,
@@ -75,9 +76,12 @@ export default async function PrincipleDetailPage({ params }: { params: Promise<
 
   return (
     <div className="space-y-8 max-w-3xl">
-      <Link href="/principles" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Principles
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/principles" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Principles
+        </Link>
+        <ViewTraceabilityLink from="principle" id={id} />
+      </div>
 
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-4">

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -2,8 +2,9 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace } from '@/actions/traceability'
-import type { GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp } from '@/actions/traceability'
+import { getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace, getTraceParticipation } from '@/actions/traceability'
+import type { GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceParticipation } from '@/actions/traceability'
+import { isTraceParticipantKind, PARTICIPANT_ROUTES } from '@/lib/trace-participants'
 import { getGoals } from '@/actions/goals'
 import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
@@ -578,6 +579,12 @@ export default async function TraceabilityPage({
     trace = await getServiceTrace(id)
     backHref = `/services/${id}`
     backLabel = '← Service'
+  } else if (isTraceParticipantKind(from)) {
+    // #695 — non-root participants get a participation panel rather than a
+    // native trace: their one-hop connections into the root trace views.
+    const participation = await getTraceParticipation(from, id)
+    if (!participation) notFound()
+    return <ParticipantView participation={participation} />
   } else {
     notFound()
   }
@@ -626,6 +633,84 @@ export default async function TraceabilityPage({
       <p className="text-xs text-muted-foreground pt-4 border-t">
         Traceability view — relationships reflect published, visible records only.
         <Link href={backHref} className="ml-2 underline underline-offset-2 hover:text-foreground">
+          Edit links on the detail page.
+        </Link>
+      </p>
+    </div>
+  )
+}
+
+// ── Participant view (#695) ───────────────────────────────────────────────────
+//
+// Rendered for entities that appear in trace chains without being trace
+// roots. Shows the record's one-hop connections to the root entities, each
+// linking into the existing root trace views — "how does this connect?" in
+// one step, without inventing a new diagram for every entity type.
+
+function ParticipantView({ participation }: { participation: TraceParticipation }) {
+  const route = PARTICIPANT_ROUTES[participation.kind]
+  const { capabilities, objectives, services } = participation.connections
+  const total = capabilities.length + objectives.length + services.length
+
+  const sections: { label: string; from: string; rows: { id: string; name: string }[] }[] = [
+    { label: 'Capabilities', from: 'capability', rows: capabilities },
+    { label: 'Strategic Objectives', from: 'objective', rows: objectives },
+    { label: 'Services', from: 'service', rows: services },
+  ]
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <Link
+          href={`${route.hrefBase}/${participation.id}`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← {route.label}
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">{participation.name}</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Traceability participation — chains this {route.label.toLowerCase()} connects to
+        </p>
+      </div>
+
+      <hr />
+
+      {total === 0 ? (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          No published traceability chains connect to this record yet. Link it to a
+          capability, objective, or service on its detail page and the chains will
+          appear here.
+        </div>
+      ) : (
+        <div className="space-y-6 max-w-3xl">
+          <p className="text-sm text-muted-foreground">
+            This record is not a trace root itself — start a trace from one of its
+            connected records below.
+          </p>
+          {sections.filter(s => s.rows.length > 0).map(section => (
+            <section key={section.from}>
+              <LayerLabel>{section.label}</LayerLabel>
+              <div className="rounded-lg border bg-card divide-y">
+                {section.rows.map(row => (
+                  <div key={row.id} className="flex items-center justify-between gap-3 px-4 py-2.5 text-sm">
+                    <span className="font-medium">{row.name}</span>
+                    <Link
+                      href={`/traceability?from=${section.from}&id=${row.id}`}
+                      className="text-xs font-medium text-primary hover:text-primary/80 transition-colors shrink-0"
+                    >
+                      Trace →
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground pt-4 border-t">
+        Traceability view — relationships reflect published, visible records only.
+        <Link href={`${route.hrefBase}/${participation.id}`} className="ml-2 underline underline-offset-2 hover:text-foreground">
           Edit links on the detail page.
         </Link>
       </p>

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -7,6 +7,7 @@ import { canEdit } from '@/lib/rbac'
 import { StageManager } from './stage-manager'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import {
   linkValueStreamPersona, unlinkValueStreamPersona,
@@ -64,9 +65,12 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
   return (
     <div className="space-y-8 max-w-3xl">
       {/* Back link */}
-      <Link href="/value-streams" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-        ← Value Streams
-      </Link>
+      <div className="flex items-center justify-between">
+        <Link href="/value-streams" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Value Streams
+        </Link>
+        <ViewTraceabilityLink from="value-stream" id={id} />
+      </div>
 
       {/* Header */}
       <div className="space-y-3">

--- a/apps/govea/src/components/view-traceability-link.tsx
+++ b/apps/govea/src/components/view-traceability-link.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+/**
+ * Consistent "View traceability →" entry point for entity detail pages
+ * (#695). Matches the markup the Goal/Objective/Capability/Service pages
+ * already use, so every participating entity offers the same affordance in
+ * the same place. Navigation-only: never renders edit affordances.
+ */
+export function ViewTraceabilityLink({ from, id }: { from: string; id: string }) {
+  return (
+    <Link
+      href={`/traceability?from=${from}&id=${id}`}
+      className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+    >
+      View traceability →
+    </Link>
+  )
+}

--- a/apps/govea/src/lib/trace-participants.ts
+++ b/apps/govea/src/lib/trace-participants.ts
@@ -1,0 +1,29 @@
+/**
+ * Trace-participant registry (#695).
+ *
+ * Entities that appear inside traceability chains without being trace roots.
+ * Their detail pages link to /traceability?from=<kind>&id=<id>, which renders
+ * a participation panel (see getTraceParticipation in actions/traceability.ts)
+ * instead of a root trace. Lives outside the 'use server' action file because
+ * server-action modules may only export async functions.
+ */
+
+export type TraceParticipantKind =
+  | 'application' | 'initiative' | 'persona' | 'value-stream' | 'adr' | 'principle'
+
+export const TRACE_PARTICIPANT_KINDS: readonly TraceParticipantKind[] =
+  ['application', 'initiative', 'persona', 'value-stream', 'adr', 'principle'] as const
+
+export function isTraceParticipantKind(value: string): value is TraceParticipantKind {
+  return (TRACE_PARTICIPANT_KINDS as readonly string[]).includes(value)
+}
+
+/** Detail-page route + back-label per participant kind. */
+export const PARTICIPANT_ROUTES: Record<TraceParticipantKind, { hrefBase: string; label: string }> = {
+  application: { hrefBase: '/applications', label: 'Application' },
+  initiative: { hrefBase: '/initiatives', label: 'Initiative' },
+  persona: { hrefBase: '/personas', label: 'Persona' },
+  'value-stream': { hrefBase: '/value-streams', label: 'Value Stream' },
+  adr: { hrefBase: '/adrs', label: 'Decision' },
+  principle: { hrefBase: '/principles', label: 'Principle' },
+}

--- a/apps/govea/tests/e2e/specs/smoke.spec.ts
+++ b/apps/govea/tests/e2e/specs/smoke.spec.ts
@@ -17,7 +17,8 @@ const ROUTES = [
   '/applications',
   '/adrs',
   '/personas',
-  '/users',      // admin-only — confirms RBAC gate doesn't crash
+  '/users',        // admin-only — confirms RBAC gate doesn't crash
+  '/traceability', // #695 — hub view; detail pages across the app link into it
 ] as const
 
 async function expectNoServerError(page: Page, route: string) {

--- a/apps/govea/tests/integration/trace-participation.test.ts
+++ b/apps/govea/tests/integration/trace-participation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for trace participation (#695).
+ *
+ * getTraceParticipation powers /traceability?from=<participant>&id=<id> for
+ * entities that appear in trace chains without being trace roots. Pins:
+ *  - one-hop root connections per participant kind
+ *  - record-level federation gate (org-private subjects in other orgs → null)
+ *  - viewer rules: connected roots are published-only for viewers
+ *  - empty participation (record exists, no connections) still resolves
+ */
+
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  applications, capabilities, services, personas, strategicObjectives, initiatives,
+  applicationCapabilities, capabilityPersonas, servicePersonas, initiativeObjectives,
+} from '@/db/schema'
+import { randomUUID } from 'node:crypto'
+import { createTestOrg, createTestUser, cleanupOrg, makeSession } from './helpers/db'
+import type { TestUser } from './helpers/db'
+import { getTraceParticipation } from '@/actions/traceability'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('getTraceParticipation (#695)', () => {
+  let orgId: string
+  let otherOrgId: string
+  let admin: TestUser
+  let viewer: TestUser
+
+  const appId = randomUUID()
+  const capPublishedId = randomUUID()
+  const capDraftId = randomUUID()
+  const personaId = randomUUID()
+  const serviceId = randomUUID()
+  const initiativeId = randomUUID()
+  const objectiveId = randomUUID()
+  const lonelyAppId = randomUUID()
+  const foreignAppId = randomUUID()
+
+  beforeAll(async () => {
+    const [org, other] = await Promise.all([createTestOrg(), createTestOrg()])
+    orgId = org.id
+    otherOrgId = other.id
+    admin = await createTestUser(orgId, 'admin')
+    viewer = await createTestUser(orgId, 'viewer')
+
+    await db.insert(capabilities).values([
+      { id: capPublishedId, organizationId: orgId, name: 'Permitting', status: 'published', visibility: 'org' },
+      { id: capDraftId, organizationId: orgId, name: 'Draft Capability', status: 'draft', visibility: 'org' },
+    ])
+    await db.insert(applications).values([
+      { id: appId, organizationId: orgId, name: 'Permit Portal', status: 'published', visibility: 'org' },
+      { id: lonelyAppId, organizationId: orgId, name: 'Unlinked App', status: 'published', visibility: 'org' },
+      // org-private subject in a different org
+      { id: foreignAppId, organizationId: otherOrgId, name: 'Foreign App', status: 'published', visibility: 'org' },
+    ])
+    await db.insert(services).values({
+      id: serviceId, organizationId: orgId, name: 'Apply for a Permit', status: 'published', visibility: 'org',
+    })
+    await db.insert(personas).values({
+      id: personaId, organizationId: orgId, name: 'Permit Applicant', status: 'published', visibility: 'org',
+    })
+    await db.insert(strategicObjectives).values({
+      id: objectiveId, organizationId: orgId, name: 'Digital Permitting', status: 'published', visibility: 'org',
+    })
+    await db.insert(initiatives).values({
+      id: initiativeId, organizationId: orgId, name: 'Permit Modernization', status: 'proposed', visibility: 'org',
+    })
+
+    await db.insert(applicationCapabilities).values([
+      { applicationId: appId, capabilityId: capPublishedId },
+      { applicationId: appId, capabilityId: capDraftId },
+    ])
+    await db.insert(capabilityPersonas).values({ capabilityId: capPublishedId, personaId })
+    await db.insert(servicePersonas).values({ serviceId, personaId })
+    await db.insert(initiativeObjectives).values({ initiativeId, objectiveId })
+  })
+
+  afterAll(async () => {
+    await cleanupOrg(orgId)
+    await cleanupOrg(otherOrgId)
+  })
+
+  it('application: returns its connected capabilities for an admin (drafts included)', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const p = await getTraceParticipation('application', appId)
+    expect(p).not.toBeNull()
+    expect(p!.name).toBe('Permit Portal')
+    expect(p!.connections.capabilities.map(c => c.id).sort())
+      .toEqual([capPublishedId, capDraftId].sort())
+    expect(p!.connections.objectives).toEqual([])
+    expect(p!.connections.services).toEqual([])
+  })
+
+  it('viewer sees published connected roots only', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    const p = await getTraceParticipation('application', appId)
+    expect(p).not.toBeNull()
+    expect(p!.connections.capabilities.map(c => c.id)).toEqual([capPublishedId])
+  })
+
+  it('persona: connects to capabilities and services', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const p = await getTraceParticipation('persona', personaId)
+    expect(p!.connections.capabilities.map(c => c.id)).toEqual([capPublishedId])
+    expect(p!.connections.services.map(s => s.id)).toEqual([serviceId])
+  })
+
+  it('initiative: connects to objectives', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const p = await getTraceParticipation('initiative', initiativeId)
+    expect(p!.connections.objectives.map(o => o.id)).toEqual([objectiveId])
+  })
+
+  it('a record with no connections still resolves (empty-state participation)', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const p = await getTraceParticipation('application', lonelyAppId)
+    expect(p).not.toBeNull()
+    expect(p!.connections.capabilities).toEqual([])
+    expect(p!.connections.objectives).toEqual([])
+    expect(p!.connections.services).toEqual([])
+  })
+
+  it('org-private subjects in other orgs are not resolvable (federation gate)', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    expect(await getTraceParticipation('application', foreignAppId)).toBeNull()
+  })
+
+  it('unknown ids resolve to null', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    expect(await getTraceParticipation('application', randomUUID())).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #695
Capability: fd-traceability-views
Capability: fd-relationship-navigation
Capability: rm-end-to-end-traceability
Persona: Content Viewer, Enterprise Architect, Department Director

## Inventory (first acceptance criterion)

The trace type model is the authoritative participant list: chains contain **applications, initiatives, personas, ADRs, principles** alongside the four roots (goal, objective, capability, service). Value streams have direct root junctions (#757) so they're included as participants too. **Debt items and data-architecture objects never appear in trace chains** — no affordance added there (their chains route through applications; a future trace slice can revisit).

## What

- **Six detail pages gain the affordance** — applications, initiatives, personas, value streams, ADRs, principles — via a shared `<ViewTraceabilityLink>` placed on the back-link row, the same position and markup the Services page already uses. The existing four root-page links are untouched ("preserve existing links").
- **Participation panel** — `/traceability?from=<participant>&id=<id>` now renders the record's one-hop connections to trace roots, each linking into the existing root trace views, with a clear empty state when nothing is linked yet. Not a new diagram — discoverability plumbing (per the issue's Notes). Unknown `from` kinds still 404.
- **`getTraceParticipation`** follows the root loaders' conventions: session check, `canReadFederatedEntity` record gate, and connected roots filtered to same-org/instance-visible — **published-only for viewers**, matching the page's "relationships reflect published, visible records only" promise. Navigation only; no edit affordances.

## Design questions (answered)

- **v1 direct roots**: unchanged (goal/objective/capability/service). Applications/initiatives route through their linked roots rather than getting native trace engines.
- **Empty state**: the link always shows; the participation view renders an explicit "no chains yet" panel with a pointer back to the detail page.
- **List rows**: out of scope — detail pages only, per the issue.

## Testing

- **Integration (7 new)**: per-kind one-hop connections (application/persona/initiative), viewer published-only filtering, the federation gate on org-private subjects in other orgs, empty participation, unknown ids.
- **Smoke**: `/traceability` (hub) added to the CI smoke routes.
- `eslint` / `tsc --noEmit` / unit suite clean locally; integration + e2e + production build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)