### PR TITLE
feat(strategy): R4 — trace the direct Strategy impact links

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -3,6 +3,7 @@
 import { db } from '@/db/client'
 import {
   strategicObjectives, capabilities, services, goals, strategies, strategyGoals,
+  strategyCapabilities, strategyValueStreams, strategyInitiatives,
   goalObjectives, objectiveCapabilities, applicationCapabilities,
   initiativeObjectives, serviceCapabilities,
   // #695 — trace-participation subjects and their one-hop root junctions
@@ -101,6 +102,12 @@ export interface StrategyTrace {
       initiatives: TraceInitiative[]
     }>
   }>
+  // Direct course-of-action links (ADR-0005): the operating model the strategy
+  // leverages/changes and the funded work that delivers it. Distinct from the
+  // capabilities/initiatives reached through goals → objectives.
+  valueStreams: { id: string; name: string }[]
+  directCapabilities: TraceCapability[]
+  directInitiatives: TraceInitiative[]
 }
 
 export type TraceData = StrategyTrace | GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace
@@ -241,6 +248,23 @@ export async function getStrategyTrace(id: string): Promise<StrategyTrace | null
     objectivesByGoal.set(goalId, list)
   }
 
+  // Direct course-of-action links (ADR-0005): operating model + delivery. These
+  // junctions are same-org by construction (the link actions enforce it).
+  const [stratCapRows, stratVsRows, stratInitRows] = await Promise.all([
+    db.query.strategyCapabilities.findMany({ where: eq(strategyCapabilities.strategyId, id) }),
+    db.query.strategyValueStreams.findMany({ where: eq(strategyValueStreams.strategyId, id), with: { valueStream: true } }),
+    db.query.strategyInitiatives.findMany({ where: eq(strategyInitiatives.strategyId, id), with: { initiative: true } }),
+  ])
+  const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name)
+  const directCapabilities = (await getCapabilitiesWithApps([...new Set(stratCapRows.map((r) => r.capabilityId))]))
+    .sort(byName)
+  const valueStreams = stratVsRows
+    .map((r) => ({ id: r.valueStream.id, name: r.valueStream.name }))
+    .sort(byName)
+  const directInitiatives = stratInitRows
+    .map((r) => ({ id: r.initiative.id, name: r.initiative.name, status: r.initiative.status }))
+    .sort(byName)
+
   return {
     kind: 'strategy',
     id: row.id,
@@ -261,6 +285,9 @@ export async function getStrategyTrace(id: string): Promise<StrategyTrace | null
         initiatives: initiativesByObjective.get(o.id) ?? [],
       })),
     })),
+    valueStreams,
+    directCapabilities,
+    directInitiatives,
   }
 }
 

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -142,13 +142,18 @@ function StrategyTraceView({ trace }: { trace: StrategyTrace }) {
   const allObjectives = dedupeById(
     trace.goals.flatMap(g => g.objectives.map(o => ({ id: o.id, name: o.name, timeHorizon: o.timeHorizon })))
   )
-  const allCapabilities = dedupeById(
-    trace.goals.flatMap(g => g.objectives.flatMap(o => o.capabilities))
-  )
+  // Capabilities/initiatives are the union of the strategy's *direct* links
+  // (course-of-action impacts/delivery) and those reached through goals →
+  // objectives. Apps roll up from the full capability set.
+  const allCapabilities = dedupeById([
+    ...trace.directCapabilities,
+    ...trace.goals.flatMap(g => g.objectives.flatMap(o => o.capabilities)),
+  ])
   const allApps = dedupeById(allCapabilities.flatMap(c => c.applications))
-  const allInitiatives = dedupeById(
-    trace.goals.flatMap(g => g.objectives.flatMap(o => o.initiatives))
-  )
+  const allInitiatives = dedupeById([
+    ...trace.directInitiatives,
+    ...trace.goals.flatMap(g => g.objectives.flatMap(o => o.initiatives)),
+  ])
 
   return (
     <div className="space-y-1 max-w-2xl">
@@ -218,6 +223,19 @@ function StrategyTraceView({ trace }: { trace: StrategyTrace }) {
               badge={i.status}
               badgeClass={INITIATIVE_STYLES[i.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
             />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Value streams (direct course-of-action impact) */}
+      <Connector label="impacts" />
+      <LayerLabel>Value Streams</LayerLabel>
+      {trace.valueStreams.length === 0 ? (
+        <Gap message="No value streams linked — the operating-model value streams this approach affects aren't mapped yet." />
+      ) : (
+        <TraceCard>
+          {trace.valueStreams.map(v => (
+            <TraceRow key={v.id} href={`/value-streams/${v.id}`} name={v.name} />
           ))}
         </TraceCard>
       )}

--- a/apps/govea/tests/integration/strategy-traceability.test.ts
+++ b/apps/govea/tests/integration/strategy-traceability.test.ts
@@ -11,8 +11,9 @@ import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { getStrategyTrace } from '@/actions/traceability'
 import { db } from '@/db/client'
 import {
-  strategies, goals, strategicObjectives, capabilities, initiatives,
+  strategies, goals, strategicObjectives, capabilities, initiatives, valueStreams,
   goalObjectives, objectiveCapabilities, initiativeObjectives, strategyGoals,
+  strategyCapabilities, strategyValueStreams, strategyInitiatives,
 } from '@/db/schema'
 import { randomUUID } from 'node:crypto'
 import {
@@ -35,6 +36,10 @@ describe('getStrategyTrace', () => {
   let objectiveId: string
   let capabilityId: string
   let initiativeId: string
+  // direct course-of-action links
+  let directCapId: string
+  let directVsId: string
+  let directInitId: string
 
   beforeAll(async () => {
     const org = await createTestOrg()
@@ -80,6 +85,24 @@ describe('getStrategyTrace', () => {
     await db.insert(goalObjectives).values({ goalId: publishedGoalId, objectiveId })
     await db.insert(objectiveCapabilities).values({ objectiveId, capabilityId })
     await db.insert(initiativeObjectives).values({ initiativeId, objectiveId })
+
+    // Direct course-of-action links (ADR-0005 R4): strategy → capability /
+    // value stream / initiative, independent of the goal chain.
+    const [dc] = await db.insert(capabilities).values({
+      organizationId: orgId, name: 'Directly Impacted Capability', status: 'published', visibility: 'org',
+    }).returning()
+    directCapId = dc.id
+    const [dv] = await db.insert(valueStreams).values({
+      organizationId: orgId, name: 'Impacted Value Stream', status: 'published', visibility: 'org',
+    }).returning()
+    directVsId = dv.id
+    const [di] = await db.insert(initiatives).values({
+      organizationId: orgId, name: 'Directly Delivering Initiative', status: 'active', visibility: 'org',
+    }).returning()
+    directInitId = di.id
+    await db.insert(strategyCapabilities).values({ strategyId, capabilityId: directCapId })
+    await db.insert(strategyValueStreams).values({ strategyId, valueStreamId: directVsId })
+    await db.insert(strategyInitiatives).values({ strategyId, initiativeId: directInitId })
   })
 
   afterAll(() => cleanupOrg(orgId))
@@ -100,6 +123,18 @@ describe('getStrategyTrace', () => {
     const obj = published.objectives.find(o => o.id === objectiveId)!
     expect(obj.capabilities.map(c => c.id)).toContain(capabilityId)
     expect(obj.initiatives.map(i => i.id)).toContain(initiativeId)
+  })
+
+  it('includes the direct course-of-action impact links (R4)', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const trace = await getStrategyTrace(strategyId)
+
+    expect(trace!.valueStreams.map(v => v.id)).toContain(directVsId)
+    expect(trace!.directCapabilities.map(c => c.id)).toContain(directCapId)
+    expect(trace!.directInitiatives.map(i => i.id)).toContain(directInitId)
+
+    // Direct capability is distinct from the goal-chain capability.
+    expect(trace!.directCapabilities.map(c => c.id)).not.toContain(capabilityId)
   })
 
   it('prunes draft member goals for viewers', async () => {


### PR DESCRIPTION
Fourth rework slice for ADR-0005. R1 gave `from=strategy` a trace through Goals → Objectives → Initiatives/Capabilities. The course-of-action model (R2/R3) also links a strategy *directly* to the operating model and delivery — this surfaces those in the trace.

Branches off `main` (R1–R3 merged) — no stacking.

## What changed
- `getStrategyTrace` loads `strategy_value_streams` / `strategy_capabilities` / `strategy_initiatives` and returns `valueStreams`, `directCapabilities` (with apps), `directInitiatives`.
- `StrategyTraceView` adds a **Value Streams** layer and **merges (dedupes)** the direct capabilities/initiatives with those reached through goals → objectives; applications roll up from the full capability set.
- Root gating unchanged — a `proposed` strategy is still not a viewer-visible root.

Matches ADR-0005: "Strategy → Goals (+ Objectives) and Strategy → {Value Streams ⇄ Capabilities} → Applications, with Initiatives as the funded delivery vehicle."

## Tests
Extended the strategy-traceability integration test: direct value-stream / capability / initiative links appear in the trace and the direct capability is distinct from the goal-chain capability.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build (`/traceability` emits). Integration tests run in CI.

Capability: fd-traceability-views
Capability: rm-end-to-end-traceability
Closes #831
Part of #805 · Decision: ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)