### PR TITLE
feat(strategy): slice 2 — strategies list/detail/edit views + module wiring

### DIFF
--- a/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
@@ -1,0 +1,119 @@
+import { auth } from '@/lib/auth'
+import { redirect, notFound } from 'next/navigation'
+import { getStrategy, adoptStrategy } from '@/actions/strategies'
+import { canEdit } from '@/lib/rbac'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import { RelationshipPanel } from '@/components/relationship-panel'
+import { MarkdownContent } from '@/components/markdown-content'
+import { Button } from '@/components/ui/button'
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: 'bg-slate-100 text-slate-700 border-slate-200',
+  adopted: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  superseded: 'bg-amber-100 text-amber-800 border-amber-200',
+  retired: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+}
+
+const VISIBILITY_STYLES: Record<string, string> = {
+  org: 'bg-slate-100 text-slate-600 border-slate-200',
+  connections: 'bg-blue-100 text-blue-700 border-blue-200',
+  instance: 'bg-violet-100 text-violet-700 border-violet-200',
+}
+
+const VISIBILITY_LABELS: Record<string, string> = {
+  org: 'Org only',
+  connections: 'Connected orgs',
+  instance: 'Instance-wide',
+}
+
+function titleCase(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export default async function StrategyDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const strategy = await getStrategy(id)
+  if (!strategy) notFound()
+
+  const editor = canEdit(session.user)
+  const orgId = session.user.organizationId!
+  const canMutate = editor && strategy.organizationId === orgId
+  const adopt = adoptStrategy.bind(null, id)
+
+  return (
+    <div className="space-y-8 max-w-3xl">
+      <div className="flex items-center justify-between">
+        <Link href="/strategies" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Strategies
+        </Link>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <h1 className="text-2xl font-bold tracking-tight">{strategy.name}</h1>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[strategy.status])}>
+              {titleCase(strategy.status)}
+            </span>
+            <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', VISIBILITY_STYLES[strategy.visibility])}>
+              {VISIBILITY_LABELS[strategy.visibility]}
+            </span>
+          </div>
+        </div>
+
+        {strategy.summary && (
+          <MarkdownContent>{strategy.summary}</MarkdownContent>
+        )}
+
+        <div className="flex flex-wrap gap-6 text-sm pt-1">
+          {strategy.planningHorizon && (
+            <div>
+              <span className="text-muted-foreground">Planning horizon: </span>
+              <span className="font-medium">{strategy.planningHorizon}</span>
+            </div>
+          )}
+          {strategy.owner?.name && (
+            <div>
+              <span className="text-muted-foreground">Owner: </span>
+              <span className="font-medium">{strategy.owner.name}</span>
+            </div>
+          )}
+          {(strategy.startDate || strategy.endDate) && (
+            <div>
+              <span className="text-muted-foreground">Dates: </span>
+              <span className="font-medium">{strategy.startDate ?? '…'} → {strategy.endDate ?? '…'}</span>
+            </div>
+          )}
+        </div>
+
+        {canMutate && strategy.status !== 'adopted' && (
+          <form action={adopt} className="pt-1">
+            <Button type="submit" size="sm">Adopt as current strategy</Button>
+          </form>
+        )}
+      </div>
+
+      <hr />
+
+      <RelationshipPanel
+        title="Goals"
+        items={strategy.goals.map(g => ({
+          id: g.id,
+          name: g.name,
+          href: `/goals/${g.id}`,
+          meta: g.status,
+        }))}
+        gapMessage="No goals belong to this strategy yet. Link goals from a goal's edit flow."
+        canEdit={false}
+      />
+
+      <div className="text-xs text-muted-foreground pt-4 border-t">
+        Created {new Date(strategy.createdAt).toLocaleDateString()} · Updated {new Date(strategy.updatedAt).toLocaleDateString()}
+      </div>
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/strategies/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/page.tsx
@@ -1,0 +1,35 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getStrategies } from '@/actions/strategies'
+import { getOrgUsersForPicker } from '@/actions/org-users'
+import { StrategyTable } from './strategy-table'
+
+export default async function StrategiesPage() {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+
+  const orgId = session.user.organizationId!
+  const role = session.user.role
+
+  const [strategyList, orgUsers] = await Promise.all([
+    getStrategies(orgId, role),
+    getOrgUsersForPicker(),
+  ])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Strategies</h1>
+        <p className="text-muted-foreground mt-1">
+          Planning-period containers that frame your goals. The single <strong>adopted</strong> strategy is your organization&apos;s current strategic direction.
+        </p>
+      </div>
+      <StrategyTable
+        strategies={strategyList}
+        orgUsers={orgUsers}
+        role={role}
+        currentOrgId={orgId}
+      />
+    </div>
+  )
+}

--- a/apps/govea/src/app/(admin)/strategies/strategy-table.tsx
+++ b/apps/govea/src/app/(admin)/strategies/strategy-table.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { createStrategy, editStrategy, deleteStrategy, adoptStrategy } from '@/actions/strategies'
+import type { Strategy } from '@/db/schema'
+import type { OrgUserPickerRow } from '@/actions/org-users'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import type { Role } from '@/lib/rbac'
+import { MarkdownEditor } from '@/components/markdown-editor'
+
+type StrategyRow = Strategy & {
+  organization: { id: string; name: string } | null
+  owner: { id: string; name: string | null } | null
+  goals: { id: string; name: string }[]
+}
+
+interface Props {
+  strategies: StrategyRow[]
+  orgUsers: OrgUserPickerRow[]
+  role: Role
+  currentOrgId: string
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: 'bg-slate-100 text-slate-700 border-slate-200',
+  adopted: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  superseded: 'bg-amber-100 text-amber-800 border-amber-200',
+  retired: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+}
+
+function titleCase(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<StrategyRow | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<StrategyRow | null>(null)
+  const [adoptTarget, setAdoptTarget] = useState<StrategyRow | null>(null)
+
+  const canEdit = role === 'admin' || role === 'contributor'
+  const canDelete = role === 'admin'
+  const refresh = () => router.refresh()
+
+  const filtered = strategies.filter(s =>
+    statusFilter === 'all' || s.status === statusFilter
+  )
+
+  async function handleCreate(formData: FormData) {
+    startTransition(async () => {
+      await createStrategy(formData)
+      setCreateOpen(false)
+      refresh()
+    })
+  }
+
+  async function handleEdit(formData: FormData) {
+    if (!editTarget) return
+    startTransition(async () => {
+      await editStrategy(editTarget.id, formData)
+      setEditTarget(null)
+      refresh()
+    })
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    startTransition(async () => {
+      await deleteStrategy(deleteTarget.id)
+      setDeleteTarget(null)
+      refresh()
+    })
+  }
+
+  async function handleAdopt() {
+    if (!adoptTarget) return
+    startTransition(async () => {
+      await adoptStrategy(adoptTarget.id)
+      setAdoptTarget(null)
+      refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value)}
+          className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <option value="all">All statuses</option>
+          <option value="draft">Draft</option>
+          <option value="adopted">Adopted</option>
+          <option value="superseded">Superseded</option>
+          <option value="retired">Retired</option>
+        </select>
+        {canEdit && (
+          <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
+            + New strategy
+          </Button>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Planning Horizon</TableHead>
+              <TableHead>Owner</TableHead>
+              <TableHead>Goals</TableHead>
+              <TableHead>Status</TableHead>
+              {canEdit && <TableHead>Actions</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={canEdit ? 6 : 5} className="text-center text-muted-foreground py-8">
+                  {strategies.length === 0
+                    ? 'No strategies yet. Add one to frame a planning period.'
+                    : 'No strategies match the current filters.'}
+                </TableCell>
+              </TableRow>
+            )}
+            {filtered.map(s => (
+              <TableRow key={s.id}>
+                <TableCell className="font-medium">
+                  <Link href={`/strategies/${s.id}`} className="hover:underline">{s.name}</Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {s.planningHorizon ?? '—'}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {s.owner?.name ?? '—'}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {s.goals.length > 0 ? s.goals.length : '—'}
+                </TableCell>
+                <TableCell>
+                  <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[s.status])}>
+                    {titleCase(s.status)}
+                  </span>
+                </TableCell>
+                {canEdit && s.organizationId === currentOrgId && (
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Link href={`/strategies/${s.id}`}>
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">View</Button>
+                      </Link>
+                      <Button variant="ghost" size="sm" onClick={() => setEditTarget(s)} className="h-7 px-2 text-xs">Edit</Button>
+                      {s.status !== 'adopted' && (
+                        <Button variant="ghost" size="sm" onClick={() => setAdoptTarget(s)} disabled={isPending}
+                          className="h-7 px-2 text-xs text-emerald-700 hover:text-emerald-700 hover:bg-emerald-50">
+                          Adopt
+                        </Button>
+                      )}
+                      {canDelete && (
+                        <Button variant="ghost" size="sm" onClick={() => setDeleteTarget(s)} disabled={isPending}
+                          className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10">
+                          Delete
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle>New Strategy</DialogTitle></DialogHeader>
+          <form action={handleCreate} className="space-y-3">
+            <StrategyFields orgUsers={orgUsers} />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button type="submit" disabled={isPending}>{isPending ? 'Creating…' : 'Create'}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle>Edit Strategy</DialogTitle></DialogHeader>
+          <form action={handleEdit} className="space-y-3">
+            <StrategyFields orgUsers={orgUsers} strategy={editTarget} />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+              <Button type="submit" disabled={isPending}>{isPending ? 'Saving…' : 'Save changes'}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Adopt Dialog */}
+      <Dialog open={!!adoptTarget} onOpenChange={open => { if (!open) setAdoptTarget(null) }}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Adopt Strategy</DialogTitle></DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Make <strong>{adoptTarget?.name}</strong> your organization&apos;s current strategy?
+            {strategies.some(s => s.status === 'adopted') && (
+              <> The currently adopted strategy will be superseded.</>
+            )}
+          </p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setAdoptTarget(null)}>Cancel</Button>
+            <Button onClick={handleAdopt} disabled={isPending}>
+              {isPending ? 'Adopting…' : 'Adopt'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Delete Strategy</DialogTitle></DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Permanently delete <strong>{deleteTarget?.name}</strong>? Member goals are kept but un-linked from this strategy. This cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isPending}>
+              {isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+/**
+ * Shared create/edit form fields. Status select deliberately omits `adopted` —
+ * adoption is the Adopt action (it supersedes the prior adopted strategy in one
+ * tx); editing never adopts.
+ */
+function StrategyFields({ orgUsers, strategy }: { orgUsers: OrgUserPickerRow[]; strategy?: StrategyRow | null }) {
+  return (
+    <>
+      <FormField label="Name" name="name" required defaultValue={strategy?.name} placeholder="e.g. FY26–FY28 Digital Strategy" />
+      <MarkdownEditor label="Summary" name="summary" rows={3} defaultValue={strategy?.summary ?? ''} placeholder="Markdown supported" />
+      <FormField label="Planning horizon" name="planningHorizon" defaultValue={strategy?.planningHorizon ?? ''} placeholder="e.g. FY26–FY28" />
+      <div className="space-y-1.5">
+        <Label>Owner</Label>
+        <select name="ownerUserId" defaultValue={strategy?.ownerUserId ?? ''}
+          className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+          <option value="">— Unassigned —</option>
+          {orgUsers.map(u => (
+            <option key={u.id} value={u.id}>{u.name ?? u.email}</option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <FormField label="Start date" name="startDate" type="date" defaultValue={strategy?.startDate ?? ''} />
+        <FormField label="End date" name="endDate" type="date" defaultValue={strategy?.endDate ?? ''} />
+      </div>
+      <div className="space-y-1.5">
+        <Label>Status</Label>
+        <select name="status" defaultValue={strategy?.status === 'adopted' ? 'draft' : (strategy?.status ?? 'draft')}
+          className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+          <option value="draft">Draft</option>
+          <option value="superseded">Superseded</option>
+          <option value="retired">Retired</option>
+        </select>
+        <p className="text-xs text-muted-foreground">Use the Adopt action to make a strategy the current one.</p>
+      </div>
+      <div className="space-y-1.5">
+        <Label>Visibility</Label>
+        <select name="visibility" defaultValue={strategy?.visibility ?? 'org'}
+          className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+          <option value="org">Org only</option>
+          <option value="connections">Connected orgs</option>
+          <option value="instance">Instance-wide</option>
+        </select>
+      </div>
+    </>
+  )
+}
+
+function FormField({ label, ...props }: { label: string } & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div className="space-y-1.5">
+      <Label>{label}</Label>
+      <Input {...props} />
+    </div>
+  )
+}

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -60,6 +60,7 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: 'Strategy',
     items: [
+      { href: '/strategies',  label: 'Strategies',  moduleKey: 'strategies' },
       { href: '/goals',       label: 'Goals',       moduleKey: 'objectives', viewerHidden: true },
       { href: '/objectives',  label: 'Objectives',  moduleKey: 'objectives' },
       { href: '/initiatives', label: 'Initiatives', moduleKey: 'initiatives' },

--- a/apps/govea/src/lib/modules.ts
+++ b/apps/govea/src/lib/modules.ts
@@ -19,6 +19,7 @@ export type ModuleKey =
   | 'applications'
   | 'adrs'
   | 'principles'
+  | 'strategies'
   | 'objectives'
   | 'initiatives'
   | 'roadmap'
@@ -60,6 +61,7 @@ export const MODULE_DEFS: ModuleDef[] = [
   { key: 'adrs',          label: 'Decisions (ADRs)',    href: '/adrs',          group: 'Portfolio' },
   { key: 'debt',          label: 'Architecture debt',   href: '/debt',          group: 'Portfolio' },
   // Strategy
+  { key: 'strategies',    label: 'Strategies',          href: '/strategies',    group: 'Strategy' },
   { key: 'objectives',    label: 'Objectives',          href: '/objectives',    group: 'Strategy' },
   { key: 'initiatives',   label: 'Initiatives',         href: '/initiatives',   group: 'Strategy' },
   { key: 'roadmap',       label: 'Roadmap',             href: '/roadmap',       group: 'Strategy' },


### PR DESCRIPTION
Second implementation slice of the Strategy planning container. UI for the schema in #812.

Design: `docs/design/strategy-entity.md` §5–6 · Decision: ADR-0004.

> **Depends on #812 (PR #813).** This branch is stacked on the slice-1 schema, so until #813 merges this PR's diff includes the slice-1 commit. Merge #813 first; this then rebases to just the slice-2 changes. (Base stays `main` per the base-is-main CI gate.)

## What changed

- **Module wiring** — new `strategies` module key under the existing **Strategy** group (`lib/modules.ts`), nav item in `app-shell.tsx`, module-gated like Objectives/Initiatives/Roadmap. The settings module-toggle UI derives from `MODULE_DEFS`, so `strategies` appears there automatically.
- **List** (`/strategies`) — status filter, create/edit dialogs, delete (admin-only), and an **Adopt** affordance that calls `adoptStrategy` (the supersede-prior-in-one-tx action from slice 1).
- **Detail** (`/strategies/[id]`) — name, status + visibility badges, markdown summary, planning horizon, owner, start/end dates; member goals shown **read-only** (link/unlink UI is slice 3); Adopt button when not adopted.
- **Forms** — name, summary (markdown), horizon, owner (org-user picker), start/end dates, status (deliberately **excludes `adopted`** — adoption is the Adopt action, which supersedes the prior one), visibility.

## Role behavior

Contributor can create/edit + adopt; admin can also delete; viewer sees read-only (no create/edit/delete/adopt controls). Server actions enforce this independently (slice 1).

## Out of scope (later slices)

Strategy↔Goal linking UI from both sides (slice 3); traceability root + affordances on Strategy/Goal pages (slice 4); executive read-only view + current-strategy badge (slice 5); import/export/backup + seed (slice 6).

Verified locally: ✅ tsc `--noEmit`, ✅ lint (no new warnings), ✅ production build (both `/strategies` routes emitted).

Capability: pl-goals
Capability: pl-strategic-objectives
Closes #814
Part of #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)