### PR TITLE
feat(strategy): slice 3 — Strategy↔Goal linking from both sides

### DIFF
--- a/apps/govea/src/actions/goals.ts
+++ b/apps/govea/src/actions/goals.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { goals, goalObjectives, strategicObjectives, objectiveCapabilities, initiativeObjectives } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, assertEntityInOrg, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -84,10 +84,12 @@ export async function createGoal(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const objectiveIds = formData.getAll('objectiveIds') as string[]
+  const strategyId = (formData.get('strategyId') as string) || null
+  if (strategyId) await assertEntityInOrg('strategy', strategyId, orgId)
 
   await db.transaction(async (tx) => {
     const [goal] = await tx.insert(goals).values({
-      name, description, planningHorizon, owner, status, visibility,
+      name, description, planningHorizon, owner, status, visibility, strategyId,
       organizationId: orgId,
       createdBy: session.user.id,
       updatedBy: session.user.id,
@@ -119,13 +121,15 @@ export async function editGoal(goalId: string, formData: FormData) {
   const status = formData.get('status') as 'draft' | 'published' | 'archived'
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
   const objectiveIds = formData.getAll('objectiveIds') as string[]
+  const strategyId = (formData.get('strategyId') as string) || null
+  if (strategyId) await assertEntityInOrg('strategy', strategyId, orgId)
 
   const before = await db.query.goals.findFirst({ where: eq(goals.id, goalId) })
   assertOwnership(before?.organizationId, orgId)
 
   await db.transaction(async (tx) => {
     await tx.update(goals).set({
-      name, description, planningHorizon, owner, status, visibility,
+      name, description, planningHorizon, owner, status, visibility, strategyId,
       updatedBy: session.user.id, updatedAt: new Date(),
     }).where(and(eq(goals.id, goalId), eq(goals.organizationId, orgId)))
 

--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -25,6 +25,7 @@ import {
   objectiveValueStreams,
   goals,
   goalObjectives,
+  strategies,
   initiatives,
   initiativeCapabilities,
   initiativeObjectives,
@@ -46,6 +47,7 @@ import { eq, and } from 'drizzle-orm'
 import { assertOwnership, assertEntityInOrg } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit } from '@/lib/rbac'
+import { writeAuditLog } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -329,6 +331,69 @@ export async function unlinkGoalObjective(goalId: string, objectiveId: string) {
   )
   revalidatePath(`/goals/${goalId}`)
   revalidatePath(`/objectives/${objectiveId}`)
+}
+
+// ── Strategy ↔ Goal (single FK on goals.strategy_id, not a junction) ─────────
+
+/**
+ * Add a goal to a strategy by setting goals.strategy_id. A goal belongs to at
+ * most one strategy (ADR-0004 Q3), so if it was already in another strategy this
+ * moves it — the FK can hold only one value. Both ends are org-checked.
+ */
+export async function linkStrategyGoal(strategyId: string, goalId: string) {
+  const { user } = await requireContributor()
+  const strategy = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
+  assertOwnership(strategy?.organizationId, user.organizationId!)
+  await assertEntityInOrg('goal', goalId, user.organizationId!)
+
+  const goal = await db.query.goals.findFirst({ where: eq(goals.id, goalId), columns: { strategyId: true } })
+  const previousStrategyId = goal?.strategyId ?? null
+
+  await db.transaction(async (tx) => {
+    await tx.update(goals)
+      .set({ strategyId, updatedBy: user.id, updatedAt: new Date() })
+      .where(and(eq(goals.id, goalId), eq(goals.organizationId, user.organizationId!)))
+    await writeAuditLog(tx, {
+      action: 'strategy.link_goal', entityType: 'goal', entityId: goalId,
+      userId: user.id, organizationId: user.organizationId!,
+      before: { strategyId: previousStrategyId }, after: { strategyId },
+    })
+  })
+
+  revalidatePath(`/strategies/${strategyId}`)
+  if (previousStrategyId && previousStrategyId !== strategyId) revalidatePath(`/strategies/${previousStrategyId}`)
+  revalidatePath(`/goals/${goalId}`)
+}
+
+/**
+ * Remove a goal from a strategy (clear goals.strategy_id). No-op unless the goal
+ * is currently in this strategy, so a stale request can't detach it from another.
+ */
+export async function unlinkStrategyGoal(strategyId: string, goalId: string) {
+  const { user } = await requireContributor()
+  const strategy = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
+  assertOwnership(strategy?.organizationId, user.organizationId!)
+
+  await db.transaction(async (tx) => {
+    const cleared = await tx.update(goals)
+      .set({ strategyId: null, updatedBy: user.id, updatedAt: new Date() })
+      .where(and(
+        eq(goals.id, goalId),
+        eq(goals.organizationId, user.organizationId!),
+        eq(goals.strategyId, strategyId),
+      ))
+      .returning({ id: goals.id })
+    if (cleared.length > 0) {
+      await writeAuditLog(tx, {
+        action: 'strategy.unlink_goal', entityType: 'goal', entityId: goalId,
+        userId: user.id, organizationId: user.organizationId!,
+        before: { strategyId }, after: { strategyId: null },
+      })
+    }
+  })
+
+  revalidatePath(`/strategies/${strategyId}`)
+  revalidatePath(`/goals/${goalId}`)
 }
 
 // ── Objective ↔ Capability ──────────────────────────────────────────────────

--- a/apps/govea/src/app/(admin)/goals/goal-table.tsx
+++ b/apps/govea/src/app/(admin)/goals/goal-table.tsx
@@ -23,9 +23,12 @@ type GoalRow = Goal & {
   goalObjectives: { objective: StrategicObjective }[]
 }
 
+type StrategyOption = { id: string; name: string; status: string }
+
 interface Props {
   goals: GoalRow[]
   objectives: StrategicObjective[]
+  strategies: StrategyOption[]
   role: Role
   currentOrgId: string
 }
@@ -36,7 +39,7 @@ const STATUS_STYLES: Record<string, string> = {
   archived: 'bg-amber-100 text-amber-800 border-amber-200',
 }
 
-export function GoalTable({ goals, objectives, role, currentOrgId }: Props) {
+export function GoalTable({ goals, objectives, strategies, role, currentOrgId }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
@@ -172,6 +175,7 @@ export function GoalTable({ goals, objectives, role, currentOrgId }: Props) {
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <FormField label="Planning horizon" name="planningHorizon" placeholder="e.g. 2026–2028, Long-term" />
             <FormField label="Owner" name="owner" placeholder="e.g. Office of the CIO" />
+            <StrategyPicker strategies={strategies} />
             {objectives.length > 0 && (
               <div className="space-y-1.5">
                 <Label>Objectives</Label>
@@ -221,6 +225,7 @@ export function GoalTable({ goals, objectives, role, currentOrgId }: Props) {
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <FormField label="Planning horizon" name="planningHorizon" defaultValue={editTarget?.planningHorizon ?? ''} />
             <FormField label="Owner" name="owner" defaultValue={editTarget?.owner ?? ''} />
+            <StrategyPicker strategies={strategies} defaultValue={editTarget?.strategyId} />
             {objectives.length > 0 && (
               <div className="space-y-1.5">
                 <Label>Objectives</Label>
@@ -277,6 +282,23 @@ export function GoalTable({ goals, objectives, role, currentOrgId }: Props) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  )
+}
+
+function StrategyPicker({ strategies, defaultValue }: { strategies: StrategyOption[]; defaultValue?: string | null }) {
+  if (strategies.length === 0) return null
+  return (
+    <div className="space-y-1.5">
+      <Label>Strategy</Label>
+      <select name="strategyId" defaultValue={defaultValue ?? ''}
+        className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
+        <option value="">— No strategy —</option>
+        {strategies.map(s => (
+          <option key={s.id} value={s.id}>{s.name}{s.status === 'adopted' ? ' (adopted)' : ''}</option>
+        ))}
+      </select>
+      <p className="text-xs text-muted-foreground">The planning-period container this goal belongs to. A goal can belong to one strategy.</p>
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/goals/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getGoals } from '@/actions/goals'
 import { getObjectives } from '@/actions/objectives'
+import { getStrategies } from '@/actions/strategies'
 import { GoalTable } from './goal-table'
 
 export default async function GoalsPage() {
@@ -11,9 +12,10 @@ export default async function GoalsPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [goalList, objectiveList] = await Promise.all([
+  const [goalList, objectiveList, strategyList] = await Promise.all([
     getGoals(orgId, role),
     getObjectives(),
+    getStrategies(orgId, role),
   ])
 
   return (
@@ -27,6 +29,7 @@ export default async function GoalsPage() {
       <GoalTable
         goals={goalList}
         objectives={objectiveList}
+        strategies={strategyList.map(s => ({ id: s.id, name: s.name, status: s.status }))}
         role={role}
         currentOrgId={orgId}
       />

--- a/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getStrategy, adoptStrategy } from '@/actions/strategies'
+import { getGoals } from '@/actions/goals'
+import { linkStrategyGoal, unlinkStrategyGoal } from '@/actions/links'
 import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
@@ -43,6 +45,16 @@ export default async function StrategyDetailPage({ params }: { params: Promise<{
   const orgId = session.user.organizationId!
   const canMutate = editor && strategy.organizationId === orgId
   const adopt = adoptStrategy.bind(null, id)
+  const addGoal = linkStrategyGoal.bind(null, id)
+  const removeGoal = unlinkStrategyGoal.bind(null, id)
+
+  // Offer only un-containered goals (strategy_id null) to add here; moving a goal
+  // out of another strategy is done from the goal's edit flow (slice 3).
+  const availableGoals = canMutate
+    ? (await getGoals(orgId, session.user.role))
+        .filter(g => g.organizationId === orgId && g.strategyId === null)
+        .map(g => ({ id: g.id, name: g.name }))
+    : []
 
   return (
     <div className="space-y-8 max-w-3xl">
@@ -107,8 +119,11 @@ export default async function StrategyDetailPage({ params }: { params: Promise<{
           href: `/goals/${g.id}`,
           meta: g.status,
         }))}
-        gapMessage="No goals belong to this strategy yet. Link goals from a goal's edit flow."
-        canEdit={false}
+        gapMessage="No goals belong to this strategy yet. Add un-containered goals here, or set this strategy from a goal's edit flow."
+        canEdit={canMutate}
+        available={availableGoals}
+        addAction={addGoal}
+        removeAction={removeGoal}
       />
 
       <div className="text-xs text-muted-foreground pt-4 border-t">

--- a/apps/govea/src/lib/federation.ts
+++ b/apps/govea/src/lib/federation.ts
@@ -1,7 +1,7 @@
 import { db } from '@/db/client'
 import {
   capabilities, personas, applications, services, valueStreams,
-  strategicObjectives, goals, initiatives, adrs, principles,
+  strategicObjectives, goals, strategies, initiatives, adrs, principles,
 } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 
@@ -35,6 +35,7 @@ export type EntityKind =
   | 'value_stream'
   | 'objective'
   | 'goal'
+  | 'strategy'
   | 'initiative'
   | 'adr'
   | 'principle'
@@ -85,6 +86,11 @@ export async function assertEntityInOrg(
     }
     case 'goal': {
       const r = await db.query.goals.findFirst({ where: eq(goals.id, id), columns: { organizationId: true } })
+      entityOrgId = r?.organizationId
+      break
+    }
+    case 'strategy': {
+      const r = await db.query.strategies.findFirst({ where: eq(strategies.id, id), columns: { organizationId: true } })
       entityOrgId = r?.organizationId
       break
     }

--- a/apps/govea/tests/integration/strategy-goal-linking.test.ts
+++ b/apps/govea/tests/integration/strategy-goal-linking.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration tests: Strategy ↔ Goal linking (#816 / #805 slice 3)
+ *
+ * The link is the single FK goals.strategy_id (not a junction). Covers:
+ *  - linkStrategyGoal sets the FK; unlinkStrategyGoal clears it
+ *  - single-strategy-per-goal: linking a goal already in another strategy moves it
+ *  - unlink is a no-op unless the goal is currently in that strategy
+ *  - role enforcement (contributor links, viewer forbidden) + cross-org rejection
+ *  - editGoal sets/clears strategy_id from the goal edit flow, validating org
+ *  - audit logs for link/unlink
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { linkStrategyGoal, unlinkStrategyGoal } from '@/actions/links'
+import { editGoal } from '@/actions/goals'
+import { db } from '@/db/client'
+import { goals } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  insertStrategy, insertGoal, getAuditLogsForEntity,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+async function strategyIdOf(goalId: string) {
+  const g = await db.query.goals.findFirst({ where: eq(goals.id, goalId), columns: { strategyId: true } })
+  return g?.strategyId ?? null
+}
+
+function goalForm(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('name', overrides.name ?? 'Edited Goal')
+  fd.set('status', overrides.status ?? 'draft')
+  fd.set('visibility', overrides.visibility ?? 'org')
+  if (overrides.strategyId !== undefined) fd.set('strategyId', overrides.strategyId)
+  return fd
+}
+
+describe('strategy ↔ goal linking', () => {
+  let orgId: string
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+  })
+
+  describe('linkStrategyGoal', () => {
+    it('sets goals.strategy_id', async () => {
+      const s = await insertStrategy(orgId, { name: 'Link Target' })
+      const g = await insertGoal(orgId, { name: 'Free Goal' })
+      await linkStrategyGoal(s.id, g.id)
+      expect(await strategyIdOf(g.id)).toBe(s.id)
+    })
+
+    it('moves a goal already in another strategy (single-strategy-per-goal)', async () => {
+      const first = await insertStrategy(orgId, { name: 'First Container' })
+      const second = await insertStrategy(orgId, { name: 'Second Container' })
+      const g = await insertGoal(orgId, { name: 'Movable Goal', strategyId: first.id })
+
+      await linkStrategyGoal(second.id, g.id)
+      expect(await strategyIdOf(g.id)).toBe(second.id)
+    })
+
+    it('viewer cannot link → Forbidden', async () => {
+      const s = await insertStrategy(orgId, { name: 'Viewer Link Block' })
+      const g = await insertGoal(orgId, { name: 'Goal VLB' })
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(linkStrategyGoal(s.id, g.id)).rejects.toThrow('Forbidden')
+    })
+
+    it('rejects a goal from another org', async () => {
+      const otherOrg = await createTestOrg()
+      const foreignGoal = await insertGoal(otherOrg.id, { name: 'Foreign Goal' })
+      const s = await insertStrategy(orgId, { name: 'Mine' })
+      await expect(linkStrategyGoal(s.id, foreignGoal.id)).rejects.toThrow()
+      await cleanupOrg(otherOrg.id)
+    })
+
+    it('writes a strategy.link_goal audit log with before/after', async () => {
+      const s = await insertStrategy(orgId, { name: 'Audit Link' })
+      const g = await insertGoal(orgId, { name: 'Audit Link Goal' })
+      await linkStrategyGoal(s.id, g.id)
+      const logs = await getAuditLogsForEntity(g.id)
+      const entry = logs.find(l => l.action === 'strategy.link_goal')
+      expect(entry).toBeDefined()
+      expect(entry!.before).toMatchObject({ strategyId: null })
+      expect(entry!.after).toMatchObject({ strategyId: s.id })
+    })
+  })
+
+  describe('unlinkStrategyGoal', () => {
+    it('clears strategy_id when the goal is in that strategy', async () => {
+      const s = await insertStrategy(orgId, { name: 'Unlink Target' })
+      const g = await insertGoal(orgId, { name: 'Linked Goal', strategyId: s.id })
+      await unlinkStrategyGoal(s.id, g.id)
+      expect(await strategyIdOf(g.id)).toBeNull()
+    })
+
+    it('is a no-op when the goal is in a different strategy', async () => {
+      const owner = await insertStrategy(orgId, { name: 'Real Owner' })
+      const other = await insertStrategy(orgId, { name: 'Other Strategy' })
+      const g = await insertGoal(orgId, { name: 'Stays Put', strategyId: owner.id })
+
+      await unlinkStrategyGoal(other.id, g.id)
+      expect(await strategyIdOf(g.id)).toBe(owner.id)
+    })
+
+    it('viewer cannot unlink → Forbidden', async () => {
+      const s = await insertStrategy(orgId, { name: 'Viewer Unlink Block' })
+      const g = await insertGoal(orgId, { name: 'Goal VUB', strategyId: s.id })
+      mockAuth.mockResolvedValue(makeSession(viewer))
+      await expect(unlinkStrategyGoal(s.id, g.id)).rejects.toThrow('Forbidden')
+    })
+  })
+
+  describe('editGoal strategy_id', () => {
+    it('sets strategy_id from the goal edit flow', async () => {
+      const s = await insertStrategy(orgId, { name: 'Edit-flow Strategy' })
+      const g = await insertGoal(orgId, { name: 'Edit Me' })
+      await editGoal(g.id, goalForm({ name: 'Edit Me', strategyId: s.id }))
+      expect(await strategyIdOf(g.id)).toBe(s.id)
+    })
+
+    it('clears strategy_id when the picker is set to none', async () => {
+      const s = await insertStrategy(orgId, { name: 'Soon Cleared' })
+      const g = await insertGoal(orgId, { name: 'Clear Me', strategyId: s.id })
+      await editGoal(g.id, goalForm({ name: 'Clear Me', strategyId: '' }))
+      expect(await strategyIdOf(g.id)).toBeNull()
+    })
+
+    it('rejects a strategy from another org', async () => {
+      const otherOrg = await createTestOrg()
+      const foreignStrategy = await insertStrategy(otherOrg.id, { name: 'Foreign Strategy' })
+      const g = await insertGoal(orgId, { name: 'Goal needing valid strategy' })
+      await expect(editGoal(g.id, goalForm({ name: 'Goal needing valid strategy', strategyId: foreignStrategy.id })))
+        .rejects.toThrow()
+      await cleanupOrg(otherOrg.id)
+    })
+  })
+})


### PR DESCRIPTION
Third implementation slice of the Strategy planning container. Wires the `goals.strategy_id` FK (from #812) into the UI from both directions.

Design: `docs/design/strategy-entity.md` §3.2 · ADR-0004 Q3 (at most one strategy per goal).

> **Stacked on #815 (slice 2).** Until #815 merges, this PR's diff includes the slice-2 commit. Merge #813 → #815 → this, in order; each rebases down to just its own changes. (Base stays `main` per the base-is-main gate.)

## What changed

- **`linkStrategyGoal` / `unlinkStrategyGoal`** (`actions/links.ts`) — set / null the single FK (not a junction), org-ownership checked on both ends, audit-logged. Linking a goal that's already in another strategy **moves** it (the FK holds one value, per ADR-0004 Q3); unlink is a **no-op** unless the goal is currently in that strategy.
- **Strategy detail page** — the Goals panel is now editable: add un-containered goals, remove members. (Moving a goal *between* strategies is done from the goal edit flow, so the strategy picker only offers free goals — no surprise moves.)
- **Goal create/edit flow** — a Strategy picker sets/clears `goals.strategy_id`; `createGoal`/`editGoal` validate the chosen strategy belongs to the org.
- New **`strategy` kind** in `assertEntityInOrg` for that validation.

## Tests (integration)

link sets FK · move-on-relink (single-strategy-per-goal) · unlink clears · unlink no-op when goal is elsewhere · contributor allowed / viewer Forbidden · cross-org goal & cross-org strategy rejected · edit-flow set + clear · audit logs for link/unlink.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build (`/goals` + `/strategies` routes emit).

Capability: pl-goals
Capability: pl-strategic-objectives
Closes #816
Part of #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)