### PR TITLE
docs(architect): refresh application architecture docs to current code + ADR-0003

### DIFF
--- a/docs/architect/README.md
+++ b/docs/architect/README.md
@@ -25,3 +25,5 @@ Update these docs when a change alters one of the main architectural seams:
 - cross-cutting concerns such as audit, taxonomy, module toggles, or search
 
 These docs do not replace ADRs. If a change records a decision or tradeoff that should remain reviewable over time, add or update an ADR under `docs/decisions/` and link to it from the relevant architecture document.
+
+**Last full review:** 2026-06-12 (#792) — covered the multi-org membership model, the session/middleware rewrite (ADR-0003), taxonomy recipes, audit telemetry, and the db:push runtime policy. Update this line when the next full review lands.

--- a/docs/architect/application-overview.md
+++ b/docs/architect/application-overview.md
@@ -39,6 +39,7 @@ GovEA uses App Router route groups to separate user experiences without adding v
 | `(auth)` | `/login`, `/setup`, `/auth-redirect`, `/error` | Authentication and bootstrap flows |
 | `(admin)` | `/dashboard`, `/applications`, `/capabilities`, `/roadmap`, `/settings` | Main organization-scoped EA workspace |
 | `(instance)` | `/instance`, `/instance/orgs`, `/instance/users` | Instance-admin platform operations |
+| API routes | `/api/auth/*`, `/api/auth/logout`, `/api/applications/export` | Auth.js endpoints, the deploy-stable sign-out handler, and data exports — the planned `/api/v1` REST surface (#775) will live here |
 | root routes | `/`, `/maintenance` | Landing redirect and maintenance surface |
 
 The main workspace is organization-scoped. The instance console is deliberately separate because `instance_admin` is an operating role for platform support, not a blanket content role inside every tenant.
@@ -81,14 +82,22 @@ Middleware performs coarse route protection. Server actions and domain helpers p
 
 | Concern | Current implementation |
 |---|---|
-| Authentication | Auth.js with local credentials and optional OIDC SSO; current provider wiring targets Microsoft Entra ID |
-| Authorization | Org-scoped roles plus separate `instance_admin` operating role |
-| Audit | Immutable audit log for content, identity, instance, and support-access events |
-| Taxonomy | Org-scoped controlled vocabularies reused across multiple entity types |
+| Authentication | Auth.js with local credentials and optional OIDC SSO (current provider wiring targets Microsoft Entra ID); deploy-stable logout endpoint with a logged-out marker guarding against post-logout session resurrection (ADR-0003) |
+| Authorization | Per-membership org roles with an active-organization context (#693), plus separate `instance_admin` operating role |
+| Audit | Audit log made append-only by a DB trigger; covers content, identity, instance, and support-access events with IP/user-agent on auth events and an instance telemetry view |
+| Taxonomy & recipes | Org-scoped controlled vocabularies reused across entity types; curated sets (e.g. TOGAF 10) install idempotently through the recipe engine, with audience markers hiding framework jargon from viewers |
+| Reports | Generic group-by-taxonomy report engine with presets, plus completeness surfaces such as the duplicate-candidates report |
 | Modules | Org-level module settings and instance-wide module availability controls |
 | Search | Embedded repository-wide search over core content |
 | Federation | Connection-aware visibility and approval-based cross-org links |
-| Demo data | Seeded Riverdale, GovEA Project dogfood org, Hartfield TOGAF demo, scale data, and system org |
+| Demo data | Seeded Riverdale, GovEA Project dogfood org, Hartfield TOGAF demo (recipe-installed), scale data, and system org |
+
+## Planned Architectural Seams
+
+Two decided roadmap items change what an architect should expect from this shape:
+
+- **REST API foundation (#775, v1.0)** — `/api/v1` read/write endpoints with token auth, RBAC/audit parity with the UI, generated OpenAPI, and bulk import. Route handlers join server actions as a first-class mutation surface; the same authorization helpers must serve both.
+- **First Tier-1 sync: ServiceNow ITSM/CMDB (#382, v2.0)** — built on the REST API foundation; integrations populate context and never silently overwrite architect-authored content.
 
 ## Design Bias
 

--- a/docs/architect/data-and-traceability.md
+++ b/docs/architect/data-and-traceability.md
@@ -19,6 +19,7 @@ flowchart LR
   Services --> Personas
   Services --> Capabilities
   Services --> ValueStreams["Value Streams"]
+  ValueStreams --> Capabilities
   Goals --> Objectives["Strategic Objectives"]
   Objectives --> Capabilities
   Objectives --> ValueStreams
@@ -33,7 +34,9 @@ flowchart LR
   Principles --> ADRs
 ```
 
-Applications are intentionally surfaced for services and objectives through linked capabilities rather than through direct service-to-application or objective-to-application joins. That keeps mission traceability anchored in capabilities.
+Applications are intentionally surfaced for services and objectives through linked capabilities rather than through direct service-to-application or objective-to-application joins. That keeps mission traceability anchored in capabilities. Value streams additionally carry direct capability mappings (#757) so stream-level views do not depend on stage-by-stage links.
+
+Traceability has two kinds of entry point (#695): **roots** (goals, objectives, capabilities, services) get native `from=` drill-downs on `/traceability`, while every other participating entity (applications, initiatives, personas, value streams, ADRs, principles) gets a participation view — its one-hop connections into the native traces — so any record can answer "how does this connect?" without inventing per-entity trace engines.
 
 ## Relationship Patterns
 
@@ -77,7 +80,7 @@ The Data Architecture module adds a dedicated metamodel for data architecture wo
 
 Data Architecture is connected to the same organization, role, workflow, and visibility rules as the rest of the repository.
 
-## Taxonomy
+## Taxonomy and Recipes
 
 Taxonomy is the shared controlled-vocabulary foundation. It supports domain and classification values across several product areas instead of creating one-off vocabulary tables for each entity.
 
@@ -93,7 +96,14 @@ Current uses include:
 - decision category
 - principle scope
 
-When adding a new classification, prefer taxonomy if the value is user-manageable, org-scoped, and likely to be reused across records.
+Structural pieces an architect should know:
+
+- Types and their values are org-scoped `taxonomy_terms` rows (parent/child); `entity_taxonomy_definitions` binds a type to the entity kinds it classifies.
+- Types carry an **audience** marker — framework-flavored types (e.g. ADM Phase) are hidden from viewer-role users and stakeholder reports, preserving the plain-language promise without forbidding the vocabulary.
+- **Recipes** install curated bundles (taxonomy types and values, glossary terms, principles, report presets) idempotently via the recipe-install engine. Framework support is recipe-shaped, not code-shaped: the TOGAF 10 starter replaced the former hard-coded framework overlay, and ADM stages exist as classification only — never workflow ([ADR-0002](../decisions/0002-adm-as-classification.md)).
+- The generic group-by-taxonomy report engine renders any bound type as a report; presets (including TOGAF views) are data, not pages.
+
+When adding a new classification, prefer taxonomy if the value is user-manageable, org-scoped, and likely to be reused across records. When shipping a curated vocabulary, prefer a recipe over seed-code or bespoke tables.
 
 ## Audit and Completeness
 
@@ -103,6 +113,7 @@ The repository is designed to be self-auditing:
 - completeness signals identify missing or stale relationships
 - repository-confidence summaries convert maintenance state into stakeholder-facing trust cues
 - architecture debt records capture known concerns and system-detected lifecycle risk
+- the duplicate-candidates report (#718) scans every entity type plus taxonomy values and entity-taxonomy assignments for exact and near-duplicate names, surfacing candidate groups for human review — it never auto-merges
 
 Completeness and confidence should remain signals for better human judgment, not hidden automation that changes architecture content without review.
 

--- a/docs/architect/runtime-and-deployment.md
+++ b/docs/architect/runtime-and-deployment.md
@@ -56,8 +56,11 @@ Common local paths:
 | `pnpm demo:db` | Start only the database |
 | `pnpm demo:container` | Run the full container stack |
 | `pnpm --filter govea dev` | Start the Next.js app after database setup |
-| `pnpm --filter govea db:migrate` | Run local migrations |
+| `pnpm --filter govea db:push` | Sync schema directly from `src/db/schema/` (pre-production policy — there are no migration files yet; see CLAUDE.md) |
+| `pnpm --filter govea db:apply-triggers` | Re-apply Postgres triggers and DB-level constraints after a push |
 | `pnpm --filter govea db:seed` | Load demo seed data |
+
+`db:migrate` exists in `package.json` but is intentionally not the current command — pre-production uses `db:push --force` everywhere, including CI. The switch to migrations happens when the first real tenant data exists; CLAUDE.md tracks the checklist.
 
 Podman is preferred when available, but the compose helper can fall back to Docker.
 
@@ -157,7 +160,8 @@ After any deployment, verify the target-specific health signal and the generic a
 
 - active revision, pod, task, or container is healthy
 - expected image tag or digest is running
-- `/login` returns HTTP 200
+- `/login` returns HTTP 200 and carries the security response headers (X-Frame-Options, nosniff, HSTS, report-only CSP — configured in `next.config.ts`, #743)
+- sign-out works post-deploy (the deploy-stable logout endpoint exists precisely because stale tabs used to fail after rollouts, #759)
 - logs show schema/migration completion, optional seed completion, and Next server ready
 - no recurring auth, database pool, server-action, or static asset errors
 

--- a/docs/architect/security-and-tenancy.md
+++ b/docs/architect/security-and-tenancy.md
@@ -1,6 +1,6 @@
 # Security and Tenancy Architecture
 
-GovEA is multi-tenant at the application layer. The normal operating boundary is the organization. Users belong to one organization, content records carry `organization_id`, and cross-organization behavior is explicit rather than implicit.
+GovEA is multi-tenant at the application layer. The normal operating boundary is the organization. Content records carry `organization_id`, and cross-organization behavior is explicit rather than implicit. Users can hold memberships in multiple organizations, but every request operates in the context of exactly one **active organization**.
 
 ## Identity Model
 
@@ -11,32 +11,52 @@ GovEA supports two sign-in paths:
 | Local credentials | Development, fallback, and self-hosted operation | Password hashes are stored for local users |
 | OIDC SSO | Government SSO path | Current provider wiring targets Microsoft Entra ID; Okta, Auth0, or other OIDC providers fit the same architectural pattern |
 
-Auth is implemented with Auth.js in `apps/govea/src/lib/auth.ts`. The current code uses the Microsoft Entra ID provider package, but the architectural boundary is OIDC-backed SSO plus pre-provisioned GovEA users rather than a Microsoft-only identity model. Middleware uses the edge-safe Auth.js configuration from `apps/govea/src/middleware.ts` so route protection does not pull Node-only APIs into the Edge Runtime.
+Auth is implemented with Auth.js in `apps/govea/src/lib/auth.ts`. The current code uses the Microsoft Entra ID provider package, but the architectural boundary is OIDC-backed SSO plus pre-provisioned GovEA users rather than a Microsoft-only identity model. Middleware (`apps/govea/src/middleware.ts`) stays edge-safe by decoding the session JWT directly with `getToken` — pure claim reads, no Node-only APIs, and no session-cookie writes ([ADR-0003](../decisions/0003-middleware-reads-tokens-never-writes.md)).
 
-SSO does not auto-create usable tenant users. The sign-in callback checks that the external identity maps to a pre-provisioned, active user with an organization assignment. This keeps tenant access admin-managed.
+SSO does not auto-create usable tenant users. The sign-in callback checks that the external identity maps to a pre-provisioned, active user with at least one active organization membership. This keeps tenant access admin-managed.
+
+## Memberships and the Active Organization
+
+Since #693, the user–organization relationship is a membership model, not a column on the user:
+
+- `user_organization_memberships` holds one row per user per organization, each carrying its **own org-scoped role** — the same person can be `admin` in one org and `viewer` in another.
+- Every session resolves an **active organization** (last-selected, falling back to a deterministic default). All org-scoped reads, writes, and role checks evaluate against the active membership only.
+- Users with multiple memberships switch via the org switcher; switching updates the session through the Auth.js session endpoint and fires the jwt callback — privileges never blend across memberships.
+- Instance admins manage memberships across organizations through the instance console; org admins manage members inside their org, with a per-org last-admin guard.
 
 ## Roles
 
 | Role | Scope | Intent |
 |---|---|---|
-| `admin` | Organization | Full tenant administration and content management |
-| `contributor` | Organization | Create and edit EA content, without user management or destructive admin powers |
-| `viewer` | Organization | Read viewer-visible published content |
+| `admin` | Per membership | Full tenant administration and content management in that org |
+| `contributor` | Per membership | Create and edit EA content, without user management or destructive admin powers |
+| `viewer` | Per membership | Read viewer-visible published content |
 | `instance_admin` | Instance | Platform operations across organizations through the instance console |
 
-`instance_admin` is stored separately from the org-scoped role. It does not mean the user owns every organization's architecture content.
+`instance_admin` is stored on the user, separately from membership roles. It does not mean the user owns every organization's architecture content.
 
 ## Route Protection
 
-Middleware handles coarse protection:
+Middleware handles coarse protection. Per [ADR-0003](../decisions/0003-middleware-reads-tokens-never-writes.md) it decodes the session JWT **read-only** via `getToken` and never writes session cookies — the only session-cookie writers are the Auth.js endpoints and the logout handler:
 
-- public paths: `/login`, `/setup`, `/error`, `/api/auth`, `/maintenance`
-- static assets are allowed
+- `/api/auth/*` is excluded from the middleware matcher entirely (those endpoints manage the session cookie themselves)
+- public paths: `/login`, `/setup`, `/error`, `/maintenance`; static assets are allowed
 - unauthenticated users are redirected to `/login`
+- the **logged-out marker** guard rejects session tokens issued before the last sign-out and actively deletes their cookies (post-logout resurrection defense, #782)
 - maintenance mode redirects non-admin users to `/maintenance`
 - `/instance` routes require `instance_admin`
+- expired-password sessions are redirected to `/change-password`, with sign-out still reachable (#527)
 
 This is only the outer gate. Server actions still need to enforce role, organization, and target-record rules.
+
+## Session Lifecycle
+
+| Event | Behavior |
+|---|---|
+| Login | Auth.js issues a rolling JWT session cookie (24h maxAge); `events.signIn` clears any logged-out marker and writes an `auth.login` audit row with IP/user-agent |
+| Refresh | Session expiry extends through the Auth.js session endpoint and server-side `auth()` calls — never through middleware (ADR-0003) |
+| Sign-out | A plain form posts to the deploy-stable `/api/auth/logout` route handler (no Server Action id, so stale tabs survive deployments, #759); the handler fires the `auth.logout` audit event, explicitly expires every session-token cookie including large-JWT chunks, sets the logged-out marker, and 303s to `/login` with no caller-controlled redirect |
+| Post-logout | Any straggler response carrying a rolled pre-logout token is rejected and deleted by the middleware marker guard; logout succeeds even if the audit write fails — cookie clearing never depends on the database |
 
 ## Tenant Boundary
 
@@ -102,10 +122,23 @@ The audit log stores:
 - before/after snapshots when useful
 - metadata for support context, reasons, impersonated orgs, or request details
 
+Hardening already in place:
+
+- **Append-only at the database layer**: a Postgres trigger blocks UPDATE and DELETE on `audit_log` (#417) — even a compromised admin role cannot rewrite history
+- **Auth telemetry**: login/logout events capture client IP and user-agent; repeated failed logins are aggregated for instance review, and instance admins have an audit telemetry view with CSV export (#720)
+
+## Hardening Posture
+
+- Security response headers ship on every response (X-Frame-Options DENY, nosniff, referrer policy, HSTS) with a Content-Security-Policy in **report-only** mode pending nonce/hash rollout (#743; enforcement is #765)
+- Org theme values are allowlisted before injection into the inline `<style>` tag, making style-tag breakout structurally impossible (#769)
+- Open hardening work is tracked in the v1.0 security wave: MFA for local credentials (#761), CI dependency/code scanning (#762), CSV formula-injection neutralization (#763), database TLS enforcement (#764), audit retention for public-records compliance (#767)
+
 ## Security Design Notes
 
 - Never trust caller-supplied `organizationId` or `role` for authorization.
+- Resolve role from the **active membership**, never from a stale per-user field.
 - Prefer server-side relationship checks over client-side hiding.
 - Keep instance-admin features visibly separate from org-admin features.
 - Treat federation as read/link coordination, not ownership transfer.
 - Keep local auth available as an SSO fallback so administrators are not locked out when an identity provider is unavailable.
+- Never write session cookies outside the Auth.js endpoints and the logout handler (ADR-0003).

--- a/docs/decisions/0003-middleware-reads-tokens-never-writes.md
+++ b/docs/decisions/0003-middleware-reads-tokens-never-writes.md
@@ -1,0 +1,38 @@
+# ADR-0003: Middleware Reads Session Tokens; It Never Writes Session Cookies
+
+**Status:** Accepted
+**Date:** 2026-06-11
+**Issues:** [#782](https://github.com/roballred/GovEA/issues/782), [#783](https://github.com/roballred/GovEA/pull/783), [#759](https://github.com/roballred/GovEA/issues/759)
+
+---
+
+## Context
+
+GovEA uses Auth.js JWT sessions (rolling, 24h maxAge). Until #783, `src/middleware.ts` wrapped its handler in the Auth.js `auth()` helper, which both *decoded* the session for route protection and — when a token was due a refresh roll — *re-issued* the session cookie on the middleware's own response.
+
+While fixing sign-out reliability (#759), a security race surfaced (#782): any response carrying a rolled session cookie that lands **after** logout's cookie deletion silently resurrects the session. Investigation showed the middleware itself was one of the emitters: its `auth()` wrapper appended a rolled `Set-Cookie` to responses *including the very redirects that were trying to delete the session*, overriding same-response deletions and producing `/login ↔ /auth-redirect` redirect loops. Because the roll only fires for tokens past the refresh threshold, the failures were timing- and user-dependent — the worst kind of intermittent.
+
+Sign-out on a shared kiosk or public terminal — common in government offices — must be final. A logout that can be undone by an in-flight request is a security defect, not a UX bug.
+
+## Decision
+
+**Middleware decodes the session JWT read-only via `getToken` (checking both the plain and `__Secure-` cookie names) and never writes session cookies. Exactly two writers own the session cookie: the Auth.js endpoints under `/api/auth/*` (login, session refresh) and the logout route handler (deletion).**
+
+Supporting decisions in the same seam:
+
+1. **Logged-out marker.** Logout sets a `govea.logged-out-at` cookie (httpOnly, lifetime = session maxAge). Middleware rejects any session token issued before the marker (plus a 60-second grace window for late-landing rolled cookies) and actively deletes its cookies. `events.signIn` deletes the marker, so a genuine re-login is exempt by construction rather than by timing.
+2. **`/api/auth/*` is excluded from the middleware matcher entirely** — those endpoints manage the session cookie themselves; running middleware over them reintroduces a second writer.
+3. **`SessionProvider` window-focus refetch is disabled** — the app is server-session based; the provider exists only for the org switcher's `update()` call, and the focus refetch rolled cookies for nothing.
+
+## Consequences
+
+- **Middleware no longer extends session expiry on page navigation.** Sessions stay alive through the Auth.js session endpoint and server-side `auth()` calls (which run in the Node runtime and own the cookie legitimately). A user who only navigates server-rendered pages for 24 hours straight without any session-endpoint traffic would be signed out at maxAge — accepted as the correct trade for deterministic logout.
+- Role, instance-role, and password-expiry checks in middleware read token claims directly instead of the derived session object. The claims are the same values the session callback derives from, but contributors editing the jwt callback must keep middleware-read claims populated.
+- The resurrection guard depends on `events.signIn` clearing the marker. If that deletion ever fails, the 60-second window means a re-login inside it could be rejected once — self-healing, but worth knowing when debugging "logged out immediately after login" reports.
+- E2E sign-out tests can assert the strong property (no live session cookie survives a click-initiated logout, even with in-flight refetches) — `tests/e2e/specs/logout.spec.ts` is the regression gate.
+
+## Alternatives Considered
+
+- **Keep the `auth()` wrapper and fight the race elsewhere** — rejected: the wrapper is itself an emitter; no amount of deletion ordering wins against a same-response re-set.
+- **Server-side session denylist (jti blocklist)** — the fully general fix; rejected for now as heavyweight (a DB read on every request) while the marker + read-only middleware closes the observed attack surface. Revisit if session revocation requirements grow (e.g., admin-forced logout).
+- **Switch to database sessions** — solves revocation but changes the session model wholesale; out of scope for a security fix and in tension with the edge-safe middleware requirement.


### PR DESCRIPTION
Closes #792
Capability: n/a — maintainer-facing architecture documentation (consistent with #584; no capability doc covers contributor docs)
Persona: Enterprise Architect (contributor/maintainer audience), Consultant/SI

## What

Full review pass over `docs/architect/` (last touched 2026-05-19/25) against the current code — changes had landed on every seam its own Maintenance Rule lists. This tool is for architects; its own architecture docs should model the discipline.

**security-and-tenancy.md** (largest rewrite)
- Tenancy: replaced the false *“Users belong to one organization”* model with the #693 membership architecture — per-membership roles, active-organization resolution, org switcher semantics, instance/org membership management with last-admin guards
- New **Session Lifecycle** table: login (marker cleared, audited with IP/UA), refresh (never via middleware), the deploy-stable logout endpoint, and the post-logout resurrection guard
- Route protection rewritten for read-only `getToken` middleware, the `/api/auth` matcher exclusion, the logged-out marker, and the password-expiry gate
- Audit hardening (DB-level immutability #417, auth telemetry #720) and a new **Hardening Posture** section (headers/report-only CSP #743, theme allowlist #769, pointers to the open v1.0 security wave)

**application-overview.md** — cross-cutting table updated (auth, per-membership authz, taxonomy & recipes, new Reports row); API routes added to the route map; new **Planned Architectural Seams** section (REST API foundation #775, ServiceNow Tier-1 #382); stale TOGAF-overlay reference removed

**data-and-traceability.md** — diagram gains direct value-stream→capability mappings (#757); documents the roots-vs-participation traceability model (#695); **Taxonomy → Taxonomy and Recipes** with the install engine, audience markers, ADR-0002 link, and the group-by report engine; duplicate-candidates report (#718) added to the self-auditing list

**runtime-and-deployment.md** — fixes the `db:migrate` instruction that contradicted the documented `db:push` pre-production policy (adds `db:apply-triggers`); operational checks now include security headers and post-deploy sign-out verification

**NEW: `docs/decisions/0003-middleware-reads-tokens-never-writes.md`** — records the #783 decision per the README's ADR rule: middleware decodes JWTs read-only and never writes session cookies; exactly two cookie writers exist. Captures the tradeoff (middleware no longer extends session expiry), the marker design, and the rejected alternatives (auth() wrapper, jti denylist, database sessions)

README gains a **Last full review** marker so staleness is visible at the next grooming pass.

## Testing

Docs-only. `node scripts/lint-business-architecture.mjs` OK; every claim cross-checked against shipped code/PRs this session (#693, #759/#778, #782/#783, #720, #671–#675, #695, #757, #718, #743, #769).

🤖 Generated with [Claude Code](https://claude.com/claude-code)