### PR TITLE
fix(theming): allowlist theme var values to prevent style-tag breakout

### DIFF
--- a/apps/govea/src/lib/themes.ts
+++ b/apps/govea/src/lib/themes.ts
@@ -91,8 +91,46 @@ export function getTheme(id: string): ThemeDefinition {
 // this inline style tag.
 const BRAND_VARS = ['--header-bg', '--header-fg', '--header-border']
 
+// #769 — defense in depth for the inline <style> injection in app-shell.
+// Theme vars are serialized into a style tag without HTML escaping, so every
+// declaration must match a conservative allowlist before it is emitted.
+// Today vars only come from the hard-coded list above (org admins pick a
+// theme *id*; updateOrgTheme rejects unknown ids), but custom org branding is
+// future fd-theming work — this keeps a '</style><script>' breakout
+// structurally impossible no matter where a value originates. None of the
+// accepted shapes can contain '<', ';', '{', '}', quotes, or backslashes.
+const SAFE_VAR_NAME = /^--[a-z][a-z0-9-]*$/
+
+const SAFE_VAR_VALUE_PATTERNS = [
+  // Space-separated HSL triple, the shadcn token format: "221 83% 40%"
+  /^\d{1,3}(\.\d+)? \d{1,3}(\.\d+)?% \d{1,3}(\.\d+)?%$/,
+  // Plain CSS length/percentage: "0.375rem", "2px", "50%"
+  /^-?\d+(\.\d+)?(rem|em|px|%)$/,
+  // Hex colors: #rgb, #rgba, #rrggbb, #rrggbbaa
+  /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/,
+  // Functional colors with a strict argument charset: rgb(...), hsl(...)
+  /^(rgb|rgba|hsl|hsla)\([\d.,%\s/]*\)$/,
+  // Named colors / keywords: "white", "transparent"
+  /^[a-zA-Z]{3,30}$/,
+]
+
+/** True when a CSS custom property is safe to emit into the inline style tag. */
+export function isSafeThemeVar(name: string, value: string): boolean {
+  return (
+    SAFE_VAR_NAME.test(name) &&
+    value.length <= 100 &&
+    SAFE_VAR_VALUE_PATTERNS.some(re => re.test(value))
+  )
+}
+
 export function themeToStyleString(theme: ThemeDefinition): string {
-  const entries = Object.entries(theme.vars)
+  const entries = Object.entries(theme.vars).filter(([k, v]) => {
+    if (isSafeThemeVar(k, v)) return true
+    // Shipped themes always pass (pinned by tests/unit/theme-value-safety.test.ts),
+    // so a strip here means a value arrived from an untrusted source.
+    console.warn(`themeToStyleString: dropped unsafe theme var ${JSON.stringify(k)}`)
+    return false
+  })
 
   const brandVars = entries
     .filter(([k]) => BRAND_VARS.includes(k))

--- a/apps/govea/tests/unit/theme-value-safety.test.ts
+++ b/apps/govea/tests/unit/theme-value-safety.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Style-tag breakout guard for org theme values (#769).
+ *
+ * themeToStyleString output is injected as an inline <style> via
+ * dangerouslySetInnerHTML in app-shell.tsx, with no HTML escaping. Every
+ * emitted declaration must therefore match a conservative allowlist
+ * (isSafeThemeVar) that structurally excludes '<', ';', braces, quotes, and
+ * backslashes — making a '</style><script>' breakout impossible even if a
+ * theme value ever arrives from an untrusted source (custom org branding is
+ * future fd-theming work).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isSafeThemeVar, themeToStyleString, themes, type ThemeDefinition } from '@/lib/themes'
+
+describe('isSafeThemeVar — accepted shapes', () => {
+  it.each([
+    ['221 83% 40%', 'shadcn HSL triple'],
+    ['0 0% 100%', 'HSL triple with zero hue'],
+    ['222.5 47% 11.2%', 'HSL triple with decimals'],
+    ['0.375rem', 'rem length'],
+    ['2px', 'px length'],
+    ['50%', 'percentage'],
+    ['#1a4fba', '6-digit hex'],
+    ['#fff', '3-digit hex'],
+    ['#1a4fba80', '8-digit hex'],
+    ['rgb(26, 79, 186)', 'legacy rgb()'],
+    ['hsl(221 83% 40% / 50%)', 'modern hsl() with alpha'],
+    ['transparent', 'named keyword'],
+  ])('accepts %s (%s)', value => {
+    expect(isSafeThemeVar('--primary', value)).toBe(true)
+  })
+})
+
+describe('isSafeThemeVar — rejected shapes', () => {
+  it.each([
+    ['</style><script>alert(1)</script>', 'style-tag breakout'],
+    ['red; } body { display: none', 'declaration/block injection'],
+    ['url(javascript:alert(1))', 'url() function'],
+    ['expression(alert(1))', 'IE expression()'],
+    ['221 83% 40%; --x: y', 'semicolon smuggling'],
+    ['"red"', 'quotes'],
+    ["'red'", 'single quotes'],
+    ['red\\0', 'backslash escape'],
+    ['221 83% 40%\n}', 'newline + brace'],
+    ['rgb(<img>)', 'angle bracket inside function args'],
+    [`#${'f'.repeat(120)}`, 'over-length value'],
+    ['', 'empty value'],
+  ])('rejects %s (%s)', value => {
+    expect(isSafeThemeVar('--primary', value)).toBe(false)
+  })
+
+  it.each([
+    ['--x</style>', 'breakout in the name'],
+    ['--UPPER', 'uppercase name'],
+    ['color', 'non-custom-property name'],
+    ['--', 'empty custom property'],
+  ])('rejects unsafe name %s (%s)', name => {
+    expect(isSafeThemeVar(name, '221 83% 40%')).toBe(false)
+  })
+})
+
+describe('themeToStyleString — strips unsafe vars instead of emitting them', () => {
+  const malicious: ThemeDefinition = {
+    id: 'govea',
+    name: 'Evil',
+    description: '',
+    darkMode: false,
+    previewColors: { header: '#000', primary: '#000', background: '#fff' },
+    vars: {
+      '--primary': '221 83% 40%', // legitimate — must survive
+      '--header-bg': '</style><script>alert(1)</script>',
+      '--x</style>': '0 0% 100%',
+      '--ring': 'red; } body { display: none',
+    },
+  }
+
+  it('emits no markup-significant characters and keeps the safe var', () => {
+    const css = themeToStyleString(malicious)
+    expect(css).not.toContain('<')
+    expect(css).not.toContain('script')
+    expect(css).not.toContain('display: none')
+    expect(css).toContain('--primary: 221 83% 40%')
+  })
+})
+
+describe('shipped themes — every var passes the allowlist', () => {
+  // Drift guard: if a legitimate brand value is added that the allowlist
+  // rejects, it would be silently stripped at render time. Fail here instead
+  // so the allowlist is consciously extended in the same PR.
+  for (const theme of themes) {
+    it(`theme "${theme.id}" emits all of its vars`, () => {
+      for (const [name, value] of Object.entries(theme.vars)) {
+        expect(isSafeThemeVar(name, value), `${name}: ${value} should be allowlisted`).toBe(true)
+      }
+    })
+  }
+})


### PR DESCRIPTION
Closes #769
Capability: fd-theming
Persona: CMS Administrator

## What

`themeToStyleString` output is injected as an inline `<style>` via `dangerouslySetInnerHTML` in app-shell with no HTML escaping. Every emitted declaration now has to pass `isSafeThemeVar` — a conservative allowlist of exactly the value shapes themes use:

- shadcn HSL triples (`221 83% 40%`), lengths (`0.375rem`), hex colors, `rgb()`/`hsl()` with a strict argument charset, and bare named-color keywords
- var names must match `--[a-z][a-z0-9-]*`; values are length-capped

None of the accepted shapes can contain `<`, `;`, `{`, `}`, quotes, or backslashes — so a `</style><script>` breakout, declaration smuggling, or block injection is structurally impossible regardless of where a value originates. Unsafe vars are stripped at render with a `console.warn`, never emitted.

## Why now

Today vars come only from the hard-coded THEMES list and `updateOrgTheme` rejects unknown theme ids, so there is no user-controlled path — this is defense in depth. But custom org branding is explicitly future fd-theming work, and this guarantee should predate that surface, not chase it.

## Testing

- New `tests/unit/theme-value-safety.test.ts` (30 tests): accepted-shape table, rejection table (breakout, declaration/block injection, `url(javascript:)`, `expression()`, quote/backslash/newline smuggling, over-length), `themeToStyleString` strip behavior on a malicious ThemeDefinition (no `<` in output, legitimate var survives), and a drift guard pinning that **every shipped theme var passes** — so the allowlist can never silently strip a real brand value; extending themes with a new value shape forces a conscious allowlist update in the same PR.
- Full unit suite: 238 pass. Lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)