### PR TITLE
fix(iam): relative logout redirect — absolute URL pointed at 0.0.0.0 behind proxy

### DIFF
--- a/apps/govea/src/app/api/auth/logout/route.ts
+++ b/apps/govea/src/app/api/auth/logout/route.ts
@@ -37,7 +37,15 @@ export async function POST(request: Request) {
 
   // 303 turns the form POST into a GET on /login. Fixed target — no
   // callback/redirect parameter is read, so no open-redirect surface.
-  const res = NextResponse.redirect(new URL('/login', request.url), 303)
+  // The Location is deliberately RELATIVE (#794): behind a TLS-terminating
+  // proxy the standalone server's request.url carries the container bind
+  // address (https://0.0.0.0/login on the demo), so an absolute URL built
+  // from it points at an unroutable origin. A relative Location resolves
+  // against whatever origin the user is actually on.
+  const res = new NextResponse(null, {
+    status: 303,
+    headers: { Location: '/login' },
+  })
 
   // Belt and braces: expire every session-token cookie on this response,
   // including large-JWT chunks (authjs.session-token.0, .1, …), rather than
@@ -61,12 +69,18 @@ export async function POST(request: Request) {
   // rejects any session token issued before this timestamp and deletes its
   // cookies. Lives as long as the max session age so no pre-logout token can
   // outlast it.
+  // x-forwarded-proto first: behind a TLS-terminating proxy request.url is
+  // the internal (http) hop even though the user is on https (#794).
+  const isHttps =
+    (request.headers.get('x-forwarded-proto') ?? '').split(',')[0].trim() === 'https' ||
+    request.url.startsWith('https')
+
   res.cookies.set(LOGGED_OUT_MARKER_COOKIE, String(Date.now()), {
     maxAge: LOGGED_OUT_MARKER_MAX_AGE_S,
     httpOnly: true,
     sameSite: 'lax',
     path: '/',
-    secure: request.url.startsWith('https'),
+    secure: isHttps,
   })
 
   return res

--- a/apps/govea/tests/e2e/specs/logout.spec.ts
+++ b/apps/govea/tests/e2e/specs/logout.spec.ts
@@ -45,9 +45,12 @@ async function expectLogoutContract(ctx: BrowserContext) {
   const res = await ctx.request.post('/api/auth/logout', { maxRedirects: 0 })
 
   expect(res.status(), 'logout should respond 303').toBe(303)
+  // Relative on purpose (#794): an absolute Location built from request.url
+  // points at the container bind address (https://0.0.0.0/login) behind a
+  // TLS-terminating proxy. Relative resolves against the user's real origin.
   expect(
-    new URL(res.headers()['location']).pathname,
-    'logout should redirect to /login, never a caller-controlled target',
+    res.headers()['location'],
+    'logout should redirect to a relative /login, never a host-derived or caller-controlled target',
   ).toBe('/login')
 
   const deletions = res

--- a/apps/govea/tests/unit/logout-route.test.ts
+++ b/apps/govea/tests/unit/logout-route.test.ts
@@ -37,7 +37,7 @@ describe('POST /api/auth/logout', () => {
 
     expect(signOutMock).toHaveBeenCalledWith({ redirect: false })
     expect(res.status).toBe(303)
-    expect(res.headers.get('location')).toBe('https://app.example.gov/login')
+    expect(res.headers.get('location')).toBe('/login')
   })
 
   it('sets the logged-out marker so middleware can reject resurrected sessions (#782)', async () => {
@@ -67,7 +67,7 @@ describe('POST /api/auth/logout', () => {
 
     expect(signOutMock).not.toHaveBeenCalled()
     expect(res.status).toBe(303)
-    expect(res.headers.get('location')).toBe('https://app.example.gov/login')
+    expect(res.headers.get('location')).toBe('/login')
   })
 
   it('never calls auth() — a rolling-session refresh would race the cookie deletion', async () => {
@@ -103,7 +103,7 @@ describe('POST /api/auth/logout', () => {
     expect(setCookies.some(c => c.startsWith('authjs.csrf-token='))).toBe(false)
   })
 
-  it('always targets /login on the request origin — no caller-controlled redirect', async () => {
+  it('always targets /login — relative, never caller-controlled', async () => {
     // A redirect/callback query string must not influence the destination.
     const res = await POST(
       new Request('https://app.example.gov/api/auth/logout?callbackUrl=https://evil.example.com', {
@@ -111,6 +111,41 @@ describe('POST /api/auth/logout', () => {
       }),
     )
 
-    expect(res.headers.get('location')).toBe('https://app.example.gov/login')
+    expect(res.headers.get('location')).toBe('/login')
+  })
+
+  it('emits a host-free Location even when the server sees its bind address (#794)', async () => {
+    // Behind a TLS-terminating proxy (Azure demo), request.url carries the
+    // container bind address. An absolute Location built from it sent users
+    // to https://0.0.0.0/login. The Location must stay relative.
+    const res = await POST(
+      new Request('https://0.0.0.0/api/auth/logout', { method: 'POST' }),
+    )
+
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/login')
+  })
+
+  it('marks the logged-out marker Secure from x-forwarded-proto behind a proxy (#794)', async () => {
+    const res = await POST(
+      new Request('http://0.0.0.0:3000/api/auth/logout', {
+        method: 'POST',
+        headers: { 'x-forwarded-proto': 'https' },
+      }),
+    )
+
+    const marker = res.headers.getSetCookie().find(c => c.startsWith('govea.logged-out-at='))
+    expect(marker).toBeDefined()
+    expect(marker).toMatch(/;\s*secure/i)
+  })
+
+  it('omits Secure on the marker for plain-http local development', async () => {
+    const res = await POST(
+      new Request('http://localhost:3000/api/auth/logout', { method: 'POST' }),
+    )
+
+    const marker = res.headers.getSetCookie().find(c => c.startsWith('govea.logged-out-at='))
+    expect(marker).toBeDefined()
+    expect(marker).not.toMatch(/;\s*secure/i)
   })
 })


### PR DESCRIPTION
Closes #794
Capability: iam-local-authentication
Persona: CMS Administrator, Content Viewer, Instance Administrator

## What

Reported on the deployed demo: Sign out landed on `https://0.0.0.0/login`. The #759 logout handler built its redirect as `new URL('/login', request.url)` — behind the TLS-terminating Azure ingress, the standalone server's `request.url` carries the container **bind address**, not the public host, so the absolute Location pointed at an unroutable origin. CI couldn't catch it: on localhost the request host and the public host coincide.

Fix:
- **Location is now literally `/login`** (relative, RFC-7231-valid) — the browser resolves it against whatever origin the user is actually on. Correct on localhost, the demo, and any future proxy topology with zero host-derivation logic; still no caller-controlled redirect surface.
- The logged-out marker's `Secure` flag reads `x-forwarded-proto` first (same proxy blindness), falling back to `request.url`.
- Cookie deletions, marker semantics, and audit behavior unchanged.

## Testing

- Unit (9 pass): new regression pins a host-free `/login` Location for a request whose URL host is `0.0.0.0`; marker `Secure` asserted behind a proxy (`x-forwarded-proto: https`) and absent on plain-http localhost.
- e2e contract assertion updated (it parsed Location as an absolute URL, which would now throw).
- Wire-level verification against a live dev server simulating the proxy (`Host: 0.0.0.0`, `x-forwarded-proto: https`): `303`, `location: /login`, epoch-expired session cookie, `Secure` marker.
- After deploy: clicking Sign out on the demo should land on the demo's own /login — the user-visible acceptance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)