### PR TITLE
docs(service-product): establish Service Product Management capability area

### DIFF
--- a/business-architecture/capabilities/cms/portfolio/po-services.md
+++ b/business-architecture/capabilities/cms/portfolio/po-services.md
@@ -1,0 +1,37 @@
+# Capability: Services
+
+## What It Does
+
+The system must allow organizations to catalog the services they deliver — public-facing or internal — and connect each service to the capabilities it realizes, the personas it serves, and the value streams it participates in. Services are the repository's bridge between what constituents experience and the architecture underneath it.
+
+This file documents the shipped service *record*; the practice of managing services as products (lifecycle, structured ownership, outcomes, discovery) is the [Service Product Management](../../ea/service-product-management/service-product-management.md) group, which builds on this capability.
+
+## Personas
+
+- **Agency EA Coordinator** — catalogs services and keeps their architecture links current
+- **Service Owner** — the accountable party the record names (free-text today; structured ownership is spm-service-ownership)
+- **Department Director** — reads the service catalog to see what their organization delivers and to whom
+- **Content Viewer** — browses published services and follows their relationships
+
+## Behaviors
+
+- Create, edit, publish, and archive service records with name, description, owner (free text), and delivery channels (online, in-person, phone, mobile)
+- Link services to the capabilities they realize, the personas they serve, and the value streams they participate in (many-to-many junctions)
+- Trace from a service through its relationships — services are native traceability roots with a `View traceability →` entry point on the detail page
+- Federate like other portfolio content: org-scoped by default, with instance-visible sharing per the cross-org visibility rules
+
+## Rules
+
+- Services follow the standard content workflow (draft → published → archived) and visibility model; viewers see published content only
+- Service relationships obey the same cross-org link validation as other junctions — no links across org-private boundaries
+- The owner field is informational free text in the shipped product; it confers no permissions
+
+## Implementation Status
+
+**Shipped (v1).** Service CRUD with channels and free-text owner, capability/persona/value-stream junctions, workflow + visibility + federation, and native traceability roots are all in place. Not yet implemented: CSV round-trip for services (#748), structured ownership, lifecycle, and the rest of the product-practice layer (see ea/service-product-management — all *Not implemented*).
+
+## Links
+
+- Depends on: IAM — Role-Based Access Control, Content Management workflow conventions
+- Enables: Service Product Management (ea/service-product-management), Value Streams (po-value-streams), Traceability Views (fd-traceability-views)
+- Related: Capability Map (po-capability-map), Application Portfolio (po-application-portfolio)

--- a/business-architecture/capabilities/cms/portfolio/portfolio.md
+++ b/business-architecture/capabilities/cms/portfolio/portfolio.md
@@ -22,6 +22,7 @@ The system must allow contributors to maintain a structured inventory of the org
 | Architecture Decision Records | [po-architecture-decisions.md](./po-architecture-decisions.md) | Record, track, and supersede architecture decisions |
 | Principles | [po-principles.md](./po-principles.md) | Capture architecture principles and link them to capabilities and decisions |
 | Glossary | [po-glossary.md](./po-glossary.md) | Maintain shared terminology to support consistent EA language across the repository |
+| Services | [po-services.md](./po-services.md) | Catalog delivered services with channels and ownership, linked to capabilities, personas, and value streams |
 | Value Streams | [po-value-streams.md](./po-value-streams.md) | Define value streams with ordered stages; link stages to capabilities and link streams to personas, objectives, and services |
 
 ## Rules
@@ -36,7 +37,7 @@ The system must allow contributors to maintain a structured inventory of the org
 - The Application → Capability → Persona chain is enforced at publish time so the repository never carries orphan applications or capability rows without persona context
 - Domain Director and Content Viewer audiences can navigate the published portfolio through the frontend without admin access
 - Cross-org link semantics on capabilities and personas preserve source-org ownership while exposing inbound attribution to the target org
-- A new content type (e.g., Services) joins the portfolio by following the same authoring + relationship + workflow conventions, not by hand-built scaffolding
+- A new content type joins the portfolio by following the same authoring + relationship + workflow conventions, not by hand-built scaffolding (Services did exactly this — see po-services.md)
 
 ## Implementation Status
 Portfolio Management is one of GovEA's strongest shipped areas. Applications, capabilities, personas, services, value streams, principles, and glossary content all have meaningful day-to-day product surface today.

--- a/business-architecture/capabilities/ea/service-product-management/service-product-management.md
+++ b/business-architecture/capabilities/ea/service-product-management/service-product-management.md
@@ -1,0 +1,70 @@
+# Capability: Service Product Management
+
+**Scope:** v2
+
+## What It Does
+
+Government services outlive the projects that build them — but most agencies manage them as projects anyway: funded to build, documented at go-live, then run on institutional memory until something breaks. This capability group lets an organization manage its services **as products**: each service has a position in a lifecycle, an accountable owner, outcomes it is measured against, an evidence trail from user research, and a portfolio-level health view that makes the whole service estate legible to leadership.
+
+The product **is** the service. This group adds no new entity type — it adds product practice to the existing Services entity (see [po-services](../../cms/portfolio/po-services.md)), reusing GovEA's existing machinery: lifecycle stages install as taxonomy via the recipe engine, outcomes follow the scorecard patterns, discovery builds on the persona junctions services already have.
+
+## Personas
+
+- **Service Owner** — lives in this group; the service record becomes the artifact they run their service with
+- **Agency EA Coordinator** — connects service product data to the rest of the architecture repository; uses portfolio health to focus attention
+- **Department Director** — reads lifecycle and outcome summaries to make investment decisions in plain language
+- **Elected Official** — sees what services exist, who they serve, and whether they are working — without EA vocabulary
+
+> ⚠️ All four personas are **Assumed**, and Service Owner was drafted specifically for this group. Per Standards.md, capabilities here may be designed but must not drive implementation until a real service owner or product manager validates the underlying need (#668 — this group is strong material for the first Tier-1 interview).
+
+## Sub-Capabilities
+
+| Capability | File | Description |
+|---|---|---|
+| Product Lifecycle | [spm-product-lifecycle.md](./spm-product-lifecycle.md) | Services carry an explicit lifecycle stage (discovery → live → retired), distinct from content workflow status |
+| Service Ownership | [spm-service-ownership.md](./spm-service-ownership.md) | Structured, accountable ownership replacing the free-text owner field; succession without knowledge loss |
+| Outcome Measurement | [spm-outcome-measurement.md](./spm-outcome-measurement.md) | Agreed outcomes per service with plain-language health reporting |
+| Continuous Discovery | [spm-continuous-discovery.md](./spm-continuous-discovery.md) | User-research evidence linked to the service record via personas and feedback |
+| Service Portfolio Health | [spm-service-portfolio-health.md](./spm-service-portfolio-health.md) | Portfolio-level view: lifecycle distribution, ownerless services, stale outcomes |
+
+## Design Principle
+
+A service record that the Service Owner maintains for their own accountability stays current; a service record maintained for the architects' benefit goes stale. Every capability in this group must make the owner's existing job easier — budget conversations, performance reviews, succession — or it will not be adopted.
+
+## Out of Scope
+
+| Capability | Rationale |
+|---|---|
+| Delivery/backlog management | GovEA is not a work tracker. Initiatives link funded change to services; sprint-level work stays in the agency's delivery tools (future DevOps integration, int-devops, is the bridge) |
+| Service desk / ticketing | Operational incidents belong to ITSM (int-itsm-cmdb). This group is about the service's life, not its tickets |
+| Citizen-facing service catalogs | Publishing a public service directory is a frontend-display concern; this group manages the practice behind it |
+
+## Success Criteria
+
+- A Service Owner can answer "where is my service in its life, who owns it, and how is it doing?" from the service record alone
+- "Who owns this service?" has a structured answer for every live service; ownerless services are visible, not invisible
+- A Department Director can read a service portfolio summary without EA vocabulary and see where attention is needed
+- Lifecycle, ownership, and outcome data flows into existing traceability and reports rather than creating a parallel surface
+
+## Rules
+
+- The Service entity is the product — no parallel Product entity, no duplicate records
+- Lifecycle stage is orthogonal to content workflow status (a *draft record* can describe a *live service*)
+- Nothing in this group auto-mutates service records; owners assert lifecycle and outcomes, the system surfaces staleness
+- All data respects existing RBAC, workflow, visibility, and federation rules — portfolio health never leaks org-private services
+
+## Implementation Status
+
+**Planned — documentation only.** The Services entity itself is shipped (CRUD, channels, free-text owner, junctions to capabilities/personas/value streams, traceability roots — see po-services). None of the product-practice capabilities in this group exist in the product. Design questions to resolve before implementation, in a follow-up design slice gated on persona validation (#668):
+
+- Lifecycle stages as an org taxonomy installed via the recipe engine (#671's install machinery) vs a fixed enum — recipe-backed is the working assumption (GDS-style stages as a starter recipe, org-customizable)
+- Structured owner: user reference vs role reference, and what happens when the user leaves (succession)
+- Initiative ↔ service linkage (initiatives currently link to capabilities and objectives only)
+- Outcome records: follow the completeness-signals/scorecard pattern (#380, #573) vs a dedicated metrics design; budget linkage waits on #563
+- Reconcile with the open modeling efforts in the same neighborhood — #694 (value chains) and #697 (Strategy entity) — before any schema work, so the three designs land as one model
+
+## Links
+
+- Depends on: Portfolio — Services (po-services), Planning — Initiatives (pl-initiatives), IAM — Role-Based Access Control
+- Enables: Frontend Display — Traceability Views, Repository — Completeness signals, future public service catalog work
+- Related: Integration (int-devops, int-itsm-cmdb), Planning — Roadmap (pl-roadmap), EA Adoption & Engagement (#71)

--- a/business-architecture/capabilities/ea/service-product-management/spm-continuous-discovery.md
+++ b/business-architecture/capabilities/ea/service-product-management/spm-continuous-discovery.md
@@ -1,0 +1,37 @@
+# Capability: Continuous Discovery
+
+## What It Does
+
+Keeps the evidence from user research attached to the service it is about. Services already link to the personas they serve; this capability adds the discovery trail — research findings, validated or disconfirmed assumptions, and feedback — so "what do we know about how people experience this service?" has an answer that survives staff turnover and project closure.
+
+In project-based delivery, user research happens once (if at all) during the build and is lost in a report. The product model treats discovery as continuous; the repository's job is to make accumulated evidence findable from the service record.
+
+## Personas
+
+- **Service Owner** — records findings and uses the evidence trail to justify roadmap choices
+- **Agency EA Coordinator** — connects discovery evidence to personas, keeping the people-centered model honest
+- **Business Stakeholder** — contributes observations from the front line of service delivery
+
+## Behaviors
+
+- Attach discovery evidence to a service: a dated finding, its source type (interview, observation, feedback, analytics), and the personas it concerns
+- Distinguish confirmations from disconfirmations — a finding that contradicts a persona assumption is the most valuable record (mirroring the practice-fit feedback log's philosophy)
+- Surface evidence staleness: a live service with no discovery evidence in N months is a signal
+- Feed service-scoped entries from the in-product feedback capture (#103) into the same trail when that ships
+
+## Rules
+
+- Evidence entries are immutable in spirit: corrections append, they do not rewrite history
+- Personally identifying details about research participants do not belong in the repository — findings are recorded at the persona level
+- Evidence respects service visibility and federation rules
+- Discovery evidence informs persona validation but does not flip a persona's Validation Status by itself — that remains an explicit decision per Standards.md
+
+## Implementation Status
+
+**Not implemented.** Services already junction to personas (shipped); the practice-fit feedback log exists as a repo-level markdown artifact, and in-product feedback capture is #103 (v1.0). No service-scoped evidence structures exist in the product. Gated on persona validation (#668) — with the irony noted that this capability is itself about making that kind of validation routine.
+
+## Links
+
+- Depends on: Portfolio — Services (po-services), Personas (po-capability-map persona linkage), feedback capture (#103)
+- Enables: Outcome Measurement (spm-outcome-measurement) — discovery surfaces what to measure
+- Related: business-architecture/feedback-log.md (practice-fit log), validation plan (docs/research/validation-plan.md)

--- a/business-architecture/capabilities/ea/service-product-management/spm-outcome-measurement.md
+++ b/business-architecture/capabilities/ea/service-product-management/spm-outcome-measurement.md
@@ -1,0 +1,38 @@
+# Capability: Outcome Measurement
+
+## What It Does
+
+Each service records the outcomes it is supposed to produce and how it is doing against them — adoption, completion rate, satisfaction, cost-to-serve, or whatever the org agrees matters. Today performance conversations about services run on anecdote and complaint volume; this capability gives the Service Owner an agreed measuring stick and gives leadership a plain-language answer to "is this service working?"
+
+This is deliberately *measurement bookkeeping*, not analytics: GovEA records what the outcomes are, their current asserted values, and when they were last reviewed. Live metric pipelines are integration work (int-bi-analytics), not repository work.
+
+## Personas
+
+- **Service Owner** — defines outcomes with their leadership, updates values at review cadence, brings the record to budget conversations
+- **Department Director** — reads outcome health without needing the underlying dashboards
+- **Elected Official** — sees whether the services constituents depend on are working, in plain language
+- **Budget & Performance Analyst** — connects outcome evidence to funding decisions
+
+## Behaviors
+
+- Define named outcomes per service with a target, a current value, and a review cadence
+- Record outcome reviews (value, date, reviewer) so the trend and the staleness are both visible
+- Roll outcome health up to the service record in plain language (on track / needs attention / stale)
+- Flag outcomes whose review date has lapsed rather than letting them silently age
+
+## Rules
+
+- Outcome values are asserted by the owner with provenance, never silently imported — automated feeds come later via integration and must be labeled as such
+- A service with no outcomes is a visible portfolio signal, not an error
+- Outcome definitions and values respect service visibility — org-private services never leak performance data through reports
+- Plain language is mandatory at the report surface: targets and values, not KPI jargon
+
+## Implementation Status
+
+**Not implemented.** No outcome structures exist. The working assumption is to follow the completeness-signals/scorecard pattern already shipped for repository quality (#380) and designed for model quality (#573); budget linkage waits on #563. Gated on persona validation (#668).
+
+## Links
+
+- Depends on: Portfolio — Services (po-services), Service Ownership (spm-service-ownership)
+- Enables: Service Portfolio Health (spm-service-portfolio-health), Executive-facing reporting
+- Related: Integration — BI & Analytics (int-bi-analytics), Planning — Strategic Objectives (pl-strategic-objectives)

--- a/business-architecture/capabilities/ea/service-product-management/spm-product-lifecycle.md
+++ b/business-architecture/capabilities/ea/service-product-management/spm-product-lifecycle.md
@@ -1,0 +1,37 @@
+# Capability: Product Lifecycle
+
+## What It Does
+
+Every service carries an explicit lifecycle stage — where it is in its life as a product, from discovery through live operation to managed retirement. The stage is the first thing leadership asks about and the thing project-based management loses track of: services today are "done" the day the build project closes, with no recorded difference between a service being piloted, one serving the whole state, and one limping toward replacement.
+
+Lifecycle stage is deliberately distinct from content workflow status: workflow status describes the *record* (draft/published), lifecycle stage describes the *service*.
+
+## Personas
+
+- **Service Owner** — asserts and updates the stage; uses it to frame budget and improvement conversations
+- **Department Director** — reads stage distribution to understand where the portfolio is aging
+- **Agency EA Coordinator** — uses stage to prioritize architecture attention (retiring services need decommission plans, not roadmaps)
+
+## Behaviors
+
+- Assign a lifecycle stage to a service from an org-level stage set (working assumption: GDS-style — discovery, alpha, beta, live, retiring, retired — shipped as a starter recipe and org-customizable as taxonomy)
+- Record stage transitions with date and actor so the service's history is reconstructible
+- Surface stage on the service detail page, list views, and portfolio reports
+- Flag stale stages (e.g., a service "in discovery" for two years) rather than auto-changing them
+
+## Rules
+
+- Lifecycle stage is orthogonal to workflow status — a draft record may describe a live service
+- Stage transitions are owner-asserted; the system never advances a stage automatically
+- Stage sets are org-scoped taxonomy, installable via recipe, so frameworks other than GDS's can be adopted without code
+- Retired services remain in the repository (history and traceability) — retirement is a stage, not a deletion
+
+## Implementation Status
+
+**Not implemented.** No lifecycle field or taxonomy exists on services; the recipe engine (#671 family) that would install stage sets is shipped and is the working substrate. Design and implementation are gated on persona validation (#668) per the group doc.
+
+## Links
+
+- Depends on: Portfolio — Services (po-services), Framework Alignment recipe-install machinery
+- Enables: Service Portfolio Health (spm-service-portfolio-health)
+- Related: Planning — Initiatives (pl-initiatives), Application Portfolio lifecycle/debt signals

--- a/business-architecture/capabilities/ea/service-product-management/spm-service-ownership.md
+++ b/business-architecture/capabilities/ea/service-product-management/spm-service-ownership.md
@@ -1,0 +1,35 @@
+# Capability: Service Ownership
+
+## What It Does
+
+Gives every service a structured, accountable owner instead of a free-text name. "Who owns this service?" is the most basic question in the product model and today has no reliable answer: the shipped `serviceOwner` field is free text — a name that goes stale the day someone changes roles, with no link to a real user, no notification path, and no way to list a person's services when they leave.
+
+## Personas
+
+- **Service Owner** — is the answer to the question; sees the services they own as a first-class list
+- **CMS Administrator** — assigns and transfers ownership; sees ownerless services during onboarding/offboarding
+- **Department Director** — knows who to ask about any service in their portfolio
+
+## Behaviors
+
+- Assign an accountable owner to a service as a structured reference (user, or named role/team where a person reference is premature)
+- List all services owned by a person — the succession view: what must be handed over when they leave
+- Surface ownerless services (no owner, or owner deactivated) as an explicit portfolio signal rather than silent staleness
+- Preserve the free-text field's flexibility for orgs that track ownership outside GovEA (an external-owner label), without weakening the structured path
+
+## Rules
+
+- Ownership is accountability for the service, not authorship of the record — it grants no extra content permissions by itself
+- Deactivating a user must not silently orphan their services: offboarding surfaces them for reassignment
+- One accountable owner per service (deputies/teams are a display concern, not a second accountable party)
+- Ownership changes are audit-logged like other settings-grade changes
+
+## Implementation Status
+
+**Not implemented.** `serviceOwner` ships today as free text on the services table. The structured-owner design (user vs role reference, succession flow, interaction with user deactivation) is a design question recorded in the group doc, gated on persona validation (#668).
+
+## Links
+
+- Depends on: Portfolio — Services (po-services), IAM — User Management, IAM — Audit Trail
+- Enables: Service Portfolio Health (spm-service-portfolio-health), Outcome Measurement (spm-outcome-measurement)
+- Related: domain-owner attribution patterns elsewhere in the repository

--- a/business-architecture/capabilities/ea/service-product-management/spm-service-portfolio-health.md
+++ b/business-architecture/capabilities/ea/service-product-management/spm-service-portfolio-health.md
@@ -1,0 +1,36 @@
+# Capability: Service Portfolio Health
+
+## What It Does
+
+The portfolio-level read across all services: lifecycle distribution, ownerless services, stale outcomes, and missing discovery evidence — in one view a Department Director or EA Coordinator can act on. The application portfolio already has this kind of surface; services, the things constituents actually experience, currently have nothing comparable. This capability makes the service estate legible the way the application estate already is.
+
+## Personas
+
+- **Department Director** — the primary reader: where is the service portfolio aging, what has no owner, what needs investment attention
+- **Agency EA Coordinator** — uses the health view to direct repository and architecture effort to the services that need it
+- **Elected Official** — high-level: what services exist for whom, and are they healthy, in plain language
+- **Service Owner** — sees their service in portfolio context — and sees what "good" looks like across peers
+
+## Behaviors
+
+- Summarize the service portfolio by lifecycle stage, ownership coverage, outcome health, and discovery freshness
+- Drill from any portfolio signal to the affected service records (the completeness drill-down pattern, #380)
+- Ship as a report preset over the generic report engine where possible, rather than a bespoke page
+- Respect role and visibility: viewers see published, viewer-safe content only; org-private services never appear cross-org
+
+## Rules
+
+- Health signals derive from data the other sub-capabilities record — this view computes, it never edits
+- An empty or sparse portfolio renders an honest empty state, not fabricated health
+- Signals are explainable: every flag states what it means and what would clear it, in plain language
+- No ranking of owners or teams — the view directs attention to services, it is not a performance league table
+
+## Implementation Status
+
+**Not implemented.** Depends on lifecycle (spm-product-lifecycle), structured ownership (spm-service-ownership), and outcomes (spm-outcome-measurement) existing first; the report-engine presets (#673 family) and completeness drill-down pattern (#380) are the shipped substrate it would build on. Gated on persona validation (#668).
+
+## Links
+
+- Depends on: Product Lifecycle (spm-product-lifecycle), Service Ownership (spm-service-ownership), Outcome Measurement (spm-outcome-measurement)
+- Enables: Executive and stakeholder reporting over the service estate
+- Related: Repository completeness drill-downs (#380), group-by-taxonomy report engine (#673), Application Portfolio (po-application-portfolio)

--- a/business-architecture/personas/service-owner.md
+++ b/business-architecture/personas/service-owner.md
@@ -1,0 +1,49 @@
+# Persona: Service Owner
+
+**Validation Status: Assumed** — drafted from the government product-operating-model literature (GDS Service Standard, USDS playbook, state CIO product-model guidance) and the 2026 EA market research. Must not drive implementation until validated through an interview with a real service owner or product manager in a state or local government agency.
+
+## Role Type
+Internal — Service Delivery Leadership (agency)
+
+## Government Equivalent
+The person accountable for a public-facing or internal government service as an ongoing concern — titles vary widely: Service Owner, Product Manager, Service Manager, Business Program Manager, or a division manager who "owns the permitting system" without any product title at all. In agencies adopting the product operating model this is an explicit role; in most agencies today it is implicit and discovered only when something breaks.
+
+## Who They Are
+The Service Owner is responsible for a service across its whole life — not for delivering a project that ends at go-live. They decide what the service should do next, justify its funding, answer for its performance, and are the person a Department Director calls when constituents complain.
+
+They are not architects and will never open an EA tool to "do EA." They think in terms of the people the service serves, the outcomes it should produce, and the roadmap of improvements they can realistically fund. Architecture matters to them only as it answers their questions: what does this service depend on, what is the technology under it costing us, and what breaks if we change it.
+
+Unlike the Programme Director, whose horizon is a delivery programme that ends, the Service Owner's horizon is indefinite — the service persists, accumulates users and obligations, and eventually needs a managed retirement.
+
+## Goals
+- Keep an accurate, shareable picture of what their service does, who it serves, and what it depends on — without maintaining a parallel spreadsheet
+- Know where the service is in its life (discovery, live, retiring) and make that status legible to leadership and budget staff
+- Tie funding asks to evidence: outcomes the service produces, gaps user research has surfaced, and the initiatives that would close them
+- See early warning when the service's underlying applications or capabilities are flagged for decommissioning, debt, or risk
+- Hand the service to a successor without the institutional knowledge leaving with them
+
+## Pain Points
+- Service knowledge lives in people's heads and project documents from the original build; nothing authoritative survives the project's end
+- "Who owns this service?" has no reliable answer — ownership is a free-text field, an org chart guess, or a former employee
+- Performance conversations happen without data: no agreed outcomes, no measures, only anecdotes and complaint volume
+- Funding is project-shaped — money arrives to build, never to continuously improve — so the case for product-style investment must be rebuilt from scratch every budget cycle
+- EA tools, where they exist, treat the service as an inventory row; nothing in them helps run the service as a product
+
+## Critical Insight
+The Service Owner will adopt an EA tool only if it makes their existing accountability easier — the service record must be the artifact they bring to budget and leadership conversations, not a duplicate they maintain for the architects' benefit. If keeping GovEA current is extra work on top of the "real" tracking, this persona will not do it; if the service record *is* the real tracking, they become the most active editor in the repository.
+
+## Distinction from Programme Director
+
+| | Programme Director | Service Owner |
+|---|---|---|
+| Horizon | A programme that ends | A service that persists |
+| Decision type | Delivery sequencing | Service investment and improvement |
+| Primary EA question | "What breaks if I decommission Y?" | "What should this service do next, and what does that cost?" |
+| Engagement trigger | In-flight programme decisions | Budget cycles, performance reviews, succession |
+
+## Relevant Capabilities
+- Service Product Management (ea/service-product-management) — the practice this persona lives in
+- Portfolio — Services (po-services) — the service record itself
+- Portfolio — Value Streams (po-value-streams) — where their service participates in end-to-end value delivery
+- Planning — Initiatives (pl-initiatives) — the funded change that touches their service
+- Frontend Display — Traceability Views (fd-traceability-views) — "how does my service connect?"


### PR DESCRIPTION
Closes #789
Capability group: ea/service-product-management
Capability: po-services
Persona: Service Owner, Agency EA Coordinator, Department Director, Elected Official

## What

Docs-first slice establishing **services managed as products** as a capability area, per the product-owner decisions recorded in #789:

- **`business-architecture/personas/service-owner.md`** — new **Assumed** persona: the accountable owner of a service as an ongoing concern (Service Owner / Product Manager / Service Manager). Includes the distinction table vs Programme Director and the critical insight that the service record must BE the owner's real tracking artifact or it will go stale.
- **`business-architecture/capabilities/ea/service-product-management/`** — new group (Scope: v2, practice-shaped like Integration) with five sub-capabilities, every one honestly **Not implemented**:
  - `spm-product-lifecycle` — GDS-style stages as recipe-installable taxonomy, orthogonal to content workflow status
  - `spm-service-ownership` — structured accountable owner replacing free-text `serviceOwner`; succession without knowledge loss
  - `spm-outcome-measurement` — owner-asserted outcomes with plain-language health; measurement bookkeeping, not analytics
  - `spm-continuous-discovery` — research evidence attached to the service via personas; disconfirmations valued over confirmations
  - `spm-service-portfolio-health` — the portfolio read (lifecycle distribution, ownerless services, stale outcomes) as report presets
- **`po-services.md`** — fixes a pre-existing gap: the Services entity shipped without a portfolio capability doc. Documents only shipped behavior; portfolio.md table updated.

## Guardrails encoded in the docs

- The Service **is** the product — no new entity type, no duplicate-record surface
- Implementation explicitly **gated on persona validation (#668)** — the group doc flags itself as first-interview material
- Reconciliation with #694 (value chains) and #697 (Strategy) required before any schema work — the #665/#313 lesson, written into Implementation Status

## Testing

`node scripts/lint-business-architecture.mjs` — OK (115 files). Docs-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)