### PR TITLE
feat(strategy): R6 — backup/export/import parity + seed; mark Strategy shipped

### DIFF
--- a/apps/govea/src/db/seeds/dev-fixtures.ts
+++ b/apps/govea/src/db/seeds/dev-fixtures.ts
@@ -533,6 +533,47 @@ export const DEV_GOALS = [
   },
 ]
 
+// ─── Strategies (City of Riverdale) — course-of-action plans (ADR-0005) ──────
+// Coverage: status = active ✓, proposed ✓, achieved ✓ (multiple may be active).
+// Each is a chosen approach that pursues goals and maps onto the operating model
+// (capabilities + value streams) and the initiatives that deliver it.
+
+export const DEV_STRATEGIES = [
+  {
+    name: 'Digital-First Resident Experience',
+    summary: 'Make digital the default channel for the highest-volume resident interactions, redesigning the permit and service-request journeys end to end and standing up shared identity so residents sign in once.',
+    planningHorizon: '2025–2027',
+    status: 'active' as const,
+    visibility: 'org' as const,
+    goals: ['Modernise Resident-Facing Services'],
+    capabilities: ['Online Permitting', 'Digital Identity & Authentication'],
+    valueStreams: ['Permit to Certificate', 'Service Request to Resolution'],
+    initiatives: ['Accela Implementation', 'Resident Portal Redesign'],
+  },
+  {
+    name: 'Cloud & Infrastructure Modernisation',
+    summary: 'Retire ageing on-premise systems in favour of a cloud-first platform, prioritising the capabilities that the resident-facing roadmap depends on.',
+    planningHorizon: '2025–2028',
+    status: 'proposed' as const,
+    visibility: 'org' as const,
+    goals: ['Strengthen Technical Infrastructure'],
+    capabilities: ['GIS Mapping'],
+    valueStreams: [],
+    initiatives: ['CityWorks Replacement'],
+  },
+  {
+    name: 'Cross-Agency Data Foundation',
+    summary: 'Established the data-sharing agreements and exchange pilot that let City departments and state agencies act on a shared view of the resident.',
+    planningHorizon: '2024–2025',
+    status: 'achieved' as const,
+    visibility: 'connections' as const,
+    goals: ['Enable Joined-Up Government'],
+    capabilities: ['Cross-Agency Data Sharing'],
+    valueStreams: [],
+    initiatives: ['Cross-Agency Data Exchange Pilot'],
+  },
+]
+
 // ─── Value Streams (City of Riverdale) ───────────────────────────────────────
 // Coverage: status = published ✓, draft ✓
 //           visibility = org ✓, connections ✓

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_PERSONA_TYPES, DEFAULT_PERSONA_TAGS,
   DEV_PERSONA_TAG_ASSIGNMENTS,
   DEV_PERSONAS, DEV_CAPABILITIES, DEV_CAPABILITY_RELATIONSHIPS, DEV_CAPABILITY_TOGAF_DOMAINS, DEV_APPLICATIONS,
-  DEV_OBJECTIVES, DEV_GOALS, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
+  DEV_OBJECTIVES, DEV_GOALS, DEV_STRATEGIES, DEV_VALUE_STREAMS, DEV_INITIATIVES, DEV_ADRS,
   DEV_PRINCIPLES, DEV_GLOSSARY, DEV_SERVICES,
   DEV_DATA_ENTITIES, DEV_DATA_ATTRIBUTES, DEV_DATA_LINKS, DEV_DATA_BUSINESS_KEYS,
   DEV_DATA_ENTITY_RELATIONS, DEV_DATA_ATTRIBUTE_SHARES,
@@ -36,6 +36,7 @@ import {
   capabilityPersonas, applicationCapabilities, capabilityRelationships,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
   goals, goalObjectives,
+  strategies, strategyGoals, strategyCapabilities, strategyValueStreams, strategyInitiatives,
   valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
   initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
@@ -532,6 +533,7 @@ async function seed() {
   console.log(`  ✓ ${DEV_OBJECTIVES.length} strategic objectives`)
 
   // Goals + goalObjectives junction
+  const devGoalIds: Record<string, string> = {}
   for (const g of DEV_GOALS) {
     const existing = await db.query.goals.findFirst({
       where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, g.name)),
@@ -567,6 +569,7 @@ async function seed() {
       })
       if (!exists) await db.insert(goalObjectives).values({ goalId, objectiveId: objId })
     }
+    devGoalIds[g.name] = goalId
   }
   console.log(`  ✓ ${DEV_GOALS.length} goals with objective links`)
 
@@ -623,6 +626,46 @@ async function seed() {
     }
   }
   console.log(`  ✓ ${DEV_INITIATIVES.length} initiatives`)
+
+  // Strategies (ADR-0005) + their goal / capability / value-stream / initiative
+  // links. Runs after goals, capabilities, value streams and initiatives so the
+  // junction ids resolve. Idempotent: upsert by (org, name), link if absent.
+  for (const s of DEV_STRATEGIES) {
+    const existing = await db.query.strategies.findFirst({
+      where: (t, { eq: e, and }) => and(e(t.organizationId, devOrgId), e(t.name, s.name)),
+    })
+    let strategyId: string
+    if (existing) {
+      await db.update(strategies).set({
+        summary: s.summary,
+        planningHorizon: s.planningHorizon,
+        status: s.status,
+        visibility: s.visibility,
+      }).where(eq(strategies.id, existing.id))
+      strategyId = existing.id
+    } else {
+      const [inserted] = await db.insert(strategies).values({
+        organizationId: devOrgId,
+        name: s.name,
+        summary: s.summary,
+        planningHorizon: s.planningHorizon,
+        status: s.status,
+        visibility: s.visibility,
+      }).returning()
+      strategyId = inserted.id
+    }
+
+    // Composite PKs make these idempotent — re-seeding is a no-op.
+    const goalIds = s.goals.map(n => devGoalIds[n]).filter(Boolean)
+    if (goalIds.length) await db.insert(strategyGoals).values(goalIds.map(goalId => ({ strategyId, goalId }))).onConflictDoNothing()
+    const capIds = s.capabilities.map(n => devCapabilityIds[n]).filter(Boolean)
+    if (capIds.length) await db.insert(strategyCapabilities).values(capIds.map(capabilityId => ({ strategyId, capabilityId }))).onConflictDoNothing()
+    const vsIds = s.valueStreams.map(n => devValueStreamIds[n]).filter(Boolean)
+    if (vsIds.length) await db.insert(strategyValueStreams).values(vsIds.map(valueStreamId => ({ strategyId, valueStreamId }))).onConflictDoNothing()
+    const iniIds = s.initiatives.map(n => devInitiativeIds[n]).filter(Boolean)
+    if (iniIds.length) await db.insert(strategyInitiatives).values(iniIds.map(initiativeId => ({ strategyId, initiativeId }))).onConflictDoNothing()
+  }
+  console.log(`  ✓ ${DEV_STRATEGIES.length} strategies with goal/capability/value-stream/initiative links`)
 
   // ADRs — insert all records first (without supersededBy), then resolve self-references
   const devAdrIds: Record<string, string> = {}

--- a/apps/govea/src/lib/backup-export.ts
+++ b/apps/govea/src/lib/backup-export.ts
@@ -42,6 +42,7 @@ import {
   valueStreams,
   strategicObjectives,
   goals,
+  strategies,
   initiatives,
   adrs,
   principles,
@@ -143,6 +144,7 @@ async function collectContent(orgId: string) {
     valueStreamRows, valueStreamStageRows, valueStreamStageCapRows, valueStreamPersonaRows, valueStreamCapRows,
     objectiveRows, objectiveCapRows, objectiveVsRows,
     goalRows, goalObjectiveRows,
+    strategyRows, strategyGoalRows, strategyCapRows, strategyVsRows, strategyIniRows,
     initiativeRows, initiativeCapRows, initiativeAppRows, initiativeObjRows,
     adrRows, adrCapRows, adrAppRows, adrIniRows, adrObjRows,
     principleRows, principleCapRows, principleAdrRows,
@@ -166,6 +168,11 @@ async function collectContent(orgId: string) {
     db.query.objectiveValueStreams.findMany({}),
     db.query.goals.findMany({ where: eq(goals.organizationId, orgId) }),
     db.query.goalObjectives.findMany({}),
+    db.query.strategies.findMany({ where: eq(strategies.organizationId, orgId) }),
+    db.query.strategyGoals.findMany({}),
+    db.query.strategyCapabilities.findMany({}),
+    db.query.strategyValueStreams.findMany({}),
+    db.query.strategyInitiatives.findMany({}),
     db.query.initiatives.findMany({ where: eq(initiatives.organizationId, orgId) }),
     db.query.initiativeCapabilities.findMany({}),
     db.query.initiativeApplications.findMany({}),
@@ -209,6 +216,7 @@ async function collectContent(orgId: string) {
   const vsIds = new Set((valueStreamRows as Array<{ id: string }>).map(r => r.id))
   const objIds = new Set((objectiveRows as Array<{ id: string }>).map(r => r.id))
   const goalIds = new Set((goalRows as Array<{ id: string }>).map(r => r.id))
+  const stratIds = new Set((strategyRows as Array<{ id: string }>).map(r => r.id))
   const iniIds = new Set((initiativeRows as Array<{ id: string }>).map(r => r.id))
   const adrIds = new Set((adrRows as Array<{ id: string }>).map(r => r.id))
   const principleIds = new Set((principleRows as Array<{ id: string }>).map(r => r.id))
@@ -223,6 +231,7 @@ async function collectContent(orgId: string) {
     valueStreams: valueStreamRows,
     objectives: objectiveRows,
     goals: goalRows,
+    strategies: strategyRows,
     initiatives: initiativeRows,
     adrs: adrRows,
     principles: principleRows,
@@ -239,6 +248,10 @@ async function collectContent(orgId: string) {
       objectiveCapabilities: (objectiveCapRows as Array<{ objectiveId: string; capabilityId: string }>).filter(r => objIds.has(r.objectiveId) && capIds.has(r.capabilityId)),
       objectiveValueStreams: (objectiveVsRows as Array<{ objectiveId: string; valueStreamId: string }>).filter(r => objIds.has(r.objectiveId) && vsIds.has(r.valueStreamId)),
       goalObjectives: (goalObjectiveRows as Array<{ goalId: string; objectiveId: string }>).filter(r => goalIds.has(r.goalId) && objIds.has(r.objectiveId)),
+      strategyGoals: (strategyGoalRows as Array<{ strategyId: string; goalId: string }>).filter(r => stratIds.has(r.strategyId) && goalIds.has(r.goalId)),
+      strategyCapabilities: (strategyCapRows as Array<{ strategyId: string; capabilityId: string }>).filter(r => stratIds.has(r.strategyId) && capIds.has(r.capabilityId)),
+      strategyValueStreams: (strategyVsRows as Array<{ strategyId: string; valueStreamId: string }>).filter(r => stratIds.has(r.strategyId) && vsIds.has(r.valueStreamId)),
+      strategyInitiatives: (strategyIniRows as Array<{ strategyId: string; initiativeId: string }>).filter(r => stratIds.has(r.strategyId) && iniIds.has(r.initiativeId)),
       initiativeCapabilities: (initiativeCapRows as Array<{ initiativeId: string; capabilityId: string }>).filter(r => iniIds.has(r.initiativeId) && capIds.has(r.capabilityId)),
       initiativeApplications: (initiativeAppRows as Array<{ initiativeId: string; applicationId: string }>).filter(r => iniIds.has(r.initiativeId) && appIds.has(r.applicationId)),
       initiativeObjectives: (initiativeObjRows as Array<{ initiativeId: string; objectiveId: string }>).filter(r => iniIds.has(r.initiativeId) && objIds.has(r.objectiveId)),

--- a/apps/govea/src/lib/backup-import.ts
+++ b/apps/govea/src/lib/backup-import.ts
@@ -41,6 +41,7 @@ import {
   valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
   goals, goalObjectives,
+  strategies, strategyGoals, strategyCapabilities, strategyValueStreams, strategyInitiatives,
   initiatives, initiativeCapabilities, initiativeApplications, initiativeObjectives,
   adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives,
   principles, principleCapabilities, principleAdrs,
@@ -93,6 +94,7 @@ interface ArchiveBundle {
     valueStreams: unknown[]
     objectives: unknown[]
     goals: unknown[]
+    strategies: unknown[]
     initiatives: unknown[]
     adrs: unknown[]
     principles: unknown[]
@@ -207,6 +209,9 @@ export async function importArchive(
     await tx.delete(principles).where(eq(principles.organizationId, destOrgId))
     await tx.delete(adrs).where(eq(adrs.organizationId, destOrgId))
     await tx.delete(initiatives).where(eq(initiatives.organizationId, destOrgId))
+    // Strategies before goals: strategy_goals cascades from either side, but
+    // deleting strategies first keeps the wipe order parent-before-children.
+    await tx.delete(strategies).where(eq(strategies.organizationId, destOrgId))
     await tx.delete(goals).where(eq(goals.organizationId, destOrgId))
     await tx.delete(strategicObjectives).where(eq(strategicObjectives.organizationId, destOrgId))
     await tx.delete(valueStreams).where(eq(valueStreams.organizationId, destOrgId))
@@ -298,6 +303,12 @@ export async function importArchive(
       )
       inserted.goals = content.goals.length
     }
+    if (content.strategies.length) {
+      await tx.insert(strategies).values(
+        (content.strategies as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
+      )
+      inserted.strategies = content.strategies.length
+    }
     if (content.initiatives.length) {
       await tx.insert(initiatives).values(
         (content.initiatives as Record<string, unknown>[]).map(r => normalize(r, ctx)) as never,
@@ -367,6 +378,10 @@ export async function importArchive(
     await replayJunction(objectiveCapabilities, 'objectiveCapabilities', false)
     await replayJunction(objectiveValueStreams, 'objectiveValueStreams', false)
     await replayJunction(goalObjectives, 'goalObjectives', false)
+    await replayJunction(strategyGoals, 'strategyGoals', false)
+    await replayJunction(strategyCapabilities, 'strategyCapabilities', false)
+    await replayJunction(strategyValueStreams, 'strategyValueStreams', false)
+    await replayJunction(strategyInitiatives, 'strategyInitiatives', false)
     await replayJunction(initiativeCapabilities, 'initiativeCapabilities', false)
     await replayJunction(initiativeApplications, 'initiativeApplications', false)
     await replayJunction(initiativeObjectives, 'initiativeObjectives', false)

--- a/apps/govea/tests/integration/backup-import.test.ts
+++ b/apps/govea/tests/integration/backup-import.test.ts
@@ -20,6 +20,7 @@ import { eq, and } from 'drizzle-orm'
 import { db } from '@/db/client'
 import {
   organizations, personas, capabilities,
+  strategies, strategyGoals, strategyCapabilities,
   crossOrgLinks, auditLog,
 } from '@/db/schema'
 import { buildArchiveExport } from '@/lib/backup-export'
@@ -31,6 +32,8 @@ import {
   insertCapability,
   insertPersona,
   insertApplication,
+  insertStrategy,
+  insertGoal,
   type TestOrg,
   type TestUser,
 } from './helpers/db'
@@ -122,6 +125,24 @@ describe('round-trip: export → wipe → import', () => {
     expect(restored.length).toBe(before.length)
     const restoredIds = new Set(restored.map(c => c.id))
     for (const id of beforeIds) expect(restoredIds.has(id)).toBe(true)
+  })
+
+  it('round-trips strategies and their goal/capability links (ADR-0005 R6)', async () => {
+    const strat = await insertStrategy(orgA.id, { name: `Strat-A-${Date.now()}`, status: 'active' })
+    const goal = await insertGoal(orgA.id, { name: `StratGoal-A-${Date.now()}`, status: 'published' })
+    const cap = await insertCapability(orgA.id, { name: `StratCap-A-${Date.now()}`, status: 'published' })
+    await db.insert(strategyGoals).values({ strategyId: strat.id, goalId: goal.id })
+    await db.insert(strategyCapabilities).values({ strategyId: strat.id, capabilityId: cap.id })
+
+    const archive = await buildArchiveExport(orgA.id)
+    await importArchive(orgA.id, adminA.id, archive.body)
+
+    const restoredStrat = await db.query.strategies.findFirst({ where: eq(strategies.id, strat.id) })
+    expect(restoredStrat?.status).toBe('active')
+    expect((await db.select().from(strategyGoals)
+      .where(and(eq(strategyGoals.strategyId, strat.id), eq(strategyGoals.goalId, goal.id)))).length).toBe(1)
+    expect((await db.select().from(strategyCapabilities)
+      .where(and(eq(strategyCapabilities.strategyId, strat.id), eq(strategyCapabilities.capabilityId, cap.id)))).length).toBe(1)
   })
 
   it('normalizes createdBy to the importing admin on restored rows', async () => {

--- a/business-architecture/capabilities/cms/planning/pl-goals.md
+++ b/business-architecture/capabilities/cms/planning/pl-goals.md
@@ -25,6 +25,7 @@ The system must allow organizations to define broad strategic goals above strate
 
 ## Implementation Status
 - **v1:** Implemented. Goals ship as a first-class planning entity with list/detail pages, CRUD, objective linking, rolled-up traceability context, and viewer filtering.
+- **Strategy (ADR-0005):** Implemented. Strategy ships as a first-class **course-of-action** entity that pursues Goals and maps onto the operating model (capabilities, value streams) and the initiatives that deliver it. Includes CRUD + lifecycle (`proposed`/`active`/`achieved`/`abandoned`), Strategy↔Goal/Capability/Value-Stream/Initiative linking from both sides, a `from=strategy` traceability root, active-strategy surfaces on Executive/Roadmap/Dashboard, and backup/export + seed parity. (Supersedes the ADR-0004 planning-container design.)
 
 ## Links
 - Depends on: Strategic Objectives, Content Workflow, Content Relationships


### PR DESCRIPTION
Final rework slice for ADR-0005. Brings strategies into backup/export/import and the dev seed, and records Strategy as shipped — the closure condition for #805.

Branches off `main` (R1–R3 merged; independent of R4/R5).

## What changed
- **backup-export**: strategy rows + the four junctions (`strategy_goals` / `_capabilities` / `_value_streams` / `_initiatives`), org-filtered into the content bundle.
- **backup-import**: wipe + replay strategies and their junctions (UUIDs preserved, same-org restore) — full round-trip parity.
- **seed** (`DEV_STRATEGIES`): one **active**, one **proposed**, one **achieved** strategy, each linked to goals / capabilities / value streams / initiatives. Idempotent via the composite PKs.
- **docs**: `pl-goals` Implementation Status now records Strategy as a shipped course-of-action entity (ADR-0005).

## Tests
Integration: a strategy plus its goal and capability links survive export → wipe → import.

Verified locally: ✅ tsc, ✅ lint (no new warnings), ✅ build, ✅ docs-lint (115 files). Integration tests run in CI.

## Closes the tracker
With Strategy marked shipped in `pl-goals`, **#805 can close** once R4 (#832), R5 (#834), and this land.

Capability: pl-goals
Capability: ac-backup-export
Closes #835
Part of #805 · Decision: ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)