### PR TITLE
feat(strategy): slice 4 — Strategy traceability root + affordances

### DIFF
--- a/apps/govea/src/actions/goals.ts
+++ b/apps/govea/src/actions/goals.ts
@@ -53,6 +53,7 @@ export async function getGoal(id: string) {
   const goal = await db.query.goals.findFirst({
     where: (g, { eq }) => eq(g.id, id),
     with: {
+      strategy: true,
       goalObjectives: {
         with: {
           objective: {

--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import {
-  strategicObjectives, capabilities, services, goals,
+  strategicObjectives, capabilities, services, goals, strategies,
   goalObjectives, objectiveCapabilities, applicationCapabilities,
   initiativeObjectives, serviceCapabilities,
   // #695 — trace-participation subjects and their one-hop root junctions
@@ -89,7 +89,21 @@ export interface GoalTrace {
   }>
 }
 
-export type TraceData = GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace
+export interface StrategyTrace {
+  kind: 'strategy'
+  id: string; name: string; summary: string | null
+  planningHorizon: string | null; status: string
+  goals: Array<{
+    id: string; name: string; planningHorizon: string | null; status: string
+    objectives: Array<{
+      id: string; name: string; timeHorizon: string | null
+      capabilities: TraceCapability[]
+      initiatives: TraceInitiative[]
+    }>
+  }>
+}
+
+export type TraceData = StrategyTrace | GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace
 
 function dedupeTraceRows<T extends { id: string }>(rows: T[]): T[] {
   return Array.from(new Map(rows.map((row) => [row.id, row])).values())
@@ -144,6 +158,108 @@ async function getGoalsByObjective(objectiveIds: string[]): Promise<Map<string, 
   }
 
   return goalsByObjective
+}
+
+// ── Strategy trace ──────────────────────────────────────────────────────────
+//
+// Strategy is the planning-period root above Goals (#697 / ADR-0004). The chain
+// is Strategy → Goals → Objectives → Initiatives → Capabilities → Applications,
+// composed entirely from existing relationships. Viewer pruning (design Q5): a
+// draft Strategy is not a viewer-visible root, and member goals are pruned to
+// published for viewers.
+
+export async function getStrategyTrace(id: string): Promise<StrategyTrace | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
+
+  const row = await db.query.strategies.findFirst({ where: eq(strategies.id, id) })
+  if (!row) return null
+  const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
+  if (!visible) return null
+  // A draft strategy is not a viewer-visible root.
+  if (isViewer && row.status === 'draft') return null
+
+  // Member goals (the one new edge); pruned to published for viewers.
+  const memberGoals = await db.query.goals.findMany({
+    where: (g, { eq: eqf, and: andf }) =>
+      isViewer
+        ? andf(eqf(g.strategyId, id), eqf(g.status, 'published'))
+        : eqf(g.strategyId, id),
+    orderBy: (g, { asc }) => [asc(g.name)],
+  })
+  const goalIds = memberGoals.map((g) => g.id)
+
+  // Objectives per member goal, then caps + initiatives for those objectives —
+  // same downstream traversal getGoalTrace uses, fanned across all member goals.
+  const goalObjectiveRows = goalIds.length > 0
+    ? await db.query.goalObjectives.findMany({
+        where: inArray(goalObjectives.goalId, goalIds),
+        with: { objective: true },
+      })
+    : []
+  const objectiveIds = [...new Set(goalObjectiveRows.map(({ objectiveId }) => objectiveId))]
+
+  const [objectiveCapRows, initiativeRows] = objectiveIds.length > 0
+    ? await Promise.all([
+        db.query.objectiveCapabilities.findMany({
+          where: inArray(objectiveCapabilities.objectiveId, objectiveIds),
+        }),
+        db.query.initiativeObjectives.findMany({
+          where: inArray(initiativeObjectives.objectiveId, objectiveIds),
+          with: { initiative: true },
+        }),
+      ])
+    : [[], []] as const
+
+  const capabilityIds = [...new Set(objectiveCapRows.map(({ capabilityId }) => capabilityId))]
+  const capabilityTraceRows = await getCapabilitiesWithApps(capabilityIds)
+  const capabilitiesById = new Map(capabilityTraceRows.map((c) => [c.id, c]))
+
+  const capabilitiesByObjective = new Map<string, TraceCapability[]>()
+  for (const { objectiveId, capabilityId } of objectiveCapRows) {
+    const capability = capabilitiesById.get(capabilityId)
+    if (!capability) continue
+    const list = capabilitiesByObjective.get(objectiveId) ?? []
+    list.push(capability)
+    capabilitiesByObjective.set(objectiveId, list)
+  }
+
+  const initiativesByObjective = new Map<string, TraceInitiative[]>()
+  for (const { objectiveId, initiative } of initiativeRows) {
+    const list = initiativesByObjective.get(objectiveId) ?? []
+    list.push({ id: initiative.id, name: initiative.name, status: initiative.status })
+    initiativesByObjective.set(objectiveId, list)
+  }
+
+  const objectivesByGoal = new Map<string, Array<{ id: string; name: string; timeHorizon: string | null }>>()
+  for (const { goalId, objective } of goalObjectiveRows) {
+    const list = objectivesByGoal.get(goalId) ?? []
+    list.push({ id: objective.id, name: objective.name, timeHorizon: objective.timeHorizon })
+    objectivesByGoal.set(goalId, list)
+  }
+
+  return {
+    kind: 'strategy',
+    id: row.id,
+    name: row.name,
+    summary: row.summary,
+    planningHorizon: row.planningHorizon,
+    status: row.status,
+    goals: memberGoals.map((g) => ({
+      id: g.id,
+      name: g.name,
+      planningHorizon: g.planningHorizon,
+      status: g.status,
+      objectives: (objectivesByGoal.get(g.id) ?? []).map((o) => ({
+        id: o.id,
+        name: o.name,
+        timeHorizon: o.timeHorizon,
+        capabilities: capabilitiesByObjective.get(o.id) ?? [],
+        initiatives: initiativesByObjective.get(o.id) ?? [],
+      })),
+    })),
+  }
 }
 
 // ── Goal trace ────────────────────────────────────────────────────────────────

--- a/apps/govea/src/app/(admin)/goals/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/[id]/page.tsx
@@ -101,6 +101,14 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
         )}
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
+          {goal.strategy && (
+            <div>
+              <span className="text-muted-foreground">Part of strategy: </span>
+              <Link href={`/strategies/${goal.strategy.id}`} className="font-medium text-primary hover:underline underline-offset-4">
+                {goal.strategy.name}
+              </Link>
+            </div>
+          )}
           {goal.planningHorizon && (
             <div>
               <span className="text-muted-foreground">Planning horizon: </span>

--- a/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import { MarkdownContent } from '@/components/markdown-content'
 import { Button } from '@/components/ui/button'
+import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-slate-100 text-slate-700 border-slate-200',
@@ -62,6 +63,7 @@ export default async function StrategyDetailPage({ params }: { params: Promise<{
         <Link href="/strategies" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
           ← Strategies
         </Link>
+        <ViewTraceabilityLink from="strategy" id={id} />
       </div>
 
       <div className="space-y-3">

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -2,9 +2,10 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace, getTraceParticipation } from '@/actions/traceability'
-import type { GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceParticipation } from '@/actions/traceability'
+import { getStrategyTrace, getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace, getTraceParticipation } from '@/actions/traceability'
+import type { StrategyTrace, GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceParticipation } from '@/actions/traceability'
 import { isTraceParticipantKind, PARTICIPANT_ROUTES } from '@/lib/trace-participants'
+import { getStrategies } from '@/actions/strategies'
 import { getGoals } from '@/actions/goals'
 import { getObjectives } from '@/actions/objectives'
 import { getCapabilities } from '@/actions/capabilities'
@@ -132,6 +133,118 @@ function AppLayer({ apps }: { apps: TraceApp[] }) {
         />
       ))}
     </TraceCard>
+  )
+}
+
+// ── Strategy trace view ───────────────────────────────────────────────────────
+
+function StrategyTraceView({ trace }: { trace: StrategyTrace }) {
+  const allObjectives = dedupeById(
+    trace.goals.flatMap(g => g.objectives.map(o => ({ id: o.id, name: o.name, timeHorizon: o.timeHorizon })))
+  )
+  const allCapabilities = dedupeById(
+    trace.goals.flatMap(g => g.objectives.flatMap(o => o.capabilities))
+  )
+  const allApps = dedupeById(allCapabilities.flatMap(c => c.applications))
+  const allInitiatives = dedupeById(
+    trace.goals.flatMap(g => g.objectives.flatMap(o => o.initiatives))
+  )
+
+  return (
+    <div className="space-y-1 max-w-2xl">
+      {/* Anchor: Strategy */}
+      <LayerLabel>Strategy</LayerLabel>
+      <TraceCard>
+        <div className="px-4 py-4">
+          <div className="font-semibold text-base">{trace.name}</div>
+          {trace.summary && (
+            <p className="text-sm text-muted-foreground mt-1">{trace.summary}</p>
+          )}
+          <div className="flex flex-wrap gap-4 mt-2 text-xs text-muted-foreground">
+            {trace.planningHorizon && <span>Horizon: {trace.planningHorizon}</span>}
+            <span>Status: {trace.status}</span>
+          </div>
+        </div>
+      </TraceCard>
+
+      {/* Goals */}
+      <Connector label="frames" />
+      <LayerLabel>Goals</LayerLabel>
+      {trace.goals.length === 0 ? (
+        <Gap message="No goals belong to this strategy yet — link goals to give this planning period strategic content." />
+      ) : (
+        <TraceCard>
+          {trace.goals.map(g => (
+            <TraceRow
+              key={g.id}
+              href={`/goals/${g.id}`}
+              name={g.name}
+              meta={g.planningHorizon ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Objectives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Strategic Objectives</LayerLabel>
+      {allObjectives.length === 0 ? (
+        <Gap message="No objectives linked through these goals — no measurable targets are defined yet." />
+      ) : (
+        <TraceCard>
+          {allObjectives.map(o => (
+            <TraceRow
+              key={o.id}
+              href={`/objectives/${o.id}`}
+              name={o.name}
+              meta={o.timeHorizon ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Initiatives */}
+      <Connector label="advanced by" />
+      <LayerLabel>Strategic Initiatives</LayerLabel>
+      {allInitiatives.length === 0 ? (
+        <Gap message="No initiatives are currently advancing this strategy's objectives." />
+      ) : (
+        <TraceCard>
+          {allInitiatives.map(i => (
+            <TraceRow
+              key={i.id}
+              href={`/initiatives/${i.id}`}
+              name={i.name}
+              badge={i.status}
+              badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Capabilities */}
+      <Connector label="requires" />
+      <LayerLabel>Capabilities</LayerLabel>
+      {allCapabilities.length === 0 ? (
+        <Gap message="No capabilities linked — the organisational foundation for this strategy is not yet mapped." />
+      ) : (
+        <TraceCard>
+          {allCapabilities.map(c => (
+            <TraceRow
+              key={c.id}
+              href={`/capabilities/${c.id}`}
+              name={c.name}
+              meta={c.domain}
+            />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Applications */}
+      <Connector label="supported by" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={allApps} />
+    </div>
   )
 }
 
@@ -563,7 +676,11 @@ export default async function TraceabilityPage({
   let backHref = '/'
   let backLabel = 'Back'
 
-  if (from === 'goal') {
+  if (from === 'strategy') {
+    trace = await getStrategyTrace(id)
+    backHref = `/strategies/${id}`
+    backLabel = '← Strategy'
+  } else if (from === 'goal') {
     trace = await getGoalTrace(id)
     backHref = `/goals/${id}`
     backLabel = '← Goal'
@@ -597,6 +714,7 @@ export default async function TraceabilityPage({
     trace.name
 
   const subtitle =
+    trace.kind === 'strategy'  ? 'Strategy → Goals → Objectives → Initiatives → Capabilities → Technology Trace' :
     trace.kind === 'goal'      ? 'Goal → Objectives → Initiatives → Capabilities → Technology Trace' :
     trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Technology Trace' :
     trace.kind === 'capability' ? 'Goal → Objective → Initiatives → Capability → Delivery Trace' :
@@ -625,6 +743,7 @@ export default async function TraceabilityPage({
 
       <hr />
 
+      {trace.kind === 'strategy'  && <StrategyTraceView trace={trace} />}
       {trace.kind === 'goal'      && <GoalTraceView trace={trace} />}
       {trace.kind === 'objective' && <ObjectiveTraceView trace={trace} />}
       {trace.kind === 'capability' && <CapabilityTraceView trace={trace} />}
@@ -729,7 +848,8 @@ function ParticipantView({ participation }: { participation: TraceParticipation 
 // objective to start from.
 
 async function TraceabilityHub({ organizationId, role }: { organizationId: string; role: string }) {
-  const [goals, objectives, capabilities, services] = await Promise.all([
+  const [strategies, goals, objectives, capabilities, services] = await Promise.all([
+    getStrategies(organizationId, role),
     getGoals(organizationId, role),
     getObjectives(),
     getCapabilities(),
@@ -739,6 +859,9 @@ async function TraceabilityHub({ organizationId, role }: { organizationId: strin
   // Viewer-only filter: traceability already enforces visibility at the
   // entity-level actions. For the hub, we restrict to published items so
   // stakeholders aren't shown drafts they can't actually trace.
+  // Strategy has no 'published' status — a draft strategy is not a traceable
+  // root (design Q5), so non-draft strategies are the hub-eligible ones.
+  const traceableStrategies = strategies.filter(s => s.status !== 'draft')
   const publishedGoals = goals.filter(g => g.status === 'published')
   const publishedObjectives = objectives.filter(o => o.status === 'published')
   const publishedCapabilities = capabilities.filter(c => c.status === 'published')
@@ -756,14 +879,14 @@ async function TraceabilityHub({ organizationId, role }: { organizationId: strin
     a === 'No domain' ? 1 : b === 'No domain' ? -1 : a.localeCompare(b)
   )
 
-  const hasAny = publishedGoals.length + publishedObjectives.length + publishedCapabilities.length + publishedServices.length > 0
+  const hasAny = traceableStrategies.length + publishedGoals.length + publishedObjectives.length + publishedCapabilities.length + publishedServices.length > 0
 
   return (
     <div className="space-y-8 max-w-3xl">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Traceability</h1>
         <p className="text-muted-foreground mt-1 text-sm">
-          Trace from a goal, strategic objective, capability, or service down to the technology that supports it.
+          Trace from a strategy, goal, strategic objective, capability, or service down to the technology that supports it.
           Pick a starting point below.
         </p>
       </div>
@@ -772,6 +895,29 @@ async function TraceabilityHub({ organizationId, role }: { organizationId: strin
         <p className="text-sm text-muted-foreground rounded-lg border bg-card p-8 text-center">
           No published content yet. Publish at least one goal, objective, capability, or service to begin tracing.
         </p>
+      )}
+
+      {traceableStrategies.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Strategies</h2>
+          <div className="rounded-lg border bg-card divide-y divide-border">
+            {traceableStrategies.map(s => (
+              <Link
+                key={s.id}
+                href={`/traceability?from=strategy&id=${s.id}`}
+                className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+              >
+                <div className="min-w-0 space-y-0.5">
+                  <p className="text-sm font-medium">{s.name}</p>
+                  {s.planningHorizon && (
+                    <p className="text-xs text-muted-foreground">{s.planningHorizon}</p>
+                  )}
+                </div>
+                <span className="text-xs text-primary shrink-0">Trace →</span>
+              </Link>
+            ))}
+          </div>
+        </section>
       )}
 
       {publishedGoals.length > 0 && (

--- a/apps/govea/tests/integration/strategy-traceability.test.ts
+++ b/apps/govea/tests/integration/strategy-traceability.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration tests: Strategy traceability root (#820 / #805 slice 4)
+ *
+ * Covers getStrategyTrace:
+ *  - builds the chain Strategy → Goals → Objectives → Initiatives/Capabilities
+ *  - viewer pruning (design Q5): a draft strategy is not a viewer-visible root
+ *  - member goals prune to published for viewers
+ *  - unknown / cross-org id → null
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { getStrategyTrace } from '@/actions/traceability'
+import { db } from '@/db/client'
+import {
+  strategies, goals, strategicObjectives, capabilities, initiatives,
+  goalObjectives, objectiveCapabilities, initiativeObjectives,
+} from '@/db/schema'
+import { randomUUID } from 'node:crypto'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('getStrategyTrace', () => {
+  let orgId: string
+  let contributor: TestUser
+  let viewer: TestUser
+  let strategyId: string
+
+  // ids for assertions
+  let publishedGoalId: string
+  let draftGoalId: string
+  let objectiveId: string
+  let capabilityId: string
+  let initiativeId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+
+    const [s] = await db.insert(strategies).values({
+      organizationId: orgId, name: 'FY26 Strategy', status: 'adopted', visibility: 'org',
+    }).returning()
+    strategyId = s.id
+
+    // Two member goals: one published (viewer-visible), one draft (pruned for viewers).
+    const [pg] = await db.insert(goals).values({
+      organizationId: orgId, name: 'Published Member Goal', status: 'published', visibility: 'org', strategyId,
+    }).returning()
+    publishedGoalId = pg.id
+    const [dg] = await db.insert(goals).values({
+      organizationId: orgId, name: 'Draft Member Goal', status: 'draft', visibility: 'org', strategyId,
+    }).returning()
+    draftGoalId = dg.id
+
+    const [o] = await db.insert(strategicObjectives).values({
+      organizationId: orgId, name: 'Measurable Objective', status: 'published', visibility: 'org',
+    }).returning()
+    objectiveId = o.id
+    const [c] = await db.insert(capabilities).values({
+      organizationId: orgId, name: 'Foundation Capability', status: 'published', visibility: 'org',
+    }).returning()
+    capabilityId = c.id
+    const [i] = await db.insert(initiatives).values({
+      organizationId: orgId, name: 'Delivery Initiative', status: 'active', visibility: 'org',
+    }).returning()
+    initiativeId = i.id
+
+    // Wire the chain: publishedGoal → objective → capability; initiative → objective.
+    await db.insert(goalObjectives).values({ goalId: publishedGoalId, objectiveId })
+    await db.insert(objectiveCapabilities).values({ objectiveId, capabilityId })
+    await db.insert(initiativeObjectives).values({ initiativeId, objectiveId })
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('builds the full chain for a non-viewer', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const trace = await getStrategyTrace(strategyId)
+
+    expect(trace).not.toBeNull()
+    expect(trace!.kind).toBe('strategy')
+    expect(trace!.name).toBe('FY26 Strategy')
+
+    // Both goals visible to a contributor.
+    expect(trace!.goals.map(g => g.id).sort()).toEqual([publishedGoalId, draftGoalId].sort())
+
+    const published = trace!.goals.find(g => g.id === publishedGoalId)!
+    expect(published.objectives.map(o => o.id)).toContain(objectiveId)
+    const obj = published.objectives.find(o => o.id === objectiveId)!
+    expect(obj.capabilities.map(c => c.id)).toContain(capabilityId)
+    expect(obj.initiatives.map(i => i.id)).toContain(initiativeId)
+  })
+
+  it('prunes draft member goals for viewers', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    const trace = await getStrategyTrace(strategyId)
+
+    expect(trace).not.toBeNull()
+    const ids = trace!.goals.map(g => g.id)
+    expect(ids).toContain(publishedGoalId)
+    expect(ids).not.toContain(draftGoalId)
+  })
+
+  it('a draft strategy is not a viewer-visible root → null', async () => {
+    const [draftStrategy] = await db.insert(strategies).values({
+      organizationId: orgId, name: 'Draft Strategy', status: 'draft', visibility: 'org',
+    }).returning()
+
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    expect(await getStrategyTrace(draftStrategy.id)).toBeNull()
+
+    // …but a non-viewer can trace it.
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    expect(await getStrategyTrace(draftStrategy.id)).not.toBeNull()
+  })
+
+  it('returns null for an unknown id', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    expect(await getStrategyTrace(randomUUID())).toBeNull()
+  })
+
+  it('returns null for a strategy in another org', async () => {
+    const otherOrg = await createTestOrg()
+    const [foreign] = await db.insert(strategies).values({
+      organizationId: otherOrg.id, name: 'Foreign Strategy', status: 'adopted', visibility: 'org',
+    }).returning()
+
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    expect(await getStrategyTrace(foreign.id)).toBeNull()
+    await cleanupOrg(otherOrg.id)
+  })
+})


### PR DESCRIPTION
Fourth implementation slice of the Strategy planning container. Makes Strategy a first-class traceability root and wires the entry-point affordances. Builds on slices 1–3 (merged) — **not stacked**, branches off `main`.

Design: `docs/design/strategy-entity.md` §4 · ADR-0004 decision 4.

## What changed

- **`getStrategyTrace(id)`** + `StrategyTrace` type — chain Strategy → Goals → Objectives → Initiatives → Capabilities → Applications, composed entirely from existing relationships (Strategy adds one new edge; everything below Goals is what already ships).
- **`/traceability?from=strategy&id=<id>`** renders `StrategyTraceView`: Strategy anchor → member Goals → aggregated Objectives / Initiatives / Capabilities / Applications, matching the existing root views.
- **Viewer-visibility pruning** (design Q5): a draft Strategy is not a viewer-visible root (`null` for viewers); member goals prune to published for viewers. Root gated by `canReadFederatedEntity` like every other root.
- **Affordances**: "View traceability →" on the Strategy detail page; "Part of strategy *X*" on linked Goal detail pages (`getGoal` now loads the `strategy` relation); a **Strategies** section in the traceability hub (non-draft strategies, since Strategy has no `published` status).

## Design note

The "Part of strategy *X*" affordance links to the **strategy detail page** (`/strategies/[id]`), consistent with how the Goal detail page links its objectives to their detail pages rather than nested traces. The strategy detail page then carries the "View traceability →" entry. Easy to repoint straight at the trace if you'd prefer the more literal reading of the design.

## Tests (integration)

Chain build (strategy→goal→objective→capability + initiative); viewer pruning of a draft root (null) and of draft member goals; non-viewer can trace a draft; unknown id and cross-org id → null.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build (`/traceability`, `/strategies`, `/goals` routes emit).

Capability: fd-traceability-views
Capability: rm-end-to-end-traceability
Closes #820
Part of #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)