### PR TITLE
feat(iam): relax users.organizationId to nullable — enable platform-only operators (#797)

### DIFF
--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -437,7 +437,8 @@ export async function suspendUserAccount(userId: string, reason: string) {
   })
   if (!target) throw new Error('User not found')
 
-  if (target.role === 'admin') {
+  // Platform-only operators have no org; skip the last-admin guard for them.
+  if (target.role === 'admin' && target.organizationId) {
     const [{ adminCount }] = await db
       .select({ adminCount: count() })
       .from(users)

--- a/apps/govea/src/db/schema/users.ts
+++ b/apps/govea/src/db/schema/users.ts
@@ -5,7 +5,10 @@ export const userRoleEnum = pgEnum('user_role', ['admin', 'contributor', 'viewer
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
-  organizationId: uuid('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  // #797 — nullable: platform-only instance admins have no tenant home org.
+  // Org deletion uses `set null` + deactivation instead of cascading identity
+  // deletion — see docs/decisions/0006-identity-lifecycle-on-org-deletion.md.
+  organizationId: uuid('organization_id').references(() => organizations.id, { onDelete: 'set null' }),
   // #693 slice 3a: the user's last-selected active org, honored first by
   // resolveActiveMembership when it's still an active membership. Nullable
   // (most users never switch); `set null` so deleting an org doesn't orphan.

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -2359,15 +2359,19 @@ async function seed() {
   const allUsers = await db
     .select({ id: users.id, organizationId: users.organizationId, role: users.role })
     .from(users)
+  let backfilled = 0
   for (const u of allUsers) {
+    // Platform-only operators have no org; skip — they have no membership to backfill.
+    if (!u.organizationId) continue
     await db.insert(userOrganizationMemberships).values({
       userId: u.id,
       organizationId: u.organizationId,
       role: u.role,
       isPrimary: true,
     }).onConflictDoNothing()
+    backfilled++
   }
-  console.log(`  ✓ ${allUsers.length} user-organization memberships (backfilled, primary)`)
+  console.log(`  ✓ ${backfilled} user-organization memberships (backfilled, primary)`)
 
   // #693 slice 3b demo — make one dev user multi-org so the org switcher is
   // exercisable in dev: Alice (City of Riverdale admin) also joins the State

--- a/apps/govea/src/lib/auth.ts
+++ b/apps/govea/src/lib/auth.ts
@@ -269,7 +269,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const dbUser = await db.query.users.findFirst({
         where: eq(users.id, user.id!),
       })
-      if (dbUser && !dbUser.organizationId) {
+      // #797 — platform-only instance admins intentionally have no org; exempt
+      // them from the deactivation net. All other org-less users are anomalous.
+      if (dbUser && !dbUser.organizationId && dbUser.instanceRole !== 'instance_admin') {
         await db.transaction(async (tx) => {
           await tx.update(users).set({ isActive: 'false' }).where(eq(users.id, user.id!))
           await writeAuditLog(tx, {

--- a/apps/govea/src/lib/security-policy.ts
+++ b/apps/govea/src/lib/security-policy.ts
@@ -16,7 +16,8 @@ import { organizations, DEFAULT_SECURITY_SETTINGS } from '@/db/schema'
 import type { SecuritySettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 
-export async function getOrgSecuritySettings(orgId: string): Promise<SecuritySettings> {
+export async function getOrgSecuritySettings(orgId: string | null): Promise<SecuritySettings> {
+  if (!orgId) return mergeWithDefaults(undefined)
   const org = await db.query.organizations.findFirst({
     where: eq(organizations.id, orgId),
     columns: { securitySettings: true },

--- a/apps/govea/src/lib/sso-guard.ts
+++ b/apps/govea/src/lib/sso-guard.ts
@@ -24,7 +24,7 @@ import { eq } from 'drizzle-orm'
 import { resolveActiveMembership } from '@/lib/active-membership'
 
 export type SsoCheckResult =
-  | { status: 'allowed'; userId: string; organizationId: string; role: string }
+  | { status: 'allowed'; userId: string; organizationId: string | null; role: string }
   | { status: 'not_provisioned' }
   | { status: 'no_org_binding'; userId: string }
   | { status: 'deactivated'; userId: string }
@@ -61,7 +61,20 @@ export async function checkSsoProvisioning(email: string): Promise<SsoCheckResul
     }
   }
 
-  if (!dbUser.organizationId) return { status: 'no_org_binding', userId: dbUser.id }
+  if (!dbUser.organizationId) {
+    // #797 — platform-only instance admins have no tenant org; allow them
+    // through so they can reach /instance. Non-instance users with no org
+    // binding are still blocked (defense-in-depth).
+    if (dbUser.instanceRole !== 'instance_admin') {
+      return { status: 'no_org_binding', userId: dbUser.id }
+    }
+    return {
+      status: 'allowed',
+      userId: dbUser.id,
+      organizationId: null,
+      role: dbUser.role,
+    }
+  }
 
   return {
     status: 'allowed',

--- a/apps/govea/src/middleware.ts
+++ b/apps/govea/src/middleware.ts
@@ -110,6 +110,12 @@ export default async function middleware(req: NextRequest) {
     return redirectTo(req, '/')
   }
 
+  // #797 — platform-only operator: instance_admin with no tenant org has no
+  // business being in the org-scoped app; redirect to /instance instead.
+  if (!token.organizationId && token.instanceRole === 'instance_admin' && !pathname.startsWith('/instance')) {
+    return redirectTo(req, '/instance')
+  }
+
   // #527 — password-expiry redirect. The token carries a snapshot of
   // `passwordExpiryDays` and `lastPasswordChangedAt`, refreshed on the
   // 5-minute active-user check. Edge-safe: pure arithmetic, no DB.

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -14,7 +14,7 @@ import {
   personas, applications, strategicObjectives, principles, valueStreams, services,
   glossaryTerms, strategies, strategyGoals, goals,
 } from '@/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, inArray } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import bcrypt from 'bcryptjs'
 
@@ -77,7 +77,21 @@ export async function createTestUser(
 
 /** Deletes the test org and all its data (cascade). */
 export async function cleanupOrg(orgId: string): Promise<void> {
+  // #797 — users.organization_id is now ON DELETE SET NULL (was CASCADE), so
+  // deleting the org no longer removes its users; they would leak with a null
+  // home org and collide on the next run (hardcoded-email tests). Capture the
+  // org's user ids first, delete the org (cascades all content — including the
+  // created_by rows that reference these users — and sets the users' org null),
+  // then delete the captured users by id. User deletion cascades to their
+  // memberships, sessions, and accounts.
+  const orgUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.organizationId, orgId))
   await db.delete(organizations).where(eq(organizations.id, orgId))
+  if (orgUsers.length > 0) {
+    await db.delete(users).where(inArray(users.id, orgUsers.map(u => u.id)))
+  }
 }
 
 // ── Session builder ───────────────────────────────────────────────────────────

--- a/apps/govea/tests/integration/sso-guard.test.ts
+++ b/apps/govea/tests/integration/sso-guard.test.ts
@@ -4,8 +4,8 @@
  * Covers:
  *  - Not-provisioned identity is blocked (no DB record for the email)
  *  - Deactivated user is blocked
- *  - User with no org binding is blocked (defense-in-depth; schema makes this
- *    impossible in normal operation but guard must handle it explicitly)
+ *  - User with no org binding is blocked (defense-in-depth)
+ *  - Platform-only instance_admin (no org) is allowed (#797)
  *  - Fully provisioned, active user with org binding is allowed
  *  - Duplicate email across orgs is rejected at the DB level (#269)
  *  - #693: org binding resolves through memberships first (same resolution
@@ -73,16 +73,47 @@ describe('checkSsoProvisioning', () => {
     }
   })
 
-  // NOTE: The `no_org_binding` branch in checkSsoProvisioning exists as
-  // defense-in-depth for a scenario the current schema makes impossible:
-  // `users.organization_id` is NOT NULL (enforced since migration 0009), so
-  // there is no way to insert or update a row to organizationId = null via
-  // Drizzle or PostgreSQL. The guard is kept in production code for forward
-  // compatibility (e.g. if the constraint is ever relaxed or a raw SQL import
-  // creates a null row), but the test case cannot be exercised against the
-  // current schema without violating the NOT NULL constraint.
-  //
-  // If the schema ever allows null org bindings again, re-enable this test.
+})
+
+// ── #797 — org-less identity paths ───────────────────────────────────────────
+// `users.organization_id` is now nullable. These tests exercise the two
+// cases that were previously dead code.
+describe('checkSsoProvisioning — org-less identities (#797)', () => {
+  afterAll(async () => {
+    // Clean up org-less users inserted in this suite by email suffix.
+    await db.delete(users).where(eq(users.email, 'orgless-regular@test.example'))
+    await db.delete(users).where(eq(users.email, 'orgless-instance-admin@test.example'))
+  })
+
+  it('returns no_org_binding for an active user with no org and no instance role', async () => {
+    await db.insert(users).values({
+      id: randomUUID(),
+      organizationId: null,
+      email: 'orgless-regular@test.example',
+      name: 'Org-less Regular',
+      role: 'viewer',
+      isActive: 'true',
+    })
+    const result = await checkSsoProvisioning('orgless-regular@test.example')
+    expect(result.status).toBe('no_org_binding')
+  })
+
+  it('returns allowed for a platform-only instance_admin with no org binding', async () => {
+    await db.insert(users).values({
+      id: randomUUID(),
+      organizationId: null,
+      email: 'orgless-instance-admin@test.example',
+      name: 'Platform Operator',
+      role: 'viewer',
+      instanceRole: 'instance_admin',
+      isActive: 'true',
+    })
+    const result = await checkSsoProvisioning('orgless-instance-admin@test.example')
+    expect(result.status).toBe('allowed')
+    if (result.status === 'allowed') {
+      expect(result.organizationId).toBeNull()
+    }
+  })
 })
 
 describe('global email uniqueness (#269)', () => {

--- a/docs/decisions/0006-identity-lifecycle-on-org-deletion.md
+++ b/docs/decisions/0006-identity-lifecycle-on-org-deletion.md
@@ -1,0 +1,43 @@
+# ADR-0006: Identity Lifecycle on Org Deletion
+
+**Status:** Accepted  
+**Date:** 2026-06-18  
+**Issue:** [#797](https://github.com/roballred/GovEA/issues/797)
+
+## Context
+
+`users.organization_id` was `NOT NULL` with `ON DELETE CASCADE`. This had two consequences:
+
+1. **No org-less identities.** A platform operator (instance admin with no tenant membership) could not exist. Every identity had to be homed in an org, which blocked the #796 use-case of a pure platform admin who manages orgs from `/instance` but belongs to none of them.
+
+2. **Org deletion destroyed identities.** Deleting an organisation cascaded to `users`, which deleted the identity row. For a user who belonged to multiple orgs (via `user_organization_memberships`, introduced in #693), deleting their *home* org wiped their identity even though their memberships in other orgs were still valid — a data-loss bug latent in the multi-org model.
+
+With `user_organization_memberships` now the canonical org-access store (#693, #796), `users.organization_id` is a legacy denormalized home pointer, not the sole authority on whether a user belongs anywhere.
+
+## Decision
+
+Relax `users.organization_id` to **nullable** with **`ON DELETE SET NULL`** instead of `CASCADE`.
+
+**Identity lifecycle on org deletion:**
+- `users.organization_id` is set to `NULL` (not deleted).
+- The application deactivates the user (`is_active = 'false'`) as a follow-on step when the deletion of the last active membership is detected, rather than at the DB layer via cascade.
+- Memberships in `user_organization_memberships` for the deleted org are removed by their own `ON DELETE CASCADE` on `organization_id`.
+- The identity row survives for audit purposes (the `audit_log` immutability constraint applies; deleting the identity would orphan those rows).
+
+**Platform-only instance admins:**
+- An instance admin may be provisioned with `organization_id = NULL` — they sign in and are redirected exclusively to `/instance`.
+- The SSO guard (`sso-guard.ts`) allows `instance_admin` users with no org through; all other org-less users receive `no_org_binding` (blocked).
+- The `events.createUser` safety net in `auth.ts` exempts `instance_admin` users from the deactivation path.
+- The edge middleware redirects platform-only operators away from org-scoped routes to `/instance`.
+
+## Alternatives considered
+
+**Keep `CASCADE` and add a separate platform-admin identity type.** This would require a separate table or a different identity path entirely. Adds complexity; nullable column on the existing table is simpler and models the reality that org membership is optional for platform roles.
+
+**`ON DELETE RESTRICT`.** Prevents org deletion if users are still homed there. Pushes the problem to the caller (admin UI must deactivate/reassign users before deleting an org). Possible future hardening, but blocks common admin workflows today.
+
+## Consequences
+
+- The application layer is now responsible for deactivating users whose last active org is deleted. This must be wired into the org-deletion action.
+- TypeScript: `users.organizationId` is now `string | null` everywhere drizzle infers the type. All `session.user.organizationId!` assertions in org-scoped pages remain safe because those pages are only reachable by org-bound sessions (the middleware guard and `(admin)` layout both check `organizationId`).
+- Pre-production only — enforced by `db:push`. When the switch to migrations lands, the first migration must include `ALTER TABLE users ALTER COLUMN organization_id DROP NOT NULL` and a matching `ON DELETE SET NULL` on the FK.


### PR DESCRIPTION
## Summary

Relaxes `users.organization_id` from `NOT NULL`/`ON DELETE CASCADE` to **nullable**/`ON DELETE SET NULL`, enabling a pure platform operator — an instance admin with no tenant membership — to exist and sign in. Splits from #796 (use-case 6).

Two problems this fixes:

1. **No org-less identities.** A platform admin who manages orgs from `/instance` but belongs to none of them could not exist, because every identity had to be homed in an org.
2. **Org deletion destroyed identities.** Deleting an org cascaded to `users`, wiping the identity even for multi-org users whose *home* org was deleted while their other memberships were still valid (a latent data-loss bug in the #693 multi-org model).

With `user_organization_memberships` now the canonical org-access store (#693, #796), `users.organization_id` is a legacy denormalized home pointer — making it nullable matches reality.

## What changed

- **Schema** (`db/schema/users.ts`): `organizationId` is nullable, `onDelete: cascade` → `set null`.
- **SSO guard** (`lib/sso-guard.ts`): an `instance_admin` with no org resolves to `allowed` (null orgId); all other org-less users still return `no_org_binding` (blocked). The previously-dead `no_org_binding` branch is now live code.
- **Security policy** (`lib/security-policy.ts`): `getOrgSecuritySettings` accepts `string | null` and returns defaults for null (platform operators have no per-org policy).
- **Auth** (`lib/auth.ts`): the `events.createUser` deactivation safety-net exempts `instance_admin`.
- **Middleware** (`middleware.ts`): a platform-only operator hitting any non-`/instance` route is redirected to `/instance`.
- **Instance actions** (`actions/instance.ts`): the last-admin guard in `suspendUserAccount` skips org-less users.
- **Seeds** (`db/seeds/run.ts`): membership backfill skips org-less users (`userOrganizationMemberships.organizationId` is NOT NULL).
- **ADR-0006** (`docs/decisions/0006-identity-lifecycle-on-org-deletion.md`): documents the identity-lifecycle decision, rationale, and alternatives (`RESTRICT`, separate identity type).
- **Test helper** (`tests/integration/helpers/db.ts`): `cleanupOrg` previously relied on the org→user cascade. With `SET NULL`, users now survive org deletion, so it captures the org's user ids first, deletes the org (cascades all content, including `created_by` rows that reference those users), then deletes the captured users.
- **Tests** (`tests/integration/sso-guard.test.ts`): re-enables the `no_org_binding` case (now reachable) and adds the platform-only `instance_admin` allowed case.

## Testing

- `tsc --noEmit` clean (the `@axe-core/playwright` error is a pre-existing missing local dep from the recent main merge, present in CI's install).
- `lint` — 0 errors.
- Docs lint — OK (115 files).
- Production `build` — passed.
- Integration suite — **1215/1215** passed (full suite, against local Postgres with the schema change applied via `db:push`).

## Follow-on (not in this PR)

Per ADR-0006, the org-deletion action should deactivate users whose *last active* org is deleted. This PR makes the schema and auth paths correct; wiring the deactivation step into the org-deletion server action is a separate slice.

Capability: iam-instance-administration
Capability: iam-user-management
Persona: Instance Administrator

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)