### PR TITLE
fix(glossary): reference source selection can set the term definition

### DIFF
--- a/apps/govea/src/app/(admin)/glossary/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/glossary/[id]/page.tsx
@@ -66,7 +66,7 @@ export default async function GlossaryTermDetailPage({ params }: { params: Promi
       {canMutate && (
         <GlossaryEditButton
           termId={id}
-          sources={term.sources.map(s => ({ name: s.name, url: s.url }))}
+          sources={term.sources.map(s => ({ name: s.name, url: s.url, definition: s.definition }))}
           initial={{
             term: term.term,
             definition: term.definition,

--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -427,11 +427,6 @@ function TermForm({
     setSources(prev => prev.map((s, idx) => idx === i ? { ...s, [field]: value } : s))
   }
 
-  // Copy a source's verbatim text into the term definition. Active-source
-  // attribution is chosen separately via GlossarySourceSelect (#837).
-  function applyAsDefinition(s: SourceRow) {
-    setDefinition(s.definition)
-  }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -514,25 +509,18 @@ function TermForm({
               rows={2}
               className="w-full rounded-md border border-input bg-transparent px-2 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
             />
-            {s.name && s.definition && (
-              <button
-                type="button"
-                onClick={() => applyAsDefinition(s)}
-                className="text-xs text-blue-600 hover:underline"
-              >
-                Use as the term definition
-              </button>
-            )}
           </div>
         ))}
       </div>
 
-      {/* Active reference source — which saved source attributes the definition (#837). */}
+      {/* Active reference source — choose which saved source attributes the
+          definition, and optionally use its text as the definition (#837/#849). */}
       <GlossarySourceSelect
         sources={sources}
         defaultSource={term?.definitionSource}
         defaultSourceUrl={term?.definitionSourceUrl}
         onChange={onDirty}
+        onUseDefinition={text => { setDefinition(text); onDirty?.() }}
       />
 
       <DialogFooter>

--- a/apps/govea/src/components/glossary-edit-button.tsx
+++ b/apps/govea/src/components/glossary-edit-button.tsx
@@ -28,6 +28,7 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
   const [editing, setEditing] = useState(false)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+  const [definition, setDefinition] = useState(initial.definition)
   const router = useRouter()
 
   if (!editing) {
@@ -44,6 +45,7 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
     e.preventDefault()
     setError(null)
     const formData = new FormData(e.currentTarget)
+    formData.set('definition', definition)
     startTransition(async () => {
       try {
         await editGlossaryTerm(termId, formData)
@@ -75,7 +77,7 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
         </div>
 
         <div className="space-y-1 sm:col-span-2">
-          <MarkdownEditor label="Definition" name="definition" defaultValue={initial.definition} rows={4} placeholder="Markdown supported" />
+          <MarkdownEditor label="Definition" name="definition" value={definition} onChange={setDefinition} rows={4} placeholder="Markdown supported" />
         </div>
 
         <div className="space-y-1">
@@ -88,6 +90,7 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
             sources={sources}
             defaultSource={initial.definitionSource}
             defaultSourceUrl={initial.definitionSourceUrl}
+            onUseDefinition={setDefinition}
           />
         </div>
 

--- a/apps/govea/src/components/glossary-source-select.tsx
+++ b/apps/govea/src/components/glossary-source-select.tsx
@@ -7,6 +7,7 @@ import { isSafeUrl } from '@/lib/url'
 export interface GlossarySourceOption {
   name: string
   url?: string | null
+  definition?: string | null
 }
 
 const CUSTOM = '__custom__'
@@ -26,17 +27,26 @@ const NONE = ''
  * value is preserved under the "Custom source" option rather than silently
  * dropped. If a previously-selected saved source is renamed or removed while
  * editing, the prior attribution falls back to Custom so nothing is lost.
+ *
+ * When `onUseDefinition` is provided and the active selection is a saved source
+ * that carries a definition, the control also offers a one-click action to use
+ * that source's verbatim definition as the term definition (#849) — coupling
+ * the definition text and its attribution in a single place. Selecting "None"
+ * or a custom source leaves the existing definition untouched, so original /
+ * custom definitions remain fully supported.
  */
 export function GlossarySourceSelect({
   sources,
   defaultSource = null,
   defaultSourceUrl = null,
   onChange,
+  onUseDefinition,
 }: {
   sources: GlossarySourceOption[]
   defaultSource?: string | null
   defaultSourceUrl?: string | null
   onChange?: () => void
+  onUseDefinition?: (definition: string) => void
 }) {
   const names = sources.map(s => s.name).filter(Boolean)
   const matchesSaved = !!defaultSource && names.includes(defaultSource)
@@ -105,6 +115,18 @@ export function GlossarySourceSelect({
             ? <a href={effectiveUrl!} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:underline">{effectiveName}</a>
             : <span className="font-medium">{effectiveName}</span>}.
         </p>
+      )}
+
+      {/* Use the selected source's verbatim text as the term definition (#849).
+          Sets the definition and keeps this source as the attribution together. */}
+      {onUseDefinition && active?.definition && (
+        <button
+          type="button"
+          onClick={() => onUseDefinition(active.definition!)}
+          className="text-xs font-medium text-blue-600 hover:underline"
+        >
+          Use this source&apos;s definition as the term definition
+        </button>
       )}
 
       {selection !== NONE && names.length === 0 && (

--- a/apps/govea/tests/integration/glossary-source-select.test.ts
+++ b/apps/govea/tests/integration/glossary-source-select.test.ts
@@ -142,4 +142,25 @@ describe('glossary active-source selection (#837)', () => {
       definitionSource: 'TOGAF 10',
     }))).rejects.toThrow('Forbidden')
   })
+
+  // #849 — using a saved source as the term definition persists the source's
+  // definition text AND its attribution together (the UI couples these via the
+  // "Use this source's definition" action on GlossarySourceSelect).
+  it('persists a saved source as the term definition together with its attribution', async () => {
+    mockAuth.mockResolvedValue(makeSession(contributor))
+    const term = await termRow('Capability')
+
+    await editGlossaryTerm(term.id, form({
+      term: 'Capability',
+      definition: SOURCES[0].definition,        // source text used as the definition
+      status: 'published', visibility: 'org',
+      definitionSource: SOURCES[0].name,         // matching attribution
+      definitionSourceUrl: SOURCES[0].url,
+    }))
+
+    const updated = await termRow('Capability')
+    expect(updated.definition).toBe(SOURCES[0].definition)
+    expect(updated.definitionSource).toBe(SOURCES[0].name)
+    expect(updated.definitionSourceUrl).toBe(SOURCES[0].url)
+  })
 })


### PR DESCRIPTION
## Summary

The #837/#839 "Active reference source" selector only persisted **attribution** (`definitionSource` / `definitionSourceUrl`). It could not set the term's actual `definition` text, and on the **detail-page edit form** saved source definitions weren't exposed at all — so picking a source changed attribution while leaving the definition unchanged. In the list dialog, the per-row "Use as the term definition" button was decoupled from the active-source selector.

## Change

`GlossarySourceSelect` becomes the single, coupled control:

- `GlossarySourceOption` now carries each source's `definition`; a new `onUseDefinition` callback is added.
- When a saved source is the active selection and has a definition, the control shows **"Use this source's definition as the term definition"** — clicking it sets the definition text *and* keeps that source as the attribution, together.
- **List/dialog `TermForm`**: the decoupled per-row "Use as the term definition" button is removed; the selector's coupled action replaces it.
- **Detail-page `GlossaryEditButton`**: the definition field is now controlled and the selector receives source definitions, so the same source-as-definition workflow works there (the detail page passes source definitions through).
- Selecting **None** or a **custom** source leaves the definition untouched, so original/custom definitions remain fully supported.

## Acceptance criteria

- [x] List/dialog edit makes the "use this source definition" ↔ "active reference source" relationship clear and saves text + attribution together.
- [x] Detail edit exposes saved source definitions and allows using one as the term definition.
- [x] Selecting a saved source as the definition persists the source's text into `glossary_terms.definition`.
- [x] …and persists matching `definitionSource` / `definitionSourceUrl`.
- [x] Original/custom definitions remain supported without forcing a saved source.
- [x] Regression coverage verifies the persisted definition + attribution from the server edit path.
- [x] Permissions unchanged: viewers cannot modify (server action still gates on `canEdit`; detail edit on `canMutate`).

## Testing

`tsc`, `lint` (0 errors), `build` pass locally. Extended `glossary-source-select.test.ts` with a source-as-definition case (definition text + attribution persisted together). The use-as-definition wiring is client-side; the node-only test env can't render components, so coverage targets the server persistence contract.

Capability: po-glossary
Capability: cm-content-authoring
Persona: CMS Administrator
Persona: Junior EA Analyst
Persona: Department Director
Persona: Business Stakeholder

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)