### PR TITLE
fix(glossary): restore visible 'use source as definition' in both edit paths

### DIFF
--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -21,7 +21,7 @@ import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
 import { MarkdownEditor } from '@/components/markdown-editor'
-import { GlossarySourceSelect } from '@/components/glossary-source-select'
+import { GlossarySourceSelect, initialSourceSelection } from '@/components/glossary-source-select'
 
 type GlossaryRow = GlossaryTerm & {
   organization: { id: string; name: string } | null
@@ -414,6 +414,11 @@ function TermForm({
   const [sources, setSources] = useState<SourceRow[]>(
     term?.sources?.map(s => ({ name: s.name, url: s.url ?? '', definition: s.definition })) ?? []
   )
+  // Active reference source is owned here so the per-source "Use as the term
+  // definition" action can set the definition text and the attribution together.
+  const [activeSource, setActiveSource] = useState<string>(() =>
+    initialSourceSelection(term?.definitionSource ?? null, (term?.sources ?? []).map(s => s.name).filter(Boolean))
+  )
 
   function addSource() {
     setSources(prev => [...prev, { name: '', url: '', definition: '' }])
@@ -425,6 +430,14 @@ function TermForm({
 
   function updateSource(i: number, field: keyof SourceRow, value: string) {
     setSources(prev => prev.map((s, idx) => idx === i ? { ...s, [field]: value } : s))
+  }
+
+  // Adopt a saved source as the term definition: copy its text into the
+  // definition and make it the active attribution (#849).
+  function adoptSourceAsDefinition(s: SourceRow) {
+    setDefinition(s.definition)
+    if (s.name) setActiveSource(s.name)
+    onDirty?.()
   }
 
 
@@ -509,18 +522,31 @@ function TermForm({
               rows={2}
               className="w-full rounded-md border border-input bg-transparent px-2 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
             />
+            {s.name && s.definition && (
+              <button
+                type="button"
+                onClick={() => adoptSourceAsDefinition(s)}
+                className="text-xs font-medium text-blue-600 hover:underline"
+              >
+                {activeSource === s.name && definition === s.definition
+                  ? '✓ Used as the term definition'
+                  : 'Use as the term definition'}
+              </button>
+            )}
           </div>
         ))}
       </div>
 
-      {/* Active reference source — choose which saved source attributes the
-          definition, and optionally use its text as the definition (#837/#849). */}
+      {/* Active reference source — which saved source attributes the definition.
+          Driven by the per-source "Use as the term definition" action above so
+          definition text and attribution stay in sync (#837/#849). */}
       <GlossarySourceSelect
         sources={sources}
         defaultSource={term?.definitionSource}
         defaultSourceUrl={term?.definitionSourceUrl}
         onChange={onDirty}
-        onUseDefinition={text => { setDefinition(text); onDirty?.() }}
+        selectedSource={activeSource}
+        onSelectedSourceChange={v => { setActiveSource(v); onDirty?.() }}
       />
 
       <DialogFooter>

--- a/apps/govea/src/components/glossary-edit-button.tsx
+++ b/apps/govea/src/components/glossary-edit-button.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MarkdownEditor } from '@/components/markdown-editor'
-import { GlossarySourceSelect, type GlossarySourceOption } from '@/components/glossary-source-select'
+import { GlossarySourceSelect, initialSourceSelection, type GlossarySourceOption } from '@/components/glossary-source-select'
 
 interface GlossaryEditButtonProps {
   termId: string
@@ -29,7 +29,17 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
   const [definition, setDefinition] = useState(initial.definition)
+  const [activeSource, setActiveSource] = useState<string>(() =>
+    initialSourceSelection(initial.definitionSource, sources.map(s => s.name).filter(Boolean))
+  )
   const router = useRouter()
+
+  // Adopt a saved source as the term definition: copy its text and make it the
+  // active attribution together (#849).
+  function adoptSourceAsDefinition(s: GlossarySourceOption) {
+    setDefinition(s.definition ?? '')
+    if (s.name) setActiveSource(s.name)
+  }
 
   if (!editing) {
     return (
@@ -85,12 +95,38 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
           <Input name="domain" defaultValue={initial.domain ?? ''} placeholder="e.g. Finance, HR, IT" />
         </div>
 
+        {sources.length > 0 && (
+          <div className="space-y-2 sm:col-span-2">
+            <Label>Reference sources</Label>
+            <div className="space-y-2">
+              {sources.map(s => (
+                <div key={s.name} className="rounded-md border bg-muted/30 p-2.5 space-y-1">
+                  <div className="text-sm font-medium">{s.name}</div>
+                  {s.definition && <p className="text-xs text-muted-foreground whitespace-pre-wrap">{s.definition}</p>}
+                  {s.definition && (
+                    <button
+                      type="button"
+                      onClick={() => adoptSourceAsDefinition(s)}
+                      className="text-xs font-medium text-blue-600 hover:underline"
+                    >
+                      {activeSource === s.name && definition === s.definition
+                        ? '✓ Used as the term definition'
+                        : 'Use as the term definition'}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         <div className="sm:col-span-2">
           <GlossarySourceSelect
             sources={sources}
             defaultSource={initial.definitionSource}
             defaultSourceUrl={initial.definitionSourceUrl}
-            onUseDefinition={setDefinition}
+            selectedSource={activeSource}
+            onSelectedSourceChange={setActiveSource}
           />
         </div>
 

--- a/apps/govea/src/components/glossary-source-select.tsx
+++ b/apps/govea/src/components/glossary-source-select.tsx
@@ -14,46 +14,62 @@ const CUSTOM = '__custom__'
 const NONE = ''
 
 /**
- * Active-reference-source selector (#837).
+ * Derive the initial selection value for a term's current attribution:
+ * a saved source name when it matches one, CUSTOM for free-text attribution
+ * that predates / doesn't match a saved source, or NONE when unattributed.
+ * Exported so parent forms can own the selection (controlled) and drive it from
+ * a "use this source" action while staying consistent with the dropdown.
+ */
+export function initialSourceSelection(defaultSource: string | null | undefined, names: string[]): string {
+  if (defaultSource && names.includes(defaultSource)) return defaultSource
+  return defaultSource ? CUSTOM : NONE
+}
+
+/**
+ * Active-reference-source selector (#837 / #849).
  *
- * Lets an editor pick which of a term's saved reference sources is the active
- * source — the one that populates `definitionSource` / `definitionSourceUrl` on
- * the term. Emits those two values as hidden inputs so the surrounding <form>
- * carries them through native FormData (works for both the controlled TermForm
- * dialog and the uncontrolled detail-view edit form).
+ * Picks which saved source attributes the term definition, emitting
+ * `definitionSource` / `definitionSourceUrl` as hidden inputs so the surrounding
+ * <form> carries them through native FormData.
  *
- * Backward compatibility: a term may carry a free-text `definitionSource` that
- * predates the sources table or does not match any saved source name. That
- * value is preserved under the "Custom source" option rather than silently
- * dropped. If a previously-selected saved source is renamed or removed while
- * editing, the prior attribution falls back to Custom so nothing is lost.
+ * The selection is conditionally controlled: when `selectedSource` /
+ * `onSelectedSourceChange` are provided, the parent owns it — so a per-source
+ * "Use as the term definition" action can set the definition text and select
+ * that source as the active attribution together (#849). Otherwise the
+ * component manages selection internally.
  *
- * When `onUseDefinition` is provided and the active selection is a saved source
- * that carries a definition, the control also offers a one-click action to use
- * that source's verbatim definition as the term definition (#849) — coupling
- * the definition text and its attribution in a single place. Selecting "None"
- * or a custom source leaves the existing definition untouched, so original /
- * custom definitions remain fully supported.
+ * Backward compatibility: a free-text `definitionSource` that doesn't match a
+ * saved source is preserved under "Custom source". If a previously-selected
+ * saved source is renamed or removed mid-edit, the prior attribution falls back
+ * to Custom so nothing is lost.
  */
 export function GlossarySourceSelect({
   sources,
   defaultSource = null,
   defaultSourceUrl = null,
   onChange,
-  onUseDefinition,
+  selectedSource,
+  onSelectedSourceChange,
 }: {
   sources: GlossarySourceOption[]
   defaultSource?: string | null
   defaultSourceUrl?: string | null
   onChange?: () => void
-  onUseDefinition?: (definition: string) => void
+  selectedSource?: string
+  onSelectedSourceChange?: (selection: string) => void
 }) {
   const names = sources.map(s => s.name).filter(Boolean)
   const matchesSaved = !!defaultSource && names.includes(defaultSource)
 
-  const [selection, setSelection] = useState<string>(
-    matchesSaved ? defaultSource! : defaultSource ? CUSTOM : NONE,
-  )
+  const controlled = selectedSource !== undefined
+  const [internalSelection, setInternalSelection] = useState<string>(() => initialSourceSelection(defaultSource, names))
+  const selection = controlled ? selectedSource! : internalSelection
+
+  function setSelection(value: string) {
+    if (!controlled) setInternalSelection(value)
+    onSelectedSourceChange?.(value)
+  }
+
   const [customName, setCustomName] = useState(matchesSaved ? '' : defaultSource ?? '')
   const [customUrl, setCustomUrl] = useState(matchesSaved ? '' : defaultSourceUrl ?? '')
 
@@ -65,6 +81,7 @@ export function GlossarySourceSelect({
       setCustomUrl('')
       setSelection(CUSTOM)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [names, selection])
 
   const active = sources.find(s => s.name === selection)
@@ -115,18 +132,6 @@ export function GlossarySourceSelect({
             ? <a href={effectiveUrl!} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:underline">{effectiveName}</a>
             : <span className="font-medium">{effectiveName}</span>}.
         </p>
-      )}
-
-      {/* Use the selected source's verbatim text as the term definition (#849).
-          Sets the definition and keeps this source as the attribution together. */}
-      {onUseDefinition && active?.definition && (
-        <button
-          type="button"
-          onClick={() => onUseDefinition(active.definition!)}
-          className="text-xs font-medium text-blue-600 hover:underline"
-        >
-          Use this source&apos;s definition as the term definition
-        </button>
       )}
 
       {selection !== NONE && names.length === 0 && (


### PR DESCRIPTION
## Why reopened

#851 closed #849 but the fix was incomplete — reported by the user as *"still not able to select reference sources as the definition."* Verified:

1. **#851 removed the discoverable affordance.** Since #839 each reference-source row had a **"Use as the term definition"** button next to its text. #851 deleted it and replaced it with a link that only appears *after* selecting that source in the "Active reference source" dropdown — so the action editors used is gone.
2. **The detail-page edit never exposed source definitions** (#849 AC #2). It only listed source *names* in a dropdown, so an editor couldn't see/choose a source's definition there.

## Fix

- **`GlossarySourceSelect`**: selection is now *conditionally controlled* (`selectedSource` / `onSelectedSourceChange`) and exports `initialSourceSelection`. This lets a parent "use this source" action set the definition text **and** select that source as the active attribution together. The dropdown-gated `onUseDefinition` link is removed in favour of direct per-source buttons.
- **List/dialog edit**: each reference-source row gets its **"Use as the term definition"** button back; clicking it sets the definition and the attribution, and shows a **"✓ Used as the term definition"** state when active.
- **Detail-page edit**: now renders the saved sources with their **definition text** and a per-source **"Use as the term definition"** button (AC #2), wired the same way.
- None/custom attribution still supported; permissions unchanged.

## Acceptance criteria

- [x] List/dialog edit: clear, direct relationship between "use this source definition" and active attribution; saves text + attribution together.
- [x] Detail edit exposes saved source definitions and allows using one as the term definition.
- [x] Selecting a saved source as the definition persists its text into `glossary_terms.definition`.
- [x] …and persists matching `definitionSource` / `definitionSourceUrl`.
- [x] Original/custom definitions still supported.
- [x] Regression coverage: server persistence (`definition` + attribution together) covered by `glossary-source-select.test.ts`.
- [x] Viewers cannot modify (unchanged gating).

## Testing

`tsc`, `lint` (0 errors), `build` pass locally. The coupling is client-side UI; the node-only test env can't render components, so automated coverage stays at the server persistence contract (existing integration test). The UI flow was traced manually in both edit surfaces.

Capability: po-glossary
Capability: cm-content-authoring
Persona: CMS Administrator
Persona: Junior EA Analyst
Persona: Department Director
Persona: Business Stakeholder

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)