### PR TITLE
fix(traceability): show upstream Strategy layer in capability traces

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -47,6 +47,9 @@ export interface TraceAdr {
 export interface TracePrinciple {
   id: string; name: string
 }
+export interface TraceStrategy {
+  id: string; name: string; status: string; planningHorizon: string | null
+}
 
 // ── Typed results ─────────────────────────────────────────────────────────────
 
@@ -62,6 +65,7 @@ export interface ObjectiveTrace {
 export interface CapabilityTrace {
   kind: 'capability'
   id: string; name: string; domain: string | null; description: string | null; status: string
+  strategies: TraceStrategy[]
   goals: TraceGoal[]
   objectives: TraceObjective[]
   strategicInitiatives: TraceInitiative[]
@@ -413,6 +417,7 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
 export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | null> {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
 
   const row = await db.query.capabilities.findFirst({
     where: eq(capabilities.id, id),
@@ -453,6 +458,19 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     objectiveIds.flatMap((objectiveId) => initiativesByObjective.get(objectiveId) ?? [])
   )
 
+  // Upstream Strategies that directly impact this capability via the
+  // course-of-action link (ADR-0005 / #831). Same-org by junction construction.
+  // A proposed strategy is not a viewer-visible root, matching getStrategyTrace.
+  const strategyCapRows = await db.query.strategyCapabilities.findMany({
+    where: eq(strategyCapabilities.capabilityId, id),
+    with: { strategy: true },
+  })
+  const upstreamStrategies = strategyCapRows
+    .map(({ strategy }) => strategy)
+    .filter((s) => !isViewer || s.status !== 'proposed')
+    .map((s) => ({ id: s.id, name: s.name, status: s.status, planningHorizon: s.planningHorizon }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
   return {
     kind: 'capability',
     id: row.id,
@@ -460,6 +478,7 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     domain: row.domain,
     description: row.description,
     status: row.status,
+    strategies: upstreamStrategies,
     goals: goalTraceRows,
     objectives: row.objectiveCapabilities.map(({ objective: o }) => ({
       id: o.id, name: o.name, timeHorizon: o.timeHorizon,

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -31,6 +31,13 @@ const INITIATIVE_STYLES: Record<string, string> = {
   cancelled:'bg-red-50 text-red-700 border-red-200',
 }
 
+const STRATEGY_STYLES: Record<string, string> = {
+  proposed:  'bg-slate-100 text-slate-700 border-slate-200',
+  active:    'bg-emerald-50 text-emerald-700 border-emerald-200',
+  achieved:  'bg-blue-50 text-blue-700 border-blue-200',
+  abandoned: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+}
+
 const ADR_STYLES: Record<string, string> = {
   accepted:   'bg-emerald-50 text-emerald-700 border-emerald-200',
   proposed:   'bg-slate-100 text-slate-700 border-slate-200',
@@ -450,7 +457,27 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
 
   return (
     <div className="space-y-1 max-w-2xl">
+      {/* Upstream: Strategies (direct course-of-action links, #842) */}
+      <LayerLabel>Strategies</LayerLabel>
+      {trace.strategies.length === 0 ? (
+        <Gap message="No strategy links upstream — no course of action currently drives this capability." />
+      ) : (
+        <TraceCard>
+          {trace.strategies.map(s => (
+            <TraceRow
+              key={s.id}
+              href={`/traceability?from=strategy&id=${s.id}`}
+              name={s.name}
+              meta={s.planningHorizon ?? undefined}
+              badge={s.status}
+              badgeClass={STRATEGY_STYLES[s.status] ?? 'bg-slate-100 text-slate-600 border-slate-200'}
+            />
+          ))}
+        </TraceCard>
+      )}
+
       {/* Upstream: Goals */}
+      <Connector label="pursued through" />
       <LayerLabel>Goals</LayerLabel>
       {trace.goals.length === 0 ? (
         <Gap message="No goals linked upstream — the strategic outcome for this capability is not yet documented." />
@@ -735,7 +762,7 @@ export default async function TraceabilityPage({
     trace.kind === 'strategy'  ? 'Strategy → Goals → Objectives → Initiatives → Capabilities → Technology Trace' :
     trace.kind === 'goal'      ? 'Goal → Objectives → Initiatives → Capabilities → Technology Trace' :
     trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Technology Trace' :
-    trace.kind === 'capability' ? 'Goal → Objective → Initiatives → Capability → Delivery Trace' :
+    trace.kind === 'capability' ? 'Strategy → Goal → Objective → Initiatives → Capability → Delivery Trace' :
     'Persona → Service → Technology Trace'
 
   return (

--- a/apps/govea/tests/integration/capability-trace-strategy.test.ts
+++ b/apps/govea/tests/integration/capability-trace-strategy.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration tests: upstream Strategy layer in capability traces (#842)
+ *
+ * A Capability trace must surface the Strategies that directly impact it (the
+ * course-of-action link, ADR-0005 / #831) as an upstream layer — and an
+ * unlinked Capability must report an empty Strategy set so the view can render
+ * an empty-state gap. Strategy status/visibility rules match getStrategyTrace:
+ * a proposed Strategy is not a viewer-visible root.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { getCapabilityTrace } from '@/actions/traceability'
+import { db } from '@/db/client'
+import { capabilities, strategies, strategyCapabilities } from '@/db/schema'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('getCapabilityTrace — upstream Strategy layer (#842)', () => {
+  let orgId: string
+  let admin: TestUser
+  let viewer: TestUser
+  let linkedCapId: string
+  let unlinkedCapId: string
+  let activeStrategyId: string
+  let proposedStrategyId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'viewer'),
+    ])
+
+    const [linked, unlinked] = await db.insert(capabilities).values([
+      { organizationId: orgId, name: 'Linked Capability', status: 'published', visibility: 'org' },
+      { organizationId: orgId, name: 'Unlinked Capability', status: 'published', visibility: 'org' },
+    ]).returning()
+    linkedCapId = linked.id
+    unlinkedCapId = unlinked.id
+
+    const [active, proposed] = await db.insert(strategies).values([
+      { organizationId: orgId, name: 'Active Strategy', status: 'active', visibility: 'org' },
+      { organizationId: orgId, name: 'Proposed Strategy', status: 'proposed', visibility: 'org' },
+    ]).returning()
+    activeStrategyId = active.id
+    proposedStrategyId = proposed.id
+
+    // Both strategies directly impact the linked capability.
+    await db.insert(strategyCapabilities).values([
+      { strategyId: activeStrategyId, capabilityId: linkedCapId },
+      { strategyId: proposedStrategyId, capabilityId: linkedCapId },
+    ])
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('an unlinked capability reports an empty Strategy set (renders an empty gap)', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const trace = await getCapabilityTrace(unlinkedCapId)
+    expect(trace).not.toBeNull()
+    expect(trace!.strategies).toEqual([])
+  })
+
+  it('lists directly-linked Strategies for an author/admin', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const trace = await getCapabilityTrace(linkedCapId)
+    expect(trace).not.toBeNull()
+    const ids = trace!.strategies.map(s => s.id)
+    expect(ids).toContain(activeStrategyId)
+    expect(ids).toContain(proposedStrategyId)
+    // Status/context carried for the view.
+    const active = trace!.strategies.find(s => s.id === activeStrategyId)!
+    expect(active.name).toBe('Active Strategy')
+    expect(active.status).toBe('active')
+  })
+
+  it('hides proposed Strategies from viewers but keeps visible ones', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    const trace = await getCapabilityTrace(linkedCapId)
+    expect(trace).not.toBeNull()
+    const ids = trace!.strategies.map(s => s.id)
+    expect(ids).toContain(activeStrategyId)
+    expect(ids).not.toContain(proposedStrategyId)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #842. A Capability trace started at the Goals layer, so the **Strategy** layer was missing from the capability metamodel view — and a Capability not linked to any Strategy showed no empty Strategy gap, unlike every other relationship area.

## Changes

- **`getCapabilityTrace`** now returns a `strategies` array: the Strategies that **directly impact** the capability via the course-of-action link (`strategyCapabilities`, ADR-0005 / #831). Proposed strategies are pruned for viewers, matching `getStrategyTrace`'s rule. Same-org by junction construction.
- **`CapabilityTrace`** type gains `strategies: TraceStrategy[]` (`{ id, name, status, planningHorizon }`).
- **`CapabilityTraceView`** renders a **Strategies** layer above Goals:
  - empty → a clear `<Gap>` empty-state (consistent with the other layers);
  - linked → each Strategy with a status badge and a link to `/traceability?from=strategy&id=<id>`.
  - Capability subtitle updated to `Strategy → Goal → Objective → …` for accuracy.

## Acceptance criteria

- [x] `getCapabilityTrace` returns upstream Strategy data via the direct `strategyCapabilities` relationship.
- [x] `CapabilityTraceView` renders a Strategy section above Goals/Objectives.
- [x] A capability with no linked Strategy renders an empty Strategy gap.
- [x] A capability with linked Strategies lists them and links to `/traceability?from=strategy&id=<id>`.
- [x] Strategy status/visibility rules match the rest of the experience (proposed hidden from viewers).
- [x] Regression coverage: unlinked capability (empty) + capability with linked strategies (admin lists both; viewer sees only non-proposed).

## Testing

`tsc --noEmit`, `lint` (0 errors), and `build` pass locally. New integration suite `capability-trace-strategy.test.ts` runs in CI (no local Postgres).

Capability: fd-traceability-views
Capability: rm-end-to-end-traceability
Persona: Enterprise Architect
Persona: Department Director
Persona: Budget & Performance Analyst

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)