### PR TITLE
fix(export): neutralize CSV formula injection in exports

### DIFF
--- a/apps/govea/src/app/api/applications/export/route.ts
+++ b/apps/govea/src/app/api/applications/export/route.ts
@@ -5,13 +5,9 @@ import { getCustomFieldSchema } from '@/actions/custom-fields'
 import { getEntityTaxonomyDefinitions, getEntityTaxonomyValuesForMany } from '@/lib/entity-taxonomy-helpers'
 import type { CustomFieldDefinition } from '@/db/schema'
 import type { EnrichedTaxonomyDefinition } from '@/components/taxonomy-ui'
-
-function escapeCsv(val: string): string {
-  if (val.includes(',') || val.includes('"') || val.includes('\n')) {
-    return `"${val.replace(/"/g, '""')}"`
-  }
-  return val
-}
+// #763 — use the shared escaper so this export gets formula-injection
+// neutralization too; a local copy silently missed the centralized fix.
+import { escapeCsv } from '@/lib/csv'
 
 function buildCsv(
   apps: Awaited<ReturnType<typeof getApplications>>,

--- a/apps/govea/src/lib/csv.ts
+++ b/apps/govea/src/lib/csv.ts
@@ -4,11 +4,35 @@
 // multi-line cells (capability `behaviors` / `rules`, ADR `context` / `decision`
 // / `consequences`, etc.) through an Export → Import round-trip.
 
+// #763 — CSV formula injection (CWE-1236). A cell whose value begins with
+// =, +, -, or @ is interpreted as a formula by Excel / Google Sheets / LibreOffice
+// when the exported file is opened, so attacker-influenced content in a
+// contributor-editable field (e.g. `=HYPERLINK(...)`, `=cmd|'/c calc'!A1`)
+// could execute on a reader's machine. The standard neutralization is to
+// prefix a single quote, which spreadsheets render as "treat the rest as
+// literal text" and do not display. `parseCsv` strips it back on import so the
+// Export→Import round-trip is lossless. Tab/CR (\t, \r) are also formula
+// triggers but cannot appear at a cell start here: \r is consumed as a row
+// terminator by the splitter, and a leading \t would be trimmed by parseCsv.
+const FORMULA_TRIGGERS = ['=', '+', '-', '@']
+
+export function neutralizeFormula(val: string): string {
+  return val.length > 0 && FORMULA_TRIGGERS.includes(val[0]) ? `'${val}` : val
+}
+
+/** Reverse of neutralizeFormula — strips the guarding quote on import. */
+export function denormalizeFormula(val: string): string {
+  return val.length > 1 && val[0] === "'" && FORMULA_TRIGGERS.includes(val[1])
+    ? val.slice(1)
+    : val
+}
+
 export function escapeCsv(val: string): string {
-  if (val.includes(',') || val.includes('"') || val.includes('\n')) {
-    return `"${val.replace(/"/g, '""')}"`
+  const safe = neutralizeFormula(val)
+  if (safe.includes(',') || safe.includes('"') || safe.includes('\n')) {
+    return `"${safe.replace(/"/g, '""')}"`
   }
-  return val
+  return safe
 }
 
 /**
@@ -66,7 +90,10 @@ export function parseCsv(text: string): Record<string, string>[] {
   if (rows.length < 2) return []
   const headers = rows[0].map(h => h.trim())
   return rows.slice(1).map(values =>
-    Object.fromEntries(headers.map((h, i) => [h, (values[i] ?? '').trim()]))
+    // #763 — strip the formula-guarding quote escapeCsv added on export so the
+    // round-trip is lossless. Trim first: a quoted "  =x" keeps its inner
+    // spaces through the splitter, and the guard sits at the trimmed start.
+    Object.fromEntries(headers.map((h, i) => [h, denormalizeFormula((values[i] ?? '').trim())]))
   )
 }
 

--- a/apps/govea/tests/unit/csv.test.ts
+++ b/apps/govea/tests/unit/csv.test.ts
@@ -8,7 +8,60 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { parseCsv, detectDelimiter, splitCsvRows } from '@/lib/csv'
+import { parseCsv, detectDelimiter, splitCsvRows, escapeCsv, neutralizeFormula } from '@/lib/csv'
+
+describe('CSV formula injection neutralization (#763)', () => {
+  it.each(['=SUM(A1:A9)', '+1+1', '-2+3', '@SUM(A1)'])(
+    'prefixes a guarding quote on cells starting with a formula trigger: %s',
+    val => {
+      expect(escapeCsv(val)).toBe(`'${val}`)
+    },
+  )
+
+  it('neutralizes the classic DDE payload', () => {
+    expect(escapeCsv('=cmd|\'/c calc\'!A1')).toBe("'=cmd|'/c calc'!A1")
+  })
+
+  it('neutralizes AND quotes a formula payload that contains commas/quotes', () => {
+    // Guard quote added first, then CSV-quoted because of the embedded comma.
+    expect(escapeCsv('=HYPERLINK("http://evil","x")')).toBe(
+      '"\'=HYPERLINK(""http://evil"",""x"")"',
+    )
+  })
+
+  it('leaves ordinary values untouched', () => {
+    for (const val of ['Permit Issuance', 'published', '12 Main St', 'a-b-c', 'x=y']) {
+      expect(escapeCsv(val)).toBe(val)
+    }
+  })
+
+  it('still quotes a neutralized cell that also needs quoting', () => {
+    // Leading '=' (neutralized) plus an embedded comma (must be quoted).
+    expect(escapeCsv('=A1,B2')).toBe('"\'=A1,B2"')
+  })
+
+  it('round-trips formula-leading values losslessly through export → import', () => {
+    const original = [
+      { name: 'Normal', note: '=SUM(A1)' },
+      { name: '-Dash lead', note: '@at lead' },
+      { name: 'Plain', note: 'nothing special' },
+    ]
+    const header = 'name,note'
+    const body = original.map(r => `${escapeCsv(r.name)},${escapeCsv(r.note)}`).join('\n')
+    const parsed = parseCsv(`${header}\n${body}\n`)
+    expect(parsed).toEqual(original)
+  })
+
+  it('does not strip a legitimate leading quote that is not a formula guard', () => {
+    // "'tis" — apostrophe not followed by a trigger char — must survive import.
+    const parsed = parseCsv(`name\n${escapeCsv("'tis a quote")}\n`)
+    expect(parsed[0].name).toBe("'tis a quote")
+  })
+
+  it('neutralizeFormula handles empty strings without indexing undefined', () => {
+    expect(neutralizeFormula('')).toBe('')
+  })
+})
 
 describe('detectDelimiter (#679)', () => {
   it('defaults to comma for a normal header', () => {


### PR DESCRIPTION
Closes #763
Capability: ac-backup-export
Persona: CMS Administrator

## What

`escapeCsv` quoted structural characters (comma, quote, newline) but left cells whose value begins with `=`, `+`, `-`, or `@` interpretable as **formulas** when the exported file is opened in Excel / Google Sheets / LibreOffice (CWE-1236). A contributor-editable field could carry `=HYPERLINK("http://attacker","click")` or the DDE classic `=cmd|'/c calc'!A1` and execute on a reader's machine.

- `escapeCsv` now prefixes a guarding `'` on formula-leading cells (rendered by spreadsheets as "literal text", not displayed), then applies the existing structural quoting on top.
- `parseCsv` strips that guard back on import, so the **Export → Import round-trip is lossless** — verified by a dedicated round-trip test.
- Tab/CR are also formula triggers but can't reach a cell start here (`\r` is a row terminator in the splitter; a leading `\t` is trimmed by parseCsv) — noted in a code comment.

## Coverage of every export

The fix lives in the shared `escapeCsv`, so all entity exports (capabilities, applications, objectives, initiatives, personas, glossary, ADRs, instance audit) inherit it. While wiring this I found the **applications export route had its own local copy of `escapeCsv`** that would have silently missed the fix — replaced with the shared helper.

## Testing

`tests/unit/csv.test.ts` adds 8 cases: per-trigger neutralization, the DDE payload, the neutralize-then-quote interaction, ordinary values untouched, a lossless round-trip, a legitimate leading-apostrophe value preserved across import, and the empty-string guard. Full unit suite + tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)