### PR TITLE
feat(strategy): R3 — reverse Strategy affordances on linked entity pages

### DIFF
--- a/apps/govea/src/actions/capabilities.ts
+++ b/apps/govea/src/actions/capabilities.ts
@@ -45,6 +45,7 @@ export async function getCapability(id: string) {
       applicationCapabilities: { with: { application: true } },
       objectiveCapabilities: { with: { objective: true } },
       initiativeCapabilities: { with: { initiative: true } },
+      strategyCapabilities: { with: { strategy: true } },
       adrCapabilities: { with: { adr: true } },
       principleCapabilities: { with: { principle: true } },
     },

--- a/apps/govea/src/actions/initiatives.ts
+++ b/apps/govea/src/actions/initiatives.ts
@@ -70,6 +70,7 @@ export async function getInitiative(id: string) {
       initiativeCapabilities: { with: { capability: true } },
       initiativeObjectives: { with: { objective: true } },
       initiativeApplications: { with: { application: true } },
+      strategyInitiatives: { with: { strategy: true } },
     },
   })
 

--- a/apps/govea/src/actions/links.ts
+++ b/apps/govea/src/actions/links.ts
@@ -421,6 +421,47 @@ export async function unlinkStrategyInitiative(strategyId: string, initiativeId:
   revalidatePath(`/strategies/${strategyId}`)
 }
 
+// ── Reverse Strategy affordances (#829) ──────────────────────────────────────
+//
+// Same junctions, driven from the *other* entity's detail page. Each delegates
+// to the strategy-first action (which org-checks both ends) and revalidates the
+// source page. The argument order is (sourceId, strategyId) so a page can bind
+// its own id: `linkCapabilityStrategy.bind(null, capabilityId)`.
+
+export async function linkGoalStrategy(goalId: string, strategyId: string) {
+  await linkStrategyGoal(strategyId, goalId) // revalidates both /goals and /strategies
+}
+export async function unlinkGoalStrategy(goalId: string, strategyId: string) {
+  await unlinkStrategyGoal(strategyId, goalId)
+}
+
+export async function linkCapabilityStrategy(capabilityId: string, strategyId: string) {
+  await linkStrategyCapability(strategyId, capabilityId)
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+export async function unlinkCapabilityStrategy(capabilityId: string, strategyId: string) {
+  await unlinkStrategyCapability(strategyId, capabilityId)
+  revalidatePath(`/capabilities/${capabilityId}`)
+}
+
+export async function linkValueStreamStrategy(valueStreamId: string, strategyId: string) {
+  await linkStrategyValueStream(strategyId, valueStreamId)
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+export async function unlinkValueStreamStrategy(valueStreamId: string, strategyId: string) {
+  await unlinkStrategyValueStream(strategyId, valueStreamId)
+  revalidatePath(`/value-streams/${valueStreamId}`)
+}
+
+export async function linkInitiativeStrategy(initiativeId: string, strategyId: string) {
+  await linkStrategyInitiative(strategyId, initiativeId)
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+export async function unlinkInitiativeStrategy(initiativeId: string, strategyId: string) {
+  await unlinkStrategyInitiative(strategyId, initiativeId)
+  revalidatePath(`/initiatives/${initiativeId}`)
+}
+
 // ── Objective ↔ Capability ──────────────────────────────────────────────────
 
 export async function linkObjectiveCapability(objectiveId: string, capabilityId: string) {

--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -76,6 +76,7 @@ export async function getValueStream(id: string) {
       valueStreamPersonas: { with: { persona: true } },
       valueStreamCapabilities: { with: { capability: true } },
       objectiveValueStreams: { with: { objective: true } },
+      strategyValueStreams: { with: { strategy: true } },
     },
   })
 

--- a/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/[id]/page.tsx
@@ -22,7 +22,9 @@ import {
   linkCapabilityObjective, unlinkCapabilityObjective,
   linkCapabilityInitiative, unlinkCapabilityInitiative,
   linkCapabilityAdr, unlinkCapabilityAdr,
+  linkCapabilityStrategy, unlinkCapabilityStrategy,
 } from '@/actions/links'
+import { getStrategies } from '@/actions/strategies'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { CrossOrgLinksPanel } from '@/components/cross-org-links-panel'
@@ -87,16 +89,17 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
   const canMutate = editor && capability.organizationId === orgId
   const canApproveCrossOrg = isAdmin(session.user) && capability.organizationId === orgId
 
-  const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs, crossOrgLinks] = editor
+  const [allPersonas, allApplications, allObjectives, allInitiatives, allAdrs, allStrategies, crossOrgLinks] = editor
     ? await Promise.all([
         getPersonas(),
         getApplications(),
         getObjectives(),
         getInitiatives(),
         getADRs(),
+        getStrategies(orgId, session.user.role),
         getCrossOrgLinkContext('capability', id),
       ])
-    : [[], [], [], [], [], { approved: [], inboundPending: [], outboundPending: [], outboundRejected: [], availableTargets: [] }]
+    : [[], [], [], [], [], [], { approved: [], inboundPending: [], outboundPending: [], outboundRejected: [], availableTargets: [] }]
 
   // Domain owner (#581 follow-up): fetch picker list for editors, plus the
   // owner attribution row for the detail line. Owner lookup is conditional
@@ -121,7 +124,11 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
   const removeInitiative = unlinkCapabilityInitiative.bind(null, id)
   const addAdr = linkCapabilityAdr.bind(null, id)
   const removeAdr = unlinkCapabilityAdr.bind(null, id)
+  const addStrategy = linkCapabilityStrategy.bind(null, id)
+  const removeStrategy = unlinkCapabilityStrategy.bind(null, id)
   const requestFederatedLink = requestCrossOrgLink.bind(null, 'capability', id)
+
+  const linkedStrategyIds = new Set(capability.strategyCapabilities.map(sc => sc.strategyId))
 
   const parents = capability.parentRelationships.map(r => r.parent)
   const children = capability.childRelationships.map(r => r.child)
@@ -273,6 +280,21 @@ export default async function CapabilityDetailPage({ params }: { params: Promise
           available={allPersonas.filter(p => p.organizationId === orgId).map(p => ({ id: p.id, name: p.name }))}
           addAction={addPersona}
           removeAction={removePersona}
+        />
+      )}
+
+      {isModuleEnabled(enabledModules, 'strategies') && (
+        <RelationshipPanel
+          title="Strategies impacting this"
+          items={capability.strategyCapabilities.map(({ strategy }) => ({
+            id: strategy.id, name: strategy.name,
+            href: `/strategies/${strategy.id}`, meta: strategy.status,
+          }))}
+          gapMessage="No strategies reference this capability yet."
+          canEdit={canMutate}
+          available={allStrategies.filter(s => s.organizationId === orgId && !linkedStrategyIds.has(s.id)).map(s => ({ id: s.id, name: s.name }))}
+          addAction={addStrategy}
+          removeAction={removeStrategy}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/goals/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/goals/[id]/page.tsx
@@ -6,7 +6,8 @@ import { canEdit } from '@/lib/rbac'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { RelationshipPanel } from '@/components/relationship-panel'
-import { linkGoalObjective, unlinkGoalObjective } from '@/actions/links'
+import { linkGoalObjective, unlinkGoalObjective, linkGoalStrategy, unlinkGoalStrategy } from '@/actions/links'
+import { getStrategies } from '@/actions/strategies'
 import { MarkdownContent } from '@/components/markdown-content'
 import { dedupeById } from '@/lib/dedup'
 
@@ -40,10 +41,15 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
   const orgId = session.user.organizationId!
   const canMutate = editor && goal.organizationId === orgId
 
-  const allObjectives = editor ? await getObjectives() : []
+  const [allObjectives, allStrategies] = editor
+    ? await Promise.all([getObjectives(), getStrategies(orgId, session.user.role)])
+    : [[], []]
 
   const addObjective = linkGoalObjective.bind(null, id)
   const removeObjective = unlinkGoalObjective.bind(null, id)
+  const addStrategy = linkGoalStrategy.bind(null, id)
+  const removeStrategy = unlinkGoalStrategy.bind(null, id)
+  const linkedStrategyIds = new Set(goal.strategyGoals.map(sg => sg.strategyId))
 
   // Aggregate rollup through linked objectives
   const initiatives = dedupeById(
@@ -101,19 +107,6 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
         )}
 
         <div className="flex flex-wrap gap-6 text-sm pt-1">
-          {goal.strategyGoals.length > 0 && (
-            <div>
-              <span className="text-muted-foreground">Pursued by strategy: </span>
-              {goal.strategyGoals.map(({ strategy }, i) => (
-                <span key={strategy.id}>
-                  {i > 0 && ', '}
-                  <Link href={`/strategies/${strategy.id}`} className="font-medium text-primary hover:underline underline-offset-4">
-                    {strategy.name}
-                  </Link>
-                </span>
-              ))}
-            </div>
-          )}
           {goal.planningHorizon && (
             <div>
               <span className="text-muted-foreground">Planning horizon: </span>
@@ -130,6 +123,21 @@ export default async function GoalDetailPage({ params }: { params: Promise<{ id:
       </div>
 
       <hr />
+
+      <RelationshipPanel
+        title="Strategies pursuing this goal"
+        items={goal.strategyGoals.map(({ strategy }) => ({
+          id: strategy.id,
+          name: strategy.name,
+          href: `/strategies/${strategy.id}`,
+          meta: strategy.status,
+        }))}
+        gapMessage="No strategies pursue this goal yet."
+        canEdit={canMutate}
+        available={allStrategies.filter(s => s.organizationId === orgId && !linkedStrategyIds.has(s.id)).map(s => ({ id: s.id, name: s.name }))}
+        addAction={addStrategy}
+        removeAction={removeStrategy}
+      />
 
       <RelationshipPanel
         title="Objectives"

--- a/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/initiatives/[id]/page.tsx
@@ -15,7 +15,9 @@ import {
   linkInitiativeCapability, unlinkInitiativeCapability,
   linkInitiativeObjective, unlinkInitiativeObjective,
   linkInitiativeApplication, unlinkInitiativeApplication,
+  linkInitiativeStrategy, unlinkInitiativeStrategy,
 } from '@/actions/links'
+import { getStrategies } from '@/actions/strategies'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
 import { MarkdownContent } from '@/components/markdown-content'
@@ -67,13 +69,14 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
   const orgId = session.user.organizationId!
   const canMutate = editor && initiative.organizationId === orgId
 
-  const [allCapabilities, allObjectives, allApplications] = editor
+  const [allCapabilities, allObjectives, allApplications, allStrategies] = editor
     ? await Promise.all([
         getCapabilities(),
         getObjectives(),
         getApplications(),
+        getStrategies(orgId, session.user.role),
       ])
-    : [[], [], []]
+    : [[], [], [], []]
 
   const addCapability = linkInitiativeCapability.bind(null, id)
   const removeCapability = unlinkInitiativeCapability.bind(null, id)
@@ -81,6 +84,9 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
   const removeObjective = unlinkInitiativeObjective.bind(null, id)
   const addApplication = linkInitiativeApplication.bind(null, id)
   const removeApplication = unlinkInitiativeApplication.bind(null, id)
+  const addStrategy = linkInitiativeStrategy.bind(null, id)
+  const removeStrategy = unlinkInitiativeStrategy.bind(null, id)
+  const linkedStrategyIds = new Set(initiative.strategyInitiatives.map(si => si.strategyId))
 
   const capabilityItems: RelationshipItem[] = initiative.initiativeCapabilities.map(({ capability, impact }) => ({
     id: capability.id, name: capability.name,
@@ -152,6 +158,21 @@ export default async function InitiativeDetailPage({ params }: { params: Promise
           available={allCapabilities.filter(c => c.organizationId === orgId).map(c => ({ id: c.id, name: c.name }))}
           addAction={addCapability}
           removeAction={removeCapability}
+        />
+      )}
+
+      {isModuleEnabled(enabledModules, 'strategies') && (
+        <RelationshipPanel
+          title="Strategies delivered by this"
+          items={initiative.strategyInitiatives.map(({ strategy }) => ({
+            id: strategy.id, name: strategy.name,
+            href: `/strategies/${strategy.id}`, meta: strategy.status,
+          }))}
+          gapMessage="No strategies are delivered by this initiative yet."
+          canEdit={canMutate}
+          available={allStrategies.filter(s => s.organizationId === orgId && !linkedStrategyIds.has(s.id)).map(s => ({ id: s.id, name: s.name }))}
+          addAction={addStrategy}
+          removeAction={removeStrategy}
         />
       )}
 

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -190,6 +190,17 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
         />
       )}
 
+      {isModuleEnabled(enabledModules, 'strategies') && vs.strategyValueStreams.length > 0 && (
+        <RelationshipPanel
+          title="Strategies impacting this"
+          items={vs.strategyValueStreams.map(({ strategy }) => ({
+            id: strategy.id, name: strategy.name,
+            href: `/strategies/${strategy.id}`, meta: strategy.status,
+          }))}
+          canEdit={false}
+        />
+      )}
+
       <div className="text-xs text-muted-foreground pt-4 border-t">
         Created {new Date(vs.createdAt).toLocaleDateString()} · Updated {new Date(vs.updatedAt).toLocaleDateString()}
       </div>

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -27,6 +27,7 @@ export const capabilitiesRelations = relations(capabilities, ({ one, many }) => 
   valueStreamCapabilities: many(valueStreamCapabilities),
   objectiveCapabilities: many(objectiveCapabilities),
   initiativeCapabilities: many(initiativeCapabilities),
+  strategyCapabilities: many(strategyCapabilities),
   applicationCapabilities: many(applicationCapabilities),
   adrCapabilities: many(adrCapabilities),
   principleCapabilities: many(principleCapabilities),
@@ -94,6 +95,7 @@ export const valueStreamsRelations = relations(valueStreams, ({ one, many }) => 
   valueStreamPersonas: many(valueStreamPersonas),
   valueStreamCapabilities: many(valueStreamCapabilities),
   objectiveValueStreams: many(objectiveValueStreams),
+  strategyValueStreams: many(strategyValueStreams),
 }))
 
 export const valueStreamCapabilitiesRelations = relations(valueStreamCapabilities, ({ one }) => ({
@@ -242,6 +244,7 @@ export const initiativesRelations = relations(initiatives, ({ one, many }) => ({
   initiativeCapabilities: many(initiativeCapabilities),
   initiativeObjectives: many(initiativeObjectives),
   initiativeApplications: many(initiativeApplications),
+  strategyInitiatives: many(strategyInitiatives),
   adrInitiatives: many(adrInitiatives),
 }))
 

--- a/apps/govea/tests/integration/strategy-reverse-links.test.ts
+++ b/apps/govea/tests/integration/strategy-reverse-links.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration tests: reverse Strategy affordances (#829 / ADR-0005 R3)
+ *
+ * The reverse actions drive the same junctions from the other entity's page.
+ * They delegate to the strategy-first actions, so these tests confirm the
+ * reverse direction links/unlinks the right row and keeps role + org guards.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import {
+  linkGoalStrategy, unlinkGoalStrategy,
+  linkCapabilityStrategy, unlinkCapabilityStrategy,
+  linkValueStreamStrategy,
+  linkInitiativeStrategy, unlinkInitiativeStrategy,
+} from '@/actions/links'
+import { db } from '@/db/client'
+import { strategyGoals, strategyCapabilities, strategyValueStreams, strategyInitiatives } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  insertStrategy, insertGoal, insertCapability, insertValueStream, insertInitiative,
+  type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('reverse strategy affordances', () => {
+  let orgId: string
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+  })
+
+  it('linkGoalStrategy / unlinkGoalStrategy drives the strategy_goals junction', async () => {
+    const s = await insertStrategy(orgId, { name: 'Rev Goal Strat' })
+    const g = await insertGoal(orgId, { name: 'Rev Goal' })
+    await linkGoalStrategy(g.id, s.id)
+    let rows = await db.select().from(strategyGoals)
+      .where(and(eq(strategyGoals.strategyId, s.id), eq(strategyGoals.goalId, g.id)))
+    expect(rows).toHaveLength(1)
+    await unlinkGoalStrategy(g.id, s.id)
+    rows = await db.select().from(strategyGoals)
+      .where(and(eq(strategyGoals.strategyId, s.id), eq(strategyGoals.goalId, g.id)))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('linkCapabilityStrategy / unlink drives the strategy_capabilities junction', async () => {
+    const s = await insertStrategy(orgId, { name: 'Rev Cap Strat' })
+    const c = await insertCapability(orgId, { name: 'Rev Cap' })
+    await linkCapabilityStrategy(c.id, s.id)
+    let rows = await db.select().from(strategyCapabilities)
+      .where(and(eq(strategyCapabilities.strategyId, s.id), eq(strategyCapabilities.capabilityId, c.id)))
+    expect(rows).toHaveLength(1)
+    await unlinkCapabilityStrategy(c.id, s.id)
+    rows = await db.select().from(strategyCapabilities)
+      .where(and(eq(strategyCapabilities.strategyId, s.id), eq(strategyCapabilities.capabilityId, c.id)))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('linkValueStreamStrategy drives the strategy_value_streams junction', async () => {
+    const s = await insertStrategy(orgId, { name: 'Rev VS Strat' })
+    const v = await insertValueStream(orgId, { name: 'Rev VS' })
+    await linkValueStreamStrategy(v.id, s.id)
+    const rows = await db.select().from(strategyValueStreams)
+      .where(and(eq(strategyValueStreams.strategyId, s.id), eq(strategyValueStreams.valueStreamId, v.id)))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('linkInitiativeStrategy / unlink drives the strategy_initiatives junction', async () => {
+    const s = await insertStrategy(orgId, { name: 'Rev Init Strat' })
+    const i = await insertInitiative(orgId, { name: 'Rev Init' })
+    await linkInitiativeStrategy(i.id, s.id)
+    let rows = await db.select().from(strategyInitiatives)
+      .where(and(eq(strategyInitiatives.strategyId, s.id), eq(strategyInitiatives.initiativeId, i.id)))
+    expect(rows).toHaveLength(1)
+    await unlinkInitiativeStrategy(i.id, s.id)
+    rows = await db.select().from(strategyInitiatives)
+      .where(and(eq(strategyInitiatives.strategyId, s.id), eq(strategyInitiatives.initiativeId, i.id)))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('viewer cannot link from the reverse side → Forbidden', async () => {
+    const s = await insertStrategy(orgId, { name: 'Rev Block Strat' })
+    const c = await insertCapability(orgId, { name: 'Rev Block Cap' })
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    await expect(linkCapabilityStrategy(c.id, s.id)).rejects.toThrow('Forbidden')
+  })
+
+  it('rejects a cross-org strategy from the reverse side', async () => {
+    const otherOrg = await createTestOrg()
+    const foreignStrategy = await insertStrategy(otherOrg.id, { name: 'Foreign Rev Strat' })
+    const g = await insertGoal(orgId, { name: 'Rev Goal X' })
+    await expect(linkGoalStrategy(g.id, foreignStrategy.id)).rejects.toThrow()
+    await cleanupOrg(otherOrg.id)
+  })
+})


### PR DESCRIPTION
Third rework slice for ADR-0005. The reverse side of the Strategy links: from a goal / capability / value-stream / initiative detail page, see and manage the strategies connected to it. R2 covered the strategy-side panels; this is "both sides."

Branches off `main` (R1 #826 + R2 #828 merged) — no stacking.

## What changed
- **Reverse relations** for capability/value-stream/initiative → their strategy junction (goals already had it).
- **8 reverse link/unlink actions** that delegate to the strategy-first actions (org-checked both ends) and revalidate the source page — argument order `(sourceId, strategyId)` so a page binds its own id.
- Detail getters load the strategy junction with its strategy.
- **Editable "Strategies" panels**: goal (*pursuing this goal*), capability (*impacting this*), initiative (*delivered by this*). The goal page's read-only "Pursued by strategy" line becomes that editable panel.
- **Value-stream**: a **read-only** Strategies panel — its detail view is read-only by design (#804), so VS↔strategy editing stays on the strategy side.

## Tests
Integration: reverse link/unlink per junction (goal/capability/value-stream/initiative), viewer-Forbidden, cross-org rejection.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build (all four routes emit). Integration tests run in CI.

Capability: pl-goals
Capability: fd-traceability-views
Closes #829
Part of #805 · Decision: ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)