### PR TITLE
fix(value-streams): move stage and persona management out of the detail view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         # is CI-safe. Other specs (iam.spec.ts, auth-security.spec.ts)
         # intentionally stay out of CI for now — they mutate app state and
         # are run locally.
-        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts tests/e2e/specs/a11y.spec.ts tests/e2e/specs/logout.spec.ts
+        run: pnpm --filter govea exec playwright test tests/e2e/specs/smoke.spec.ts tests/e2e/specs/overview.spec.ts tests/e2e/specs/a11y.spec.ts tests/e2e/specs/logout.spec.ts tests/e2e/specs/value-streams.spec.ts
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/apps/govea/src/app/(admin)/value-streams/[id]/edit/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/edit/page.tsx
@@ -1,0 +1,121 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import { getValueStream } from '@/actions/value-streams'
+import { getCapabilities } from '@/actions/capabilities'
+import { getPersonas } from '@/actions/personas'
+import { canEdit } from '@/lib/rbac'
+import Link from 'next/link'
+import { StageManager } from '../stage-manager'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import { ValueStreamEditButton } from '@/components/value-stream-edit-button'
+import {
+  linkValueStreamPersona, unlinkValueStreamPersona,
+  linkValueStreamCapability, unlinkValueStreamCapability,
+} from '@/actions/links'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
+
+/**
+ * Value stream edit view (#726).
+ *
+ * The detail page (`/value-streams/[id]`) is read-only; all authoring of a
+ * value stream's structure and relationships lives here: details, stages,
+ * stage capabilities, stream-level capabilities, and personas.
+ */
+export default async function ValueStreamEditPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  if (!canEdit(session.user)) redirect(`/value-streams/${id}`)
+
+  const orgId = session.user.organizationId!
+
+  const [vs, capabilityList, allPersonas, enabledModules] = await Promise.all([
+    getValueStream(id),
+    getCapabilities(),
+    getPersonas(),
+    getEnabledModules(),
+  ])
+
+  if (!vs) notFound()
+  // Editing is owner-org only — never mutate a federated/remote stream.
+  if (vs.organizationId !== orgId) redirect(`/value-streams/${id}`)
+
+  const addPersona = linkValueStreamPersona.bind(null, id)
+  const removePersona = unlinkValueStreamPersona.bind(null, id)
+  const addCapability = linkValueStreamCapability.bind(null, id)
+  const removeCapability = unlinkValueStreamCapability.bind(null, id)
+
+  const directCapIds = new Set(vs.valueStreamCapabilities.map(({ capability }) => capability.id))
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <div>
+        <Link href={`/value-streams/${id}`} className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Back to value stream
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight mt-2">Edit value stream</h1>
+      </div>
+
+      <ValueStreamEditButton
+        valueStreamId={id}
+        startOpen
+        initial={{
+          name: vs.name,
+          description: vs.description,
+          valueItem: vs.valueItem,
+          status: vs.status,
+          visibility: vs.visibility,
+        }}
+      />
+
+      <hr />
+
+      {/* Stages + stage capabilities */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Stages</h2>
+        <StageManager
+          valueStreamId={vs.id}
+          stages={vs.stages}
+          capabilities={capabilityList.filter(c => c.organizationId === orgId)}
+        />
+      </div>
+
+      {isModuleEnabled(enabledModules, 'capabilities') && (
+        <div className="space-y-1.5">
+          <RelationshipPanel
+            title="Business Capabilities"
+            items={vs.valueStreamCapabilities.map(({ capability }) => ({
+              id: capability.id, name: capability.name,
+              href: `/capabilities/${capability.id}`,
+            }))}
+            canEdit
+            available={capabilityList
+              .filter(c => c.organizationId === orgId && !directCapIds.has(c.id))
+              .map(c => ({ id: c.id, name: c.name }))}
+            addAction={addCapability}
+            removeAction={removeCapability}
+            emptyMessage="No stream-level capabilities linked yet."
+          />
+          <p className="text-xs text-muted-foreground">
+            These capabilities apply to the whole value stream. Capabilities tied to a single step are managed per stage above.
+          </p>
+        </div>
+      )}
+
+      {isModuleEnabled(enabledModules, 'personas') && (
+        <RelationshipPanel
+          title="Personas"
+          items={vs.valueStreamPersonas.map(({ persona }) => ({
+            id: persona.id, name: persona.name,
+            href: `/personas/${persona.id}`,
+          }))}
+          canEdit
+          available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
+          addAction={addPersona}
+          removeAction={removePersona}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -1,22 +1,15 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getValueStream } from '@/actions/value-streams'
-import { getCapabilities } from '@/actions/capabilities'
-import { getPersonas } from '@/actions/personas'
 import { canEdit } from '@/lib/rbac'
-import { StageManager } from './stage-manager'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 import { RelationshipPanel } from '@/components/relationship-panel'
-import {
-  linkValueStreamPersona, unlinkValueStreamPersona,
-  linkValueStreamCapability, unlinkValueStreamCapability,
-} from '@/actions/links'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { MarkdownContent } from '@/components/markdown-content'
-import { ValueStreamEditButton } from '@/components/value-stream-edit-button'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -44,23 +37,16 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
 
-  const [vs, capabilityList, allPersonas, enabledModules] = await Promise.all([
+  const [vs, enabledModules] = await Promise.all([
     getValueStream(id),
-    getCapabilities(),
-    editor ? getPersonas() : Promise.resolve([]),
     getEnabledModules(),
   ])
 
   if (!vs) notFound()
+  // #726 — the detail page is read-oriented. Editing stages, stage
+  // capabilities, stream-level capabilities, and personas lives on the
+  // dedicated edit route; here we only show whether to offer the edit link.
   const canMutate = editor && vs.organizationId === orgId
-
-  const addPersona = linkValueStreamPersona.bind(null, id)
-  const removePersona = unlinkValueStreamPersona.bind(null, id)
-  const addCapability = linkValueStreamCapability.bind(null, id)
-  const removeCapability = unlinkValueStreamCapability.bind(null, id)
-
-  // IDs already linked directly to the stream, so the picker excludes them.
-  const directCapIds = new Set(vs.valueStreamCapabilities.map(({ capability }) => capability.id))
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -106,16 +92,11 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
       </div>
 
       {canMutate && (
-        <ValueStreamEditButton
-          valueStreamId={id}
-          initial={{
-            name: vs.name,
-            description: vs.description,
-            valueItem: vs.valueItem,
-            status: vs.status,
-            visibility: vs.visibility,
-          }}
-        />
+        <div className="flex justify-end">
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/value-streams/${id}/edit`}>Edit value stream</Link>
+          </Button>
+        </div>
       )}
 
       <hr />
@@ -129,8 +110,11 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
           </span>
         </div>
 
-        {vs.stages.length === 0 && !canMutate && (
-          <p className="text-sm text-muted-foreground py-4">No stages have been defined for this value stream yet.</p>
+        {vs.stages.length === 0 && (
+          <p className="text-sm text-muted-foreground py-4">
+            No stages have been defined for this value stream yet.
+            {canMutate && <> Use <Link href={`/value-streams/${id}/edit`} className="underline hover:text-foreground">Edit value stream</Link> to add some.</>}
+          </p>
         )}
 
         {/* Existing stages (read view) */}
@@ -165,14 +149,6 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
           </div>
         )}
 
-        {/* Stage manager for editors */}
-        {canMutate && (
-          <StageManager
-            valueStreamId={vs.id}
-            stages={vs.stages}
-            capabilities={capabilityList.filter(c => c.organizationId === orgId)}
-          />
-        )}
       </div>
 
       {isModuleEnabled(enabledModules, 'capabilities') && (
@@ -183,12 +159,7 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
               id: capability.id, name: capability.name,
               href: `/capabilities/${capability.id}`,
             }))}
-            canEdit={canMutate}
-            available={capabilityList
-              .filter(c => c.organizationId === orgId && !directCapIds.has(c.id))
-              .map(c => ({ id: c.id, name: c.name }))}
-            addAction={addCapability}
-            removeAction={removeCapability}
+            canEdit={false}
             emptyMessage="No stream-level capabilities linked yet."
           />
           <p className="text-xs text-muted-foreground">
@@ -204,10 +175,7 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
             id: persona.id, name: persona.name,
             href: `/personas/${persona.id}`,
           }))}
-          canEdit={canMutate}
-          available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
-          addAction={addPersona}
-          removeAction={removePersona}
+          canEdit={false}
         />
       )}
 

--- a/apps/govea/src/components/value-stream-edit-button.tsx
+++ b/apps/govea/src/components/value-stream-edit-button.tsx
@@ -17,12 +17,19 @@ interface ValueStreamEditButtonProps {
     status: 'draft' | 'published' | 'archived'
     visibility: 'org' | 'connections' | 'instance'
   }
+  /**
+   * Render the form directly instead of behind an "Edit value stream" button.
+   * Used on the dedicated edit route (#726) where the page is already the edit
+   * surface; save keeps the form open and the page's back link handles return.
+   */
+  startOpen?: boolean
 }
 
-export function ValueStreamEditButton({ valueStreamId, initial }: ValueStreamEditButtonProps) {
-  const [editing, setEditing] = useState(false)
+export function ValueStreamEditButton({ valueStreamId, initial, startOpen = false }: ValueStreamEditButtonProps) {
+  const [editing, setEditing] = useState(startOpen)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
   const router = useRouter()
 
   if (!editing) {
@@ -38,12 +45,14 @@ export function ValueStreamEditButton({ valueStreamId, initial }: ValueStreamEdi
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     setError(null)
+    setSaved(false)
     const formData = new FormData(e.currentTarget)
     startTransition(async () => {
       try {
         await editValueStream(valueStreamId, formData)
         router.refresh()
-        setEditing(false)
+        if (startOpen) setSaved(true)
+        else setEditing(false)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Save failed')
       }
@@ -53,14 +62,19 @@ export function ValueStreamEditButton({ valueStreamId, initial }: ValueStreamEdi
   return (
     <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border bg-card p-4">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold">Edit Value Stream</h3>
-        <button type="button" onClick={() => setEditing(false)} className="text-xs text-muted-foreground hover:text-foreground">
-          Cancel
-        </button>
+        <h3 className="text-sm font-semibold">Value stream details</h3>
+        {!startOpen && (
+          <button type="button" onClick={() => setEditing(false)} className="text-xs text-muted-foreground hover:text-foreground">
+            Cancel
+          </button>
+        )}
       </div>
 
       {error && (
         <p className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive">{error}</p>
+      )}
+      {saved && (
+        <p className="rounded-md bg-emerald-50 border border-emerald-200 px-3 py-2 text-sm text-emerald-800 dark:bg-emerald-950/20 dark:border-emerald-800 dark:text-emerald-300">Details saved.</p>
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
@@ -98,7 +112,9 @@ export function ValueStreamEditButton({ valueStreamId, initial }: ValueStreamEdi
       </div>
 
       <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" size="sm" onClick={() => setEditing(false)}>Cancel</Button>
+        {!startOpen && (
+          <Button type="button" variant="outline" size="sm" onClick={() => setEditing(false)}>Cancel</Button>
+        )}
         <Button type="submit" size="sm" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
       </div>
     </form>

--- a/apps/govea/tests/e2e/specs/value-streams.spec.ts
+++ b/apps/govea/tests/e2e/specs/value-streams.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Value stream detail vs edit separation (#726).
+ *
+ * The detail page (`/value-streams/[id]`) is read-oriented: it shows the
+ * ordered stages, stage capability badges, and linked capabilities/personas,
+ * but exposes no controls to add/edit/reorder stages, manage stage
+ * capabilities, or add/remove personas. All authoring lives on the dedicated
+ * edit view (`/value-streams/[id]/edit`), reached via a single "Edit value
+ * stream" affordance.
+ *
+ * Capability: po-value-streams
+ * Persona: Enterprise Architect, Agency EA Coordinator
+ *
+ * Requires the seeded demo org (the admin storageState org has value streams).
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.use({ storageState: 'tests/e2e/.auth/admin.json' })
+
+test('detail view is read-only; authoring lives on the edit view', async ({ page }) => {
+  await page.goto('/value-streams')
+
+  // Open the first value stream's detail page (links carry an id segment; the
+  // nav "/value-streams" link has no trailing id and is excluded).
+  const firstStream = page.locator('a[href^="/value-streams/"]').first()
+  await expect(firstStream, 'seed should provide at least one value stream').toBeVisible()
+  await firstStream.click()
+
+  await expect(page, 'should be on a value stream detail page').toHaveURL(/\/value-streams\/[0-9a-f-]+$/)
+
+  // Read-only: no stage/persona/capability mutation controls on the detail page.
+  await expect(page.getByRole('button', { name: '+ Add stage' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /add capabilit/i })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /add persona/i })).toHaveCount(0)
+
+  // Single edit affordance present (admin can mutate the org's own stream).
+  const editLink = page.getByRole('link', { name: 'Edit value stream' })
+  await expect(editLink).toBeVisible()
+  await editLink.click()
+
+  // Edit view: URL is the dedicated route and the authoring controls appear.
+  await expect(page).toHaveURL(/\/value-streams\/[0-9a-f-]+\/edit$/)
+  await expect(page.getByRole('button', { name: '+ Add stage' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Edit value stream' })).toBeVisible()
+})

--- a/business-architecture/capabilities/cms/portfolio/po-value-streams.md
+++ b/business-architecture/capabilities/cms/portfolio/po-value-streams.md
@@ -14,7 +14,7 @@ Schema: `value_streams`, `value_stream_stages`, `value_stream_stage_capabilities
 
 Server actions: create, edit, delete, add/edit/delete/reorder stages, add/remove capability per stage (`apps/govea/src/actions/value-streams.ts`); `linkValueStreamCapability` / `unlinkValueStreamCapability` for direct stream-level links (`apps/govea/src/actions/links.ts`)
 
-Admin UI: list view, detail view with inline stage management, a stream-level Business Capabilities panel, and persona management (`apps/govea/src/app/(admin)/value-streams/`)
+Admin UI: list view, a read-only detail view (ordered stages, stage capability badges, linked capabilities and personas), and a dedicated edit view (`/value-streams/[id]/edit`) where Contributors/Admins manage details, stages, stage capabilities, stream-level capabilities, and personas. Detail view authoring was moved to the edit view in #726 so the detail page stays read-oriented. (`apps/govea/src/app/(admin)/value-streams/`)
 
 ## Personas
 


### PR DESCRIPTION
Closes #726
Capability: po-value-streams
Persona: Enterprise Architect, Agency EA Coordinator, Department Director

## What

`/value-streams/[id]` is now a read-oriented view. All authoring of a value stream's structure and relationships moved to a dedicated edit route.

**Detail view (read-only):**
- Ordered stage list, stage capability badges, linked stream-level capabilities, and linked personas all render read-only (`RelationshipPanel canEdit={false}`).
- The inline `StageManager` and the inline details form are gone; a single **Edit value stream** link is the only authoring affordance (shown to Contributors/Admins on their own org's stream).
- The empty-stages hint points editors at the edit view.

**Edit view — new `/value-streams/[id]/edit`:**
- `canEdit`-gated and **owner-org only** (redirects a federated/remote stream back to detail), mirroring the existing `data/*` and `debt` edit routes.
- Hosts the details form (via `ValueStreamEditButton`'s new `startOpen` mode — renders the form directly, save stays in place, the back link returns), `StageManager` (add/edit/delete/reorder stages + per-stage capabilities), and the editable stream-level capability and persona panels.

## Acceptance criteria

- ✅ Detail exposes no controls to add/edit/delete/reorder stages, manage stage capabilities, or add/remove personas (or stream-level capabilities).
- ✅ Detail still shows the full ordered stage list, stage capability badges, and linked personas.
- ✅ Edit view exposes all stage/stage-capability/persona controls.
- ✅ Users without edit permission see no edit controls (the link is `canMutate`-gated; the route redirects non-editors).
- ✅ `po-value-streams.md` updated — it no longer describes inline detail-view management.

## Testing

New `tests/e2e/specs/value-streams.spec.ts` (added to the CI e2e job — read-only, no mutation): opens the first seeded value stream, asserts the detail page has no `+ Add stage` / add-capability / add-persona controls and does show the **Edit value stream** link, then follows it and asserts the edit route exposes `+ Add stage`. Unit suite (245), tsc, eslint, docs-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)