### PR TITLE
feat(strategy): R5 — executive read-only view + active-strategies surfaces

### DIFF
--- a/apps/govea/src/actions/strategies.ts
+++ b/apps/govea/src/actions/strategies.ts
@@ -73,6 +73,25 @@ export async function getStrategy(id: string) {
   return strategy
 }
 
+/**
+ * Active (status='active') strategies for an org, with the goals they pursue and
+ * their impact/delivery links. Backs the executive / roadmap / dashboard
+ * "active strategies" surfaces (ADR-0005 R5). Org-scoped; multiple strategies can
+ * be active at once (the course-of-action model has no single "current" one).
+ */
+export async function getActiveStrategies(organizationId: string) {
+  return db.query.strategies.findMany({
+    where: (s, { eq, and }) => and(eq(s.organizationId, organizationId), eq(s.status, 'active')),
+    orderBy: (s, { asc }) => [asc(s.name)],
+    with: {
+      strategyGoals: { with: { goal: true } },
+      strategyCapabilities: true,
+      strategyValueStreams: true,
+      strategyInitiatives: true,
+    },
+  })
+}
+
 function parseDate(value: FormDataEntryValue | null): string | null {
   const v = (value as string)?.trim()
   return v ? v : null

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -27,6 +27,9 @@ import {
 import Link from 'next/link'
 import { FirstSignInModal } from '@/components/first-sign-in-modal'
 import { ViewerDashboard } from './viewer-dashboard'
+import { getActiveStrategies } from '@/actions/strategies'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
 
 const RAG_TEXT_CLASS: Record<RagBucket, string> = {
   green:   'text-green-700 dark:text-green-400',
@@ -238,6 +241,11 @@ export default async function DashboardPage() {
     hasAny: Object.values(fedByStatus).some(n => n > 0) || fedInboundLinks.length > 0 || flaggedCount > 0,
   }
 
+  const enabledModules = await getEnabledModules()
+  const activeStrategies = isModuleEnabled(enabledModules, 'strategies')
+    ? await getActiveStrategies(orgId)
+    : []
+
   return (
     <div className="space-y-6">
       {/* First-sign-in modal (#587 follow-up). Self-managed via localStorage;
@@ -250,6 +258,21 @@ export default async function DashboardPage() {
           Welcome back{session.user.name ? `, ${session.user.name}` : ''}.
         </p>
       </div>
+
+      {/* Active strategies — quick context on the live course-of-action plans (ADR-0005 R5) */}
+      {activeStrategies.length > 0 && (
+        <div className="rounded-lg border bg-muted/30 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Active strategies</p>
+          <div className="flex flex-wrap gap-2">
+            {activeStrategies.map(s => (
+              <Link key={s.id} href={`/strategies/${s.id}`}
+                className="inline-flex items-center rounded-md border bg-card px-2.5 py-1 text-sm font-medium hover:text-primary transition-colors">
+                {s.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {isAdminUser && !emailConfigured && (
         <div

--- a/apps/govea/src/app/(admin)/executive/page.tsx
+++ b/apps/govea/src/app/(admin)/executive/page.tsx
@@ -8,6 +8,7 @@ import {
 import { and, count, desc, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { isModuleEnabled } from '@/lib/modules'
+import { getActiveStrategies } from '@/actions/strategies'
 import { ConfidenceSummary } from '@/components/confidence-summary'
 import { PrintExportButton } from '@/components/print-export'
 import { PrintCoverSheet } from '@/components/print-cover-sheet'
@@ -98,6 +99,11 @@ export default async function ExecutiveDashboardPage() {
   const hasCapabilities= isModuleEnabled(enabledModules, 'capabilities')
   const hasInitiatives = isModuleEnabled(enabledModules, 'initiatives')
   const hasObjectives  = isModuleEnabled(enabledModules, 'objectives')
+  const hasStrategies  = isModuleEnabled(enabledModules, 'strategies')
+
+  // Active strategies (course-of-action; multiple may be active). Read-only
+  // leadership surface (ADR-0005 R5).
+  const activeStrategies = hasStrategies ? await getActiveStrategies(orgId) : []
 
   // eslint-disable-next-line react-hooks/purity -- server component, Date.now() is intentional
   const staleThreshold = new Date(Date.now() - STALE_MONTHS * 30 * 24 * 60 * 60 * 1000)
@@ -349,6 +355,50 @@ export default async function ExecutiveDashboardPage() {
           />
         )}
       </div>
+
+      {/* ── Active strategy ─────────────────────────────────────────────────── */}
+      {hasStrategies && activeStrategies.length > 0 && (
+        <div>
+          <SectionLabel>Active Strategy</SectionLabel>
+          <div className="space-y-3">
+            {activeStrategies.map(s => {
+              const goals = s.strategyGoals
+                .map(sg => sg.goal)
+                .filter(g => g.status === 'published')
+              const rollup = [
+                `pursues ${goals.length} ${goals.length === 1 ? 'goal' : 'goals'}`,
+                `impacts ${s.strategyCapabilities.length} ${s.strategyCapabilities.length === 1 ? 'capability' : 'capabilities'}`,
+                `${s.strategyValueStreams.length} ${s.strategyValueStreams.length === 1 ? 'value stream' : 'value streams'}`,
+                `delivered by ${s.strategyInitiatives.length} ${s.strategyInitiatives.length === 1 ? 'initiative' : 'initiatives'}`,
+              ].join(' · ')
+              return (
+                <div key={s.id} className="rounded-xl border bg-card p-5 space-y-3">
+                  <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <Link href={`/strategies/${s.id}`} className="font-semibold hover:text-primary transition-colors">
+                      {s.name}
+                    </Link>
+                    <Link href={`/traceability?from=strategy&id=${s.id}`} className="text-xs text-primary hover:underline underline-offset-4 shrink-0">
+                      View traceability →
+                    </Link>
+                  </div>
+                  {s.summary && <p className="text-sm text-muted-foreground">{s.summary}</p>}
+                  {goals.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {goals.map(g => (
+                        <Link key={g.id} href={`/goals/${g.id}`}
+                          className="inline-flex items-center rounded-md border bg-muted/40 px-2 py-0.5 text-xs hover:bg-muted transition-colors">
+                          {g.name}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                  <p className="text-xs text-muted-foreground border-t pt-2 capitalize">{rollup}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       {/* ── Application portfolio ───────────────────────────────────────────── */}
       {hasApps && totalPublishedApps > 0 && (

--- a/apps/govea/src/app/(admin)/roadmap/page.tsx
+++ b/apps/govea/src/app/(admin)/roadmap/page.tsx
@@ -1,6 +1,9 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { getInitiatives } from '@/actions/initiatives'
+import { getActiveStrategies } from '@/actions/strategies'
+import { getEnabledModules } from '@/lib/get-enabled-modules'
+import { isModuleEnabled } from '@/lib/modules'
 import { ConfidenceSummary } from '@/components/confidence-summary'
 import { PrintExportButton } from '@/components/print-export'
 import { PrintCoverSheet } from '@/components/print-cover-sheet'
@@ -258,9 +261,11 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
 
   const orgId = session.user.organizationId!
   const role = session.user.role
-  const [allInitiatives, org] = await Promise.all([
+  const enabledModules = await getEnabledModules()
+  const [allInitiatives, org, activeStrategies] = await Promise.all([
     getInitiatives(),
     db.query.organizations.findFirst({ where: eq(organizations.id, orgId), columns: { name: true } }),
+    isModuleEnabled(enabledModules, 'strategies') ? getActiveStrategies(orgId) : Promise.resolve([]),
   ])
   const hasInitiatives = allInitiatives.length > 0
 
@@ -322,6 +327,21 @@ export default async function RoadmapPage({ searchParams }: RoadmapPageProps) {
 
       {/* Repository confidence — shown when org has authenticated visibility on (#380 PR-4) */}
       <ConfidenceSummary orgId={orgId} />
+
+      {/* Active strategies — the course-of-action context this roadmap delivers (ADR-0005 R5) */}
+      {activeStrategies.length > 0 && (
+        <div className="rounded-lg border bg-muted/30 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">Active strategies</p>
+          <div className="flex flex-wrap gap-2">
+            {activeStrategies.map(s => (
+              <Link key={s.id} href={`/strategies/${s.id}`}
+                className="inline-flex items-center rounded-md border bg-card px-2.5 py-1 text-sm font-medium hover:text-primary transition-colors">
+                {s.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Empty state */}
       {!hasInitiatives && (

--- a/apps/govea/tests/integration/active-strategies.test.ts
+++ b/apps/govea/tests/integration/active-strategies.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration tests: getActiveStrategies (#833 / ADR-0005 R5)
+ *
+ * Backs the executive / roadmap / dashboard "active strategies" surfaces:
+ * returns only status='active' strategies for the org, with pursued goals and
+ * the impact/delivery junctions loaded.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { getActiveStrategies } from '@/actions/strategies'
+import { db } from '@/db/client'
+import { strategyGoals, strategyCapabilities } from '@/db/schema'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  insertStrategy, insertGoal, insertCapability,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('getActiveStrategies', () => {
+  let orgId: string
+  let activeId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    const user = await createTestUser(orgId, 'contributor')
+    mockAuth.mockResolvedValue(makeSession(user))
+
+    const active = await insertStrategy(orgId, { name: 'Active Strategy', status: 'active' })
+    activeId = active.id
+    await insertStrategy(orgId, { name: 'Proposed Strategy', status: 'proposed' })
+    await insertStrategy(orgId, { name: 'Achieved Strategy', status: 'achieved' })
+
+    const goal = await insertGoal(orgId, { name: 'Pursued Goal', status: 'published' })
+    const cap = await insertCapability(orgId, { name: 'Impacted Cap' })
+    await db.insert(strategyGoals).values({ strategyId: activeId, goalId: goal.id })
+    await db.insert(strategyCapabilities).values({ strategyId: activeId, capabilityId: cap.id })
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('returns only active strategies, with goals and impact links loaded', async () => {
+    const rows = await getActiveStrategies(orgId)
+    expect(rows.map(r => r.id)).toEqual([activeId])
+
+    const s = rows[0]
+    expect(s.strategyGoals).toHaveLength(1)
+    expect(s.strategyGoals[0].goal.name).toBe('Pursued Goal')
+    expect(s.strategyCapabilities).toHaveLength(1)
+  })
+
+  it('excludes another org\'s active strategy', async () => {
+    const otherOrg = await createTestOrg()
+    await insertStrategy(otherOrg.id, { name: 'Foreign Active', status: 'active' })
+    const rows = await getActiveStrategies(orgId)
+    expect(rows.map(r => r.id)).toEqual([activeId])
+    await cleanupOrg(otherOrg.id)
+  })
+})


### PR DESCRIPTION
Fifth rework slice for ADR-0005. Surfaces the course-of-action strategies where leadership looks. Because multiple strategies can be active at once (no single "adopted"), the original "current strategy" badge becomes **"active strategies"**.

Branches off `main` (R1–R3 merged; independent of R4).

## What changed
- **`getActiveStrategies(orgId)`** — active (`status='active'`) strategies with pursued goals + impact/delivery junctions.
- **Executive Summary** — a read-only **Active Strategy** section: each active strategy with its summary, pursued (published) goals as chips, and a plain-language rollup *"pursues N goals · impacts N capabilities · N value streams · delivered by N initiatives"*, linking to the strategy and its traceability. Plain language for directors / elected officials.
- **Roadmap** + **Dashboard** — a compact "Active strategies" surface linking to each.
- All gated by the `strategies` module; renders nothing when there are no active strategies.

## Tests
Integration: `getActiveStrategies` returns only active strategies, org-scoped, with goals + impact links loaded.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build (`/executive`, `/roadmap`, `/dashboard` emit). Integration tests run in CI.

Capability: pl-goals
Capability: rm-end-to-end-traceability
Closes #833
Part of #805 · Decision: ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)