### PR TITLE
fix(iam): memberships as the single source of truth on every org-access write path

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -609,11 +609,10 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
   // ── Existing identity → grant org access via membership (#756) ────────────
   // The email already belongs to an identity (e.g. an instance admin). Rather
   // than the old global-duplicate crash, attach that identity to the selected
-  // org by creating or reactivating a membership. The `users` row is left
-  // untouched: instanceRole, password, and other identity fields are preserved.
-  // (Promoting an existing identity to platform admin has its own dedicated
-  // control — `promoteInstanceAdmin` — so the create form's checkbox is not
-  // applied here.)
+  // org by creating or reactivating a membership. Password and other identity
+  // fields are preserved. The platform-admin checkbox IS honored (#796 — it
+  // was previously ignored silently): promotion is applied with the same
+  // audit action as the dedicated promoteInstanceAdmin control.
   if (existing) {
     const [membership] = await db
       .select({
@@ -635,6 +634,7 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
     }
 
     const reactivated = Boolean(membership)
+    const promoted = grantPlatformAdmin && existing.instanceRole !== 'instance_admin'
     await db.transaction(async (tx) => {
       if (reactivated) {
         await tx.update(userOrganizationMemberships)
@@ -659,12 +659,31 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
         before: reactivated ? { role: membership!.role, isActive: membership!.isActive } : undefined,
         after: { email, role, organizationId, organizationName: organization.name },
       })
+
+      // #796 — honor the platform-admin checkbox for existing identities,
+      // with the same audit action as the dedicated promote control.
+      if (promoted) {
+        await tx.update(users)
+          .set({ instanceRole: 'instance_admin', updatedAt: new Date() })
+          .where(eq(users.id, existing.id))
+
+        await writeAuditLog(tx, {
+          action: 'instance.user.promote',
+          metadata: await auditMeta(),
+          entityType: 'user',
+          entityId: existing.id,
+          userId: session.user.id,
+          organizationId: null,
+          after: { instanceRole: 'instance_admin', reason: 'granted via create-account form' },
+        })
+      }
     })
 
+    const promotedSuffix = promoted ? ' Also granted platform admin access.' : ''
     revalidatePath('/instance/users')
     return reactivated
-      ? { status: 'membership_reactivated', message: `Reactivated ${email}’s membership in ${organization.name} as ${role}.` }
-      : { status: 'membership_added', message: `Added ${email} to ${organization.name} as ${role}.` }
+      ? { status: 'membership_reactivated', message: `Reactivated ${email}’s membership in ${organization.name} as ${role}.${promotedSuffix}` }
+      : { status: 'membership_added', message: `Added ${email} to ${organization.name} as ${role}.${promotedSuffix}` }
   }
 
   // ── New identity → create the user row (original path) ─────────────────────
@@ -682,6 +701,14 @@ export async function createInstanceUser(formData: FormData): Promise<CreateInst
       instanceRole: grantPlatformAdmin ? 'instance_admin' : null,
       isActive: 'true',
     }).returning()
+
+    // #796 — the membership row is the canonical org binding: sessions, the
+    // org switcher, membership management, and the SSO guard all resolve from
+    // it. Without this row the account could reach /instance (via
+    // instanceRole) but never functioned as an org member.
+    await tx.insert(userOrganizationMemberships).values({
+      userId: user.id, organizationId, role, isActive: true, isPrimary: true,
+    })
 
     await writeAuditLog(tx, {
       action: 'instance.user.create',

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { users } from '@/db/schema'
+import { users, userOrganizationMemberships } from '@/db/schema'
 import { eq, and, count } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
 import { auth } from '@/lib/auth'
@@ -9,6 +9,7 @@ import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
 import { validatePassword } from '@/lib/password'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
+import { upsertMembership, setMembershipActiveFlag } from '@/lib/membership-sync'
 import { redirect } from 'next/navigation'
 
 async function requireAdmin() {
@@ -22,17 +23,34 @@ export async function getUsers() {
   const session = await requireAdmin()
   const orgId = session.user.organizationId!
 
-  return db.query.users.findMany({
+  // #796 — memberships are the canonical org-access store. List everyone
+  // with an active membership in this org (covers users added cross-org via
+  // the instance console, #756), unioned with legacy rows whose home-org
+  // column points here but that predate the #693 backfill. The membership
+  // role wins when both exist — it is what the session actually resolves.
+  const memberRows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      role: userOrganizationMemberships.role,
+      isActive: users.isActive,
+    })
+    .from(userOrganizationMemberships)
+    .innerJoin(users, eq(users.id, userOrganizationMemberships.userId))
+    .where(and(
+      eq(userOrganizationMemberships.organizationId, orgId),
+      eq(userOrganizationMemberships.isActive, true),
+    ))
+
+  const legacyRows = await db.query.users.findMany({
     where: eq(users.organizationId, orgId),
-    columns: {
-      id: true,
-      name: true,
-      email: true,
-      role: true,
-      isActive: true,
-    },
-    orderBy: (u, { asc }) => [asc(u.name)],
+    columns: { id: true, name: true, email: true, role: true, isActive: true },
   })
+
+  const byId = new Map<string, (typeof legacyRows)[number]>(legacyRows.map(u => [u.id, u]))
+  for (const m of memberRows) byId.set(m.id, m)
+  return [...byId.values()].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
 }
 
 export async function createUser(formData: FormData) {
@@ -60,6 +78,12 @@ export async function createUser(formData: FormData) {
       isActive: 'true',
     }).returning()
 
+    // #796 — the membership row is what sessions, the org switcher, and the
+    // SSO guard actually resolve; create it with the identity.
+    await upsertMembership(tx, {
+      userId: user.id, organizationId: orgId, role, isPrimary: true,
+    })
+
     await writeAuditLog(tx, {
       action: 'user.create',
       entityType: 'user',
@@ -76,10 +100,24 @@ export async function updateUserRole(userId: string, role: 'admin' | 'contributo
   const orgId = session.user.organizationId!
 
   const before = await db.query.users.findFirst({ where: eq(users.id, userId) })
+
+  // #796 — last-admin guard (was only on editUser; a demotion through this
+  // path could previously strand the org without an active admin).
+  if (before?.role === 'admin' && role !== 'admin') {
+    const [adminCount] = await db.select({ count: count() }).from(users).where(
+      and(eq(users.organizationId, orgId), eq(users.role, 'admin'), eq(users.isActive, 'true'))
+    )
+    if (adminCount.count <= 1) throw new Error('Cannot demote the last admin')
+  }
+
   await db.transaction(async (tx) => {
     await tx.update(users).set({ role, updatedAt: new Date() }).where(
       and(eq(users.id, userId), eq(users.organizationId, orgId))
     )
+
+    // #796 — sessions resolve role from the membership row; without this the
+    // role change never takes effect. Upsert also heals pre-#693 accounts.
+    await upsertMembership(tx, { userId, organizationId: orgId, role })
 
     await writeAuditLog(tx, {
       action: 'user.role_changed',
@@ -109,6 +147,9 @@ export async function deactivateUser(userId: string) {
     await tx.update(users).set({ isActive: 'false', updatedAt: new Date() }).where(
       and(eq(users.id, userId), eq(users.organizationId, orgId))
     )
+
+    // #796 — keep the canonical membership row in step with the account flag.
+    await setMembershipActiveFlag(tx, userId, orgId, false)
 
     await writeAuditLog(tx, {
       action: 'user.deactivate',
@@ -154,6 +195,9 @@ export async function reactivateUser(userId: string) {
     await tx.update(users).set({ isActive: 'true', updatedAt: new Date() }).where(
       and(eq(users.id, userId), eq(users.organizationId, orgId))
     )
+
+    // #796 — keep the canonical membership row in step with the account flag.
+    await setMembershipActiveFlag(tx, userId, orgId, true)
 
     await writeAuditLog(tx, {
       action: 'user.reactivate',
@@ -213,6 +257,9 @@ export async function editUser(userId: string, formData: FormData) {
     await tx.update(users).set(updates).where(
       and(eq(users.id, userId), eq(users.organizationId, orgId))
     )
+
+    // #796 — sessions resolve role from the membership row; sync it.
+    await upsertMembership(tx, { userId, organizationId: orgId, role })
 
     await writeAuditLog(tx, {
       action: 'user.edit',

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -20,6 +20,29 @@ async function requireAdmin() {
 }
 
 /**
+ * #796/#799 — true when the target belongs to the actor's org via the legacy
+ * home-org column or any membership row. Org-side actions are silent no-ops
+ * for unrelated users (pinned by cross-org.test.ts); without this gate the
+ * membership upsert below would mint org access for a foreign user.
+ */
+async function belongsToOrg(
+  target: { organizationId: string | null },
+  userId: string,
+  orgId: string,
+): Promise<boolean> {
+  if (target.organizationId === orgId) return true
+  const [m] = await db
+    .select({ id: userOrganizationMemberships.id })
+    .from(userOrganizationMemberships)
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, orgId),
+    ))
+    .limit(1)
+  return Boolean(m)
+}
+
+/**
  * #799 — does this user have org access beyond `orgId`? An org admin's
  * authority ends at their org boundary: remove/deactivate may only touch the
  * global identity when this org is the user's sole access anchor. Anchors:
@@ -122,6 +145,7 @@ export async function updateUserRole(userId: string, role: 'admin' | 'contributo
   const orgId = session.user.organizationId!
 
   const before = await db.query.users.findFirst({ where: eq(users.id, userId) })
+  if (!before || !(await belongsToOrg(before, userId, orgId))) return
 
   // #796 — last-admin guard (was only on editUser; a demotion through this
   // path could previously strand the org without an active admin).
@@ -161,7 +185,8 @@ export async function deactivateUser(userId: string) {
     and(eq(users.organizationId, orgId), eq(users.role, 'admin'), eq(users.isActive, 'true'))
   )
   const target = await db.query.users.findFirst({ where: eq(users.id, userId) })
-  if (target?.role === 'admin' && adminCount.count <= 1) {
+  if (!target || !(await belongsToOrg(target, userId, orgId))) return
+  if (target.role === 'admin' && adminCount.count <= 1) {
     throw new Error('Cannot deactivate the last admin')
   }
 
@@ -201,7 +226,8 @@ export async function deleteUser(userId: string) {
     and(eq(users.organizationId, orgId), eq(users.role, 'admin'))
   )
   const target = await db.query.users.findFirst({ where: eq(users.id, userId) })
-  if (target?.role === 'admin' && adminCount.count <= 1) {
+  if (!target || !(await belongsToOrg(target, userId, orgId))) return
+  if (target.role === 'admin' && adminCount.count <= 1) {
     throw new Error('Cannot delete the last admin')
   }
 
@@ -314,6 +340,7 @@ export async function editUser(userId: string, formData: FormData) {
   const newPassword = formData.get('password') as string | null
 
   const before = await db.query.users.findFirst({ where: eq(users.id, userId) })
+  if (!before || !(await belongsToOrg(before, userId, orgId))) return
 
   // Guard against duplicate email across orgs when email is being changed (#269)
   if (email !== before?.email) {

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import { users, userOrganizationMemberships } from '@/db/schema'
-import { eq, and, count } from 'drizzle-orm'
+import { eq, and, count, ne, asc } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
@@ -17,6 +17,28 @@ async function requireAdmin() {
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) throw new Error('Forbidden')
   return session
+}
+
+/**
+ * #799 — does this user have org access beyond `orgId`? An org admin's
+ * authority ends at their org boundary: remove/deactivate may only touch the
+ * global identity when this org is the user's sole access anchor. Anchors:
+ * an active membership elsewhere, a platform role, or a legacy home-org
+ * pointer at another org (pre-#693 accounts).
+ */
+async function hasAnchorsBeyondOrg(
+  target: { organizationId: string | null; instanceRole: string | null },
+  userId: string,
+  orgId: string,
+): Promise<boolean> {
+  if (target.instanceRole === 'instance_admin') return true
+  if (target.organizationId && target.organizationId !== orgId) return true
+  const [other] = await db.select({ c: count() }).from(userOrganizationMemberships).where(and(
+    eq(userOrganizationMemberships.userId, userId),
+    ne(userOrganizationMemberships.organizationId, orgId),
+    eq(userOrganizationMemberships.isActive, true),
+  ))
+  return (other?.c ?? 0) > 0
 }
 
 export async function getUsers() {
@@ -143,12 +165,21 @@ export async function deactivateUser(userId: string) {
     throw new Error('Cannot deactivate the last admin')
   }
 
-  await db.transaction(async (tx) => {
-    await tx.update(users).set({ isActive: 'false', updatedAt: new Date() }).where(
-      and(eq(users.id, userId), eq(users.organizationId, orgId))
-    )
+  // #799 — membership-scoped unless this org is the user's sole anchor.
+  // Deactivating someone's membership here must not lock them out of their
+  // other orgs or strip a platform admin of /instance access.
+  const membershipOnly = target
+    ? await hasAnchorsBeyondOrg(target, userId, orgId)
+    : false
 
-    // #796 — keep the canonical membership row in step with the account flag.
+  await db.transaction(async (tx) => {
+    if (!membershipOnly) {
+      await tx.update(users).set({ isActive: 'false', updatedAt: new Date() }).where(
+        and(eq(users.id, userId), eq(users.organizationId, orgId))
+      )
+    }
+
+    // #796 — the canonical membership row always reflects the org-level state.
     await setMembershipActiveFlag(tx, userId, orgId, false)
 
     await writeAuditLog(tx, {
@@ -157,6 +188,7 @@ export async function deactivateUser(userId: string) {
       entityId: userId,
       userId: session.user.id,
       organizationId: orgId,
+      after: { scope: membershipOnly ? 'membership' : 'account' },
     })
   })
 }
@@ -173,16 +205,79 @@ export async function deleteUser(userId: string) {
     throw new Error('Cannot delete the last admin')
   }
 
+  // #799 — removing a user from this org only deletes the *identity* when
+  // this org is their sole access anchor. Otherwise it severs the membership
+  // and leaves the identity, their other orgs, and any platform role intact:
+  // an org admin must not be able to destroy a platform admin's account.
+  const membershipOnly = target
+    ? await hasAnchorsBeyondOrg(target, userId, orgId)
+    : false
+
+  if (!membershipOnly) {
+    await db.transaction(async (tx) => {
+      await tx.delete(users).where(and(eq(users.id, userId), eq(users.organizationId, orgId)))
+
+      await writeAuditLog(tx, {
+        action: 'user.delete',
+        entityType: 'user',
+        entityId: userId,
+        userId: session.user.id,
+        organizationId: orgId,
+        before: { name: target?.name, email: target?.email },
+      })
+    })
+    return
+  }
+
   await db.transaction(async (tx) => {
-    await tx.delete(users).where(and(eq(users.id, userId), eq(users.organizationId, orgId)))
+    await tx.delete(userOrganizationMemberships).where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, orgId),
+    ))
+
+    // The legacy home-org column is NOT NULL (#797) and must follow a real
+    // membership: repoint it when it pointed at this org.
+    if (target!.organizationId === orgId) {
+      const [nextHome] = await tx
+        .select({ organizationId: userOrganizationMemberships.organizationId })
+        .from(userOrganizationMemberships)
+        .where(and(
+          eq(userOrganizationMemberships.userId, userId),
+          eq(userOrganizationMemberships.isActive, true),
+        ))
+        .orderBy(asc(userOrganizationMemberships.createdAt))
+        .limit(1)
+
+      if (!nextHome) {
+        // Platform admin with no other membership — the identity cannot be
+        // repointed (organizationId is NOT NULL, #797). Throwing rolls back
+        // the membership deletion above.
+        throw new Error(
+          'This account is a platform admin with no other organization. ' +
+          'Manage their access from the instance console instead.',
+        )
+      }
+      await tx.update(users)
+        .set({ organizationId: nextHome.organizationId, updatedAt: new Date() })
+        .where(eq(users.id, userId))
+    }
+
+    // Clear a stale last-active pointer so their next session resolves to a
+    // surviving membership.
+    if (target!.lastActiveOrganizationId === orgId) {
+      await tx.update(users)
+        .set({ lastActiveOrganizationId: null, updatedAt: new Date() })
+        .where(eq(users.id, userId))
+    }
 
     await writeAuditLog(tx, {
-      action: 'user.delete',
+      action: 'user.remove_from_org',
       entityType: 'user',
       entityId: userId,
       userId: session.user.id,
       organizationId: orgId,
       before: { name: target?.name, email: target?.email },
+      after: { scope: 'membership', identityRetained: true },
     })
   })
 }

--- a/apps/govea/src/lib/membership-sync.ts
+++ b/apps/govea/src/lib/membership-sync.ts
@@ -1,0 +1,72 @@
+/**
+ * Membership write-sync helpers (#796).
+ *
+ * Since #693 the session's active org/role, the org switcher, the SSO guard,
+ * and membership management all read `user_organization_memberships`. Every
+ * flow that grants or changes org access must therefore write the membership
+ * row in the same transaction as the legacy denormalized `users` columns —
+ * otherwise the change simply does not take effect (the membership row wins
+ * at session resolution) or the user becomes invisible to membership-based
+ * reads.
+ */
+
+import { db } from '@/db/client'
+import { userOrganizationMemberships } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import type { Role } from '@/lib/rbac'
+
+// The transaction object handed to db.transaction callbacks.
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+/**
+ * Insert-or-update the membership for (user, org) inside the caller's
+ * transaction. Updating also heals legacy accounts that predate the #693
+ * backfill: their first org-side role change creates the canonical row.
+ */
+export async function upsertMembership(
+  tx: Tx,
+  opts: {
+    userId: string
+    organizationId: string
+    role: Role
+    isPrimary?: boolean
+    isActive?: boolean
+  },
+): Promise<void> {
+  const { userId, organizationId, role, isPrimary = false, isActive = true } = opts
+
+  const updated = await tx
+    .update(userOrganizationMemberships)
+    .set({ role, isActive, updatedAt: new Date() })
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, organizationId),
+    ))
+    .returning({ id: userOrganizationMemberships.id })
+
+  if (updated.length === 0) {
+    await tx.insert(userOrganizationMemberships).values({
+      userId, organizationId, role, isPrimary, isActive,
+    })
+  }
+}
+
+/**
+ * Sync the membership's isActive flag for (user, org). A no-op when no
+ * membership row exists — account-level `users.isActive` already gates those
+ * legacy accounts, and deactivation must not mint new rows.
+ */
+export async function setMembershipActiveFlag(
+  tx: Tx,
+  userId: string,
+  organizationId: string,
+  isActive: boolean,
+): Promise<void> {
+  await tx
+    .update(userOrganizationMemberships)
+    .set({ isActive, updatedAt: new Date() })
+    .where(and(
+      eq(userOrganizationMemberships.userId, userId),
+      eq(userOrganizationMemberships.organizationId, organizationId),
+    ))
+}

--- a/apps/govea/tests/integration/iam-membership-sync.test.ts
+++ b/apps/govea/tests/integration/iam-membership-sync.test.ts
@@ -291,6 +291,27 @@ describe('org-side removal is membership-scoped (#799)', () => {
   })
 })
 
+describe('cross-org boundary stays silent-no-op (#796)', () => {
+  it('acting on an unrelated user neither changes them nor mints a membership', async () => {
+    const otherOrg = await createTestOrg()
+    const foreign = await createTestUser(otherOrg.id, 'admin')
+
+    await updateUserRole(foreign.id, 'viewer')
+    await deactivateUser(foreign.id)
+    await deleteUser(foreign.id)
+
+    const account = await db.query.users.findFirst({ where: eq(users.id, foreign.id) })
+    expect(account?.role, 'role unchanged').toBe('admin')
+    expect(account?.isActive, 'still active').toBe('true')
+    expect(
+      await membershipRow(foreign.id, org.id),
+      'no membership minted in the actor org',
+    ).toBeUndefined()
+
+    await cleanupOrg(otherOrg.id)
+  })
+})
+
 describe('SSO guard sees instance-created users (#796)', () => {
   it('allows SSO sign-in for an identity created via the instance console', async () => {
     mockAuth.mockResolvedValue(makeSession(actor, { instanceRole: 'instance_admin' }))

--- a/apps/govea/tests/integration/iam-membership-sync.test.ts
+++ b/apps/govea/tests/integration/iam-membership-sync.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration tests: memberships as the single source of truth for org
+ * access (#796).
+ *
+ * Sessions, the org switcher, the SSO guard, and membership management all
+ * resolve org access from user_organization_memberships — so every IAM write
+ * path must keep that row in step with the legacy users columns. Each test
+ * pins one row of the defect table in #796:
+ *
+ *   - org-side createUser           → membership created with the identity
+ *   - org-side updateUserRole       → membership role synced (+ heals missing rows)
+ *   - org-side deactivate/reactivate → membership isActive synced
+ *   - org-side getUsers             → membership-only members are visible
+ *   - instance createInstanceUser   → new identity gets a primary membership
+ *   - instance create, existing id  → platform-admin checkbox honored + audited
+ *   - SSO guard                     → instance-created identities resolve via membership
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { db } from '@/db/client'
+import { users, userOrganizationMemberships, auditLog } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+} from './helpers/db'
+import type { TestOrg, TestUser } from './helpers/db'
+import {
+  createUser, updateUserRole, deactivateUser, reactivateUser, getUsers,
+} from '@/actions/users'
+import { createInstanceUser } from '@/actions/instance'
+import { checkSsoProvisioning } from '@/lib/sso-guard'
+import { randomUUID } from 'node:crypto'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+const PASSWORD = 'Str0ng!Passw0rd#796'
+
+let org: TestOrg
+let actor: TestUser
+
+function fd(fields: Record<string, string>): FormData {
+  const data = new FormData()
+  for (const [k, v] of Object.entries(fields)) data.append(k, v)
+  return data
+}
+
+async function membershipRow(userId: string, orgId: string) {
+  const [m] = await db.select().from(userOrganizationMemberships).where(and(
+    eq(userOrganizationMemberships.userId, userId),
+    eq(userOrganizationMemberships.organizationId, orgId),
+  ))
+  return m
+}
+
+beforeEach(async () => {
+  org = await createTestOrg()
+  actor = await createTestUser(org.id, 'admin')
+  await db.insert(userOrganizationMemberships).values({
+    userId: actor.id, organizationId: org.id, role: 'admin', isPrimary: true,
+  })
+  mockAuth.mockResolvedValue(makeSession(actor))
+})
+
+afterEach(async () => {
+  await cleanupOrg(org.id)
+})
+
+describe('org-side user CRUD keeps memberships in sync (#796)', () => {
+  it('createUser creates the canonical primary membership with the identity', async () => {
+    const email = `iam796-${randomUUID().slice(0, 8)}@test.example`
+    await createUser(fd({ name: 'New Member', email, password: PASSWORD, role: 'contributor' }))
+
+    const user = await db.query.users.findFirst({ where: eq(users.email, email) })
+    expect(user).toBeTruthy()
+    expect(await membershipRow(user!.id, org.id)).toMatchObject({
+      role: 'contributor', isActive: true, isPrimary: true,
+    })
+  })
+
+  it('updateUserRole syncs the membership role — the value sessions resolve', async () => {
+    const email = `iam796-${randomUUID().slice(0, 8)}@test.example`
+    await createUser(fd({ name: 'Role Target', email, password: PASSWORD, role: 'viewer' }))
+    const user = await db.query.users.findFirst({ where: eq(users.email, email) })
+
+    await updateUserRole(user!.id, 'admin')
+    expect((await membershipRow(user!.id, org.id)).role).toBe('admin')
+  })
+
+  it('updateUserRole heals a pre-#693 account with no membership row', async () => {
+    // Legacy-shaped account: users.organizationId set, no membership row.
+    const legacy = await createTestUser(org.id, 'viewer')
+    expect(await membershipRow(legacy.id, org.id)).toBeUndefined()
+
+    await updateUserRole(legacy.id, 'contributor')
+    expect(await membershipRow(legacy.id, org.id)).toMatchObject({
+      role: 'contributor', isActive: true,
+    })
+  })
+
+  it('deactivateUser and reactivateUser sync the membership isActive flag', async () => {
+    const email = `iam796-${randomUUID().slice(0, 8)}@test.example`
+    await createUser(fd({ name: 'Toggle Target', email, password: PASSWORD, role: 'viewer' }))
+    const user = await db.query.users.findFirst({ where: eq(users.email, email) })
+
+    await deactivateUser(user!.id)
+    expect((await membershipRow(user!.id, org.id)).isActive).toBe(false)
+
+    await reactivateUser(user!.id)
+    expect((await membershipRow(user!.id, org.id)).isActive).toBe(true)
+  })
+
+  it('getUsers lists membership-only members added cross-org via the instance console', async () => {
+    // Identity homed in another org, granted access here purely by membership
+    // (the #756 instance-console path).
+    const otherOrg = await createTestOrg()
+    const guest = await createTestUser(otherOrg.id, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: guest.id, organizationId: org.id, role: 'contributor',
+    })
+
+    const rows = await getUsers()
+    const listed = rows.find(r => r.id === guest.id)
+    expect(listed, 'membership-only member must be visible to the org admin').toBeTruthy()
+    expect(listed!.role, 'membership role wins — it is what the session resolves').toBe('contributor')
+
+    await cleanupOrg(otherOrg.id)
+  })
+})
+
+describe('instance console creation paths (#796)', () => {
+  beforeEach(() => {
+    mockAuth.mockResolvedValue(makeSession(actor, { instanceRole: 'instance_admin' }))
+  })
+
+  it('new identity gets a users row AND a primary membership in one transaction', async () => {
+    const email = `iam796-inst-${randomUUID().slice(0, 8)}@test.example`
+    const result = await createInstanceUser(fd({
+      organizationId: org.id, name: 'Instance Created', email, password: PASSWORD,
+      role: 'admin', instanceAdmin: 'on',
+    }))
+
+    expect(result.status).toBe('identity_created')
+    const user = await db.query.users.findFirst({ where: eq(users.email, email) })
+    expect(user?.instanceRole).toBe('instance_admin')
+    expect(await membershipRow(user!.id, org.id)).toMatchObject({
+      role: 'admin', isActive: true, isPrimary: true,
+    })
+  })
+
+  it('new identity without the checkbox stays a regular org user', async () => {
+    const email = `iam796-inst-${randomUUID().slice(0, 8)}@test.example`
+    await createInstanceUser(fd({
+      organizationId: org.id, name: 'Plain User', email, password: PASSWORD, role: 'viewer',
+    }))
+
+    const user = await db.query.users.findFirst({ where: eq(users.email, email) })
+    expect(user?.instanceRole).toBeNull()
+    expect(await membershipRow(user!.id, org.id)).toMatchObject({ role: 'viewer' })
+  })
+
+  it('existing identity: platform-admin checkbox is honored and audited, not ignored', async () => {
+    const otherOrg = await createTestOrg()
+    const existing = await createTestUser(otherOrg.id, 'viewer')
+
+    const result = await createInstanceUser(fd({
+      organizationId: org.id, name: existing.name, email: existing.email,
+      password: 'irrelevant', role: 'contributor', instanceAdmin: 'on',
+    }))
+
+    expect(result.status).toBe('membership_added')
+    expect(result.message).toMatch(/platform admin/i)
+    const user = await db.query.users.findFirst({ where: eq(users.id, existing.id) })
+    expect(user?.instanceRole).toBe('instance_admin')
+    expect(await membershipRow(existing.id, org.id)).toMatchObject({ role: 'contributor' })
+
+    const [promoteAudit] = await db.select().from(auditLog).where(and(
+      eq(auditLog.action, 'instance.user.promote'),
+      eq(auditLog.entityId, existing.id),
+    ))
+    expect(promoteAudit, 'promotion via the create form must be audited').toBeTruthy()
+
+    await cleanupOrg(otherOrg.id)
+  })
+
+  it('existing identity already holding platform admin is not re-promoted', async () => {
+    const otherOrg = await createTestOrg()
+    const existing = await createTestUser(otherOrg.id, 'viewer')
+    await db.update(users).set({ instanceRole: 'instance_admin' }).where(eq(users.id, existing.id))
+
+    const result = await createInstanceUser(fd({
+      organizationId: org.id, name: existing.name, email: existing.email,
+      password: 'irrelevant', role: 'viewer', instanceAdmin: 'on',
+    }))
+
+    expect(result.status).toBe('membership_added')
+    expect(result.message).not.toMatch(/platform admin/i)
+
+    await cleanupOrg(otherOrg.id)
+  })
+})
+
+describe('SSO guard sees instance-created users (#796)', () => {
+  it('allows SSO sign-in for an identity created via the instance console', async () => {
+    mockAuth.mockResolvedValue(makeSession(actor, { instanceRole: 'instance_admin' }))
+    const email = `iam796-sso-${randomUUID().slice(0, 8)}@test.example`
+    await createInstanceUser(fd({
+      organizationId: org.id, name: 'SSO Candidate', email, password: PASSWORD, role: 'viewer',
+    }))
+
+    // Resolves through the membership row created with the identity — not
+    // the legacy users-column fallback.
+    expect(await checkSsoProvisioning(email)).toMatchObject({
+      status: 'allowed', organizationId: org.id, role: 'viewer',
+    })
+  })
+})

--- a/apps/govea/tests/integration/iam-membership-sync.test.ts
+++ b/apps/govea/tests/integration/iam-membership-sync.test.ts
@@ -24,7 +24,7 @@ import {
 } from './helpers/db'
 import type { TestOrg, TestUser } from './helpers/db'
 import {
-  createUser, updateUserRole, deactivateUser, reactivateUser, getUsers,
+  createUser, updateUserRole, deactivateUser, reactivateUser, deleteUser, getUsers,
 } from '@/actions/users'
 import { createInstanceUser } from '@/actions/instance'
 import { checkSsoProvisioning } from '@/lib/sso-guard'
@@ -196,6 +196,98 @@ describe('instance console creation paths (#796)', () => {
     expect(result.message).not.toMatch(/platform admin/i)
 
     await cleanupOrg(otherOrg.id)
+  })
+})
+
+describe('org-side removal is membership-scoped (#799)', () => {
+  it('deactivating a multi-org member only deactivates the local membership', async () => {
+    const otherOrg = await createTestOrg()
+    const guest = await createTestUser(otherOrg.id, 'viewer')
+    await db.insert(userOrganizationMemberships).values([
+      { userId: guest.id, organizationId: otherOrg.id, role: 'viewer', isPrimary: true },
+      { userId: guest.id, organizationId: org.id, role: 'contributor' },
+    ])
+
+    await deactivateUser(guest.id)
+
+    expect((await membershipRow(guest.id, org.id)).isActive).toBe(false)
+    expect((await membershipRow(guest.id, otherOrg.id)).isActive, 'other org untouched').toBe(true)
+    const account = await db.query.users.findFirst({ where: eq(users.id, guest.id) })
+    expect(account?.isActive, 'identity stays active — they still belong elsewhere').toBe('true')
+
+    await cleanupOrg(otherOrg.id)
+  })
+
+  it('deactivating a platform admin does not deactivate their identity', async () => {
+    const padmin = await createTestUser(org.id, 'viewer')
+    await db.update(users).set({ instanceRole: 'instance_admin' }).where(eq(users.id, padmin.id))
+    await db.insert(userOrganizationMemberships).values({
+      userId: padmin.id, organizationId: org.id, role: 'viewer', isPrimary: true,
+    })
+
+    await deactivateUser(padmin.id)
+
+    expect((await membershipRow(padmin.id, org.id)).isActive).toBe(false)
+    const account = await db.query.users.findFirst({ where: eq(users.id, padmin.id) })
+    expect(account?.isActive, 'platform admins keep /instance access').toBe('true')
+    expect(account?.instanceRole).toBe('instance_admin')
+  })
+
+  it('deactivating a sole-anchor user still deactivates the account (unchanged)', async () => {
+    const solo = await createTestUser(org.id, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: solo.id, organizationId: org.id, role: 'viewer', isPrimary: true,
+    })
+
+    await deactivateUser(solo.id)
+
+    const account = await db.query.users.findFirst({ where: eq(users.id, solo.id) })
+    expect(account?.isActive).toBe('false')
+  })
+
+  it('deleting a multi-org member severs the membership, keeps the identity, repoints home', async () => {
+    const otherOrg = await createTestOrg()
+    // Homed in the actor's org, member of both, last-active here.
+    const dual = await createTestUser(org.id, 'viewer')
+    await db.insert(userOrganizationMemberships).values([
+      { userId: dual.id, organizationId: org.id, role: 'viewer', isPrimary: true },
+      { userId: dual.id, organizationId: otherOrg.id, role: 'contributor' },
+    ])
+    await db.update(users).set({ lastActiveOrganizationId: org.id }).where(eq(users.id, dual.id))
+
+    await deleteUser(dual.id)
+
+    const account = await db.query.users.findFirst({ where: eq(users.id, dual.id) })
+    expect(account, 'identity must survive').toBeTruthy()
+    expect(account?.organizationId, 'home repointed to surviving membership').toBe(otherOrg.id)
+    expect(account?.lastActiveOrganizationId, 'stale last-active cleared').toBeNull()
+    expect(await membershipRow(dual.id, org.id)).toBeUndefined()
+    expect((await membershipRow(dual.id, otherOrg.id)).role).toBe('contributor')
+
+    await db.delete(users).where(eq(users.id, dual.id))
+    await cleanupOrg(otherOrg.id)
+  })
+
+  it('deleting a sole-org platform admin is blocked and rolls back', async () => {
+    const padmin = await createTestUser(org.id, 'viewer')
+    await db.update(users).set({ instanceRole: 'instance_admin' }).where(eq(users.id, padmin.id))
+    await db.insert(userOrganizationMemberships).values({
+      userId: padmin.id, organizationId: org.id, role: 'viewer', isPrimary: true,
+    })
+
+    await expect(deleteUser(padmin.id)).rejects.toThrow(/platform admin/i)
+    expect(await membershipRow(padmin.id, org.id), 'rollback keeps the membership').toBeTruthy()
+    expect(await db.query.users.findFirst({ where: eq(users.id, padmin.id) })).toBeTruthy()
+  })
+
+  it('deleting a sole-anchor plain user still deletes the identity (unchanged)', async () => {
+    const solo = await createTestUser(org.id, 'viewer')
+    await db.insert(userOrganizationMemberships).values({
+      userId: solo.id, organizationId: org.id, role: 'viewer', isPrimary: true,
+    })
+
+    await deleteUser(solo.id)
+    expect(await db.query.users.findFirst({ where: eq(users.id, solo.id) })).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Closes #796
Closes #799
Capability: iam-instance-administration
Capability: iam-user-management
Persona: Instance Administrator, CMS Administrator

## What

Since #693, sessions, the org switcher, the SSO guard, and membership management resolve org access from `user_organization_memberships` — but several write paths still only touched the legacy denormalized `users` columns, producing the split-brain defects in #796 and the identity-scope bug in #799 (removing an account from one org destroyed the whole identity, platform role included).

**Memberships in step on every write path (#796):**

| Path | Change |
|---|---|
| `createInstanceUser` (new identity) | creates the **primary membership** with the identity |
| `createInstanceUser` (existing identity, #756) | **platform-admin checkbox honored** — `instance.user.promote` audit, reflected in the result message; no-op when already platform admin |
| org-side `createUser` | creates the primary membership |
| org-side `updateUserRole` / `editUser` | syncs the membership role (upsert heals pre-backfill accounts); `updateUserRole` gains the missing **last-admin guard** |
| org-side `getUsers` | memberships ∪ legacy home-org rows; membership role wins; instance-added members now visible to their org admin |

**Org-side removal is membership-scoped (#799):**

- `deactivateUser` / `deleteUser` act on the **membership** when the user has anchors beyond the org (another active membership, a platform role, or a legacy home-org elsewhere); the identity is only deactivated/deleted when this org is their sole anchor (previous behavior, preserved for the common case)
- membership-scoped delete repoints the NOT NULL home-org column to a surviving membership and clears a stale `lastActiveOrganizationId`
- a sole-org **platform admin** cannot be identity-deleted from the org side — blocked with a clear message, transaction rolled back (full support is #797)
- audit distinguishes scopes: `user.remove_from_org` (identity retained) vs `user.delete`, and `user.deactivate` records `scope: membership | account`

## Use-case matrix (#796 + #799)

1. ✅ Instance-created user w/ org + platform-admin → /instance works AND the org workspace works AND the org admin can see/manage them
2. ✅ Existing identity added to another org → visible there; org switcher works
3. ✅ Promote / demote instance admin — unchanged, org access untouched
4. ✅ Org admin changes a member's role → takes effect at session resolution
5. ✅ Org admin removes a multi-org member or platform admin → only that org's membership is severed
6. ⏭ Org-less platform operator — schema-impossible today (`users.organizationId` NOT NULL); split to #797

## Testing

`tests/integration/iam-membership-sync.test.ts` — 16 tests in CI against Postgres: one per defect-table row plus the full removal matrix (multi-org deactivate/delete, platform-admin protection incl. rollback, sole-anchor behavior preservation, home repointing, last-active clearing). Unit suite (241), tsc, eslint clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)