### PR TITLE
test(e2e): harden flaky value-streams detail smoke test

### DIFF
--- a/apps/govea/tests/e2e/specs/value-streams.spec.ts
+++ b/apps/govea/tests/e2e/specs/value-streams.spec.ts
@@ -25,9 +25,15 @@ test('detail view is read-only; authoring lives on the edit view', async ({ page
   // nav "/value-streams" link has no trailing id and is excluded).
   const firstStream = page.locator('a[href^="/value-streams/"]').first()
   await expect(firstStream, 'seed should provide at least one value stream').toBeVisible()
-  await firstStream.click()
 
-  await expect(page, 'should be on a value stream detail page').toHaveURL(/\/value-streams\/[0-9a-f-]+$/)
+  // Retry the click+navigation as a unit: a Next.js <Link> click landing in the
+  // hydration window can be swallowed (handler attached before the client router
+  // is ready), leaving the URL on the list page (#818). toPass re-clicks until
+  // the navigation actually happens.
+  await expect(async () => {
+    await firstStream.click()
+    await expect(page, 'should be on a value stream detail page').toHaveURL(/\/value-streams\/[0-9a-f-]+$/, { timeout: 2000 })
+  }).toPass()
 
   // Read-only: no stage/persona/capability mutation controls on the detail page.
   await expect(page.getByRole('button', { name: '+ Add stage' })).toHaveCount(0)
@@ -37,10 +43,12 @@ test('detail view is read-only; authoring lives on the edit view', async ({ page
   // Single edit affordance present (admin can mutate the org's own stream).
   const editLink = page.getByRole('link', { name: 'Edit value stream' })
   await expect(editLink).toBeVisible()
-  await editLink.click()
 
-  // Edit view: URL is the dedicated route and the authoring controls appear.
-  await expect(page).toHaveURL(/\/value-streams\/[0-9a-f-]+\/edit$/)
+  // Same hydration-race guard as above (#818).
+  await expect(async () => {
+    await editLink.click()
+    await expect(page).toHaveURL(/\/value-streams\/[0-9a-f-]+\/edit$/, { timeout: 2000 })
+  }).toPass()
   await expect(page.getByRole('button', { name: '+ Add stage' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Edit value stream' })).toBeVisible()
 })


### PR DESCRIPTION
`tests/e2e/specs/value-streams.spec.ts:21` flakes intermittently — it has blocked PRs #813 and #815 (Strategy-stack PRs touching no value-stream code) and failed on `main` (2026-06-13). Re-running passes, so it's non-deterministic.

## Root cause

The test clicked the first value-stream `<Link>` as soon as it was visible. A click landing in the hydration window can be swallowed (the Next.js Link handler is attached before the client router is ready), so the click is a no-op, the URL stays on `/value-streams`, and the `toHaveURL` retry polls the list page until it times out. Same pattern on the "Edit value stream" click.

## Fix

Wrap each click + URL assertion in `expect(...).toPass()`, so a swallowed first click is retried as a unit until navigation actually happens. Tightened per-assert timeout to 2s inside the retry. No product code change; the behavior under test is unchanged — only the test's robustness improves.

Verified locally: ✅ tsc, ✅ lint (no new warnings). The spec itself runs in the CI E2E smoke job.

Capability: po-value-streams
Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)