### PR TITLE
feat(strategy): R1 — rework schema to BIZBOK course-of-action model

### DIFF
--- a/apps/govea/src/actions/goals.ts
+++ b/apps/govea/src/actions/goals.ts
@@ -3,7 +3,7 @@
 import { db } from '@/db/client'
 import { goals, goalObjectives, strategicObjectives, objectiveCapabilities, initiativeObjectives } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
-import { assertOwnership, assertEntityInOrg, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
+import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
@@ -53,7 +53,7 @@ export async function getGoal(id: string) {
   const goal = await db.query.goals.findFirst({
     where: (g, { eq }) => eq(g.id, id),
     with: {
-      strategy: true,
+      strategyGoals: { with: { strategy: true } },
       goalObjectives: {
         with: {
           objective: {
@@ -85,12 +85,10 @@ export async function createGoal(formData: FormData) {
   const status = (formData.get('status') as 'draft' | 'published' | 'archived') ?? 'draft'
   const visibility = (formData.get('visibility') as 'org' | 'connections' | 'instance') ?? 'org'
   const objectiveIds = formData.getAll('objectiveIds') as string[]
-  const strategyId = (formData.get('strategyId') as string) || null
-  if (strategyId) await assertEntityInOrg('strategy', strategyId, orgId)
 
   await db.transaction(async (tx) => {
     const [goal] = await tx.insert(goals).values({
-      name, description, planningHorizon, owner, status, visibility, strategyId,
+      name, description, planningHorizon, owner, status, visibility,
       organizationId: orgId,
       createdBy: session.user.id,
       updatedBy: session.user.id,
@@ -122,15 +120,13 @@ export async function editGoal(goalId: string, formData: FormData) {
   const status = formData.get('status') as 'draft' | 'published' | 'archived'
   const visibility = formData.get('visibility') as 'org' | 'connections' | 'instance'
   const objectiveIds = formData.getAll('objectiveIds') as string[]
-  const strategyId = (formData.get('strategyId') as string) || null
-  if (strategyId) await assertEntityInOrg('strategy', strategyId, orgId)
 
   const before = await db.query.goals.findFirst({ where: eq(goals.id, goalId) })
   assertOwnership(before?.organizationId, orgId)
 
   await db.transaction(async (tx) => {
     await tx.update(goals).set({
-      name, description, planningHorizon, owner, status, visibility, strategyId,
+      name, description, planningHorizon, owner, status, visibility,
       updatedBy: session.user.id, updatedAt: new Date(),
     }).where(and(eq(goals.id, goalId), eq(goals.organizationId, orgId)))
 

--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -26,6 +26,7 @@ import {
   goals,
   goalObjectives,
   strategies,
+  strategyGoals,
   initiatives,
   initiativeCapabilities,
   initiativeObjectives,
@@ -47,7 +48,6 @@ import { eq, and } from 'drizzle-orm'
 import { assertOwnership, assertEntityInOrg } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit } from '@/lib/rbac'
-import { writeAuditLog } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -333,65 +333,29 @@ export async function unlinkGoalObjective(goalId: string, objectiveId: string) {
   revalidatePath(`/objectives/${objectiveId}`)
 }
 
-// ── Strategy ↔ Goal (single FK on goals.strategy_id, not a junction) ─────────
+// ── Strategy ↔ Goal (strategy_goals junction — a Strategy pursues Goals) ──────
 
 /**
- * Add a goal to a strategy by setting goals.strategy_id. A goal belongs to at
- * most one strategy (ADR-0004 Q3), so if it was already in another strategy this
- * moves it — the FK can hold only one value. Both ends are org-checked.
+ * Link a Strategy to a Goal it pursues (ADR-0005). Many-to-many: a goal can be
+ * pursued by several strategies. Both ends are org-checked.
  */
 export async function linkStrategyGoal(strategyId: string, goalId: string) {
   const { user } = await requireContributor()
   const strategy = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
   assertOwnership(strategy?.organizationId, user.organizationId!)
   await assertEntityInOrg('goal', goalId, user.organizationId!)
-
-  const goal = await db.query.goals.findFirst({ where: eq(goals.id, goalId), columns: { strategyId: true } })
-  const previousStrategyId = goal?.strategyId ?? null
-
-  await db.transaction(async (tx) => {
-    await tx.update(goals)
-      .set({ strategyId, updatedBy: user.id, updatedAt: new Date() })
-      .where(and(eq(goals.id, goalId), eq(goals.organizationId, user.organizationId!)))
-    await writeAuditLog(tx, {
-      action: 'strategy.link_goal', entityType: 'goal', entityId: goalId,
-      userId: user.id, organizationId: user.organizationId!,
-      before: { strategyId: previousStrategyId }, after: { strategyId },
-    })
-  })
-
+  await db.insert(strategyGoals).values({ strategyId, goalId }).onConflictDoNothing()
   revalidatePath(`/strategies/${strategyId}`)
-  if (previousStrategyId && previousStrategyId !== strategyId) revalidatePath(`/strategies/${previousStrategyId}`)
   revalidatePath(`/goals/${goalId}`)
 }
 
-/**
- * Remove a goal from a strategy (clear goals.strategy_id). No-op unless the goal
- * is currently in this strategy, so a stale request can't detach it from another.
- */
 export async function unlinkStrategyGoal(strategyId: string, goalId: string) {
   const { user } = await requireContributor()
   const strategy = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
   assertOwnership(strategy?.organizationId, user.organizationId!)
-
-  await db.transaction(async (tx) => {
-    const cleared = await tx.update(goals)
-      .set({ strategyId: null, updatedBy: user.id, updatedAt: new Date() })
-      .where(and(
-        eq(goals.id, goalId),
-        eq(goals.organizationId, user.organizationId!),
-        eq(goals.strategyId, strategyId),
-      ))
-      .returning({ id: goals.id })
-    if (cleared.length > 0) {
-      await writeAuditLog(tx, {
-        action: 'strategy.unlink_goal', entityType: 'goal', entityId: goalId,
-        userId: user.id, organizationId: user.organizationId!,
-        before: { strategyId }, after: { strategyId: null },
-      })
-    }
-  })
-
+  await db.delete(strategyGoals).where(
+    and(eq(strategyGoals.strategyId, strategyId), eq(strategyGoals.goalId, goalId)),
+  )
   revalidatePath(`/strategies/${strategyId}`)
   revalidatePath(`/goals/${goalId}`)
 }

--- a/apps/govea/src/actions/strategies.ts
+++ b/apps/govea/src/actions/strategies.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import { strategies } from '@/db/schema'
-import { eq, and, ne } from 'drizzle-orm'
+import { eq, and } from 'drizzle-orm'
 import { assertOwnership, canReadFederatedEntity, getConnectedOrgIds } from '@/lib/federation'
 import { auth } from '@/lib/auth'
 import { canEdit, isAdmin } from '@/lib/rbac'
@@ -10,7 +10,7 @@ import { writeAuditLog } from '@/lib/audit'
 import { redirect } from 'next/navigation'
 import { revalidatePath } from 'next/cache'
 
-type StrategyStatus = 'draft' | 'adopted' | 'superseded' | 'retired'
+type StrategyStatus = 'proposed' | 'active' | 'achieved' | 'abandoned'
 type Visibility = 'org' | 'connections' | 'instance'
 
 async function requireContributor() {
@@ -35,8 +35,8 @@ export async function getStrategies(organizationId: string, role?: string) {
     where: (s, { eq, or, and, inArray, ne }) => {
       const base = eq(s.organizationId, organizationId)
       const instanceWide = eq(s.visibility, 'instance')
-      // A draft strategy is not a viewer-visible root (design §4 / Q5).
-      const statusFilter = isViewer ? ne(s.status, 'draft') : undefined
+      // A proposed strategy is not a viewer-visible root (design §4 / ADR-0005).
+      const statusFilter = isViewer ? ne(s.status, 'proposed') : undefined
       const orgFilter = connectedOrgIds.length === 0
         ? or(base, instanceWide)
         : or(base, instanceWide, and(inArray(s.organizationId, connectedOrgIds), inArray(s.visibility, ['connections', 'instance'])))
@@ -46,7 +46,7 @@ export async function getStrategies(organizationId: string, role?: string) {
     with: {
       organization: true,
       owner: true,
-      goals: true,
+      strategyGoals: true,
     },
   })
 }
@@ -59,14 +59,14 @@ export async function getStrategy(id: string) {
     where: (s, { eq }) => eq(s.id, id),
     with: {
       owner: true,
-      goals: { with: { goalObjectives: { with: { objective: true } } } },
+      strategyGoals: { with: { goal: true } },
     },
   })
 
   if (!strategy) return null
   const visible = await canReadFederatedEntity(strategy.organizationId, strategy.visibility, session.user.organizationId!)
   if (!visible) return null
-  if (session.user.role === 'viewer' && strategy.status === 'draft') return null
+  if (session.user.role === 'viewer' && strategy.status === 'proposed') return null
   return strategy
 }
 
@@ -83,16 +83,10 @@ export async function createStrategy(formData: FormData) {
   const summary = (formData.get('summary') as string) || null
   const planningHorizon = (formData.get('planningHorizon') as string) || null
   const ownerUserId = (formData.get('ownerUserId') as string) || null
-  const status = ((formData.get('status') as StrategyStatus) ?? 'draft')
+  const status = ((formData.get('status') as StrategyStatus) ?? 'proposed')
   const visibility = ((formData.get('visibility') as Visibility) ?? 'org')
   const startDate = parseDate(formData.get('startDate'))
   const endDate = parseDate(formData.get('endDate'))
-
-  // Adoption is a governance act — it routes through adoptStrategy so the prior
-  // adopted strategy is superseded in the same tx. A bare create may not adopt.
-  if (status === 'adopted') {
-    throw new Error('Use adoptStrategy to adopt a strategy')
-  }
 
   await db.transaction(async (tx) => {
     const [strategy] = await tx.insert(strategies).values({
@@ -124,12 +118,6 @@ export async function editStrategy(strategyId: string, formData: FormData) {
   const startDate = parseDate(formData.get('startDate'))
   const endDate = parseDate(formData.get('endDate'))
 
-  // Editing never adopts — that path supersedes the prior adopted strategy and
-  // belongs to adoptStrategy. Keeps the single adoption code path.
-  if (status === 'adopted') {
-    throw new Error('Use adoptStrategy to adopt a strategy')
-  }
-
   const before = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
   assertOwnership(before?.organizationId, orgId)
 
@@ -151,56 +139,6 @@ export async function editStrategy(strategyId: string, formData: FormData) {
   revalidatePath(`/strategies/${strategyId}`)
 }
 
-/**
- * Adopt a strategy as the org's current strategy. Supersedes whatever was
- * adopted before, in the same transaction, so the single-adopted invariant
- * (ADR-0004 / partial unique index) holds without the user ever hitting a
- * constraint error. Idempotent: adopting the already-adopted strategy is a
- * no-op that still records an audit entry.
- */
-export async function adoptStrategy(strategyId: string) {
-  const session = await requireContributor()
-  const orgId = session.user.organizationId!
-
-  const target = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
-  assertOwnership(target?.organizationId, orgId)
-  if (!target) throw new Error('Strategy not found')
-
-  await db.transaction(async (tx) => {
-    // Supersede the currently-adopted strategy (if any, and not this one) FIRST,
-    // so the partial unique index is never momentarily violated.
-    const superseded = await tx.update(strategies)
-      .set({ status: 'superseded', updatedBy: session.user.id, updatedAt: new Date() })
-      .where(and(
-        eq(strategies.organizationId, orgId),
-        eq(strategies.status, 'adopted'),
-        ne(strategies.id, strategyId),
-      ))
-      .returning({ id: strategies.id, name: strategies.name })
-
-    await tx.update(strategies)
-      .set({ status: 'adopted', updatedBy: session.user.id, updatedAt: new Date() })
-      .where(and(eq(strategies.id, strategyId), eq(strategies.organizationId, orgId)))
-
-    for (const prior of superseded) {
-      await writeAuditLog(tx, {
-        action: 'strategy.supersede', entityType: 'strategy', entityId: prior.id,
-        userId: session.user.id, organizationId: orgId,
-        before: { status: 'adopted' }, after: { status: 'superseded', supersededBy: strategyId },
-      })
-    }
-
-    await writeAuditLog(tx, {
-      action: 'strategy.adopt', entityType: 'strategy', entityId: strategyId,
-      userId: session.user.id, organizationId: orgId,
-      before: { status: target.status }, after: { status: 'adopted' },
-    })
-  })
-
-  revalidatePath('/strategies')
-  revalidatePath(`/strategies/${strategyId}`)
-}
-
 export async function deleteStrategy(strategyId: string) {
   const session = await requireAdmin()
   const orgId = session.user.organizationId!
@@ -209,7 +147,8 @@ export async function deleteStrategy(strategyId: string) {
   assertOwnership(before?.organizationId, orgId)
 
   await db.transaction(async (tx) => {
-    // goals.strategy_id is ON DELETE SET NULL — member goals are orphaned, not deleted.
+    // Junction rows (strategy_goals/_capabilities/_value_streams/_initiatives)
+    // cascade on delete; the linked goals/capabilities/etc. are untouched.
     await tx.delete(strategies).where(
       and(eq(strategies.id, strategyId), eq(strategies.organizationId, orgId)),
     )

--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db/client'
 import {
-  strategicObjectives, capabilities, services, goals, strategies,
+  strategicObjectives, capabilities, services, goals, strategies, strategyGoals,
   goalObjectives, objectiveCapabilities, applicationCapabilities,
   initiativeObjectives, serviceCapabilities,
   // #695 — trace-participation subjects and their one-hop root junctions
@@ -162,11 +162,11 @@ async function getGoalsByObjective(objectiveIds: string[]): Promise<Map<string, 
 
 // ── Strategy trace ──────────────────────────────────────────────────────────
 //
-// Strategy is the planning-period root above Goals (#697 / ADR-0004). The chain
-// is Strategy → Goals → Objectives → Initiatives → Capabilities → Applications,
-// composed entirely from existing relationships. Viewer pruning (design Q5): a
-// draft Strategy is not a viewer-visible root, and member goals are pruned to
-// published for viewers.
+// Strategy is a course-of-action root that pursues Goals (#697 / ADR-0005). The
+// chain is Strategy → Goals → Objectives → Initiatives → Capabilities →
+// Applications, composed entirely from existing relationships. Viewer pruning:
+// a proposed Strategy is not a viewer-visible root, and pursued goals are pruned
+// to published for viewers.
 
 export async function getStrategyTrace(id: string): Promise<StrategyTrace | null> {
   const session = await auth()
@@ -177,17 +177,19 @@ export async function getStrategyTrace(id: string): Promise<StrategyTrace | null
   if (!row) return null
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
-  // A draft strategy is not a viewer-visible root.
-  if (isViewer && row.status === 'draft') return null
+  // A proposed strategy is not a viewer-visible root.
+  if (isViewer && row.status === 'proposed') return null
 
-  // Member goals (the one new edge); pruned to published for viewers.
-  const memberGoals = await db.query.goals.findMany({
-    where: (g, { eq: eqf, and: andf }) =>
-      isViewer
-        ? andf(eqf(g.strategyId, id), eqf(g.status, 'published'))
-        : eqf(g.strategyId, id),
-    orderBy: (g, { asc }) => [asc(g.name)],
+  // Goals this strategy pursues (via the strategy_goals junction); pruned to
+  // published for viewers.
+  const pursuedRows = await db.query.strategyGoals.findMany({
+    where: eq(strategyGoals.strategyId, id),
+    with: { goal: true },
   })
+  const memberGoals = pursuedRows
+    .map((r) => r.goal)
+    .filter((g) => !isViewer || g.status === 'published')
+    .sort((a, b) => a.name.localeCompare(b.name))
   const goalIds = memberGoals.map((g) => g.id)
 
   // Objectives per member goal, then caps + initiatives for those objectives —

--- a/apps/govea/src/app/(admin)/goals/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/[id]/page.tsx
@@ -101,12 +101,17 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
         )}
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
-          {goal.strategy && (
+          {goal.strategyGoals.length > 0 && (
             <div>
-              <span className="text-muted-foreground">Part of strategy: </span>
-              <Link href={`/strategies/${goal.strategy.id}`} className="font-medium text-primary hover:underline underline-offset-4">
-                {goal.strategy.name}
-              </Link>
+              <span className="text-muted-foreground">Pursued by strategy: </span>
+              {goal.strategyGoals.map(({ strategy }, i) => (
+                <span key={strategy.id}>
+                  {i > 0 && ', '}
+                  <Link href={`/strategies/${strategy.id}`} className="font-medium text-primary hover:underline underline-offset-4">
+                    {strategy.name}
+                  </Link>
+                </span>
+              ))}
             </div>
           )}
           {goal.planningHorizon && (

--- a/apps/govea/src/app/(admin)/goals/goal-table.tsx
+++ b/apps/govea/src/app/(admin)/goals/goal-table.tsx
@@ -23,12 +23,9 @@ type GoalRow = Goal & {
   goalObjectives: { objective: StrategicObjective }[]
 }
 
-type StrategyOption = { id: string; name: string; status: string }
-
 interface Props {
   goals: GoalRow[]
   objectives: StrategicObjective[]
-  strategies: StrategyOption[]
   role: Role
   currentOrgId: string
 }
@@ -39,7 +36,7 @@ const STATUS_STYLES: Record<string, string> = {
   archived: 'bg-amber-100 text-amber-800 border-amber-200',
 }
 
-export function GoalTable({ goals, objectives, strategies, role, currentOrgId }: Props) {
+export function GoalTable({ goals, objectives, role, currentOrgId }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [statusFilter, setStatusFilter] = useState('all')
@@ -175,7 +172,6 @@ export function GoalTable({ goals, objectives, strategies, role, currentOrgId }:
             <MarkdownEditor label="Description" name="description" rows={2} placeholder="Markdown supported" />
             <FormField label="Planning horizon" name="planningHorizon" placeholder="e.g. 2026–2028, Long-term" />
             <FormField label="Owner" name="owner" placeholder="e.g. Office of the CIO" />
-            <StrategyPicker strategies={strategies} />
             {objectives.length > 0 && (
               <div className="space-y-1.5">
                 <Label>Objectives</Label>
@@ -225,7 +221,6 @@ export function GoalTable({ goals, objectives, strategies, role, currentOrgId }:
             <MarkdownEditor label="Description" name="description" rows={2} defaultValue={editTarget?.description ?? ''} placeholder="Markdown supported" />
             <FormField label="Planning horizon" name="planningHorizon" defaultValue={editTarget?.planningHorizon ?? ''} />
             <FormField label="Owner" name="owner" defaultValue={editTarget?.owner ?? ''} />
-            <StrategyPicker strategies={strategies} defaultValue={editTarget?.strategyId} />
             {objectives.length > 0 && (
               <div className="space-y-1.5">
                 <Label>Objectives</Label>
@@ -282,23 +277,6 @@ export function GoalTable({ goals, objectives, strategies, role, currentOrgId }:
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  )
-}
-
-function StrategyPicker({ strategies, defaultValue }: { strategies: StrategyOption[]; defaultValue?: string | null }) {
-  if (strategies.length === 0) return null
-  return (
-    <div className="space-y-1.5">
-      <Label>Strategy</Label>
-      <select name="strategyId" defaultValue={defaultValue ?? ''}
-        className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
-        <option value="">— No strategy —</option>
-        {strategies.map(s => (
-          <option key={s.id} value={s.id}>{s.name}{s.status === 'adopted' ? ' (adopted)' : ''}</option>
-        ))}
-      </select>
-      <p className="text-xs text-muted-foreground">The planning-period container this goal belongs to. A goal can belong to one strategy.</p>
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/goals/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/page.tsx
@@ -2,7 +2,6 @@ import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getGoals } from '@/actions/goals'
 import { getObjectives } from '@/actions/objectives'
-import { getStrategies } from '@/actions/strategies'
 import { GoalTable } from './goal-table'
 
 export default async function GoalsPage() {
@@ -12,10 +11,9 @@ export default async function GoalsPage() {
   const orgId = session.user.organizationId!
   const role = session.user.role
 
-  const [goalList, objectiveList, strategyList] = await Promise.all([
+  const [goalList, objectiveList] = await Promise.all([
     getGoals(orgId, role),
     getObjectives(),
-    getStrategies(orgId, role),
   ])
 
   return (
@@ -29,7 +27,6 @@ export default async function GoalsPage() {
       <GoalTable
         goals={goalList}
         objectives={objectiveList}
-        strategies={strategyList.map(s => ({ id: s.id, name: s.name, status: s.status }))}
         role={role}
         currentOrgId={orgId}
       />

--- a/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
-import { getStrategy, adoptStrategy } from '@/actions/strategies'
+import { getStrategy } from '@/actions/strategies'
 import { getGoals } from '@/actions/goals'
 import { linkStrategyGoal, unlinkStrategyGoal } from '@/actions/links'
 import { canEdit } from '@/lib/rbac'
@@ -8,14 +8,13 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
 import { MarkdownContent } from '@/components/markdown-content'
-import { Button } from '@/components/ui/button'
 import { ViewTraceabilityLink } from '@/components/view-traceability-link'
 
 const STATUS_STYLES: Record<string, string> = {
-  draft: 'bg-slate-100 text-slate-700 border-slate-200',
-  adopted: 'bg-emerald-100 text-emerald-800 border-emerald-200',
-  superseded: 'bg-amber-100 text-amber-800 border-amber-200',
-  retired: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+  proposed: 'bg-slate-100 text-slate-700 border-slate-200',
+  active: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  achieved: 'bg-blue-100 text-blue-800 border-blue-200',
+  abandoned: 'bg-zinc-100 text-zinc-600 border-zinc-200',
 }
 
 const VISIBILITY_STYLES: Record<string, string> = {
@@ -45,15 +44,15 @@ export default async function StrategyDetailPage({ params }: { params: Promise<{
   const editor = canEdit(session.user)
   const orgId = session.user.organizationId!
   const canMutate = editor && strategy.organizationId === orgId
-  const adopt = adoptStrategy.bind(null, id)
   const addGoal = linkStrategyGoal.bind(null, id)
   const removeGoal = unlinkStrategyGoal.bind(null, id)
 
-  // Offer only un-containered goals (strategy_id null) to add here; moving a goal
-  // out of another strategy is done from the goal's edit flow (slice 3).
+  // Goals a Strategy can pursue: any org goal not already linked here (a goal can
+  // be pursued by several strategies, so no un-linked-only restriction).
+  const linkedGoalIds = new Set(strategy.strategyGoals.map(sg => sg.goalId))
   const availableGoals = canMutate
     ? (await getGoals(orgId, session.user.role))
-        .filter(g => g.organizationId === orgId && g.strategyId === null)
+        .filter(g => g.organizationId === orgId && !linkedGoalIds.has(g.id))
         .map(g => ({ id: g.id, name: g.name }))
     : []
 
@@ -104,24 +103,19 @@ export default async function StrategyDetailPage({ params }: { params: Promise<{
           )}
         </div>
 
-        {canMutate && strategy.status !== 'adopted' && (
-          <form action={adopt} className="pt-1">
-            <Button type="submit" size="sm">Adopt as current strategy</Button>
-          </form>
-        )}
       </div>
 
       <hr />
 
       <RelationshipPanel
-        title="Goals"
-        items={strategy.goals.map(g => ({
-          id: g.id,
-          name: g.name,
-          href: `/goals/${g.id}`,
-          meta: g.status,
+        title="Goals pursued"
+        items={strategy.strategyGoals.map(({ goal }) => ({
+          id: goal.id,
+          name: goal.name,
+          href: `/goals/${goal.id}`,
+          meta: goal.status,
         }))}
-        gapMessage="No goals belong to this strategy yet. Add un-containered goals here, or set this strategy from a goal's edit flow."
+        gapMessage="This strategy doesn't pursue any goals yet. Link the goals this approach is meant to achieve."
         canEdit={canMutate}
         available={availableGoals}
         addAction={addGoal}

--- a/apps/govea/src/app/(admin)/strategies/page.tsx
+++ b/apps/govea/src/app/(admin)/strategies/page.tsx
@@ -21,7 +21,7 @@ export default async function StrategiesPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Strategies</h1>
         <p className="text-muted-foreground mt-1">
-          Planning-period containers that frame your goals. The single <strong>adopted</strong> strategy is your organization&apos;s current strategic direction.
+          Your chosen <strong>courses of action</strong> — the approaches you&apos;re taking to achieve your goals, and the capabilities, value streams, and initiatives each one leverages.
         </p>
       </div>
       <StrategyTable

--- a/apps/govea/src/app/(admin)/strategies/strategy-table.tsx
+++ b/apps/govea/src/app/(admin)/strategies/strategy-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { createStrategy, editStrategy, deleteStrategy, adoptStrategy } from '@/actions/strategies'
+import { createStrategy, editStrategy, deleteStrategy } from '@/actions/strategies'
 import type { Strategy } from '@/db/schema'
 import type { OrgUserPickerRow } from '@/actions/org-users'
 import { useRouter } from 'next/navigation'
@@ -22,7 +22,7 @@ import { MarkdownEditor } from '@/components/markdown-editor'
 type StrategyRow = Strategy & {
   organization: { id: string; name: string } | null
   owner: { id: string; name: string | null } | null
-  goals: { id: string; name: string }[]
+  strategyGoals: { strategyId: string; goalId: string }[]
 }
 
 interface Props {
@@ -33,10 +33,10 @@ interface Props {
 }
 
 const STATUS_STYLES: Record<string, string> = {
-  draft: 'bg-slate-100 text-slate-700 border-slate-200',
-  adopted: 'bg-emerald-100 text-emerald-800 border-emerald-200',
-  superseded: 'bg-amber-100 text-amber-800 border-amber-200',
-  retired: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+  proposed: 'bg-slate-100 text-slate-700 border-slate-200',
+  active: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  achieved: 'bg-blue-100 text-blue-800 border-blue-200',
+  abandoned: 'bg-zinc-100 text-zinc-600 border-zinc-200',
 }
 
 function titleCase(s: string) {
@@ -50,7 +50,6 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
   const [createOpen, setCreateOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<StrategyRow | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<StrategyRow | null>(null)
-  const [adoptTarget, setAdoptTarget] = useState<StrategyRow | null>(null)
 
   const canEdit = role === 'admin' || role === 'contributor'
   const canDelete = role === 'admin'
@@ -86,15 +85,6 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
     })
   }
 
-  async function handleAdopt() {
-    if (!adoptTarget) return
-    startTransition(async () => {
-      await adoptStrategy(adoptTarget.id)
-      setAdoptTarget(null)
-      refresh()
-    })
-  }
-
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
@@ -104,10 +94,10 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
           className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <option value="all">All statuses</option>
-          <option value="draft">Draft</option>
-          <option value="adopted">Adopted</option>
-          <option value="superseded">Superseded</option>
-          <option value="retired">Retired</option>
+          <option value="proposed">Proposed</option>
+          <option value="active">Active</option>
+          <option value="achieved">Achieved</option>
+          <option value="abandoned">Abandoned</option>
         </select>
         {canEdit && (
           <Button onClick={() => setCreateOpen(true)} size="sm" className="ml-auto">
@@ -150,7 +140,7 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
                   {s.owner?.name ?? '—'}
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
-                  {s.goals.length > 0 ? s.goals.length : '—'}
+                  {s.strategyGoals.length > 0 ? s.strategyGoals.length : '—'}
                 </TableCell>
                 <TableCell>
                   <span className={cn('inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[s.status])}>
@@ -164,12 +154,6 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
                         <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">View</Button>
                       </Link>
                       <Button variant="ghost" size="sm" onClick={() => setEditTarget(s)} className="h-7 px-2 text-xs">Edit</Button>
-                      {s.status !== 'adopted' && (
-                        <Button variant="ghost" size="sm" onClick={() => setAdoptTarget(s)} disabled={isPending}
-                          className="h-7 px-2 text-xs text-emerald-700 hover:text-emerald-700 hover:bg-emerald-50">
-                          Adopt
-                        </Button>
-                      )}
                       {canDelete && (
                         <Button variant="ghost" size="sm" onClick={() => setDeleteTarget(s)} disabled={isPending}
                           className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10">
@@ -213,31 +197,12 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
         </DialogContent>
       </Dialog>
 
-      {/* Adopt Dialog */}
-      <Dialog open={!!adoptTarget} onOpenChange={open => { if (!open) setAdoptTarget(null) }}>
-        <DialogContent>
-          <DialogHeader><DialogTitle>Adopt Strategy</DialogTitle></DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Make <strong>{adoptTarget?.name}</strong> your organization&apos;s current strategy?
-            {strategies.some(s => s.status === 'adopted') && (
-              <> The currently adopted strategy will be superseded.</>
-            )}
-          </p>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setAdoptTarget(null)}>Cancel</Button>
-            <Button onClick={handleAdopt} disabled={isPending}>
-              {isPending ? 'Adopting…' : 'Adopt'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       {/* Delete Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <DialogContent>
           <DialogHeader><DialogTitle>Delete Strategy</DialogTitle></DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Permanently delete <strong>{deleteTarget?.name}</strong>? Member goals are kept but un-linked from this strategy. This cannot be undone.
+            Permanently delete <strong>{deleteTarget?.name}</strong>? Linked goals, capabilities, value streams and initiatives are kept; only their links to this strategy are removed. This cannot be undone.
           </p>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
@@ -251,11 +216,7 @@ export function StrategyTable({ strategies, orgUsers, role, currentOrgId }: Prop
   )
 }
 
-/**
- * Shared create/edit form fields. Status select deliberately omits `adopted` —
- * adoption is the Adopt action (it supersedes the prior adopted strategy in one
- * tx); editing never adopts.
- */
+/** Shared create/edit form fields for a strategy (course of action). */
 function StrategyFields({ orgUsers, strategy }: { orgUsers: OrgUserPickerRow[]; strategy?: StrategyRow | null }) {
   return (
     <>
@@ -278,13 +239,13 @@ function StrategyFields({ orgUsers, strategy }: { orgUsers: OrgUserPickerRow[]; 
       </div>
       <div className="space-y-1.5">
         <Label>Status</Label>
-        <select name="status" defaultValue={strategy?.status === 'adopted' ? 'draft' : (strategy?.status ?? 'draft')}
+        <select name="status" defaultValue={strategy?.status ?? 'proposed'}
           className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring">
-          <option value="draft">Draft</option>
-          <option value="superseded">Superseded</option>
-          <option value="retired">Retired</option>
+          <option value="proposed">Proposed</option>
+          <option value="active">Active</option>
+          <option value="achieved">Achieved</option>
+          <option value="abandoned">Abandoned</option>
         </select>
-        <p className="text-xs text-muted-foreground">Use the Adopt action to make a strategy the current one.</p>
       </div>
       <div className="space-y-1.5">
         <Label>Visibility</Label>

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -859,9 +859,9 @@ async function TraceabilityHub({ organizationId, role }: { organizationId: strin
   // Viewer-only filter: traceability already enforces visibility at the
   // entity-level actions. For the hub, we restrict to published items so
   // stakeholders aren't shown drafts they can't actually trace.
-  // Strategy has no 'published' status — a draft strategy is not a traceable
-  // root (design Q5), so non-draft strategies are the hub-eligible ones.
-  const traceableStrategies = strategies.filter(s => s.status !== 'draft')
+  // Strategy has no 'published' status — a proposed strategy is not a traceable
+  // root (ADR-0005), so non-proposed strategies are the hub-eligible ones.
+  const traceableStrategies = strategies.filter(s => s.status !== 'proposed')
   const publishedGoals = goals.filter(g => g.status === 'published')
   const publishedObjectives = objectives.filter(o => o.status === 'published')
   const publishedCapabilities = capabilities.filter(c => c.status === 'published')

--- a/apps/govea/src/db/schema/goals.ts
+++ b/apps/govea/src/db/schema/goals.ts
@@ -3,7 +3,6 @@ import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 import { workflowStatusEnum } from './personas'
 import { strategicObjectives } from './objectives'
-import { strategies } from './strategies'
 
 export const goals = pgTable('goals', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -11,10 +10,9 @@ export const goals = pgTable('goals', {
   name: text('name').notNull(),
   description: text('description'),
   planningHorizon: text('planning_horizon'),
-  // Optional parent Strategy container (#697/#805). null = un-containered goal
-  // (valid, back-compat). At most one strategy per goal — many-to-one, no join
-  // table (ADR-0004 Q3). set null so deleting a strategy orphans, not deletes.
-  strategyId: uuid('strategy_id').references(() => strategies.id, { onDelete: 'set null' }),
+  // Strategy↔Goal is now a many-to-many junction (strategy_goals), per ADR-0005:
+  // a Strategy is a course of action that *pursues* goals, and a goal may be
+  // pursued by several strategies. (The old goals.strategy_id FK was dropped.)
   owner: text('owner'),
   status: workflowStatusEnum('status').notNull().default('draft'),
   visibility: visibilityEnum('visibility').notNull().default('org'),

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -7,7 +7,7 @@ import { organizations } from './organizations'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities } from './value-streams'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from './objectives'
 import { goals, goalObjectives } from './goals'
-import { strategies } from './strategies'
+import { strategies, strategyGoals, strategyCapabilities, strategyValueStreams, strategyInitiatives } from './strategies'
 import { users } from './users'
 import { initiatives, initiativeCapabilities, initiativeObjectives, initiativeApplications } from './initiatives'
 import { adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives } from './adrs'
@@ -144,10 +144,7 @@ export const goalsRelations = relations(goals, ({ one, many }) => ({
     fields: [goals.organizationId],
     references: [organizations.id],
   }),
-  strategy: one(strategies, {
-    fields: [goals.strategyId],
-    references: [strategies.id],
-  }),
+  strategyGoals: many(strategyGoals),
   goalObjectives: many(goalObjectives),
 }))
 
@@ -162,7 +159,30 @@ export const strategiesRelations = relations(strategies, ({ one, many }) => ({
     fields: [strategies.ownerUserId],
     references: [users.id],
   }),
-  goals: many(goals),
+  strategyGoals: many(strategyGoals),
+  strategyCapabilities: many(strategyCapabilities),
+  strategyValueStreams: many(strategyValueStreams),
+  strategyInitiatives: many(strategyInitiatives),
+}))
+
+export const strategyGoalsRelations = relations(strategyGoals, ({ one }) => ({
+  strategy: one(strategies, { fields: [strategyGoals.strategyId], references: [strategies.id] }),
+  goal: one(goals, { fields: [strategyGoals.goalId], references: [goals.id] }),
+}))
+
+export const strategyCapabilitiesRelations = relations(strategyCapabilities, ({ one }) => ({
+  strategy: one(strategies, { fields: [strategyCapabilities.strategyId], references: [strategies.id] }),
+  capability: one(capabilities, { fields: [strategyCapabilities.capabilityId], references: [capabilities.id] }),
+}))
+
+export const strategyValueStreamsRelations = relations(strategyValueStreams, ({ one }) => ({
+  strategy: one(strategies, { fields: [strategyValueStreams.strategyId], references: [strategies.id] }),
+  valueStream: one(valueStreams, { fields: [strategyValueStreams.valueStreamId], references: [valueStreams.id] }),
+}))
+
+export const strategyInitiativesRelations = relations(strategyInitiatives, ({ one }) => ({
+  strategy: one(strategies, { fields: [strategyInitiatives.strategyId], references: [strategies.id] }),
+  initiative: one(initiatives, { fields: [strategyInitiatives.initiativeId], references: [initiatives.id] }),
 }))
 
 export const goalObjectivesRelations = relations(goalObjectives, ({ one }) => ({

--- a/apps/govea/src/db/schema/strategies.ts
+++ b/apps/govea/src/db/schema/strategies.ts
@@ -1,30 +1,32 @@
-import { date, index, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
-import { sql } from 'drizzle-orm'
+import { date, index, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
+import { goals } from './goals'
+import { capabilities } from './capabilities'
+import { valueStreams } from './value-streams'
+import { initiatives } from './initiatives'
 
 /**
- * Strategy: the first-class planning container above Goals (#697, #805).
+ * Strategy: a BIZBOK **course of action** — the broad chosen *approach* to
+ * achieve one or more Goals (#697 / ADR-0005, superseding ADR-0004's container).
  *
- * A Strategy frames a planning period — horizon, owner, dates, summary — and
- * holds Goals (via the nullable `goals.strategy_id` FK in ./goals). The
- * strategic *content* is its Goals; Strategy authors little of its own. See
- * `docs/design/strategy-entity.md` and ADR-0004 for the load-bearing decisions.
+ * Strategy is a *means*, not a container above Goals: Goals/Objectives are the
+ * ends, a Strategy is how we intend to get there, and it maps onto the operating
+ * model it leverages and changes — Capabilities and Value Streams (cross-mapped
+ * peers) — and is delivered by Initiatives. See `docs/design/strategy-entity.md`.
  *
- * Lifecycle is planning-specific (not the generic draft/published/archived):
- *   draft → adopted → superseded → retired
- * Adoption is a governance act. **At most one `adopted` strategy per org** is
- * the single source of truth for "the current strategy" that dashboard /
- * executive surfaces read — enforced at the DB layer by the partial unique
- * index below, no trigger needed. `adoptStrategy` (actions/strategies.ts)
- * supersedes the prior adopted strategy in the same transaction so the
- * invariant holds without ever surfacing a constraint error to the user.
+ * Lifecycle is a course-of-action lifecycle (not a content publish, not the old
+ * adopt/supersede governance act):
+ *   proposed → active → achieved → abandoned
+ * Multiple strategies can be `active` at once — there is no single "current"
+ * strategy, so no partial unique index. "Active strategies" is what executive
+ * surfaces read.
  */
 export const strategyStatusEnum = pgEnum('strategy_status', [
-  'draft',
-  'adopted',
-  'superseded',
-  'retired',
+  'proposed',
+  'active',
+  'achieved',
+  'abandoned',
 ])
 
 export const strategies = pgTable(
@@ -33,10 +35,10 @@ export const strategies = pgTable(
     id: uuid('id').primaryKey().defaultRandom(),
     organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
     name: text('name').notNull(),
-    summary: text('summary'), // markdown, like other planning descriptions
-    planningHorizon: text('planning_horizon'), // same shape as goals.planning_horizon, e.g. "FY26–FY28"
+    summary: text('summary'), // markdown — the approach, in prose
+    planningHorizon: text('planning_horizon'), // e.g. "FY26–FY28"
     ownerUserId: uuid('owner_user_id').references(() => users.id, { onDelete: 'set null' }),
-    status: strategyStatusEnum('status').notNull().default('draft'),
+    status: strategyStatusEnum('status').notNull().default('proposed'),
     visibility: visibilityEnum('visibility').notNull().default('org'),
     // Proper date columns — do NOT extend the free-text-date debt (data-model.md §4).
     startDate: date('start_date'),
@@ -47,10 +49,6 @@ export const strategies = pgTable(
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },
   (t) => [
-    // "At most one adopted strategy per org" — partial unique index (Q1 / ADR-0004).
-    uniqueIndex('strategies_one_adopted_per_org_uniq')
-      .on(t.organizationId)
-      .where(sql`${t.status} = 'adopted'`),
     index('strategies_org_status_idx').on(t.organizationId, t.status),
     index('strategies_org_updated_at_idx').on(t.organizationId, t.updatedAt),
   ],
@@ -58,3 +56,38 @@ export const strategies = pgTable(
 
 export type Strategy = typeof strategies.$inferSelect
 export type NewStrategy = typeof strategies.$inferInsert
+
+// ── Junctions ────────────────────────────────────────────────────────────────
+// Strategy is a means: it *pursues* Goals, *impacts* the operating model
+// (capabilities + value streams), and is *delivered by* Initiatives. All
+// many-to-many — a goal can be pursued by several strategies, etc.
+
+/** Strategy pursues Goal. */
+export const strategyGoals = pgTable('strategy_goals', {
+  strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
+  goalId: uuid('goal_id').notNull().references(() => goals.id, { onDelete: 'cascade' }),
+})
+export type StrategyGoal = typeof strategyGoals.$inferSelect
+
+/** Strategy impacts Capability (leverage/build/improve/retire). */
+export const strategyCapabilities = pgTable('strategy_capabilities', {
+  strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
+  capabilityId: uuid('capability_id').notNull().references(() => capabilities.id, { onDelete: 'cascade' }),
+  impact: text('impact'), // 'leverage' | 'build' | 'improve' | 'retire' | null
+})
+export type StrategyCapability = typeof strategyCapabilities.$inferSelect
+
+/** Strategy impacts Value Stream. */
+export const strategyValueStreams = pgTable('strategy_value_streams', {
+  strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
+  valueStreamId: uuid('value_stream_id').notNull().references(() => valueStreams.id, { onDelete: 'cascade' }),
+  impact: text('impact'), // 'leverage' | 'build' | 'improve' | 'retire' | null
+})
+export type StrategyValueStream = typeof strategyValueStreams.$inferSelect
+
+/** Strategy is delivered by Initiative. */
+export const strategyInitiatives = pgTable('strategy_initiatives', {
+  strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
+  initiativeId: uuid('initiative_id').notNull().references(() => initiatives.id, { onDelete: 'cascade' }),
+})
+export type StrategyInitiative = typeof strategyInitiatives.$inferSelect

--- a/apps/govea/src/db/schema/strategies.ts
+++ b/apps/govea/src/db/schema/strategies.ts
@@ -1,4 +1,4 @@
-import { date, index, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { date, index, pgEnum, pgTable, primaryKey, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { organizations, visibilityEnum } from './organizations'
 import { users } from './users'
 import { goals } from './goals'
@@ -66,7 +66,7 @@ export type NewStrategy = typeof strategies.$inferInsert
 export const strategyGoals = pgTable('strategy_goals', {
   strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
   goalId: uuid('goal_id').notNull().references(() => goals.id, { onDelete: 'cascade' }),
-})
+}, (t) => [primaryKey({ columns: [t.strategyId, t.goalId] })])
 export type StrategyGoal = typeof strategyGoals.$inferSelect
 
 /** Strategy impacts Capability (leverage/build/improve/retire). */
@@ -74,7 +74,7 @@ export const strategyCapabilities = pgTable('strategy_capabilities', {
   strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
   capabilityId: uuid('capability_id').notNull().references(() => capabilities.id, { onDelete: 'cascade' }),
   impact: text('impact'), // 'leverage' | 'build' | 'improve' | 'retire' | null
-})
+}, (t) => [primaryKey({ columns: [t.strategyId, t.capabilityId] })])
 export type StrategyCapability = typeof strategyCapabilities.$inferSelect
 
 /** Strategy impacts Value Stream. */
@@ -82,12 +82,12 @@ export const strategyValueStreams = pgTable('strategy_value_streams', {
   strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
   valueStreamId: uuid('value_stream_id').notNull().references(() => valueStreams.id, { onDelete: 'cascade' }),
   impact: text('impact'), // 'leverage' | 'build' | 'improve' | 'retire' | null
-})
+}, (t) => [primaryKey({ columns: [t.strategyId, t.valueStreamId] })])
 export type StrategyValueStream = typeof strategyValueStreams.$inferSelect
 
 /** Strategy is delivered by Initiative. */
 export const strategyInitiatives = pgTable('strategy_initiatives', {
   strategyId: uuid('strategy_id').notNull().references(() => strategies.id, { onDelete: 'cascade' }),
   initiativeId: uuid('initiative_id').notNull().references(() => initiatives.id, { onDelete: 'cascade' }),
-})
+}, (t) => [primaryKey({ columns: [t.strategyId, t.initiativeId] })])
 export type StrategyInitiative = typeof strategyInitiatives.$inferSelect

--- a/apps/govea/src/lib/backup-import.ts
+++ b/apps/govea/src/lib/backup-import.ts
@@ -294,14 +294,7 @@ export async function importArchive(
     }
     if (content.goals.length) {
       await tx.insert(goals).values(
-        (content.goals as Record<string, unknown>[]).map(r => {
-          // Strategy backup parity lands in slice 6 (#805). Until strategies are
-          // exported and their ids remapped, a carried-over strategy_id would
-          // dangle (FK to a strategy not in this backup) or mislink across
-          // tenants — so drop it on import. Goals restore un-containered.
-          const { strategyId: _strategyId, ...rest } = r
-          return normalize(rest, ctx)
-        }) as never,
+        (content.goals as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
       )
       inserted.goals = content.goals.length
     }

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -12,7 +12,7 @@ import { db } from '@/db/client'
 import {
   organizations, users, capabilities, initiatives, adrs, auditLog,
   personas, applications, strategicObjectives, principles, valueStreams, services,
-  glossaryTerms, strategies, goals,
+  glossaryTerms, strategies, strategyGoals, goals,
 } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
@@ -141,12 +141,12 @@ export async function getStrategiesForOrg(orgId: string) {
   return db.select().from(strategies).where(eq(strategies.organizationId, orgId))
 }
 
-/** Insert a strategy row directly — used to seed specific statuses for invariant tests. */
+/** Insert a strategy row directly — used to seed specific statuses for tests. */
 export async function insertStrategy(
   orgId: string,
   overrides: {
     name?: string
-    status?: 'draft' | 'adopted' | 'superseded' | 'retired'
+    status?: 'proposed' | 'active' | 'achieved' | 'abandoned'
     visibility?: 'org' | 'connections' | 'instance'
   } = {},
 ) {
@@ -156,17 +156,17 @@ export async function insertStrategy(
     .values({
       organizationId: orgId,
       name: overrides.name ?? `Test Strategy ${suffix}`,
-      status: overrides.status ?? 'draft',
+      status: overrides.status ?? 'proposed',
       visibility: overrides.visibility ?? 'org',
     })
     .returning()
   return row
 }
 
-/** Insert a goal row directly — used by strategy FK (set null) tests. */
+/** Insert a goal row directly. */
 export async function insertGoal(
   orgId: string,
-  overrides: { name?: string; strategyId?: string | null } = {},
+  overrides: { name?: string; status?: 'draft' | 'published' | 'archived' } = {},
 ) {
   const suffix = randomUUID().slice(0, 8)
   const [row] = await db
@@ -174,10 +174,15 @@ export async function insertGoal(
     .values({
       organizationId: orgId,
       name: overrides.name ?? `Test Goal ${suffix}`,
-      strategyId: overrides.strategyId ?? null,
+      status: overrides.status ?? 'draft',
     })
     .returning()
   return row
+}
+
+/** Link a strategy to a goal it pursues (strategy_goals junction). */
+export async function linkStrategyGoalRow(strategyId: string, goalId: string) {
+  await db.insert(strategyGoals).values({ strategyId, goalId }).onConflictDoNothing()
 }
 
 /** Convenience: insert a capability row directly for cross-org / setup scenarios. */

--- a/apps/govea/tests/integration/strategies.test.ts
+++ b/apps/govea/tests/integration/strategies.test.ts
@@ -1,24 +1,22 @@
 /**
- * Integration tests: strategies server actions + schema invariants (#812 / #805)
+ * Integration tests: strategies server actions (#825 / ADR-0005)
  *
- * Covers:
+ * Strategy is a course of action (proposed→active→achieved→abandoned), not a
+ * container — no adopt, no single-adopted invariant. Covers:
  *  - CRUD role enforcement (contributor create/edit, admin delete, viewer forbidden)
- *  - createStrategy / editStrategy / deleteStrategy write rows + audit logs
- *  - adoptStrategy supersedes the prior adopted strategy in one tx
- *  - Single-adopted invariant at the action layer AND the DB layer (partial unique index)
- *  - goals.strategy_id is nullable and ON DELETE SET NULL (member goals orphan, not delete)
+ *  - create/edit/delete write rows + audit logs on the new lifecycle
+ *  - delete cascades junction rows but leaves linked goals intact
  */
 import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import {
-  createStrategy, editStrategy, deleteStrategy, adoptStrategy,
-} from '@/actions/strategies'
+import { createStrategy, editStrategy, deleteStrategy } from '@/actions/strategies'
+import { linkStrategyGoal } from '@/actions/links'
 import { db } from '@/db/client'
 import { strategies, goals } from '@/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import {
   createTestOrg, createTestUser, cleanupOrg,
   makeSession, getStrategiesForOrg, getAuditLogsForEntity,
-  insertStrategy, insertGoal,
+  insertGoal,
   type TestUser,
 } from './helpers/db'
 
@@ -28,7 +26,7 @@ vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
 function stratForm(overrides: Record<string, string> = {}): FormData {
   const fd = new FormData()
   fd.set('name', overrides.name ?? 'Test Strategy')
-  fd.set('status', overrides.status ?? 'draft')
+  fd.set('status', overrides.status ?? 'proposed')
   fd.set('visibility', overrides.visibility ?? 'org')
   if (overrides.summary) fd.set('summary', overrides.summary)
   if (overrides.planningHorizon) fd.set('planningHorizon', overrides.planningHorizon)
@@ -55,37 +53,36 @@ describe('strategies actions', () => {
 
   afterAll(() => cleanupOrg(orgId))
 
-  // ── createStrategy ───────────────────────────────────────────────────────────
-
   describe('createStrategy', () => {
     beforeEach(() => {
       mockAuth.mockResolvedValue(makeSession(contributor))
     })
 
-    it('contributor can create a strategy', async () => {
+    it('contributor can create a strategy (default proposed)', async () => {
       const before = await getStrategiesForOrg(orgId)
-      await createStrategy(stratForm({ name: 'FY26 Strategy' }))
+      await createStrategy(stratForm({ name: 'Cloud-First Approach' }))
       const after = await getStrategiesForOrg(orgId)
 
       expect(after).toHaveLength(before.length + 1)
-      const row = after.find(s => s.name === 'FY26 Strategy')!
+      const row = after.find(s => s.name === 'Cloud-First Approach')!
       expect(row.organizationId).toBe(orgId)
       expect(row.createdBy).toBe(contributor.id)
-      expect(row.status).toBe('draft')
+      expect(row.status).toBe('proposed')
     })
 
-    it('persists proper date columns and horizon', async () => {
+    it('persists active status, dates and horizon', async () => {
       await createStrategy(stratForm({
-        name: 'Dated Strategy', planningHorizon: 'FY26–FY28',
+        name: 'Dated Strategy', status: 'active', planningHorizon: 'FY26–FY28',
         startDate: '2026-07-01', endDate: '2028-06-30',
       }))
       const row = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Dated Strategy')!
+      expect(row.status).toBe('active')
       expect(row.planningHorizon).toBe('FY26–FY28')
       expect(row.startDate).toBe('2026-07-01')
       expect(row.endDate).toBe('2028-06-30')
     })
 
-    it('viewer cannot create → throws Forbidden', async () => {
+    it('viewer cannot create → Forbidden', async () => {
       mockAuth.mockResolvedValue(makeSession(viewer))
       await expect(createStrategy(stratForm())).rejects.toThrow('Forbidden')
     })
@@ -95,23 +92,22 @@ describe('strategies actions', () => {
       await expect(createStrategy(stratForm())).rejects.toThrow(/REDIRECT:\/login/)
     })
 
-    it('cannot create directly as adopted → must use adoptStrategy', async () => {
-      await expect(createStrategy(stratForm({ name: 'Sneaky Adopt', status: 'adopted' })))
-        .rejects.toThrow(/adoptStrategy/)
-    })
-
     it('writes audit log: action=strategy.create', async () => {
       await createStrategy(stratForm({ name: 'Audit Create Target' }))
       const row = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Audit Create Target')!
       const logs = await getAuditLogsForEntity(row.id)
       expect(logs).toHaveLength(1)
       expect(logs[0].action).toBe('strategy.create')
-      expect(logs[0].before).toBeNull()
-      expect(logs[0].after).toMatchObject({ name: 'Audit Create Target' })
+      expect(logs[0].after).toMatchObject({ name: 'Audit Create Target', status: 'proposed' })
+    })
+
+    it('multiple strategies can be active at once (no single-adopted invariant)', async () => {
+      await createStrategy(stratForm({ name: 'Active One', status: 'active' }))
+      await createStrategy(stratForm({ name: 'Active Two', status: 'active' }))
+      const active = (await getStrategiesForOrg(orgId)).filter(s => s.status === 'active')
+      expect(active.length).toBeGreaterThanOrEqual(2)
     })
   })
-
-  // ── editStrategy ─────────────────────────────────────────────────────────────
 
   describe('editStrategy', () => {
     let strategyId: string
@@ -122,163 +118,76 @@ describe('strategies actions', () => {
       strategyId = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Edit Me')!.id
     })
 
-    it('contributor can edit an owned strategy', async () => {
+    it('contributor can edit and advance the lifecycle', async () => {
       mockAuth.mockResolvedValue(makeSession(contributor))
-      await editStrategy(strategyId, stratForm({ name: 'Edited Name', status: 'retired' }))
+      await editStrategy(strategyId, stratForm({ name: 'Edited Name', status: 'achieved' }))
       const row = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
       expect(row?.name).toBe('Edited Name')
-      expect(row?.status).toBe('retired')
+      expect(row?.status).toBe('achieved')
       expect(row?.updatedBy).toBe(contributor.id)
     })
 
-    it('editing to adopted is rejected → must use adoptStrategy', async () => {
-      mockAuth.mockResolvedValue(makeSession(contributor))
-      await expect(editStrategy(strategyId, stratForm({ name: 'Edited Name', status: 'adopted' })))
-        .rejects.toThrow(/adoptStrategy/)
-    })
-
-    it('viewer cannot edit → throws Forbidden', async () => {
+    it('viewer cannot edit → Forbidden', async () => {
       mockAuth.mockResolvedValue(makeSession(viewer))
-      await expect(editStrategy(strategyId, stratForm({ name: 'Hijack', status: 'draft' })))
+      await expect(editStrategy(strategyId, stratForm({ name: 'Hijack', status: 'active' })))
         .rejects.toThrow('Forbidden')
     })
 
     it('writes audit log with before/after snapshot', async () => {
       mockAuth.mockResolvedValue(makeSession(contributor))
-      await editStrategy(strategyId, stratForm({ name: 'Before State', status: 'draft' }))
-      await editStrategy(strategyId, stratForm({ name: 'After State', status: 'retired' }))
+      await editStrategy(strategyId, stratForm({ name: 'Before State', status: 'proposed' }))
+      await editStrategy(strategyId, stratForm({ name: 'After State', status: 'active' }))
       const logs = await getAuditLogsForEntity(strategyId)
       const entry = logs.find(
         l => l.action === 'strategy.edit' && (l.after as Record<string, unknown>)?.name === 'After State',
       )
       expect(entry).toBeDefined()
-      expect(entry!.before).toMatchObject({ name: 'Before State', status: 'draft' })
-      expect(entry!.after).toMatchObject({ name: 'After State', status: 'retired' })
+      expect(entry!.before).toMatchObject({ name: 'Before State', status: 'proposed' })
+      expect(entry!.after).toMatchObject({ name: 'After State', status: 'active' })
     })
   })
-
-  // ── adoptStrategy + single-adopted invariant ─────────────────────────────────
-
-  describe('adoptStrategy', () => {
-    beforeEach(() => {
-      mockAuth.mockResolvedValue(makeSession(contributor))
-    })
-
-    it('adopting a draft strategy makes it the current (adopted) one', async () => {
-      const s = await insertStrategy(orgId, { name: 'To Adopt', status: 'draft' })
-      await adoptStrategy(s.id)
-      const row = await db.query.strategies.findFirst({ where: eq(strategies.id, s.id) })
-      expect(row?.status).toBe('adopted')
-    })
-
-    it('adopting a second strategy supersedes the first in one tx (single-adopted invariant)', async () => {
-      const first = await insertStrategy(orgId, { name: 'First Adopted' })
-      const second = await insertStrategy(orgId, { name: 'Second Adopted' })
-
-      await adoptStrategy(first.id)
-      await adoptStrategy(second.id)
-
-      const rows = await getStrategiesForOrg(orgId)
-      const adopted = rows.filter(s => s.status === 'adopted')
-      expect(adopted).toHaveLength(1)
-      expect(adopted[0].id).toBe(second.id)
-      expect(rows.find(s => s.id === first.id)?.status).toBe('superseded')
-    })
-
-    it('writes adopt + supersede audit logs', async () => {
-      const first = await insertStrategy(orgId, { name: 'Audit First' })
-      const second = await insertStrategy(orgId, { name: 'Audit Second' })
-      await adoptStrategy(first.id)
-      await adoptStrategy(second.id)
-
-      const adoptLogs = await getAuditLogsForEntity(second.id)
-      expect(adoptLogs.some(l => l.action === 'strategy.adopt')).toBe(true)
-      const supersedeLogs = await getAuditLogsForEntity(first.id)
-      expect(supersedeLogs.some(l => l.action === 'strategy.supersede')).toBe(true)
-    })
-
-    it('viewer cannot adopt → throws Forbidden', async () => {
-      const s = await insertStrategy(orgId, { name: 'Viewer Adopt Block' })
-      mockAuth.mockResolvedValue(makeSession(viewer))
-      await expect(adoptStrategy(s.id)).rejects.toThrow('Forbidden')
-    })
-  })
-
-  // ── DB-level guard: partial unique index ─────────────────────────────────────
-
-  describe('single-adopted partial unique index', () => {
-    it('a direct second adopted insert violates the unique index', async () => {
-      const guardOrg = await createTestOrg()
-      await db.insert(strategies).values({
-        organizationId: guardOrg.id, name: 'DB Adopted One', status: 'adopted', visibility: 'org',
-      })
-      await expect(
-        db.insert(strategies).values({
-          organizationId: guardOrg.id, name: 'DB Adopted Two', status: 'adopted', visibility: 'org',
-        }),
-      ).rejects.toThrow()
-      await cleanupOrg(guardOrg.id)
-    })
-
-    it('two orgs can each have one adopted strategy', async () => {
-      const orgA = await createTestOrg()
-      const orgB = await createTestOrg()
-      await expect(Promise.all([
-        db.insert(strategies).values({ organizationId: orgA.id, name: 'A Adopted', status: 'adopted', visibility: 'org' }),
-        db.insert(strategies).values({ organizationId: orgB.id, name: 'B Adopted', status: 'adopted', visibility: 'org' }),
-      ])).resolves.not.toThrow()
-      await Promise.all([cleanupOrg(orgA.id), cleanupOrg(orgB.id)])
-    })
-  })
-
-  // ── goals.strategy_id FK behavior ────────────────────────────────────────────
-
-  describe('goals.strategy_id', () => {
-    it('a goal with strategy_id = null is valid (back-compat)', async () => {
-      const g = await insertGoal(orgId, { name: 'Uncontainered Goal' })
-      expect(g.strategyId).toBeNull()
-    })
-
-    it('deleting a strategy sets member goals strategy_id to null (orphans, not deletes)', async () => {
-      const s = await insertStrategy(orgId, { name: 'Has Goals' })
-      const g = await insertGoal(orgId, { name: 'Member Goal', strategyId: s.id })
-      expect(g.strategyId).toBe(s.id)
-
-      mockAuth.mockResolvedValue(makeSession(admin))
-      await deleteStrategy(s.id)
-
-      const goalAfter = await db.query.goals.findFirst({ where: eq(goals.id, g.id) })
-      expect(goalAfter).toBeDefined()
-      expect(goalAfter?.strategyId).toBeNull()
-    })
-  })
-
-  // ── deleteStrategy role enforcement ──────────────────────────────────────────
 
   describe('deleteStrategy', () => {
     it('admin can delete a strategy', async () => {
-      const s = await insertStrategy(orgId, { name: 'Delete Me' })
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createStrategy(stratForm({ name: 'Delete Me' }))
+      const strategyId = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Delete Me')!.id
+
       mockAuth.mockResolvedValue(makeSession(admin))
-      await deleteStrategy(s.id)
-      const check = await db.query.strategies.findFirst({ where: eq(strategies.id, s.id) })
+      await deleteStrategy(strategyId)
+      const check = await db.query.strategies.findFirst({ where: eq(strategies.id, strategyId) })
       expect(check).toBeUndefined()
     })
 
     it('contributor cannot delete → admin required', async () => {
-      const s = await insertStrategy(orgId, { name: 'Protected Strategy' })
       mockAuth.mockResolvedValue(makeSession(contributor))
-      await expect(deleteStrategy(s.id)).rejects.toThrow('Forbidden')
-      const check = await db.query.strategies.findFirst({
-        where: and(eq(strategies.id, s.id), eq(strategies.organizationId, orgId)),
-      })
-      expect(check).toBeDefined()
+      await createStrategy(stratForm({ name: 'Protected Strategy' }))
+      const strategyId = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Protected Strategy')!.id
+      await expect(deleteStrategy(strategyId)).rejects.toThrow('Forbidden')
+    })
+
+    it('deleting a strategy removes its goal links but keeps the goals', async () => {
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createStrategy(stratForm({ name: 'Has Links' }))
+      const strategyId = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Has Links')!.id
+      const g = await insertGoal(orgId, { name: 'Pursued Goal' })
+      await linkStrategyGoal(strategyId, g.id)
+
+      mockAuth.mockResolvedValue(makeSession(admin))
+      await deleteStrategy(strategyId)
+
+      const goalAfter = await db.query.goals.findFirst({ where: eq(goals.id, g.id) })
+      expect(goalAfter).toBeDefined() // goal survives; junction row cascaded away
     })
 
     it('delete writes audit log with before snapshot', async () => {
-      const s = await insertStrategy(orgId, { name: 'Audit Delete Target' })
+      mockAuth.mockResolvedValue(makeSession(contributor))
+      await createStrategy(stratForm({ name: 'Audit Delete Target' }))
+      const strategyId = (await getStrategiesForOrg(orgId)).find(s => s.name === 'Audit Delete Target')!.id
+
       mockAuth.mockResolvedValue(makeSession(admin))
-      await deleteStrategy(s.id)
-      const logs = await getAuditLogsForEntity(s.id)
+      await deleteStrategy(strategyId)
+      const logs = await getAuditLogsForEntity(strategyId)
       const deleteLog = logs.find(l => l.action === 'strategy.delete')!
       expect(deleteLog).toBeDefined()
       expect(deleteLog.before).toMatchObject({ name: 'Audit Delete Target' })

--- a/apps/govea/tests/integration/strategy-goal-linking.test.ts
+++ b/apps/govea/tests/integration/strategy-goal-linking.test.ts
@@ -1,44 +1,38 @@
 /**
- * Integration tests: Strategy ↔ Goal linking (#816 / #805 slice 3)
+ * Integration tests: Strategy ↔ Goal linking (#825 / ADR-0005)
  *
- * The link is the single FK goals.strategy_id (not a junction). Covers:
- *  - linkStrategyGoal sets the FK; unlinkStrategyGoal clears it
- *  - single-strategy-per-goal: linking a goal already in another strategy moves it
- *  - unlink is a no-op unless the goal is currently in that strategy
- *  - role enforcement (contributor links, viewer forbidden) + cross-org rejection
- *  - editGoal sets/clears strategy_id from the goal edit flow, validating org
- *  - audit logs for link/unlink
+ * Strategy↔Goal is now the strategy_goals junction (many-to-many: a strategy
+ * pursues goals; a goal can be pursued by several strategies). Covers:
+ *  - linkStrategyGoal inserts a junction row; idempotent
+ *  - a goal can be pursued by two strategies (no "move")
+ *  - unlinkStrategyGoal removes only that pair
+ *  - role enforcement + cross-org rejection
  */
 import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { linkStrategyGoal, unlinkStrategyGoal } from '@/actions/links'
-import { editGoal } from '@/actions/goals'
 import { db } from '@/db/client'
-import { goals } from '@/db/schema'
-import { eq } from 'drizzle-orm'
+import { strategyGoals } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
 import {
   createTestOrg, createTestUser, cleanupOrg, makeSession,
-  insertStrategy, insertGoal, getAuditLogsForEntity,
+  insertStrategy, insertGoal,
   type TestUser,
 } from './helpers/db'
 
 const mockAuth = vi.hoisted(() => vi.fn())
 vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
 
-async function strategyIdOf(goalId: string) {
-  const g = await db.query.goals.findFirst({ where: eq(goals.id, goalId), columns: { strategyId: true } })
-  return g?.strategyId ?? null
+async function strategiesForGoal(goalId: string) {
+  const rows = await db.select().from(strategyGoals).where(eq(strategyGoals.goalId, goalId))
+  return rows.map(r => r.strategyId)
+}
+async function isLinked(strategyId: string, goalId: string) {
+  const rows = await db.select().from(strategyGoals)
+    .where(and(eq(strategyGoals.strategyId, strategyId), eq(strategyGoals.goalId, goalId)))
+  return rows.length > 0
 }
 
-function goalForm(overrides: Record<string, string> = {}): FormData {
-  const fd = new FormData()
-  fd.set('name', overrides.name ?? 'Edited Goal')
-  fd.set('status', overrides.status ?? 'draft')
-  fd.set('visibility', overrides.visibility ?? 'org')
-  if (overrides.strategyId !== undefined) fd.set('strategyId', overrides.strategyId)
-  return fd
-}
-
-describe('strategy ↔ goal linking', () => {
+describe('strategy ↔ goal linking (junction)', () => {
   let orgId: string
   let contributor: TestUser
   let viewer: TestUser
@@ -59,20 +53,30 @@ describe('strategy ↔ goal linking', () => {
   })
 
   describe('linkStrategyGoal', () => {
-    it('sets goals.strategy_id', async () => {
+    it('inserts a strategy_goals row', async () => {
       const s = await insertStrategy(orgId, { name: 'Link Target' })
-      const g = await insertGoal(orgId, { name: 'Free Goal' })
+      const g = await insertGoal(orgId, { name: 'Goal A' })
       await linkStrategyGoal(s.id, g.id)
-      expect(await strategyIdOf(g.id)).toBe(s.id)
+      expect(await isLinked(s.id, g.id)).toBe(true)
     })
 
-    it('moves a goal already in another strategy (single-strategy-per-goal)', async () => {
-      const first = await insertStrategy(orgId, { name: 'First Container' })
-      const second = await insertStrategy(orgId, { name: 'Second Container' })
-      const g = await insertGoal(orgId, { name: 'Movable Goal', strategyId: first.id })
+    it('is idempotent (no duplicate rows)', async () => {
+      const s = await insertStrategy(orgId, { name: 'Idempotent' })
+      const g = await insertGoal(orgId, { name: 'Goal B' })
+      await linkStrategyGoal(s.id, g.id)
+      await linkStrategyGoal(s.id, g.id)
+      const rows = await db.select().from(strategyGoals)
+        .where(and(eq(strategyGoals.strategyId, s.id), eq(strategyGoals.goalId, g.id)))
+      expect(rows).toHaveLength(1)
+    })
 
-      await linkStrategyGoal(second.id, g.id)
-      expect(await strategyIdOf(g.id)).toBe(second.id)
+    it('a goal can be pursued by two strategies (no move)', async () => {
+      const s1 = await insertStrategy(orgId, { name: 'Strategy One' })
+      const s2 = await insertStrategy(orgId, { name: 'Strategy Two' })
+      const g = await insertGoal(orgId, { name: 'Shared Goal' })
+      await linkStrategyGoal(s1.id, g.id)
+      await linkStrategyGoal(s2.id, g.id)
+      expect((await strategiesForGoal(g.id)).sort()).toEqual([s1.id, s2.id].sort())
     })
 
     it('viewer cannot link → Forbidden', async () => {
@@ -89,66 +93,27 @@ describe('strategy ↔ goal linking', () => {
       await expect(linkStrategyGoal(s.id, foreignGoal.id)).rejects.toThrow()
       await cleanupOrg(otherOrg.id)
     })
-
-    it('writes a strategy.link_goal audit log with before/after', async () => {
-      const s = await insertStrategy(orgId, { name: 'Audit Link' })
-      const g = await insertGoal(orgId, { name: 'Audit Link Goal' })
-      await linkStrategyGoal(s.id, g.id)
-      const logs = await getAuditLogsForEntity(g.id)
-      const entry = logs.find(l => l.action === 'strategy.link_goal')
-      expect(entry).toBeDefined()
-      expect(entry!.before).toMatchObject({ strategyId: null })
-      expect(entry!.after).toMatchObject({ strategyId: s.id })
-    })
   })
 
   describe('unlinkStrategyGoal', () => {
-    it('clears strategy_id when the goal is in that strategy', async () => {
-      const s = await insertStrategy(orgId, { name: 'Unlink Target' })
-      const g = await insertGoal(orgId, { name: 'Linked Goal', strategyId: s.id })
-      await unlinkStrategyGoal(s.id, g.id)
-      expect(await strategyIdOf(g.id)).toBeNull()
-    })
+    it('removes only the targeted pair', async () => {
+      const s1 = await insertStrategy(orgId, { name: 'Keeps Link' })
+      const s2 = await insertStrategy(orgId, { name: 'Loses Link' })
+      const g = await insertGoal(orgId, { name: 'Goal C' })
+      await linkStrategyGoal(s1.id, g.id)
+      await linkStrategyGoal(s2.id, g.id)
 
-    it('is a no-op when the goal is in a different strategy', async () => {
-      const owner = await insertStrategy(orgId, { name: 'Real Owner' })
-      const other = await insertStrategy(orgId, { name: 'Other Strategy' })
-      const g = await insertGoal(orgId, { name: 'Stays Put', strategyId: owner.id })
-
-      await unlinkStrategyGoal(other.id, g.id)
-      expect(await strategyIdOf(g.id)).toBe(owner.id)
+      await unlinkStrategyGoal(s2.id, g.id)
+      expect(await isLinked(s2.id, g.id)).toBe(false)
+      expect(await isLinked(s1.id, g.id)).toBe(true)
     })
 
     it('viewer cannot unlink → Forbidden', async () => {
       const s = await insertStrategy(orgId, { name: 'Viewer Unlink Block' })
-      const g = await insertGoal(orgId, { name: 'Goal VUB', strategyId: s.id })
+      const g = await insertGoal(orgId, { name: 'Goal VUB' })
+      await linkStrategyGoal(s.id, g.id)
       mockAuth.mockResolvedValue(makeSession(viewer))
       await expect(unlinkStrategyGoal(s.id, g.id)).rejects.toThrow('Forbidden')
-    })
-  })
-
-  describe('editGoal strategy_id', () => {
-    it('sets strategy_id from the goal edit flow', async () => {
-      const s = await insertStrategy(orgId, { name: 'Edit-flow Strategy' })
-      const g = await insertGoal(orgId, { name: 'Edit Me' })
-      await editGoal(g.id, goalForm({ name: 'Edit Me', strategyId: s.id }))
-      expect(await strategyIdOf(g.id)).toBe(s.id)
-    })
-
-    it('clears strategy_id when the picker is set to none', async () => {
-      const s = await insertStrategy(orgId, { name: 'Soon Cleared' })
-      const g = await insertGoal(orgId, { name: 'Clear Me', strategyId: s.id })
-      await editGoal(g.id, goalForm({ name: 'Clear Me', strategyId: '' }))
-      expect(await strategyIdOf(g.id)).toBeNull()
-    })
-
-    it('rejects a strategy from another org', async () => {
-      const otherOrg = await createTestOrg()
-      const foreignStrategy = await insertStrategy(otherOrg.id, { name: 'Foreign Strategy' })
-      const g = await insertGoal(orgId, { name: 'Goal needing valid strategy' })
-      await expect(editGoal(g.id, goalForm({ name: 'Goal needing valid strategy', strategyId: foreignStrategy.id })))
-        .rejects.toThrow()
-      await cleanupOrg(otherOrg.id)
     })
   })
 })

--- a/apps/govea/tests/integration/strategy-traceability.test.ts
+++ b/apps/govea/tests/integration/strategy-traceability.test.ts
@@ -12,7 +12,7 @@ import { getStrategyTrace } from '@/actions/traceability'
 import { db } from '@/db/client'
 import {
   strategies, goals, strategicObjectives, capabilities, initiatives,
-  goalObjectives, objectiveCapabilities, initiativeObjectives,
+  goalObjectives, objectiveCapabilities, initiativeObjectives, strategyGoals,
 } from '@/db/schema'
 import { randomUUID } from 'node:crypto'
 import {
@@ -45,19 +45,23 @@ describe('getStrategyTrace', () => {
     ])
 
     const [s] = await db.insert(strategies).values({
-      organizationId: orgId, name: 'FY26 Strategy', status: 'adopted', visibility: 'org',
+      organizationId: orgId, name: 'FY26 Strategy', status: 'active', visibility: 'org',
     }).returning()
     strategyId = s.id
 
-    // Two member goals: one published (viewer-visible), one draft (pruned for viewers).
+    // Two pursued goals: one published (viewer-visible), one draft (pruned for viewers).
     const [pg] = await db.insert(goals).values({
-      organizationId: orgId, name: 'Published Member Goal', status: 'published', visibility: 'org', strategyId,
+      organizationId: orgId, name: 'Published Member Goal', status: 'published', visibility: 'org',
     }).returning()
     publishedGoalId = pg.id
     const [dg] = await db.insert(goals).values({
-      organizationId: orgId, name: 'Draft Member Goal', status: 'draft', visibility: 'org', strategyId,
+      organizationId: orgId, name: 'Draft Member Goal', status: 'draft', visibility: 'org',
     }).returning()
     draftGoalId = dg.id
+    await db.insert(strategyGoals).values([
+      { strategyId, goalId: publishedGoalId },
+      { strategyId, goalId: draftGoalId },
+    ])
 
     const [o] = await db.insert(strategicObjectives).values({
       organizationId: orgId, name: 'Measurable Objective', status: 'published', visibility: 'org',
@@ -108,17 +112,17 @@ describe('getStrategyTrace', () => {
     expect(ids).not.toContain(draftGoalId)
   })
 
-  it('a draft strategy is not a viewer-visible root → null', async () => {
-    const [draftStrategy] = await db.insert(strategies).values({
-      organizationId: orgId, name: 'Draft Strategy', status: 'draft', visibility: 'org',
+  it('a proposed strategy is not a viewer-visible root → null', async () => {
+    const [proposedStrategy] = await db.insert(strategies).values({
+      organizationId: orgId, name: 'Proposed Strategy', status: 'proposed', visibility: 'org',
     }).returning()
 
     mockAuth.mockResolvedValue(makeSession(viewer))
-    expect(await getStrategyTrace(draftStrategy.id)).toBeNull()
+    expect(await getStrategyTrace(proposedStrategy.id)).toBeNull()
 
     // …but a non-viewer can trace it.
     mockAuth.mockResolvedValue(makeSession(contributor))
-    expect(await getStrategyTrace(draftStrategy.id)).not.toBeNull()
+    expect(await getStrategyTrace(proposedStrategy.id)).not.toBeNull()
   })
 
   it('returns null for an unknown id', async () => {
@@ -129,7 +133,7 @@ describe('getStrategyTrace', () => {
   it('returns null for a strategy in another org', async () => {
     const otherOrg = await createTestOrg()
     const [foreign] = await db.insert(strategies).values({
-      organizationId: otherOrg.id, name: 'Foreign Strategy', status: 'adopted', visibility: 'org',
+      organizationId: otherOrg.id, name: 'Foreign Strategy', status: 'active', visibility: 'org',
     }).returning()
 
     mockAuth.mockResolvedValue(makeSession(contributor))

--- a/docs/design/strategy-entity.md
+++ b/docs/design/strategy-entity.md
@@ -1,150 +1,119 @@
-# Design: First-class Strategy entity
+# Design: First-class Strategy entity (course of action)
 
-**Status:** Proposed — design slice for #697; implementation gated on the tracker issue and #668 validation
-**Issue:** [#697](https://github.com/roballred/GovEA/issues/697)
+**Status:** Accepted — implements [ADR-0005](../decisions/0005-reconcile-strategy-with-bizbok.md) (supersedes the ADR-0004 container design)
+**Issue:** [#697](https://github.com/roballred/GovEA/issues/697) · Tracker [#805](https://github.com/roballred/GovEA/issues/805)
 **Capabilities:** `pl-goals`, `pl-strategic-objectives`, `pl-initiatives`, `fd-traceability-views`, `rm-end-to-end-traceability` (capability group `cms/planning`)
 **Personas:** Enterprise Architect, Agency EA Coordinator, Department Director, Budget & Performance Analyst
-**Related:** [ADR-0004](../decisions/0004-strategy-as-planning-container.md), `docs/data-model.md` (planning entities), `docs/architect/data-and-traceability.md` (traceability chain)
+**Related:** [ADR-0005](../decisions/0005-reconcile-strategy-with-bizbok.md), `docs/data-model.md`, `docs/architect/data-and-traceability.md`
 
 ---
 
 ## Why this doc exists
 
-#697 asks us to add a missing **Strategy** container above the shipped
-Goal → Objective → Initiative hierarchy — *without* blurring that hierarchy and
-*without* turning Strategy into a static document upload. This doc makes the
-product distinction, resolves the issue's open design questions, specifies the
-data model and traceability behavior, and lists what stays gated.
+#697 asks for a first-class **Strategy** entity. ADR-0004 first modeled it as a
+*container above Goals*; on review that inverted the BMM/BIZBOK ends-means
+relationship, and **ADR-0005** reworked it: a **Strategy is a course of action**
+— the broad chosen *approach* to achieve Goals — that maps onto the operating
+model (capabilities and value streams) and is delivered by Initiatives.
 
-> **Bottom line:** Add a lightweight, first-class **`strategies`** planning
-> entity that acts as the *container and planning-period frame* for Goals. A
-> Goal belongs to **at most one** Strategy (nullable many-to-one), Goals are
-> the unit of strategic content (themes/priorities are Goals, not a new
-> sub-type), and Strategy becomes a **traceability root** above Goals. Strategy
-> uses a **planning-specific lifecycle** (`draft` → `adopted` → `superseded` →
-> `retired`) with **at most one adopted strategy per org**, which is what the
-> dashboard/executive surfaces read as "the current strategy." No change to the
-> Goal/Objective/Initiative model other than an optional `strategy_id` on goals.
+> **Bottom line:** Strategy is a *means*, not a container. Goals/Objectives are
+> the **ends** (what we want, and how we measure it); a Strategy is **how we
+> intend to get there**. It *pursues* one or more Goals, *impacts* Capabilities
+> and Value Streams (the operating model it leverages and changes), and is
+> *delivered by* Initiatives. Lifecycle is a course-of-action lifecycle
+> (`proposed → active → achieved → abandoned`); multiple strategies can be
+> active at once.
 
 ---
 
-## 1. The product distinction (acceptance criterion #1)
+## 1. The product distinction
 
-| Entity | Question it answers | Shape | Shipped? |
+The four planning concepts are kept distinct so we don't create overlapping
+records (BMM roles in parentheses):
+
+| Entity | Role | Question it answers | Shape |
 |---|---|---|---|
-| **Strategy** (proposed) | "What is our overall strategic direction for this planning period, and which goals belong to it?" | A named **container** with a planning horizon, owner, and lifecycle. Holds Goals; authors little content of its own beyond a summary. | No |
-| **Goal** | "What broad outcome are we trying to achieve?" | Mission-level aim; the **unit of strategic content**. Themes/priorities are expressed as Goals. | Yes |
-| **Strategic Objective** | "What measurable result advances a goal?" | Has a success metric + time horizon; links to capabilities and value streams. | Yes |
-| **Initiative** | "What funded work delivers the objectives?" | Time-boxed effort; links to objectives, capabilities, applications. | Yes |
-| **Roadmap** | "When does the work land, against the architecture?" | A **view** over initiatives, not an entity. | Yes (view) |
+| **Goal** | End | What broad outcome are we trying to achieve? | Mission-level aim. |
+| **Strategic Objective** | End (measurable) | How do we measure progress toward the goal? | Success metric + horizon; links to capabilities and value streams. |
+| **Strategy** | **Means — course of action** | What is our broad chosen *approach* to achieve the goal? | Named approach with a horizon, owner, lifecycle; pursues goals, impacts the operating model, delivered by initiatives. |
+| **Initiative** | Means — funded work (≈ Tactic) | What funded effort *delivers* the approach? | Time-boxed effort; links to objectives, capabilities, applications. |
 
-Strategy is the planning-period frame above Goals; it does not replace or
-reshape anything below Goals. The clean Goal → Objective → Initiative chain that
-GovEA recently established is preserved intact.
+Strategy sits *beside* Goals/Objectives as the chosen approach — it does not
+contain them. The shipped Goal → Objective → Initiative chain is untouched.
 
-## 2. Resolved design questions
+## 2. Data model
 
-| # | Question | Decision | Why |
-|---|---|---|---|
-| Q1 | Multiple active strategies, or one current per horizon? | **At most one `adopted` strategy per org** (partial unique index). Multiple `draft`/`superseded`/`retired` records coexist for history and planning. | Gives "the current strategy" a single unambiguous answer for dashboard/executive surfaces; history is still first-class. |
-| Q2 | Standard `draft/published/archived` workflow, or a planning lifecycle? | **Planning lifecycle: `draft` → `adopted` → `superseded` → `retired`.** | Adoption is a governance act, not a content publish. Matches the precedent that planning entities carry domain-specific statuses (initiatives: `proposed/active/on-hold/complete/cancelled`; ADRs: `proposed/accepted/deprecated/superseded`). |
-| Q3 | Goal in exactly one Strategy, or many? | **At most one** — nullable `goals.strategy_id` (many-to-one). A Goal may have no Strategy (back-compat). | Single-answer "which strategy does this goal belong to?"; keeps the container concept and traceability unambiguous. A join table would invite many-to-many and blur the hierarchy. |
-| Q4 | Themes/priorities on Strategy, or as Goals? | **As Goals.** Strategy holds only a summary + horizon + ownership; the strategic content *is* its Goals. | Avoids a parallel themes sub-entity and a second authoring surface; reuses everything Goals already do (objectives, traceability). |
-| Q5 | Strategy-root traceability with draft/non-viewer-visible downstream? | Same rules as every existing root: the chain **prunes nodes the viewer can't see**. Viewers see only viewer-visible Strategy/Goal/Objective/Initiative records; editors see all. | Consistent with the #695 participation-panel scoping and the existing root loaders — no new visibility semantics. |
-| Q6 | In main nav, or under Planning/Strategy module settings? | Under the existing **Strategy** module group as a new `strategies` module (`/strategies`), gated by module settings like Objectives/Initiatives/Roadmap. | No new top-level nav; respects the org's module toggles. |
-
-## 3. Data model
-
-### 3.1 `strategies` (new)
+### 2.1 `strategies`
 
 | Column | Type | Notes |
 |---|---|---|
 | `id` | uuid pk | |
 | `organization_id` | uuid → organizations (cascade) | tenant scope |
 | `name` | text not null | |
-| `summary` | text | markdown, like other planning descriptions |
-| `planning_horizon` | text | same shape as `goals.planning_horizon` (e.g. "FY26–FY28") |
-| `owner_user_id` | uuid → users (set null) | nullable; the strategy's accountable owner |
-| `status` | enum `strategy_status` | `draft` \| `adopted` \| `superseded` \| `retired`; default `draft` |
-| `visibility` | enum (shared with content) | `org` \| `connections` \| `instance` |
-| `start_date` / `end_date` | `date` | proper date columns — **do not** extend the free-text-date debt noted in `data-model.md` §4 |
-| `created_at` / `updated_at` / `created_by` / `updated_by` | standard audit columns | |
+| `summary` | text | markdown — the approach, in prose |
+| `planning_horizon` | text | e.g. "FY26–FY28" |
+| `owner_user_id` | uuid → users (set null) | accountable owner |
+| `status` | enum `strategy_status` | `proposed` \| `active` \| `achieved` \| `abandoned`; default `proposed` |
+| `visibility` | enum | `org` \| `connections` \| `instance` |
+| `start_date` / `end_date` | `date` | proper date columns |
+| audit columns | | `created_at/_by`, `updated_at/_by` |
 
-**Constraint:** partial unique index `(organization_id) WHERE status = 'adopted'`
-enforces "at most one adopted strategy per org" at the DB layer (a Postgres
-partial unique index; no trigger needed). Adoption is a server action that flips
-any currently-adopted strategy to `superseded` in the same transaction.
+No single-`active` constraint: multiple strategies may be active. "Active
+strategies" (plural) is what executive surfaces read — there is no single
+"current strategy."
 
-### 3.2 `goals.strategy_id` (new nullable column)
+### 2.2 Junctions (all many-to-many)
 
-`uuid → strategies (set null)`, nullable. A Goal with `strategy_id = null` is a
-valid, un-containered goal (back-compat for every existing goal). The link is
-editable from both the Strategy detail page (manage member goals) and the Goal
-edit flow (pick a strategy), per acceptance criteria.
+| Table | Meaning | Extra |
+|---|---|---|
+| `strategy_goals` | Strategy **pursues** Goal | — |
+| `strategy_capabilities` | Strategy **impacts** Capability | `impact` (`leverage`/`build`/`improve`/`retire`) |
+| `strategy_value_streams` | Strategy **impacts** Value Stream | `impact` |
+| `strategy_initiatives` | Strategy is **delivered by** Initiative | — |
 
-> No new junction table: the many-to-one decision (Q3) makes a column the
-> correct and simplest shape, and it keeps the uniqueness ("one strategy per
-> goal") trivially enforced.
+A goal can be pursued by several strategies, and vice-versa. Capabilities and
+value streams stay cross-mapped peers; Strategy references both directly rather
+than reaching them only through objectives.
 
-### 3.3 Derived chain (no new joins below Goals)
+> The old `goals.strategy_id` FK and the single-`adopted` partial unique index
+> from ADR-0004 are **dropped**.
 
-Strategy → Goals (FK) → Objectives (`goal_objectives`) → Initiatives
-(`initiative_objectives`) → Capabilities / Value Streams / Services /
-Applications, all through **existing** relationships. Strategy adds exactly one
-new edge (Strategy→Goal); everything downstream is composed from what ships
-today, mirroring how `data-and-traceability.md` already derives applications for
-objectives through capabilities.
+## 3. Traceability
 
-## 4. Traceability
+- **Root:** `/traceability?from=strategy&id=<id>` renders Strategy at the top of
+  a chain: Strategy → Goals (it pursues) → Objectives → Initiatives →
+  Capabilities → Applications, reusing the existing Goal/Objective traversal.
+  (The direct Strategy→Capability / →Value Stream / →Initiative impact links are
+  surfaced on the detail page; folding them into the trace view is a follow-up.)
+- **Affordances:** `View traceability →` on the Strategy detail page; on a Goal
+  detail page, "Pursued by strategy *X*" linking to each strategy.
+- **Visibility:** the root is gated by `canReadFederatedEntity`; a `proposed`
+  strategy is not a viewer-visible root; pursued goals prune to published for
+  viewers.
 
-- **New root:** `/traceability?from=strategy&id=<id>` renders Strategy at the top
-  of the planning chain, then Strategy → Goals → Objectives → Initiatives →
-  architecture, reusing the existing Goal/Objective/Initiative traversal.
-- **Affordances:** a `View traceability →` link on the Strategy detail page, and
-  on linked Goal detail pages a "part of strategy *X*" link into the strategy's
-  trace (consistent with the #695 affordance pattern).
-- **Visibility:** the trace prunes non-viewer-visible nodes exactly as the
-  existing roots do (Q5). A draft Strategy is not a viewer-visible root.
+## 4. Boundary statements (Gate B)
 
-## 5. Surfaces
+- **Strategy vs. value-chain grouping (#694):** a value chain groups *value
+  streams* (operating-model structure); a Strategy is a *chosen approach* that
+  *references* the value streams it affects. Strategy links to value streams; it
+  does not group them.
+- **Strategy vs. service-product container (#791):** a service-product is a
+  *delivery container* for what the org offers; a Strategy is the *approach* to
+  achieve goals. A strategy may change the capabilities behind a product, but it
+  does not contain products.
 
-- **List + detail** for Strategies using the same authoring conventions as other
-  planning content (create/edit forms, status + visibility selects, markdown
-  summary).
-- **Read-only executive view** suitable for Department Directors / Budget &
-  Performance: the adopted strategy, its goals, and a plain-language rollup of
-  objectives/initiatives — no authoring chrome.
-- **Current-strategy badge** on Dashboard / Roadmap / Executive surfaces, reading
-  the single `adopted` strategy.
-- **Import/export/backup** gain Strategy records and the `strategy_id` on goal
-  rows once the entity ships (round-trip parity, per the export conventions).
-- **Seed:** one `adopted` strategy linked to several goals, plus one
-  `draft` and one `superseded` strategy, to demonstrate planning-period behavior.
-
-## 6. What stays gated
-
-This is a **design slice**. The current planning model is shipped and useful, so
-the build proceeds deliberately:
-
-- **Gate A — validation (#668).** The Department Director / Budget & Performance
-  value of a Strategy container is an *assumed* persona need. The first Tier-1
-  interview should confirm that a real Agency EA Coordinator or director wants a
-  strategy *record* (vs. just goals with a horizon) before the schema lands.
-- **Gate B — reconcile with adjacent design.** Confirm Strategy does not overlap
-  the value-chains grouping (#694) or the service-product container (#791); each
-  answers a different question, but the boundaries should be stated before build.
-- **Implementation slices** (each its own issue under the tracker): (1) schema +
-  `strategy_id` + adoption action; (2) list/detail/edit + module wiring; (3)
-  Strategy↔Goal linking from both sides; (4) traceability root + affordances;
-  (5) executive read view + current-strategy surfaces; (6) import/export/backup +
-  seed. Tests per slice: CRUD, role enforcement, link integrity, single-adopted
-  invariant, Strategy-root traceability, visibility pruning, seeded rendering.
-
-## 7. Capability mapping
+## 5. Capability mapping
 
 No new capability doc. Strategy extends the **`cms/planning`** group: `pl-goals`
-(Goals gain a parent container), `pl-strategic-objectives` / `pl-initiatives`
-(unchanged, reached via Goals), and `fd-traceability-views` /
-`rm-end-to-end-traceability` (Strategy becomes a traceable root). If a future
-maintainer wants Strategy modeled as its own sub-capability (`pl-strategy`),
-that is a clean follow-up — flagged, not assumed.
+(goals gain pursuing strategies), `pl-strategic-objectives` / `pl-initiatives`
+(unchanged), and `fd-traceability-views` / `rm-end-to-end-traceability`
+(Strategy is a traceable root). A future `pl-strategy` sub-capability remains a
+clean follow-up.
+
+## 6. Build sequence
+
+Implemented as rework slices under #805 (see ADR-0005): **R1** schema +
+strategy CRUD + `strategy_goals` linking (this doc); **R2** detail/edit
+surfacing of the capability/value-stream/initiative links; **R3** linking UI for
+those three junctions; **R4** traceability polish; then executive surfaces and
+import/export/seed on the new shape.


### PR DESCRIPTION
First rework slice for **ADR-0005**, superseding the ADR-0004 container schema (#812). Strategy becomes a BIZBOK **course of action** — a *means* that pursues Goals and maps onto the operating model — not a container above Goals.

The FK→junction change cascades through the merged container slices, so this PR touches schema, actions, the goal/strategy UI, and traceability together to keep `tsc`/lint/build green.

## Schema
- `strategy_status` → `proposed`→`active`→`achieved`→`abandoned` (default `proposed`)
- **drop** `goals.strategy_id` and the single-`adopted` partial unique index
- new junctions: `strategy_goals`, `strategy_capabilities` (impact), `strategy_value_streams` (impact), `strategy_initiatives`; relations for each

## Actions / UI
- retire `adoptStrategy`; `createStrategy`/`editStrategy` on the new lifecycle
- `linkStrategyGoal`/`unlinkStrategyGoal` operate on `strategy_goals` (many-to-many: a goal can be pursued by several strategies)
- goal create/edit drop `strategyId`; goal detail shows "Pursued by strategy" (list)
- strategy list/detail/edit drop Adopt; status uses the new lifecycle; detail "Goals pursued" panel links via the junction
- `getStrategyTrace` reads pursued goals via the junction; hub viewer-filter uses `proposed`
- backup-import: drop the now-obsolete `goals.strategy_id` strip

## Tests (integration)
Reworked: CRUD + role + audit on the new lifecycle (multiple active strategies allowed); junction link integrity (idempotent, many-to-many, targeted unlink, cross-org rejection); strategy-root traceability via the junction with `proposed`/viewer pruning.

Design doc `strategy-entity.md` rewritten to the course-of-action model.

## Out of scope (later rework slices)
Strategy↔Capability/Value Stream/Initiative **linking UI** (R3) and their detail/edit surfacing (R2); traceability of the direct impact links (R4); executive surfaces (5); import/export/backup + seed (6).

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build. Integration tests run in CI.

Capability: pl-goals
Capability: pl-strategic-objectives
Closes #825
Part of #805 · Decision: ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)