### PR TITLE
fix(traceability): place Value Streams between initiatives and capabilities

### DIFF
--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -423,6 +423,9 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
         </TraceCard>
       )}
 
+      {/* Value Streams (between initiatives and capabilities) */}
+      <ValueStreamLayer valueStreams={trace.valueStreams} />
+
       {/* Capabilities */}
       <Connector label="requires" />
       <LayerLabel>Capabilities</LayerLabel>
@@ -445,8 +448,6 @@ function ObjectiveTraceView({ trace }: { trace: ObjectiveTrace }) {
       <Connector label="supported by" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
-
-      <RelatedValueStreams valueStreams={trace.valueStreams} />
     </div>
   )
 }
@@ -532,6 +533,9 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
           ))}
         </TraceCard>
       )}
+
+      {/* Value Streams (between initiatives and the capability) */}
+      <ValueStreamLayer valueStreams={trace.valueStreams} />
 
       {/* Anchor: Capability */}
       <Connector label="requires" />
@@ -623,8 +627,6 @@ function CapabilityTraceView({ trace }: { trace: CapabilityTrace }) {
           </TraceCard>
         </>
       )}
-
-      <RelatedValueStreams valueStreams={trace.valueStreams} />
     </div>
   )
 }
@@ -674,6 +676,9 @@ function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
         </div>
       </TraceCard>
 
+      {/* Value Streams (delivery layer above capabilities) */}
+      <ValueStreamLayer valueStreams={trace.valueStreams} />
+
       {/* Capabilities */}
       <Connector label="requires" />
       <LayerLabel>Capabilities</LayerLabel>
@@ -696,34 +701,38 @@ function ServiceTraceView({ trace }: { trace: ServiceTrace }) {
       <Connector label="runs on" />
       <LayerLabel>Applications</LayerLabel>
       <AppLayer apps={allApps} />
-
-      <RelatedValueStreams valueStreams={trace.valueStreams} />
     </div>
   )
 }
 
-// ── Related value streams (#809) ────────────────────────────────────────────────
+// ── Value stream layer (#809 / #848) ───────────────────────────────────────────
 //
-// Lateral delivery context surfaced on objective/capability/service traces.
-// Rendered only when links exist; each row deep-links to the value stream's own
-// trace where its stages and stage capabilities are shown.
+// The delivery/value layer sits between Strategic Initiatives and Capabilities in
+// the traceability metamodel: Initiatives → Value Streams → Capabilities. Always
+// rendered as its own layer (with an empty-state gap when nothing is linked) so
+// the chain order is consistent and the value-stream layer is never skipped. Each
+// row deep-links to the value stream's own trace, where its stages and stage
+// capabilities are shown.
 
-function RelatedValueStreams({ valueStreams }: { valueStreams: TraceValueStream[] }) {
-  if (valueStreams.length === 0) return null
+function ValueStreamLayer({ valueStreams }: { valueStreams: TraceValueStream[] }) {
   return (
     <>
       <Connector label="delivered through" />
       <LayerLabel>Value Streams</LayerLabel>
-      <TraceCard>
-        {valueStreams.map(v => (
-          <TraceRow
-            key={v.id}
-            href={`/traceability?from=value-stream&id=${v.id}`}
-            name={v.name}
-            meta={v.valueItem ?? undefined}
-          />
-        ))}
-      </TraceCard>
+      {valueStreams.length === 0 ? (
+        <Gap message="No value streams linked — the delivery layer between strategic initiatives and capabilities isn't mapped yet." />
+      ) : (
+        <TraceCard>
+          {valueStreams.map(v => (
+            <TraceRow
+              key={v.id}
+              href={`/traceability?from=value-stream&id=${v.id}`}
+              name={v.name}
+              meta={v.valueItem ?? undefined}
+            />
+          ))}
+        </TraceCard>
+      )}
     </>
   )
 }
@@ -900,11 +909,11 @@ export default async function TraceabilityPage({
     trace.name
 
   const subtitle =
-    trace.kind === 'strategy'  ? 'Strategy → Goals → Objectives → Initiatives → Capabilities → Technology Trace' :
+    trace.kind === 'strategy'  ? 'Strategy → Goals → Objectives → Initiatives → Value Streams → Capabilities → Technology Trace' :
     trace.kind === 'goal'      ? 'Goal → Objectives → Initiatives → Capabilities → Technology Trace' :
-    trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Technology Trace' :
-    trace.kind === 'capability' ? 'Strategy → Goal → Objective → Initiatives → Capability → Delivery Trace' :
-    'Persona → Service → Technology Trace'
+    trace.kind === 'objective' ? 'Goal → Objective → Initiatives → Value Streams → Capabilities → Technology Trace' :
+    trace.kind === 'capability' ? 'Strategy → Goal → Objective → Initiatives → Value Streams → Capability → Delivery Trace' :
+    'Persona → Service → Value Streams → Capabilities → Technology Trace'
 
   return (
     <div className="space-y-8">

--- a/apps/govea/tests/unit/traceability-metamodel-order.test.ts
+++ b/apps/govea/tests/unit/traceability-metamodel-order.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit test: traceability metamodel layer order (#848)
+ *
+ * Value Streams sit between Strategic Initiatives and Capabilities in every
+ * trace view that renders that part of the chain:
+ *   Strategy → Goals → Objectives → Initiatives → Value Streams → Capabilities → Applications
+ *
+ * The trace views are non-exported server components, so this guards the
+ * rendered section order at the source level — the cheapest deterministic guard
+ * given the node-only test environment. It fails if a future change moves the
+ * Value Streams layer out from between initiatives and capabilities (the #844
+ * regression this issue fixes, where value streams rendered after Applications).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const pagePath = fileURLToPath(new URL('../../src/app/(admin)/traceability/page.tsx', import.meta.url))
+const src = readFileSync(pagePath, 'utf-8')
+
+/** Source of a single view function, from its declaration to the next one. */
+function viewBody(name: string): string {
+  const start = src.indexOf(`function ${name}(`)
+  expect(start, `${name} should exist`).toBeGreaterThan(-1)
+  const rest = src.slice(start + `function ${name}(`.length)
+  const next = rest.indexOf('\nfunction ')
+  return next === -1 ? rest : rest.slice(0, next)
+}
+
+/** Index of a `<LayerLabel>label</LayerLabel>` within a view body. */
+function labelIndex(body: string, label: string): number {
+  return body.indexOf(`<LayerLabel>${label}</LayerLabel>`)
+}
+
+/**
+ * Index of the Value Streams layer, whether rendered inline (Strategy) or via
+ * the shared `<ValueStreamLayer />` component (objective/capability/service).
+ */
+function valueStreamIndex(body: string): number {
+  const inline = labelIndex(body, 'Value Streams')
+  const component = body.indexOf('<ValueStreamLayer')
+  const found = [inline, component].filter(i => i > -1)
+  return found.length === 0 ? -1 : Math.min(...found)
+}
+
+describe('traceability metamodel order (#848)', () => {
+  it('Strategy trace renders Value Streams between initiatives and capabilities', () => {
+    const body = viewBody('StrategyTraceView')
+    const inits = labelIndex(body, 'Strategic Initiatives')
+    const vs = labelIndex(body, 'Value Streams')
+    const caps = labelIndex(body, 'Capabilities')
+    expect(inits).toBeGreaterThan(-1)
+    expect(vs).toBeGreaterThan(inits)
+    expect(caps).toBeGreaterThan(vs)
+  })
+
+  it('Objective trace renders Value Streams between initiatives and capabilities', () => {
+    const body = viewBody('ObjectiveTraceView')
+    const inits = labelIndex(body, 'Strategic Initiatives')
+    const vs = labelIndex(body, 'Value Streams')
+    const caps = labelIndex(body, 'Capabilities')
+    expect(inits).toBeGreaterThan(-1)
+    expect(vs).toBeGreaterThan(inits)
+    expect(caps).toBeGreaterThan(vs)
+  })
+
+  it('Capability trace renders Value Streams between initiatives and the capability anchor', () => {
+    const body = viewBody('CapabilityTraceView')
+    const inits = labelIndex(body, 'Strategic Initiatives')
+    const vs = labelIndex(body, 'Value Streams')
+    const anchor = labelIndex(body, 'Capability') // anchor layer label
+    expect(inits).toBeGreaterThan(-1)
+    expect(vs).toBeGreaterThan(inits)
+    expect(anchor).toBeGreaterThan(vs)
+  })
+
+  it('Service trace renders Value Streams above Capabilities (not stranded after Applications)', () => {
+    const body = viewBody('ServiceTraceView')
+    const vs = labelIndex(body, 'Value Streams')
+    const caps = labelIndex(body, 'Capabilities')
+    const apps = labelIndex(body, 'Applications')
+    expect(vs).toBeGreaterThan(-1)
+    expect(caps).toBeGreaterThan(vs)
+    expect(apps).toBeGreaterThan(caps)
+  })
+
+  it('chain subtitles place Value Streams between Initiatives and Capabilities', () => {
+    expect(src).toContain('Initiatives → Value Streams → Capabilities')
+    expect(src).toContain('Initiatives → Value Streams → Capability →')
+  })
+})

--- a/apps/govea/tests/unit/traceability-metamodel-order.test.ts
+++ b/apps/govea/tests/unit/traceability-metamodel-order.test.ts
@@ -47,7 +47,7 @@ describe('traceability metamodel order (#848)', () => {
   it('Strategy trace renders Value Streams between initiatives and capabilities', () => {
     const body = viewBody('StrategyTraceView')
     const inits = labelIndex(body, 'Strategic Initiatives')
-    const vs = labelIndex(body, 'Value Streams')
+    const vs = valueStreamIndex(body)
     const caps = labelIndex(body, 'Capabilities')
     expect(inits).toBeGreaterThan(-1)
     expect(vs).toBeGreaterThan(inits)
@@ -57,7 +57,7 @@ describe('traceability metamodel order (#848)', () => {
   it('Objective trace renders Value Streams between initiatives and capabilities', () => {
     const body = viewBody('ObjectiveTraceView')
     const inits = labelIndex(body, 'Strategic Initiatives')
-    const vs = labelIndex(body, 'Value Streams')
+    const vs = valueStreamIndex(body)
     const caps = labelIndex(body, 'Capabilities')
     expect(inits).toBeGreaterThan(-1)
     expect(vs).toBeGreaterThan(inits)
@@ -67,7 +67,7 @@ describe('traceability metamodel order (#848)', () => {
   it('Capability trace renders Value Streams between initiatives and the capability anchor', () => {
     const body = viewBody('CapabilityTraceView')
     const inits = labelIndex(body, 'Strategic Initiatives')
-    const vs = labelIndex(body, 'Value Streams')
+    const vs = valueStreamIndex(body)
     const anchor = labelIndex(body, 'Capability') // anchor layer label
     expect(inits).toBeGreaterThan(-1)
     expect(vs).toBeGreaterThan(inits)
@@ -76,7 +76,7 @@ describe('traceability metamodel order (#848)', () => {
 
   it('Service trace renders Value Streams above Capabilities (not stranded after Applications)', () => {
     const body = viewBody('ServiceTraceView')
-    const vs = labelIndex(body, 'Value Streams')
+    const vs = valueStreamIndex(body)
     const caps = labelIndex(body, 'Capabilities')
     const apps = labelIndex(body, 'Applications')
     expect(vs).toBeGreaterThan(-1)


### PR DESCRIPTION
## Summary

Value Streams are the delivery/value layer of the traceability metamodel and belong **between Strategic Initiatives and Capabilities**:

`Strategy → Goals → Objectives → Initiatives → Value Streams → Capabilities → Applications/Services`

#844 added value streams to the objective/capability/service traces, but rendered them in a trailing `Related value streams` block **after Applications**, with no empty state — so the chain visually skipped from initiatives to capabilities and the value-stream layer was stranded at the bottom.

## Changes (`traceability/page.tsx`)

- `RelatedValueStreams` → **`ValueStreamLayer`**: always renders the layer with an empty-state `<Gap>` when nothing is linked (previously rendered nothing when empty).
- **Objective** and **Capability** traces now render it between Strategic Initiatives and the Capabilities / Capability anchor.
- **Service** trace renders it above Capabilities (it has no initiatives) instead of after Applications.
- **Strategy** trace already rendered it inline in the correct position — unchanged.
- Chain **subtitles** updated to include Value Streams in the right slot.

## Acceptance criteria

- [x] Views with initiatives + value streams + capabilities render Value Streams between initiatives and capabilities.
- [x] Value-stream rows still deep-link to the value stream's own trace (stage context preserved there); capability links are not flattened.
- [x] Empty state: a clear Value Stream gap renders between initiatives and capabilities when none are linked.
- [x] Labels, section ordering, and subtitle/help text use the same ordering.
- [x] Regression coverage asserts the rendered order (unit test across all four views + subtitles).
- [x] Visibility/status rules unchanged (no query changes).

## Testing

- `tsc`, `lint` (0 errors), `build` pass locally.
- New `tests/unit/traceability-metamodel-order.test.ts` guards the section order at the source level (node-only test env, server-component views). Existing `value-stream-traceability` integration test already proves the layer is populated in objective/capability/service traces.

Capability: rm-end-to-end-traceability
Capability: po-value-streams
Persona: Enterprise Architect
Persona: Agency EA Coordinator
Persona: Department Director

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)