### PR TITLE
feat(traceability): include value streams in traceability views

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -10,6 +10,7 @@ import {
   applications, initiatives, personas, valueStreams, adrs, principles,
   initiativeCapabilities, capabilityPersonas, servicePersonas,
   serviceValueStreams, valueStreamCapabilities, objectiveValueStreams,
+  valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas,
   adrCapabilities, adrObjectives, principleCapabilities,
 } from '@/db/schema'
 import { eq, inArray } from 'drizzle-orm'
@@ -47,6 +48,9 @@ export interface TraceAdr {
 export interface TracePrinciple {
   id: string; name: string
 }
+export interface TraceValueStream {
+  id: string; name: string; valueItem: string | null; status: string
+}
 
 // ── Typed results ─────────────────────────────────────────────────────────────
 
@@ -57,6 +61,7 @@ export interface ObjectiveTrace {
   goals: TraceGoal[]
   capabilities: TraceCapability[]
   initiatives: TraceInitiative[]
+  valueStreams: TraceValueStream[]
 }
 
 export interface CapabilityTrace {
@@ -70,6 +75,7 @@ export interface CapabilityTrace {
   personas: TracePersona[]
   adrs: TraceAdr[]
   principles: TracePrinciple[]
+  valueStreams: TraceValueStream[]
 }
 
 export interface ServiceTrace {
@@ -77,6 +83,20 @@ export interface ServiceTrace {
   id: string; name: string; description: string | null; channels: string[]; status: string
   personas: TracePersona[]
   capabilities: TraceCapability[]
+  valueStreams: TraceValueStream[]
+}
+
+export interface ValueStreamTrace {
+  kind: 'value-stream'
+  id: string; name: string; valueItem: string | null; description: string | null; status: string
+  personas: TracePersona[]
+  objectives: Array<{ id: string; name: string; timeHorizon: string | null }>
+  services: Array<{ id: string; name: string }>
+  stages: Array<{
+    id: string; name: string; description: string | null; order: number
+    capabilities: TraceCapability[]
+  }>
+  applications: TraceApp[]
 }
 
 export interface GoalTrace {
@@ -110,7 +130,7 @@ export interface StrategyTrace {
   directInitiatives: TraceInitiative[]
 }
 
-export type TraceData = StrategyTrace | GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace
+export type TraceData = StrategyTrace | GoalTrace | ObjectiveTrace | CapabilityTrace | ServiceTrace | ValueStreamTrace
 
 function dedupeTraceRows<T extends { id: string }>(rows: T[]): T[] {
   return Array.from(new Map(rows.map((row) => [row.id, row])).values())
@@ -165,6 +185,21 @@ async function getGoalsByObjective(objectiveIds: string[]): Promise<Map<string, 
   }
 
   return goalsByObjective
+}
+
+// Summaries for value streams surfaced as related context on other trace views
+// (#809). Same-org by junction construction; pruned to published for viewers.
+async function getValueStreamSummaries(valueStreamIds: string[], isViewer: boolean): Promise<TraceValueStream[]> {
+  const ids = [...new Set(valueStreamIds)]
+  if (ids.length === 0) return []
+  const rows = await db.query.valueStreams.findMany({
+    where: inArray(valueStreams.id, ids),
+    columns: { id: true, name: true, valueItem: true, status: true },
+  })
+  return rows
+    .filter((v) => !isViewer || v.status === 'published')
+    .map((v) => ({ id: v.id, name: v.name, valueItem: v.valueItem, status: v.status }))
+    .sort((a, b) => a.name.localeCompare(b.name))
 }
 
 // ── Strategy trace ──────────────────────────────────────────────────────────
@@ -366,6 +401,7 @@ export async function getGoalTrace(id: string): Promise<GoalTrace | null> {
 export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | null> {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
 
   const row = await db.query.strategicObjectives.findFirst({
     where: eq(strategicObjectives.id, id),
@@ -375,7 +411,7 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
 
-  const [objectiveCapRows, initiativeRows] = await Promise.all([
+  const [objectiveCapRows, initiativeRows, objectiveVsRows] = await Promise.all([
     db.query.objectiveCapabilities.findMany({
       where: eq(objectiveCapabilities.objectiveId, id),
     }),
@@ -383,11 +419,15 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
       where: eq(initiativeObjectives.objectiveId, id),
       with: { initiative: true },
     }),
+    db.query.objectiveValueStreams.findMany({
+      where: eq(objectiveValueStreams.objectiveId, id),
+    }),
   ])
   const capabilityIds = objectiveCapRows.map(({ capabilityId }) => capabilityId)
-  const [capabilityTraceRows, goalsByObjective] = await Promise.all([
+  const [capabilityTraceRows, goalsByObjective, valueStreamSummaries] = await Promise.all([
     getCapabilitiesWithApps(capabilityIds),
     getGoalsByObjective([id]),
+    getValueStreamSummaries(objectiveVsRows.map(({ valueStreamId }) => valueStreamId), isViewer),
   ])
 
   return {
@@ -405,6 +445,7 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
     initiatives: initiativeRows.map(({ initiative: i }) => ({
       id: i.id, name: i.name, status: i.status,
     })),
+    valueStreams: valueStreamSummaries,
   }
 }
 
@@ -413,6 +454,7 @@ export async function getObjectiveTrace(id: string): Promise<ObjectiveTrace | nu
 export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | null> {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
 
   const row = await db.query.capabilities.findFirst({
     where: eq(capabilities.id, id),
@@ -453,6 +495,25 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     objectiveIds.flatMap((objectiveId) => initiativesByObjective.get(objectiveId) ?? [])
   )
 
+  // Value streams this capability participates in — directly (stream-level) or
+  // through one of their stages (#809). Apps are still reached through the
+  // capability, not a value-stream shortcut.
+  const [vsDirectRows, vsStageCapRows] = await Promise.all([
+    db.query.valueStreamCapabilities.findMany({ where: eq(valueStreamCapabilities.capabilityId, id) }),
+    db.query.valueStreamStageCapabilities.findMany({ where: eq(valueStreamStageCapabilities.capabilityId, id) }),
+  ])
+  const stageIds = vsStageCapRows.map(({ stageId }) => stageId)
+  const stageRows = stageIds.length > 0
+    ? await db.query.valueStreamStages.findMany({
+        where: inArray(valueStreamStages.id, stageIds),
+        columns: { valueStreamId: true },
+      })
+    : []
+  const valueStreamSummaries = await getValueStreamSummaries(
+    [...vsDirectRows.map(({ valueStreamId }) => valueStreamId), ...stageRows.map(({ valueStreamId }) => valueStreamId)],
+    isViewer,
+  )
+
   return {
     kind: 'capability',
     id: row.id,
@@ -482,6 +543,7 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     principles: row.principleCapabilities.map(({ principle: p }) => ({
       id: p.id, name: p.name,
     })),
+    valueStreams: valueStreamSummaries,
   }
 }
 
@@ -490,6 +552,7 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
 export async function getServiceTrace(id: string): Promise<ServiceTrace | null> {
   const session = await auth()
   if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
 
   const row = await db.query.services.findFirst({
     where: eq(services.id, id),
@@ -502,10 +565,14 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
   const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
   if (!visible) return null
 
-  const serviceCapRows = await db.query.serviceCapabilities.findMany({
-    where: eq(serviceCapabilities.serviceId, id),
-  })
-  const capabilityTraceRows = await getCapabilitiesWithApps(serviceCapRows.map(({ capabilityId }) => capabilityId))
+  const [serviceCapRows, serviceVsRows] = await Promise.all([
+    db.query.serviceCapabilities.findMany({ where: eq(serviceCapabilities.serviceId, id) }),
+    db.query.serviceValueStreams.findMany({ where: eq(serviceValueStreams.serviceId, id) }),
+  ])
+  const [capabilityTraceRows, valueStreamSummaries] = await Promise.all([
+    getCapabilitiesWithApps(serviceCapRows.map(({ capabilityId }) => capabilityId)),
+    getValueStreamSummaries(serviceVsRows.map(({ valueStreamId }) => valueStreamId), isViewer),
+  ])
 
   return {
     kind: 'service',
@@ -520,6 +587,96 @@ export async function getServiceTrace(id: string): Promise<ServiceTrace | null> 
     capabilities: serviceCapRows
       .map(({ capabilityId }) => capabilityTraceRows.find((c) => c.id === capabilityId))
       .filter((c): c is TraceCapability => Boolean(c)),
+    valueStreams: valueStreamSummaries,
+  }
+}
+
+// ── Value stream trace (#809) ───────────────────────────────────────────────────
+//
+// Value streams are a first-class trace root: stakeholders/personas and upstream
+// objectives/services on the way in, ordered stages with their stage-level
+// capabilities, and the applications reached *through* those capabilities (no
+// value-stream-to-application shortcut). Stage context is preserved — stages are
+// not flattened into a single capability list.
+
+export async function getValueStreamTrace(id: string): Promise<ValueStreamTrace | null> {
+  const session = await auth()
+  if (!session?.user) redirect('/login')
+  const isViewer = session.user.role === 'viewer'
+
+  const row = await db.query.valueStreams.findFirst({
+    where: eq(valueStreams.id, id),
+    with: {
+      stages: {
+        orderBy: (s, { asc }) => [asc(s.order)],
+        with: { stageCapabilities: { with: { capability: true } } },
+      },
+      valueStreamPersonas: { with: { persona: true } },
+      valueStreamCapabilities: { with: { capability: true } },
+      objectiveValueStreams: { with: { objective: true } },
+    },
+  })
+
+  if (!row) return null
+  const visible = await canReadFederatedEntity(row.organizationId, row.visibility, session.user.organizationId!)
+  if (!visible) return null
+  // A non-published value stream is not viewer-visible (matches getValueStream).
+  if (isViewer && row.status !== 'published') return null
+
+  // Services that deliver this value stream — no relation on valueStreams, so
+  // resolved from the serviceValueStreams junction directly.
+  const serviceVsRows = await db.query.serviceValueStreams.findMany({
+    where: eq(serviceValueStreams.valueStreamId, id),
+    with: { service: true },
+  })
+
+  // Viewers only traverse published capabilities; status lives on the joined
+  // capability row.
+  const capAllowed = (status: string) => !isViewer || status === 'published'
+  const stageCapIds = row.stages.flatMap((s) =>
+    s.stageCapabilities.filter((sc) => capAllowed(sc.capability.status)).map((sc) => sc.capabilityId),
+  )
+  const directCapIds = row.valueStreamCapabilities
+    .filter((vc) => capAllowed(vc.capability.status))
+    .map((vc) => vc.capabilityId)
+  const capWithApps = await getCapabilitiesWithApps([...new Set([...stageCapIds, ...directCapIds])])
+  const capById = new Map(capWithApps.map((c) => [c.id, c]))
+
+  const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name)
+
+  return {
+    kind: 'value-stream',
+    id: row.id,
+    name: row.name,
+    valueItem: row.valueItem,
+    description: row.description,
+    status: row.status,
+    personas: row.valueStreamPersonas
+      .map(({ persona: p }) => p)
+      .filter((p) => !isViewer || p.status === 'published')
+      .map((p) => ({ id: p.id, name: p.name, type: p.type }))
+      .sort(byName),
+    objectives: row.objectiveValueStreams
+      .map(({ objective: o }) => o)
+      .filter((o) => !isViewer || o.status === 'published')
+      .map((o) => ({ id: o.id, name: o.name, timeHorizon: o.timeHorizon }))
+      .sort(byName),
+    services: serviceVsRows
+      .map(({ service: s }) => s)
+      .filter((s) => !isViewer || s.status === 'published')
+      .map((s) => ({ id: s.id, name: s.name }))
+      .sort(byName),
+    stages: row.stages.map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      order: s.order,
+      capabilities: s.stageCapabilities
+        .filter((sc) => capAllowed(sc.capability.status))
+        .map((sc) => capById.get(sc.capabilityId))
+        .filter((c): c is TraceCapability => Boolean(c)),
+    })),
+    applications: dedupeTraceRows(capWithApps.flatMap((c) => c.applications)),
   }
 }
 
@@ -561,7 +718,6 @@ export async function getTraceParticipation(
     kind === 'application' ? await db.query.applications.findFirst({ where: eq(applications.id, id) })
     : kind === 'initiative' ? await db.query.initiatives.findFirst({ where: eq(initiatives.id, id) })
     : kind === 'persona' ? await db.query.personas.findFirst({ where: eq(personas.id, id) })
-    : kind === 'value-stream' ? await db.query.valueStreams.findFirst({ where: eq(valueStreams.id, id) })
     : kind === 'adr' ? await db.query.adrs.findFirst({ where: eq(adrs.id, id) })
     : await db.query.principles.findFirst({ where: eq(principles.id, id) })
 
@@ -596,18 +752,6 @@ export async function getTraceParticipation(
     ])
     capabilityIds.push(...caps.map(r => r.id))
     serviceIds.push(...svcs.map(r => r.id))
-  } else if (kind === 'value-stream') {
-    const [caps, svcs, objs] = await Promise.all([
-      db.select({ id: valueStreamCapabilities.capabilityId })
-        .from(valueStreamCapabilities).where(eq(valueStreamCapabilities.valueStreamId, id)),
-      db.select({ id: serviceValueStreams.serviceId })
-        .from(serviceValueStreams).where(eq(serviceValueStreams.valueStreamId, id)),
-      db.select({ id: objectiveValueStreams.objectiveId })
-        .from(objectiveValueStreams).where(eq(objectiveValueStreams.valueStreamId, id)),
-    ])
-    capabilityIds.push(...caps.map(r => r.id))
-    serviceIds.push(...svcs.map(r => r.id))
-    objectiveIds.push(...objs.map(r => r.id))
   } else if (kind === 'adr') {
     const [caps, objs] = await Promise.all([
       db.select({ id: adrCapabilities.capabilityId })

--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -2,8 +2,8 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
-import { getStrategyTrace, getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace, getTraceParticipation } from '@/actions/traceability'
-import type { StrategyTrace, GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, TraceApp, TraceParticipation } from '@/actions/traceability'
+import { getStrategyTrace, getGoalTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace, getValueStreamTrace, getTraceParticipation } from '@/actions/traceability'
+import type { StrategyTrace, GoalTrace, ObjectiveTrace, CapabilityTrace, ServiceTrace, ValueStreamTrace, TraceValueStream, TraceApp, TraceParticipation } from '@/actions/traceability'
 import { isTraceParticipantKind, PARTICIPANT_ROUTES } from '@/lib/trace-participants'
 import { getStrategies } from '@/actions/strategies'
 import { getGoals } from '@/actions/goals'
@@ -438,6 +438,8 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
       <Connector label="supported by" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
+
+      <RelatedValueStreams valueStreams={trace.valueStreams} />
     </div>
   )
 }
@@ -594,6 +596,8 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
           </TraceCard>
         </>
       )}
+
+      <RelatedValueStreams valueStreams={trace.valueStreams} />
     </div>
   )
 }
@@ -665,6 +669,139 @@ function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
       <Connector label="runs on" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
+
+      <RelatedValueStreams valueStreams={trace.valueStreams} />
+    </div>
+  )
+}
+
+// ── Related value streams (#809) ────────────────────────────────────────────────
+//
+// Lateral delivery context surfaced on objective/capability/service traces.
+// Rendered only when links exist; each row deep-links to the value stream's own
+// trace where its stages and stage capabilities are shown.
+
+function RelatedValueStreams({ valueStreams }: { valueStreams: TraceValueStream[] }) {
+  if (valueStreams.length === 0) return null
+  return (
+    <>
+      <Connector label="delivered through" />
+      <LayerLabel>Value Streams</LayerLabel>
+      <TraceCard>
+        {valueStreams.map(v => (
+          <TraceRow
+            key={v.id}
+            href={`/traceability?from=value-stream&id=${v.id}`}
+            name={v.name}
+            meta={v.valueItem ?? undefined}
+          />
+        ))}
+      </TraceCard>
+    </>
+  )
+}
+
+// ── Value stream trace view (#809) ──────────────────────────────────────────────
+
+function ValueStreamTraceView({ trace }: { trace: ValueStreamTrace }) {
+  return (
+    <div className="space-y-1 max-w-2xl">
+      {/* Upstream context: objectives & services */}
+      <LayerLabel>Strategic Objectives</LayerLabel>
+      {trace.objectives.length === 0 ? (
+        <Gap message="No strategic objectives linked — the mission intent this value stream serves isn't mapped yet." />
+      ) : (
+        <TraceCard>
+          {trace.objectives.map(o => (
+            <TraceRow key={o.id} href={`/objectives/${o.id}`} name={o.name} meta={o.timeHorizon ?? undefined} />
+          ))}
+        </TraceCard>
+      )}
+
+      <Connector label="delivered by" />
+      <LayerLabel>Services</LayerLabel>
+      {trace.services.length === 0 ? (
+        <Gap message="No services linked — the stakeholder-facing services this value stream delivers aren't mapped yet." />
+      ) : (
+        <TraceCard>
+          {trace.services.map(s => (
+            <TraceRow key={s.id} href={`/services/${s.id}`} name={s.name} />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Anchor: Value Stream */}
+      <Connector label="realised by" />
+      <LayerLabel>Value Stream</LayerLabel>
+      <TraceCard>
+        <div className="px-4 py-4">
+          <div className="font-semibold text-base">{trace.name}</div>
+          {trace.description && (
+            <p className="text-sm text-muted-foreground mt-1">{trace.description}</p>
+          )}
+          <div className="flex flex-wrap gap-4 mt-2 text-xs text-muted-foreground">
+            {trace.valueItem && <span>Delivers: {trace.valueItem}</span>}
+            <span>Status: {trace.status}</span>
+          </div>
+        </div>
+      </TraceCard>
+
+      {/* Stakeholders */}
+      <Connector label="serves" />
+      <LayerLabel>Stakeholders</LayerLabel>
+      {trace.personas.length === 0 ? (
+        <Gap message="No personas linked — the stakeholders this value stream serves aren't identified yet." />
+      ) : (
+        <TraceCard>
+          {trace.personas.map(p => (
+            <TraceRow key={p.id} href={`/personas/${p.id}`} name={p.name} meta={p.type ?? undefined} />
+          ))}
+        </TraceCard>
+      )}
+
+      {/* Ordered stages, each with its stage-level capabilities */}
+      <Connector label="flows through" />
+      <LayerLabel>Stages</LayerLabel>
+      {trace.stages.length === 0 ? (
+        <Gap message="No stages defined — add ordered stages to map how this value stream delivers value." />
+      ) : (
+        <div className="space-y-3">
+          {trace.stages.map((stage, idx) => (
+            <TraceCard key={stage.id}>
+              <div className="px-4 py-3 space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">{idx + 1}</span>
+                  <span className="font-medium text-sm">{stage.name}</span>
+                </div>
+                {stage.description && (
+                  <p className="text-xs text-muted-foreground">{stage.description}</p>
+                )}
+                {stage.capabilities.length === 0 ? (
+                  <p className="text-xs text-muted-foreground italic">No capabilities assigned to this stage yet.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {stage.capabilities.map(c => (
+                      <Link
+                        key={c.id}
+                        href={`/traceability?from=capability&id=${c.id}`}
+                        className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-1.5 text-sm hover:bg-muted/60 transition-colors"
+                      >
+                        <span className="font-medium">{c.name}</span>
+                        {c.domain && <span className="text-xs text-muted-foreground">{c.domain}</span>}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </TraceCard>
+          ))}
+        </div>
+      )}
+
+      {/* Applications reached through stage capabilities */}
+      <Connector label="supported by" />
+      <LayerLabel>Applications</LayerLabel>
+      <AppLayer apps={trace.applications} />
     </div>
   )
 }
@@ -714,6 +851,10 @@ export default async function TraceabilityPage({
     trace = await getServiceTrace(id)
     backHref = `/services/${id}`
     backLabel = '← Service'
+  } else if (from === 'value-stream') {
+    trace = await getValueStreamTrace(id)
+    backHref = `/value-streams/${id}`
+    backLabel = '← Value Stream'
   } else if (isTraceParticipantKind(from)) {
     // #695 — non-root participants get a participation panel rather than a
     // native trace: their one-hop connections into the root trace views.
@@ -736,6 +877,7 @@ export default async function TraceabilityPage({
     trace.kind === 'goal'      ? 'Goal → Objectives → Initiatives → Capabilities → Technology Trace' :
     trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Technology Trace' :
     trace.kind === 'capability' ? 'Goal → Objective → Initiatives → Capability → Delivery Trace' :
+    trace.kind === 'value-stream' ? 'Objectives/Services → Value Stream → Stages → Capabilities → Technology Trace' :
     'Persona → Service → Technology Trace'
 
   return (
@@ -766,6 +908,7 @@ export default async function TraceabilityPage({
       {trace.kind === 'objective' && <ObjectiveTraceView trace={trace} />}
       {trace.kind === 'capability' && <CapabilityTraceView trace={trace} />}
       {trace.kind === 'service' && <ServiceTraceView trace={trace} />}
+      {trace.kind === 'value-stream' && <ValueStreamTraceView trace={trace} />}
 
       <p className="text-xs text-muted-foreground pt-4 border-t">
         Traceability view — relationships reflect published, visible records only.

--- a/apps/govea/src/lib/trace-participants.ts
+++ b/apps/govea/src/lib/trace-participants.ts
@@ -9,10 +9,10 @@
  */
 
 export type TraceParticipantKind =
-  | 'application' | 'initiative' | 'persona' | 'value-stream' | 'adr' | 'principle'
+  | 'application' | 'initiative' | 'persona' | 'adr' | 'principle'
 
 export const TRACE_PARTICIPANT_KINDS: readonly TraceParticipantKind[] =
-  ['application', 'initiative', 'persona', 'value-stream', 'adr', 'principle'] as const
+  ['application', 'initiative', 'persona', 'adr', 'principle'] as const
 
 export function isTraceParticipantKind(value: string): value is TraceParticipantKind {
   return (TRACE_PARTICIPANT_KINDS as readonly string[]).includes(value)
@@ -23,7 +23,6 @@ export const PARTICIPANT_ROUTES: Record<TraceParticipantKind, { hrefBase: string
   application: { hrefBase: '/applications', label: 'Application' },
   initiative: { hrefBase: '/initiatives', label: 'Initiative' },
   persona: { hrefBase: '/personas', label: 'Persona' },
-  'value-stream': { hrefBase: '/value-streams', label: 'Value Stream' },
   adr: { hrefBase: '/adrs', label: 'Decision' },
   principle: { hrefBase: '/principles', label: 'Principle' },
 }

--- a/apps/govea/tests/integration/value-stream-traceability.test.ts
+++ b/apps/govea/tests/integration/value-stream-traceability.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests: value streams as first-class trace participants (#809)
+ *
+ * Covers:
+ *  - getValueStreamTrace builds the value-stream root: stakeholders, upstream
+ *    objectives/services, ordered stages with stage-level capabilities (stage
+ *    context preserved, not flattened), and applications reached through those
+ *    capabilities.
+ *  - Viewer traversal respects status: a non-published value stream is not a
+ *    viewer-visible root; draft capabilities are pruned from stages for viewers.
+ *  - Objective / capability / service traces surface the related value streams.
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { getValueStreamTrace, getObjectiveTrace, getCapabilityTrace, getServiceTrace } from '@/actions/traceability'
+import { db } from '@/db/client'
+import {
+  valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamCapabilities,
+  valueStreamPersonas, objectiveValueStreams, serviceValueStreams,
+  capabilities, applications, applicationCapabilities, personas, strategicObjectives, services,
+} from '@/db/schema'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+describe('value stream traceability (#809)', () => {
+  let orgId: string
+  let admin: TestUser
+  let viewer: TestUser
+  let vsId: string
+  let draftVsId: string
+  let stage1Id: string
+  let stage2Id: string
+  let capAId: string
+  let capBId: string
+  let capDraftId: string
+  let appId: string
+  let personaId: string
+  let objectiveId: string
+  let serviceId: string
+
+  beforeAll(async () => {
+    const org = await createTestOrg()
+    orgId = org.id
+    ;[admin, viewer] = await Promise.all([
+      createTestUser(orgId, 'admin'),
+      createTestUser(orgId, 'viewer'),
+    ])
+
+    const [vs] = await db.insert(valueStreams).values({
+      organizationId: orgId, name: 'Permit Issuance', valueItem: 'An issued permit', status: 'published', visibility: 'org',
+    }).returning()
+    vsId = vs.id
+    const [draftVs] = await db.insert(valueStreams).values({
+      organizationId: orgId, name: 'Draft Stream', status: 'draft', visibility: 'org',
+    }).returning()
+    draftVsId = draftVs.id
+
+    const [capA, capB, capDraft] = await db.insert(capabilities).values([
+      { organizationId: orgId, name: 'Intake Capability', status: 'published', visibility: 'org' },
+      { organizationId: orgId, name: 'Review Capability', status: 'published', visibility: 'org' },
+      { organizationId: orgId, name: 'Draft Capability', status: 'draft', visibility: 'org' },
+    ]).returning()
+    capAId = capA.id; capBId = capB.id; capDraftId = capDraft.id
+
+    const [app] = await db.insert(applications).values({
+      organizationId: orgId, name: 'Permit Portal', status: 'published', visibility: 'org', lifecycleStatus: 'active',
+    }).returning()
+    appId = app.id
+    await db.insert(applicationCapabilities).values({ applicationId: appId, capabilityId: capAId })
+
+    // Two ordered stages: stage 1 → {Intake, Draft}, stage 2 → {Review}.
+    const [s1, s2] = await db.insert(valueStreamStages).values([
+      { valueStreamId: vsId, name: 'Submit', order: 0 },
+      { valueStreamId: vsId, name: 'Decide', order: 1 },
+    ]).returning()
+    stage1Id = s1.id; stage2Id = s2.id
+    await db.insert(valueStreamStageCapabilities).values([
+      { stageId: stage1Id, capabilityId: capAId },
+      { stageId: stage1Id, capabilityId: capDraftId },
+      { stageId: stage2Id, capabilityId: capBId },
+    ])
+    // Stream-level direct capability link too.
+    await db.insert(valueStreamCapabilities).values({ valueStreamId: vsId, capabilityId: capAId })
+
+    const [persona] = await db.insert(personas).values({
+      organizationId: orgId, name: 'Permit Applicant', status: 'published', visibility: 'org',
+    }).returning()
+    personaId = persona.id
+    await db.insert(valueStreamPersonas).values({ valueStreamId: vsId, personaId })
+
+    const [objective] = await db.insert(strategicObjectives).values({
+      organizationId: orgId, name: 'Faster Permitting', status: 'published', visibility: 'org',
+    }).returning()
+    objectiveId = objective.id
+    await db.insert(objectiveValueStreams).values({ objectiveId, valueStreamId: vsId })
+
+    const [service] = await db.insert(services).values({
+      organizationId: orgId, name: 'Online Permit Service', status: 'published', visibility: 'org',
+    }).returning()
+    serviceId = service.id
+    await db.insert(serviceValueStreams).values({ serviceId, valueStreamId: vsId })
+  })
+
+  afterAll(() => cleanupOrg(orgId))
+
+  it('builds the value-stream root with ordered stages and stage-level capabilities', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const trace = await getValueStreamTrace(vsId)
+
+    expect(trace).not.toBeNull()
+    expect(trace!.kind).toBe('value-stream')
+    expect(trace!.name).toBe('Permit Issuance')
+
+    // Stage order preserved, not flattened.
+    expect(trace!.stages.map(s => s.id)).toEqual([stage1Id, stage2Id])
+    expect(trace!.stages[0].capabilities.map(c => c.id).sort()).toEqual([capAId, capDraftId].sort())
+    expect(trace!.stages[1].capabilities.map(c => c.id)).toEqual([capBId])
+
+    // Apps reached through stage capabilities.
+    expect(trace!.applications.map(a => a.id)).toContain(appId)
+
+    // Upstream/lateral context.
+    expect(trace!.personas.map(p => p.id)).toContain(personaId)
+    expect(trace!.objectives.map(o => o.id)).toContain(objectiveId)
+    expect(trace!.services.map(s => s.id)).toContain(serviceId)
+  })
+
+  it('prunes draft stage capabilities for viewers but keeps published ones', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    const trace = await getValueStreamTrace(vsId)
+    expect(trace).not.toBeNull()
+    const stage1 = trace!.stages.find(s => s.id === stage1Id)!
+    expect(stage1.capabilities.map(c => c.id)).toContain(capAId)
+    expect(stage1.capabilities.map(c => c.id)).not.toContain(capDraftId)
+  })
+
+  it('a non-published value stream is not a viewer-visible root', async () => {
+    mockAuth.mockResolvedValue(makeSession(viewer))
+    expect(await getValueStreamTrace(draftVsId)).toBeNull()
+    mockAuth.mockResolvedValue(makeSession(admin))
+    expect(await getValueStreamTrace(draftVsId)).not.toBeNull()
+  })
+
+  it('surfaces the value stream in objective, capability, and service traces', async () => {
+    mockAuth.mockResolvedValue(makeSession(admin))
+    const [objTrace, capTrace, svcTrace] = await Promise.all([
+      getObjectiveTrace(objectiveId),
+      getCapabilityTrace(capAId),
+      getServiceTrace(serviceId),
+    ])
+    expect(objTrace!.valueStreams.map(v => v.id)).toContain(vsId)
+    expect(capTrace!.valueStreams.map(v => v.id)).toContain(vsId)
+    expect(svcTrace!.valueStreams.map(v => v.id)).toContain(vsId)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #809. Value streams had their own list/detail experience and stage-level capability links, but were not a navigable layer in the mission-to-technology chain — only a one-hop participation panel. This makes them **first-class trace participants**: a proper trace root, and related delivery context on the other root views.

## Changes

**New value-stream root trace** — `getValueStreamTrace(id)` returns:
- stakeholders (personas), upstream **objectives** and **services**,
- **ordered stages**, each with its **stage-level capabilities** (stage context preserved — not flattened into one capability list),
- **applications** reached *through* those capabilities (AC #4 — no value-stream→application shortcut).

`ValueStreamTraceView` renders this with a clear empty state for each missing relationship area (AC #5).

**Promoted value-stream from participant → root:** removed from `TRACE_PARTICIPANT_KINDS` / `PARTICIPANT_ROUTES` and `getTraceParticipation`. `/traceability?from=value-stream&id=<id>` now renders the root view, and the value-stream detail page's `View traceability →` affordance opens it.

**Surfaced on other traces (AC #3):** objective, capability, and service traces gain a related **Value Streams** section (shown when links exist) that deep-links into each value stream's own trace. Capability→value-stream resolves through both stream-level and stage-level capability links.

**Visibility (AC #7):** a non-published value stream is not a viewer-visible root; draft capabilities are pruned from stages for viewers; surfaced value streams are pruned to published for viewers.

## Acceptance criteria

- [x] `/traceability?from=value-stream&id=<id>` supported for a value stream starting point.
- [x] Ordered stages and stage-level capability links shown without flattening stage context.
- [x] Objective, capability, and service traces surface related value streams.
- [x] Downstream applications derived through linked capabilities, not a direct shortcut.
- [x] Empty/missing relationship states explained in plain language.
- [x] Tests: a value stream with multiple stages and multiple capability links.
- [x] Viewer-visible traversal respects status and visibility rules.

## Testing

`tsc --noEmit`, `lint` (0 errors), and `build` pass locally. New integration suite `value-stream-traceability.test.ts` runs in CI (no local Postgres).

> Note: overlaps #843 (#842) in `getCapabilityTrace` / `CapabilityTraceView` and `traceability/page.tsx`. Both are independent off `main`; whichever merges second needs a small rebase.

Capability: rm-end-to-end-traceability
Capability: po-value-streams
Persona: Enterprise Architect
Persona: Agency EA Coordinator
Persona: Department Director

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)