### PR TITLE
fix(iam): make middleware auth redirects relative (no 0.0.0.0)

### DIFF
--- a/apps/govea/src/middleware.ts
+++ b/apps/govea/src/middleware.ts
@@ -24,6 +24,39 @@ const PASSWORD_EXPIRED_ALLOWED = ['/change-password', '/api/auth/signout']
 
 const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === 'true'
 
+/**
+ * Browser-visible redirect that never echoes the container bind address (#807).
+ *
+ * Next.js middleware requires an **absolute** Location — it does `new URL(loc)`
+ * internally and throws "Invalid URL" on a relative path (unlike a Route
+ * Handler, where the logout fix's relative Location works, #794). So we build
+ * an absolute URL, but guard the host: behind GovEA's TLS-terminating proxy the
+ * standalone server's request origin can be the bind address (`0.0.0.0:3000`),
+ * which would send users to `https://0.0.0.0:3000/login`. When the origin is
+ * that bind host we rebuild from the proxy's forwarded host, then the
+ * configured public origin — never `0.0.0.0`. Normal requests (real Host, or
+ * localhost in CI/dev) are unaffected and redirect as before.
+ */
+function redirectTo(req: NextRequest, path: string): NextResponse {
+  const target = new URL(path, req.nextUrl.origin)
+  if (target.hostname === '0.0.0.0') {
+    const fwdHost = req.headers.get('x-forwarded-host')?.split(',')[0].trim()
+    const fwdProto = req.headers.get('x-forwarded-proto')?.split(',')[0].trim()
+    const base =
+      (fwdHost && !fwdHost.startsWith('0.0.0.0') && `${fwdProto || 'https'}://${fwdHost}`) ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      null
+    if (base) {
+      try {
+        return NextResponse.redirect(new URL(path, base))
+      } catch {
+        /* malformed base — fall through to the request-origin target */
+      }
+    }
+  }
+  return NextResponse.redirect(target)
+}
+
 /** Read-only session decode — checks both secure and plain cookie names. */
 async function decodeSession(req: NextRequest): Promise<JWT | null> {
   const secret = process.env.AUTH_SECRET
@@ -51,7 +84,7 @@ export default async function middleware(req: NextRequest) {
   // because events.signIn (auth.ts) deletes the marker.
   const loggedOutMarker = req.cookies.get(LOGGED_OUT_MARKER_COOKIE)?.value
   if (token && isResurrectedSession(loggedOutMarker, token.iat)) {
-    const res = NextResponse.redirect(new URL('/login', req.url))
+    const res = redirectTo(req, '/login')
     for (const cookie of req.cookies.getAll()) {
       if (cookie.name.includes('authjs.session-token')) {
         res.cookies.set(cookie.name, '', {
@@ -66,15 +99,15 @@ export default async function middleware(req: NextRequest) {
   }
 
   if (!token) {
-    return NextResponse.redirect(new URL('/login', req.url))
+    return redirectTo(req, '/login')
   }
 
   if (MAINTENANCE_MODE && token.role !== 'admin') {
-    return NextResponse.redirect(new URL('/maintenance', req.url))
+    return redirectTo(req, '/maintenance')
   }
 
   if (pathname.startsWith('/instance') && token.instanceRole !== 'instance_admin') {
-    return NextResponse.redirect(new URL('/', req.url))
+    return redirectTo(req, '/')
   }
 
   // #527 — password-expiry redirect. The token carries a snapshot of
@@ -86,7 +119,7 @@ export default async function middleware(req: NextRequest) {
     const expired = !lastChanged
       || (Date.now() - lastChanged) > expiryDays * 24 * 60 * 60 * 1000
     if (expired) {
-      return NextResponse.redirect(new URL('/change-password?reason=expired', req.url))
+      return redirectTo(req, '/change-password?reason=expired')
     }
   }
 

--- a/apps/govea/tests/integration/middleware-auth.test.ts
+++ b/apps/govea/tests/integration/middleware-auth.test.ts
@@ -18,6 +18,11 @@
  *   4. /instance/* requires the `instance_admin` role even with a session.
  *   5. #782 — a session token issued before the logged-out marker is
  *      rejected and its cookies are deleted (post-logout resurrection guard).
+ *   6. #807 — when the internal request origin is the container bind address
+ *      (`0.0.0.0:3000`, as it can be behind a TLS-terminating proxy), the
+ *      browser-visible redirect Location is rebuilt from the proxy's
+ *      `x-forwarded-host` (then `NEXT_PUBLIC_APP_URL`) and never echoes
+ *      `0.0.0.0`. Normal requests keep their absolute same-origin redirect.
  *
  * If you add a new public path, also add it to the PASSTHROUGH_PATHS list
  * here. If you intentionally make a previously-protected route public,
@@ -51,11 +56,20 @@ type MockReq = {
   nextUrl: URL
   url: string
   token: MockToken
+  // Models the NextRequest header API the middleware reads for the #807
+  // forwarded-host rebuild. Only `.get` is used.
+  headers: { get: (name: string) => string | null }
   // Models the NextRequest cookie API the middleware reads (#782).
   cookies: {
     get: (name: string) => { name: string; value: string } | undefined
     getAll: () => { name: string; value: string }[]
   }
+}
+
+/** Build a case-insensitive header bag matching NextRequest.headers.get. */
+function headerBag(h: Record<string, string> = {}): { get: (name: string) => string | null } {
+  const lower = Object.fromEntries(Object.entries(h).map(([k, v]) => [k.toLowerCase(), v]))
+  return { get: (name: string) => lower[name.toLowerCase()] ?? null }
 }
 
 type SingleArg = (req: MockReq) => Promise<Response>
@@ -76,6 +90,7 @@ function makeRequest(
     nextUrl: url,
     url: url.toString(),
     token,
+    headers: headerBag(),
     cookies: {
       get: (name: string) => entries.find(e => e.name === name),
       getAll: () => entries,
@@ -252,6 +267,95 @@ describe('middleware — #782 post-logout resurrection guard', () => {
     const res = await m(req)
     expect(res.status).toBe(307)
     expect(res.headers.get('location')).toBe('https://example.test/login')
+  })
+})
+
+describe('middleware — #807 never redirects to the container bind address', () => {
+  /**
+   * A request whose internal origin is the container bind address, as it can
+   * arrive at the standalone Next server behind a TLS-terminating proxy. The
+   * browser is really on a public origin; only `req.nextUrl` carries
+   * `0.0.0.0:3000`. The redirect must NOT echo that host back — middleware
+   * rebuilds it from `x-forwarded-host` / `NEXT_PUBLIC_APP_URL`.
+   */
+  function proxiedRequest(
+    pathname: string,
+    token: MockToken = null,
+    headers: Record<string, string> = {},
+  ): MockReq {
+    const url = new URL(`http://0.0.0.0:3000${pathname}`)
+    return {
+      nextUrl: url,
+      url: url.toString(),
+      token,
+      headers: headerBag(headers),
+      cookies: { get: () => undefined, getAll: () => [] },
+    }
+  }
+
+  const FORWARDED = {
+    'x-forwarded-host': 'govea.example.gov',
+    'x-forwarded-proto': 'https',
+  }
+
+  it('rebuilds /login from x-forwarded-host, not 0.0.0.0', async () => {
+    const m = await loadMiddleware()
+    const res = await m(proxiedRequest('/dashboard', null, FORWARDED))
+    const location = res.headers.get('location')
+    expect(res.status).toBe(307)
+    expect(location).toBe('https://govea.example.gov/login')
+    expect(location).not.toContain('0.0.0.0')
+  })
+
+  it('rebuilds the instance-admin gate redirect from x-forwarded-host', async () => {
+    const m = await loadMiddleware()
+    const res = await m(proxiedRequest('/instance/orgs', asRegularUser(), FORWARDED))
+    const location = res.headers.get('location')
+    expect(res.status).toBe(307)
+    expect(location).toBe('https://govea.example.gov/')
+    expect(location).not.toContain('0.0.0.0')
+  })
+
+  it('rebuilds the password-expiry redirect from x-forwarded-host', async () => {
+    const m = await loadMiddleware()
+    const res = await m(proxiedRequest(
+      '/dashboard',
+      { role: 'admin', instanceRole: null, passwordExpiryDays: 90, lastPasswordChangedAt: null },
+      FORWARDED,
+    ))
+    const location = res.headers.get('location')
+    expect(res.status).toBe(307)
+    expect(location).toBe('https://govea.example.gov/change-password?reason=expired')
+    expect(location).not.toContain('0.0.0.0')
+  })
+
+  it('falls back to NEXT_PUBLIC_APP_URL when no forwarded host is present', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://configured.example.gov'
+    vi.resetModules()
+    try {
+      const m = await loadMiddleware()
+      const res = await m(proxiedRequest('/dashboard'))
+      const location = res.headers.get('location')
+      expect(res.status).toBe(307)
+      expect(location).toBe('https://configured.example.gov/login')
+      expect(location).not.toContain('0.0.0.0')
+    } finally {
+      delete process.env.NEXT_PUBLIC_APP_URL
+    }
+  })
+
+  it('ignores a spoofed 0.0.0.0 forwarded host and uses the configured origin', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://configured.example.gov'
+    vi.resetModules()
+    try {
+      const m = await loadMiddleware()
+      const res = await m(proxiedRequest('/dashboard', null, { 'x-forwarded-host': '0.0.0.0:3000' }))
+      const location = res.headers.get('location')
+      expect(location).toBe('https://configured.example.gov/login')
+      expect(location).not.toContain('0.0.0.0')
+    } finally {
+      delete process.env.NEXT_PUBLIC_APP_URL
+    }
   })
 })
 


### PR DESCRIPTION
Closes #807
Capability: iam-local-authentication
Persona: CMS Administrator, Content Viewer, Instance Administrator

## Root cause

#794 fixed the **logout** route to emit a relative `Location`, but `apps/govea/src/middleware.ts` still built every redirect with `NextResponse.redirect(new URL(path, req.url))`. That bakes the request origin into an **absolute** Location. Behind GovEA's TLS-terminating proxy the standalone Next server's request origin can be the container bind address (`0.0.0.0:3000`), so any of these could send the browser to `https://0.0.0.0:3000/login`:

- anonymous access to a protected route (`!token` → `/login`)
- the #782 post-logout resurrection guard (→ `/login`)
- the instance-admin gate (→ `/`)
- maintenance mode (→ `/maintenance`)
- password expiry (→ `/change-password?reason=expired`)

## Why not a relative Location (like the logout fix)

A relative `Location` works in the logout **Route Handler** (#794) but **not** in middleware: Next.js does `new URL(location)` on a middleware redirect and throws `TypeError: Invalid URL` on a relative path. (My first attempt did exactly this and the e2e smoke job caught it — every protected request 500'd with `Invalid URL`. Good catch by the existing end-to-end coverage.)

## Fix

All five middleware redirects go through a `redirectTo(req, path)` helper that builds an **absolute** URL from the request origin, then **guards the host**: when the origin is the `0.0.0.0` bind address, it rebuilds the Location from the proxy's `x-forwarded-host` (Azure Container Apps' ingress sets it), then `NEXT_PUBLIC_APP_URL` (set to the public origin by `scripts/azure-dev.sh`), and skips any `0.0.0.0` value at each step. **Normal requests** — a real public Host, or `localhost` in CI/dev — are unaffected and redirect exactly as before, which is why the rest of the e2e suite stays green.

A spoofed `x-forwarded-host: 0.0.0.0` is explicitly ignored, so the guard can't be used to keep the bind address either.

## Audit result (AC: "audit all login/logout/protected-route redirects")

- `grep` for `redirect(new URL` across `src` — middleware was the **sole** offender; no other absolute auth redirect exists.
- Server-component/action `redirect('/login')` calls already emit a relative Location (Next's `next/navigation`).
- The Auth.js `signIn` page is the relative `/login`; `/api/auth/*` is excluded from the matcher entirely.
- Container startup still logs `Network: http://0.0.0.0:3000` — the bind line, **not** a browser redirect (AC explicitly allows this).

## Testing

- `tests/integration/middleware-auth.test.ts`: existing same-origin assertions unchanged (absolute, `https://example.test/...`); a new block drives a request whose internal origin is `0.0.0.0:3000` and asserts the Location is rebuilt from `x-forwarded-host` (`https://govea.example.gov/...`), falls back to `NEXT_PUBLIC_APP_URL` when no forwarded host is present, ignores a spoofed `0.0.0.0` forwarded host, and **never contains `0.0.0.0`**. 37 tests pass; tsc + eslint clean.
- The CI e2e smoke suite asserts anonymous `GET /dashboard` → 307 `/login` against a real Next server — the guard that caught the relative-Location dead end.
- **Demo verification** (AC) is the post-merge deploy step — not run here, per the repo's mutating-deploy policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)