### PR TITLE
fix(glossary): select the active reference source from edit/detail views

### DIFF
--- a/apps/govea/src/actions/glossary.ts
+++ b/apps/govea/src/actions/glossary.ts
@@ -118,7 +118,7 @@ export async function createGlossaryTerm(formData: FormData) {
       entityId: entry.id,
       userId: session.user.id,
       organizationId: orgId,
-      after: { term, status, visibility },
+      after: { term, status, visibility, definitionSource },
     })
   })
 }
@@ -167,8 +167,8 @@ export async function editGlossaryTerm(termId: string, formData: FormData) {
       entityId: termId,
       userId: session.user.id,
       organizationId: orgId,
-      before: { term: before?.term, status: before?.status },
-      after: { term, status, visibility },
+      before: { term: before?.term, status: before?.status, definitionSource: before?.definitionSource },
+      after: { term, status, visibility, definitionSource },
     })
   })
 }

--- a/apps/govea/src/app/(admin)/glossary/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/glossary/[id]/page.tsx
@@ -66,6 +66,7 @@ export default async function GlossaryTermDetailPage({ params }: { params: Promi
       {canMutate && (
         <GlossaryEditButton
           termId={id}
+          sources={term.sources.map(s => ({ name: s.name, url: s.url }))}
           initial={{
             term: term.term,
             definition: term.definition,

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -16,12 +16,12 @@ import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import { isSafeUrl } from '@/lib/url'
 import type { Role } from '@/lib/rbac'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { GlossarySourceSelect } from '@/components/glossary-source-select'
 
 type GlossaryRow = GlossaryTerm & {
   organization: { id: string; name: string } | null
@@ -411,8 +411,6 @@ function TermForm({
   pendingLabel: string
 }) {
   const [definition, setDefinition] = useState(term?.definition ?? '')
-  const [defSource, setDefSource] = useState(term?.definitionSource ?? '')
-  const [defSourceUrl, setDefSourceUrl] = useState(term?.definitionSourceUrl ?? '')
   const [sources, setSources] = useState<SourceRow[]>(
     term?.sources?.map(s => ({ name: s.name, url: s.url ?? '', definition: s.definition })) ?? []
   )
@@ -429,23 +427,18 @@ function TermForm({
     setSources(prev => prev.map((s, idx) => idx === i ? { ...s, [field]: value } : s))
   }
 
-  function applySource(s: SourceRow) {
+  // Copy a source's verbatim text into the term definition. Active-source
+  // attribution is chosen separately via GlossarySourceSelect (#837).
+  function applyAsDefinition(s: SourceRow) {
     setDefinition(s.definition)
-    setDefSource(s.name)
-    setDefSourceUrl(s.url)
-  }
-
-  function clearSource() {
-    setDefSource('')
-    setDefSourceUrl('')
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const fd = new FormData(e.currentTarget)
     fd.set('definition', definition)
-    fd.set('definitionSource', defSource)
-    fd.set('definitionSourceUrl', defSourceUrl)
+    // definitionSource / definitionSourceUrl are carried by the hidden inputs
+    // GlossarySourceSelect renders inside this form.
     fd.set('sources', JSON.stringify(sources.filter(s => s.name && s.definition)))
     onSubmit(fd)
   }
@@ -454,21 +447,8 @@ function TermForm({
     <form onSubmit={handleSubmit} onChange={onDirty} className="space-y-4">
       <FormField label="Term" name="term" required defaultValue={term?.term} placeholder="e.g. Capability" />
 
-      {/* Definition with attribution */}
       <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="glossary-definition">Definition <span className="text-destructive">*</span></Label>
-          {defSource && (
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span>Source:</span>
-              {isSafeUrl(defSourceUrl)
-                ? <a href={defSourceUrl} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:underline">{defSource}</a>
-                : <span className="font-medium">{defSource}</span>
-              }
-              <button type="button" onClick={clearSource} className="ml-1 text-muted-foreground hover:text-foreground">×</button>
-            </div>
-          )}
-        </div>
+        <Label htmlFor="glossary-definition">Definition <span className="text-destructive">*</span></Label>
         <MarkdownEditor
           name="definition"
           id="glossary-definition"
@@ -537,15 +517,23 @@ function TermForm({
             {s.name && s.definition && (
               <button
                 type="button"
-                onClick={() => applySource(s)}
+                onClick={() => applyAsDefinition(s)}
                 className="text-xs text-blue-600 hover:underline"
               >
-                Use this definition
+                Use as the term definition
               </button>
             )}
           </div>
         ))}
       </div>
+
+      {/* Active reference source — which saved source attributes the definition (#837). */}
+      <GlossarySourceSelect
+        sources={sources}
+        defaultSource={term?.definitionSource}
+        defaultSourceUrl={term?.definitionSourceUrl}
+        onChange={onDirty}
+      />
 
       <DialogFooter>
         <Button type="button" variant="outline" onClick={onCancel}>Cancel</Button>

--- a/apps/govea/src/components/glossary-edit-button.tsx
+++ b/apps/govea/src/components/glossary-edit-button.tsx
@@ -7,9 +7,11 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MarkdownEditor } from '@/components/markdown-editor'
+import { GlossarySourceSelect, type GlossarySourceOption } from '@/components/glossary-source-select'
 
 interface GlossaryEditButtonProps {
   termId: string
+  sources: GlossarySourceOption[]
   initial: {
     term: string
     definition: string
@@ -22,7 +24,7 @@ interface GlossaryEditButtonProps {
   }
 }
 
-export function GlossaryEditButton({ termId, initial }: GlossaryEditButtonProps) {
+export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditButtonProps) {
   const [editing, setEditing] = useState(false)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
@@ -81,14 +83,12 @@ export function GlossaryEditButton({ termId, initial }: GlossaryEditButtonProps)
           <Input name="domain" defaultValue={initial.domain ?? ''} placeholder="e.g. Finance, HR, IT" />
         </div>
 
-        <div className="space-y-1">
-          <Label>Definition source</Label>
-          <Input name="definitionSource" defaultValue={initial.definitionSource ?? ''} placeholder="Organization or document name" />
-        </div>
-
-        <div className="space-y-1 sm:col-span-2">
-          <Label>Source URL</Label>
-          <Input name="definitionSourceUrl" type="url" defaultValue={initial.definitionSourceUrl ?? ''} placeholder="https://…" />
+        <div className="sm:col-span-2">
+          <GlossarySourceSelect
+            sources={sources}
+            defaultSource={initial.definitionSource}
+            defaultSourceUrl={initial.definitionSourceUrl}
+          />
         </div>
 
         <div className="space-y-1 sm:col-span-2">

--- a/apps/govea/src/components/glossary-source-select.tsx
+++ b/apps/govea/src/components/glossary-source-select.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useId, useState } from 'react'
+import { Label } from '@/components/ui/label'
+import { isSafeUrl } from '@/lib/url'
+
+export interface GlossarySourceOption {
+  name: string
+  url?: string | null
+}
+
+const CUSTOM = '__custom__'
+const NONE = ''
+
+/**
+ * Active-reference-source selector (#837).
+ *
+ * Lets an editor pick which of a term's saved reference sources is the active
+ * source — the one that populates `definitionSource` / `definitionSourceUrl` on
+ * the term. Emits those two values as hidden inputs so the surrounding <form>
+ * carries them through native FormData (works for both the controlled TermForm
+ * dialog and the uncontrolled detail-view edit form).
+ *
+ * Backward compatibility: a term may carry a free-text `definitionSource` that
+ * predates the sources table or does not match any saved source name. That
+ * value is preserved under the "Custom source" option rather than silently
+ * dropped. If a previously-selected saved source is renamed or removed while
+ * editing, the prior attribution falls back to Custom so nothing is lost.
+ */
+export function GlossarySourceSelect({
+  sources,
+  defaultSource = null,
+  defaultSourceUrl = null,
+  onChange,
+}: {
+  sources: GlossarySourceOption[]
+  defaultSource?: string | null
+  defaultSourceUrl?: string | null
+  onChange?: () => void
+}) {
+  const names = sources.map(s => s.name).filter(Boolean)
+  const matchesSaved = !!defaultSource && names.includes(defaultSource)
+
+  const [selection, setSelection] = useState<string>(
+    matchesSaved ? defaultSource! : defaultSource ? CUSTOM : NONE,
+  )
+  const [customName, setCustomName] = useState(matchesSaved ? '' : defaultSource ?? '')
+  const [customUrl, setCustomUrl] = useState(matchesSaved ? '' : defaultSourceUrl ?? '')
+
+  // If a previously-selected saved source is renamed or removed mid-edit, fall
+  // back to Custom and preserve the prior attribution as free text.
+  useEffect(() => {
+    if (selection !== NONE && selection !== CUSTOM && !names.includes(selection)) {
+      setCustomName(selection)
+      setCustomUrl('')
+      setSelection(CUSTOM)
+    }
+  }, [names, selection])
+
+  const active = sources.find(s => s.name === selection)
+  const effectiveName = selection === CUSTOM ? customName : selection === NONE ? '' : active?.name ?? ''
+  const effectiveUrl = selection === CUSTOM ? customUrl : selection === NONE ? '' : active?.url ?? ''
+
+  const selectId = useId()
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={selectId}>Active reference source</Label>
+      <select
+        id={selectId}
+        value={selection}
+        onChange={e => { setSelection(e.target.value); onChange?.() }}
+        className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+      >
+        <option value={NONE}>No source — original definition</option>
+        {names.map(n => <option key={n} value={n}>{n}</option>)}
+        <option value={CUSTOM}>Custom source…</option>
+      </select>
+
+      {selection === CUSTOM && (
+        <div className="grid gap-2 pt-1 sm:grid-cols-2">
+          <input
+            type="text"
+            aria-label="Custom source name"
+            placeholder="Source name"
+            value={customName}
+            onChange={e => { setCustomName(e.target.value); onChange?.() }}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <input
+            type="url"
+            aria-label="Custom source URL"
+            placeholder="https://…"
+            value={customUrl}
+            onChange={e => { setCustomUrl(e.target.value); onChange?.() }}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        </div>
+      )}
+
+      {selection !== NONE && effectiveName && (
+        <p className="text-xs text-muted-foreground">
+          Definition attributed to{' '}
+          {isSafeUrl(effectiveUrl)
+            ? <a href={effectiveUrl!} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:underline">{effectiveName}</a>
+            : <span className="font-medium">{effectiveName}</span>}.
+        </p>
+      )}
+
+      {selection !== NONE && names.length === 0 && (
+        <p className="text-xs text-muted-foreground">No saved sources yet — add one above, or enter a custom attribution.</p>
+      )}
+
+      {/* Hidden inputs carry the active-source attribution through native FormData. */}
+      <input type="hidden" name="definitionSource" value={effectiveName} />
+      <input type="hidden" name="definitionSourceUrl" value={effectiveUrl} />
+    </div>
+  )
+}

--- a/apps/govea/tests/integration/glossary-source-select.test.ts
+++ b/apps/govea/tests/integration/glossary-source-select.test.ts
@@ -28,7 +28,9 @@ function form(fields: Record<string, string>): FormData {
 
 const SOURCES = [
   { name: 'TOGAF 10', url: 'https://www.opengroup.org/togaf', definition: 'A business or technical capability.' },
-  { name: 'NIST SP 800-145', url: 'https://nist.gov', definition: 'On-demand network access to shared resources.' },
+  // Path-bearing URL: validateWebUrl normalizes a bare host to a trailing slash,
+  // so use a stable path so the round-trip equals the input exactly.
+  { name: 'NIST SP 800-145', url: 'https://csrc.nist.gov/pubs/sp/800/145/final', definition: 'On-demand network access to shared resources.' },
 ]
 
 describe('glossary active-source selection (#837)', () => {
@@ -81,8 +83,8 @@ describe('glossary active-source selection (#837)', () => {
     }))
 
     const updated = await termRow('Capability')
-    expect(updated.definitionSource).toBe('NIST SP 800-145')
-    expect(updated.definitionSourceUrl).toBe('https://nist.gov')
+    expect(updated.definitionSource).toBe(SOURCES[1].name)
+    expect(updated.definitionSourceUrl).toBe(SOURCES[1].url)
     expect(await sourceCount(updated.id)).toBe(2)
   })
 

--- a/apps/govea/tests/integration/glossary-source-select.test.ts
+++ b/apps/govea/tests/integration/glossary-source-select.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests: glossary active-reference-source selection (#837)
+ *
+ * A glossary term may carry several saved reference/source definitions; exactly
+ * one can be the active source, populating `definitionSource` /
+ * `definitionSourceUrl` on the term. These tests exercise the server action that
+ * persists that choice (editGlossaryTerm), covering: selecting a saved source,
+ * preserving the saved sources while doing so, clearing the active source,
+ * role enforcement, terms with no sources, and audit capture of the change.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { glossaryTerms, glossaryTermSources } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { createGlossaryTerm, editGlossaryTerm } from '@/actions/glossary'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, getAuditLogs, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+function form(fields: Record<string, string>): FormData {
+  const fd = new FormData()
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v)
+  return fd
+}
+
+const SOURCES = [
+  { name: 'TOGAF 10', url: 'https://www.opengroup.org/togaf', definition: 'A business or technical capability.' },
+  { name: 'NIST SP 800-145', url: 'https://nist.gov', definition: 'On-demand network access to shared resources.' },
+]
+
+describe('glossary active-source selection (#837)', () => {
+  let orgId: string
+  let contributor: TestUser
+  let viewer: TestUser
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[contributor, viewer] = await Promise.all([
+      createTestUser(orgId, 'contributor'),
+      createTestUser(orgId, 'viewer'),
+    ])
+  })
+  afterAll(() => cleanupOrg(orgId))
+
+  async function termRow(term: string) {
+    const [r] = await db.select().from(glossaryTerms)
+      .where(and(eq(glossaryTerms.organizationId, orgId), eq(glossaryTerms.term, term)))
+    return r
+  }
+  async function sourceCount(termId: string) {
+    const rows = await db.select().from(glossaryTermSources).where(eq(glossaryTermSources.termId, termId))
+    return rows.length
+  }
+
+  it('selects a saved source as active and preserves the saved sources', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+
+    // Create a term with two saved sources and no active source yet.
+    await createGlossaryTerm(form({
+      term: 'Capability',
+      definition: 'A particular ability the organization possesses.',
+      status: 'published', visibility: 'org',
+      sources: JSON.stringify(SOURCES),
+    }))
+    const created = await termRow('Capability')
+    expect(created.definitionSource).toBeNull()
+    expect(await sourceCount(created.id)).toBe(2)
+
+    // Select the second saved source as active. `sources` is omitted, so the
+    // saved sources must be preserved untouched.
+    await editGlossaryTerm(created.id, form({
+      term: 'Capability',
+      definition: 'A particular ability the organization possesses.',
+      status: 'published', visibility: 'org',
+      definitionSource: SOURCES[1].name,
+      definitionSourceUrl: SOURCES[1].url,
+    }))
+
+    const updated = await termRow('Capability')
+    expect(updated.definitionSource).toBe('NIST SP 800-145')
+    expect(updated.definitionSourceUrl).toBe('https://nist.gov')
+    expect(await sourceCount(updated.id)).toBe(2)
+  })
+
+  it('records the active-source change in the audit log', async () => {
+    const logs = await getAuditLogs(orgId, 'glossary.edit')
+    const term = await termRow('Capability')
+    const entry = logs.find(l => l.entityId === term.id)
+    expect(entry).toBeDefined()
+    expect((entry!.after as { definitionSource?: string }).definitionSource).toBe('NIST SP 800-145')
+  })
+
+  it('clears the active source back to none', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const term = await termRow('Capability')
+    await editGlossaryTerm(term.id, form({
+      term: 'Capability',
+      definition: 'A particular ability the organization possesses.',
+      status: 'published', visibility: 'org',
+      definitionSource: '',
+      definitionSourceUrl: '',
+    }))
+    const cleared = await termRow('Capability')
+    expect(cleared.definitionSource).toBeNull()
+    expect(cleared.definitionSourceUrl).toBeNull()
+  })
+
+  it('saves cleanly for a term that has no sources', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    await createGlossaryTerm(form({
+      term: 'Service',
+      definition: 'A repeatable activity that delivers value.',
+      status: 'draft', visibility: 'org',
+    }))
+    const term = await termRow('Service')
+    expect(await sourceCount(term.id)).toBe(0)
+
+    await editGlossaryTerm(term.id, form({
+      term: 'Service',
+      definition: 'A repeatable activity that delivers value.',
+      status: 'draft', visibility: 'org',
+      definitionSource: '',
+      definitionSourceUrl: '',
+    }))
+    const after = await termRow('Service')
+    expect(after.definitionSource).toBeNull()
+  })
+
+  it('rejects a viewer', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    const term = await termRow('Capability')
+    await expect(editGlossaryTerm(term.id, form({
+      term: 'Capability',
+      definition: 'A particular ability the organization possesses.',
+      status: 'published', visibility: 'org',
+      definitionSource: 'TOGAF 10',
+    }))).rejects.toThrow('Forbidden')
+  })
+})


### PR DESCRIPTION
## What

Glossary terms can carry several saved reference/source definitions, but exactly one is the *active* source that populates `definitionSource` / `definitionSourceUrl` on the term. Until now there was no clear control to choose it — editors had to retype a source name into free-text fields, and the detail-view edit form didn't even surface the saved sources. This adds a proper selector.

## Changes

- **New `GlossarySourceSelect`** (`src/components/glossary-source-select.tsx`): lists the term's saved sources plus "No source" and "Custom", and emits the chosen attribution as hidden `definitionSource` / `definitionSourceUrl` inputs so it works in both the controlled dialog form and the uncontrolled detail-view form. Pre-existing free-text sources (common in seed data, e.g. `TOGAF 10 (adapted)`) are preserved under "Custom" rather than dropped. If a selected saved source is renamed/removed mid-edit, it falls back to Custom so attribution is never lost.
- **Detail-view edit** (`GlossaryEditButton`) now renders the selector and receives the term's saved sources from the detail page.
- **List dialog** (`TermForm`) uses the same selector; the old "Use this definition" button now only copies a source's verbatim text into the definition (attribution is chosen via the selector).
- **Audit logging** for `glossary.create` / `glossary.edit` now records `definitionSource` (before/after), so active-source changes are auditable.
- Detail view continues to badge the active source distinctly from other available sources.

## Acceptance criteria

- [x] Edit view provides a clear control for choosing the active reference source from saved sources.
- [x] Selecting an active source persists `definitionSource` / `definitionSourceUrl` consistently.
- [x] Detail view displays the active source distinctly (Active badge).
- [x] Terms with no source definitions still render cleanly and keep the add/edit path.
- [x] Permissions respected — viewers cannot change the source (server action gates on `canEdit`; detail edit gated on `canMutate`).
- [x] Audit logging captures active-source changes.
- [x] Regression coverage: a term with multiple sources, verifying the selected active source persists and the saved sources are preserved.

## Testing

- `tsc --noEmit`, `lint`, and `build` pass locally.
- New integration suite `tests/integration/glossary-source-select.test.ts` (runs in CI — no local Postgres): select-among-many, preserve saved sources, clear to none, no-sources term, viewer rejection, audit capture.

Capability: po-glossary
Capability: cm-content-authoring
Persona: CMS Administrator
Persona: Junior EA Analyst
Persona: Department Director
Persona: Business Stakeholder

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)