### PR TITLE
fix(traceability): restore TraceValueStream type + capability value-stream query (main is red)

### DIFF
--- a/apps/govea/src/actions/traceability.ts
+++ b/apps/govea/src/actions/traceability.ts
@@ -51,6 +51,9 @@ export interface TracePrinciple {
 export interface TraceStrategy {
   id: string; name: string; status: string; planningHorizon: string | null
 }
+export interface TraceValueStream {
+  id: string; name: string; valueItem: string | null; status: string
+}
 
 // ── Typed results ─────────────────────────────────────────────────────────────
 
@@ -508,6 +511,25 @@ export async function getCapabilityTrace(id: string): Promise<CapabilityTrace | 
     .filter((s) => !isViewer || s.status !== 'proposed')
     .map((s) => ({ id: s.id, name: s.name, status: s.status, planningHorizon: s.planningHorizon }))
     .sort((a, b) => a.name.localeCompare(b.name))
+
+  // Value streams this capability participates in — directly (stream-level) or
+  // through one of their stages (#809). Apps are still reached through the
+  // capability, not a value-stream shortcut.
+  const [vsDirectRows, vsStageCapRows] = await Promise.all([
+    db.query.valueStreamCapabilities.findMany({ where: eq(valueStreamCapabilities.capabilityId, id) }),
+    db.query.valueStreamStageCapabilities.findMany({ where: eq(valueStreamStageCapabilities.capabilityId, id) }),
+  ])
+  const stageIds = vsStageCapRows.map(({ stageId }) => stageId)
+  const stageRows = stageIds.length > 0
+    ? await db.query.valueStreamStages.findMany({
+        where: inArray(valueStreamStages.id, stageIds),
+        columns: { valueStreamId: true },
+      })
+    : []
+  const valueStreamSummaries = await getValueStreamSummaries(
+    [...vsDirectRows.map(({ valueStreamId }) => valueStreamId), ...stageRows.map(({ valueStreamId }) => valueStreamId)],
+    isViewer,
+  )
 
   return {
     kind: 'capability',


### PR DESCRIPTION
## ⚠️ main is currently broken — merge this first

Merging **#843** (capability→strategy layer) and **#844** (value streams as trace participants) — which I'd flagged as overlapping in `traceability.ts` — dropped two pieces during conflict resolution, so `main` no longer type-checks or builds:

1. The `export interface TraceValueStream { … }` definition was lost (its 4 usages — `CapabilityTrace.valueStreams`, `ServiceTrace.valueStreams`, `ObjectiveTrace.valueStreams`, and `getValueStreamSummaries`'s return — all remained → `TS2304: Cannot find name 'TraceValueStream'`).
2. The `valueStreamSummaries` computation block in `getCapabilityTrace` was lost (the `valueStreams: valueStreamSummaries` return reference remained → `TS2552`).

Both #843 and #844 passed CI individually; the breakage is purely from the merge resolution.

## Fix

Restores exactly those two dropped pieces — the `TraceValueStream` interface (after `TraceStrategy`) and the value-stream lookup in `getCapabilityTrace`. No behavior change beyond making the already-merged value-stream traceability work as intended.

## Verification
`tsc --noEmit` and `build` pass locally.

> This unblocks every open PR (they all fail CI against the red main). In particular #846 (#748 list-view CSV) will go green once this lands and it's rebased.

Capability: fd-traceability-views

🤖 Generated with [Claude Code](https://claude.com/claude-code)