### PR TITLE
feat(iam): multi-org users choose their workspace at login

### DIFF
--- a/apps/govea/src/app/(auth)/auth-redirect/page.tsx
+++ b/apps/govea/src/app/(auth)/auth-redirect/page.tsx
@@ -1,15 +1,17 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { isInstanceAdmin } from '@/lib/rbac'
-import { safeCallbackUrl, defaultLandingPath } from '@/lib/auth-redirect'
+import { safeCallbackUrl, postLoginDestination } from '@/lib/auth-redirect'
+import { getMyActiveOrganizations } from '@/actions/active-org'
 
 /**
  * Role-aware post-signin bouncer.
  *
  * Routing order:
  *   1. An explicit, safe `callbackUrl` always wins (preserves deep-links).
- *   2. Otherwise, fall back to `defaultLandingPath(role, isInstanceAdmin)`
- *      — see that helper for the role-based routing rule.
+ *   2. Multi-org users choose their workspace on /select-org (#800).
+ *   3. Otherwise, fall back to the role-based landing — see
+ *      `postLoginDestination` for the rule.
  */
 export default async function AuthRedirectPage({
   searchParams,
@@ -25,8 +27,10 @@ export default async function AuthRedirectPage({
     if (explicit) redirect(explicit)
   }
 
-  redirect(defaultLandingPath({
+  const memberships = await getMyActiveOrganizations()
+  redirect(postLoginDestination({
     role: session.user.role,
     isInstanceAdmin: isInstanceAdmin(session.user),
+    activeMembershipCount: memberships.length,
   }))
 }

--- a/apps/govea/src/app/(auth)/select-org/page.tsx
+++ b/apps/govea/src/app/(auth)/select-org/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { isInstanceAdmin } from '@/lib/rbac'
+import { defaultLandingPath } from '@/lib/auth-redirect'
+import { getMyActiveOrganizations } from '@/actions/active-org'
+import { OrgSelectList } from '@/components/org-select-list'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+/**
+ * Post-login organization choice for multi-org users (#800).
+ *
+ * The /auth-redirect bouncer sends users here when they hold more than one
+ * active membership; everyone else never sees this page (and navigating here
+ * directly with a single membership redirects straight to the landing).
+ * Selection reuses the org switcher's server-authoritative mechanics.
+ */
+export default async function SelectOrgPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const organizations = await getMyActiveOrganizations()
+  if (organizations.length <= 1) {
+    redirect(defaultLandingPath({
+      role: session.user.role,
+      isInstanceAdmin: isInstanceAdmin(session.user),
+    }))
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/30">
+      <Card className="w-full max-w-md shadow-md">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Choose your organization</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            You belong to {organizations.length} organizations. Pick the workspace
+            to open — you can switch any time from the header.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <OrgSelectList organizations={organizations} />
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/apps/govea/src/components/org-select-list.tsx
+++ b/apps/govea/src/components/org-select-list.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { switchActiveOrganization, type MyOrganization } from '@/actions/active-org'
+import { defaultLandingPath } from '@/lib/auth-redirect'
+import { cn } from '@/lib/utils'
+
+/**
+ * Organization choice list for the post-login /select-org page (#800).
+ *
+ * Mirrors the org switcher's mechanics exactly: persist the choice
+ * server-side (switchActiveOrganization validates the membership — the
+ * client's claim is never trusted), fire the NextAuth session update() so
+ * the JWT re-resolves the active org/role, then land role-appropriately
+ * for the chosen org.
+ */
+export function OrgSelectList({ organizations }: { organizations: MyOrganization[] }) {
+  const { update } = useSession()
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  function choose(org: MyOrganization) {
+    setPendingId(org.organizationId)
+    setError(null)
+    startTransition(async () => {
+      try {
+        await switchActiveOrganization(org.organizationId)
+        // Pass data so NextAuth POSTs to /api/auth/session and fires the jwt
+        // `update` trigger — a bare update() only refetches and won't
+        // re-resolve the active org (see org-switcher.tsx).
+        await update({ activeOrganizationId: org.organizationId })
+        // The role differs per org: land where the *chosen* membership says.
+        router.replace(defaultLandingPath({ role: org.role, isInstanceAdmin: false }))
+      } catch {
+        setError('Could not open that organization. Try another, or contact your administrator.')
+        setPendingId(null)
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+      <ul className="space-y-2">
+        {organizations.map(org => (
+          <li key={org.organizationId}>
+            <button
+              type="button"
+              onClick={() => choose(org)}
+              disabled={pending}
+              className={cn(
+                'flex w-full items-center justify-between gap-3 rounded-lg border px-4 py-3 text-left text-sm transition-colors',
+                'hover:border-primary/50 hover:bg-muted/50 disabled:opacity-60',
+                org.isCurrent && 'border-primary/40 bg-muted/30',
+              )}
+            >
+              <span className="min-w-0">
+                <span className="block truncate font-medium">
+                  {pendingId === org.organizationId ? 'Opening…' : org.name}
+                </span>
+                <span className="block text-xs text-muted-foreground capitalize">{org.role}</span>
+              </span>
+              {org.isCurrent && (
+                <span className="shrink-0 rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+                  Last used
+                </span>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/govea/src/lib/auth-redirect.ts
+++ b/apps/govea/src/lib/auth-redirect.ts
@@ -27,6 +27,26 @@ export function defaultLandingPath(opts: { role: Role; isInstanceAdmin: boolean 
 }
 
 /**
+ * Post-login destination once membership context is known (#800).
+ *
+ * Users with more than one active membership choose their workspace on
+ * /select-org before landing; everyone else goes straight to their
+ * role-based landing. Instance admins keep landing on /instance — their
+ * org choice happens via the in-shell switcher when they enter the agency
+ * portal. An explicit safe callbackUrl is handled by the caller and always
+ * wins over selection (deep links must not detour through a picker).
+ */
+export function postLoginDestination(opts: {
+  role: Role
+  isInstanceAdmin: boolean
+  activeMembershipCount: number
+}): string {
+  if (opts.isInstanceAdmin) return '/instance'
+  if (opts.activeMembershipCount > 1) return '/select-org'
+  return defaultLandingPath(opts)
+}
+
+/**
  * Returns a safe post-login destination, falling back to `fallback` if the
  * supplied URL would trap the user in an auth or error route.
  *

--- a/apps/govea/tests/e2e/global-setup.ts
+++ b/apps/govea/tests/e2e/global-setup.ts
@@ -19,7 +19,9 @@ import path from 'path'
 const AUTH_DIR = path.join(__dirname, '.auth')
 
 const DEV_ROLES = [
-  { name: 'admin',       shortcutLabel: 'Riverdale Admin',       file: 'admin.json'       },
+  // alice is the seeded multi-org user (#693): she hits the /select-org step
+  // (#800), so her expected workspace is named for the click-through below.
+  { name: 'admin',       shortcutLabel: 'Riverdale Admin',       file: 'admin.json', selectOrg: 'City of Riverdale' },
   { name: 'contributor', shortcutLabel: 'Riverdale Contributor', file: 'contributor.json' },
   { name: 'viewer',      email: 'victor@govea.dev', password: 'dev-password', file: 'viewer.json' },
   { name: 'state-admin', shortcutLabel: 'State Admin',           file: 'state-admin.json' },
@@ -50,13 +52,19 @@ export default async function globalSetup() {
       await page.getByLabel('Password').fill(role.password)
       await page.getByRole('button', { name: 'Sign in', exact: true }).click()
     }
-    // Role-aware landing per defaultLandingPath() in @/lib/auth-redirect:
+    // Role-aware landing per postLoginDestination() in @/lib/auth-redirect:
     //   instance admin → /instance
+    //   multi-org      → /select-org (#800) — click the expected workspace
     //   viewer         → /executive (#548)
     //   everyone else  → /dashboard
-    // Wait for any of the three so the seed-step works regardless of which
-    // role this iteration is signing in as.
-    await page.waitForURL(/\/(dashboard|executive|instance)(\?|$)/)
+    await page.waitForURL(/\/(dashboard|executive|instance|select-org)(\?|$)/)
+    if (page.url().includes('/select-org')) {
+      if (!('selectOrg' in role)) {
+        throw new Error(`${role.name} unexpectedly hit /select-org — add a selectOrg workspace to DEV_ROLES`)
+      }
+      await page.getByRole('button', { name: role.selectOrg }).click()
+      await page.waitForURL(/\/(dashboard|executive)(\?|$)/)
+    }
 
     await context.storageState({ path: path.join(AUTH_DIR, role.file) })
     await context.close()

--- a/apps/govea/tests/unit/auth-redirect.test.ts
+++ b/apps/govea/tests/unit/auth-redirect.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { safeCallbackUrl, defaultLandingPath } from '@/lib/auth-redirect'
+import { safeCallbackUrl, defaultLandingPath, postLoginDestination } from '@/lib/auth-redirect'
 
 describe('safeCallbackUrl', () => {
   describe('valid destinations — returned as-is', () => {
@@ -102,5 +102,33 @@ describe('defaultLandingPath', () => {
   it('sends Admin and Contributor users to /dashboard', () => {
     expect(defaultLandingPath({ role: 'admin',       isInstanceAdmin: false })).toBe('/dashboard')
     expect(defaultLandingPath({ role: 'contributor', isInstanceAdmin: false })).toBe('/dashboard')
+  })
+})
+
+// #800 — multi-org users choose their workspace before landing; pinned as a
+// pure function for the same reason as defaultLandingPath above.
+describe('postLoginDestination', () => {
+  it('sends multi-org users to /select-org', () => {
+    expect(postLoginDestination({ role: 'admin', isInstanceAdmin: false, activeMembershipCount: 2 }))
+      .toBe('/select-org')
+    expect(postLoginDestination({ role: 'viewer', isInstanceAdmin: false, activeMembershipCount: 3 }))
+      .toBe('/select-org')
+  })
+
+  it('instance admins land on /instance even with multiple memberships', () => {
+    expect(postLoginDestination({ role: 'admin', isInstanceAdmin: true, activeMembershipCount: 2 }))
+      .toBe('/instance')
+  })
+
+  it('single-org users keep their role-based landing', () => {
+    expect(postLoginDestination({ role: 'viewer', isInstanceAdmin: false, activeMembershipCount: 1 }))
+      .toBe('/executive')
+    expect(postLoginDestination({ role: 'admin', isInstanceAdmin: false, activeMembershipCount: 1 }))
+      .toBe('/dashboard')
+  })
+
+  it('zero-membership (legacy home-org only) users keep their landing', () => {
+    expect(postLoginDestination({ role: 'contributor', isInstanceAdmin: false, activeMembershipCount: 0 }))
+      .toBe('/dashboard')
   })
 })


### PR DESCRIPTION
Closes #800
Capability: iam-sso-authentication
Capability: iam-role-based-access-control
Persona: CMS Administrator, Enterprise Architect (multi-agency)

## What

- **`/select-org`** — post-login organization choice for users with more than one active membership: org name, the role they hold there, and a **Last used** marker. Picking one persists the choice server-side (`switchActiveOrganization` — membership validated, never trusts the client), fires the session `update()` trigger so the JWT re-resolves org/role, and lands role-appropriately for the *chosen* org (viewers → /executive).
- **`postLoginDestination()`** — the routing rule as a pure function: instance admins → /instance (unchanged; their org choice stays in the in-shell switcher), multi-org → /select-org, everyone else → existing role landing. `/auth-redirect` now uses it; an explicit safe `callbackUrl` still wins, so deep links never detour through the picker.
- Single-membership users see nothing new; navigating to /select-org with one membership redirects straight through. In-session switching is untouched (org switcher, #693).

## Testing

- Unit: `postLoginDestination` decision table (multi-org, instance admin, single-org viewer/admin, zero-membership legacy).
- e2e: global-setup now clicks through the interstitial for the seeded multi-org admin (alice) — every CI e2e run exercises login → select → workspace for real, and fails if the picker breaks.
- tsc, eslint clean; full unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)