### PR TITLE
feat(value-streams): add entry and exit criteria to value stream stages (#810)

### DIFF
--- a/apps/govea/src/actions/value-streams.ts
+++ b/apps/govea/src/actions/value-streams.ts
@@ -179,7 +179,13 @@ export async function deleteValueStream(valueStreamId: string) {
 
 // ── Stages ────────────────────────────────────────────────────────────────────
 
-export async function addStage(valueStreamId: string, name: string, description: string) {
+export async function addStage(
+  valueStreamId: string,
+  name: string,
+  description: string,
+  entryCriteria = '',
+  exitCriteria = '',
+) {
   const session = await requireContributor()
   const orgId = session.user.organizationId!
 
@@ -195,11 +201,28 @@ export async function addStage(valueStreamId: string, name: string, description:
   })
   const nextOrder = existing.length > 0 ? Math.max(...existing.map(s => s.order)) + 1 : 0
 
-  await db.insert(valueStreamStages).values({
-    valueStreamId,
-    name: name.trim(),
-    description: description.trim() || null,
-    order: nextOrder,
+  const trimmedName = name.trim()
+  const entry = entryCriteria.trim() || null
+  const exit = exitCriteria.trim() || null
+
+  await db.transaction(async (tx) => {
+    const [stage] = await tx.insert(valueStreamStages).values({
+      valueStreamId,
+      name: trimmedName,
+      description: description.trim() || null,
+      entryCriteria: entry,
+      exitCriteria: exit,
+      order: nextOrder,
+    }).returning()
+
+    await writeAuditLog(tx, {
+      action: 'value_stream.stage.create',
+      entityType: 'value_stream_stage',
+      entityId: stage.id,
+      userId: session.user.id,
+      organizationId: orgId,
+      after: { valueStreamId, name: trimmedName, entryCriteria: entry, exitCriteria: exit },
+    })
   })
 }
 
@@ -213,14 +236,39 @@ async function requireStageOwnership(stageId: string, orgId: string) {
   return stage
 }
 
-export async function editStage(stageId: string, name: string, description: string) {
+export async function editStage(
+  stageId: string,
+  name: string,
+  description: string,
+  entryCriteria = '',
+  exitCriteria = '',
+) {
   const session = await requireContributor()
-  await requireStageOwnership(stageId, session.user.organizationId!)
+  const orgId = session.user.organizationId!
+  const before = await requireStageOwnership(stageId, orgId)
 
-  await db.update(valueStreamStages).set({
-    name: name.trim(),
-    description: description.trim() || null,
-  }).where(eq(valueStreamStages.id, stageId))
+  const trimmedName = name.trim()
+  const entry = entryCriteria.trim() || null
+  const exit = exitCriteria.trim() || null
+
+  await db.transaction(async (tx) => {
+    await tx.update(valueStreamStages).set({
+      name: trimmedName,
+      description: description.trim() || null,
+      entryCriteria: entry,
+      exitCriteria: exit,
+    }).where(eq(valueStreamStages.id, stageId))
+
+    await writeAuditLog(tx, {
+      action: 'value_stream.stage.edit',
+      entityType: 'value_stream_stage',
+      entityId: stageId,
+      userId: session.user.id,
+      organizationId: orgId,
+      before: { name: before.name, entryCriteria: before.entryCriteria, exitCriteria: before.exitCriteria },
+      after: { name: trimmedName, entryCriteria: entry, exitCriteria: exit },
+    })
+  })
 }
 
 export async function deleteStage(stageId: string) {

--- a/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/page.tsx
@@ -131,6 +131,22 @@ export default async function ValueStreamDetailPage({ params }: { params: Promis
                 {stage.description && (
                   <p className="text-sm text-muted-foreground pl-9">{stage.description}</p>
                 )}
+                {(stage.entryCriteria || stage.exitCriteria) && (
+                  <dl className="pl-9 space-y-1.5 text-sm">
+                    {stage.entryCriteria && (
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Entry criteria</dt>
+                        <dd className="whitespace-pre-line text-foreground">{stage.entryCriteria}</dd>
+                      </div>
+                    )}
+                    {stage.exitCriteria && (
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Exit criteria</dt>
+                        <dd className="whitespace-pre-line text-foreground">{stage.exitCriteria}</dd>
+                      </div>
+                    )}
+                  </dl>
+                )}
                 {isModuleEnabled(enabledModules, 'capabilities') && stage.stageCapabilities.length > 0 && (
                   <div className="flex flex-wrap gap-1.5 pl-9">
                     {stage.stageCapabilities.map(({ capability }) => (

--- a/apps/govea/src/app/(admin)/value-streams/[id]/stage-manager.tsx
+++ b/apps/govea/src/app/(admin)/value-streams/[id]/stage-manager.tsx
@@ -32,15 +32,23 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
   const [deleteTarget, setDeleteTarget] = useState<StageWithCapabilities | null>(null)
   const [newName, setNewName] = useState('')
   const [newDesc, setNewDesc] = useState('')
+  const [newEntry, setNewEntry] = useState('')
+  const [newExit, setNewExit] = useState('')
 
   const refresh = () => router.refresh()
+
+  function resetFields() {
+    setNewName('')
+    setNewDesc('')
+    setNewEntry('')
+    setNewExit('')
+  }
 
   function handleAdd() {
     if (!newName.trim()) return
     startTransition(async () => {
-      await addStage(valueStreamId, newName, newDesc)
-      setNewName('')
-      setNewDesc('')
+      await addStage(valueStreamId, newName, newDesc, newEntry, newExit)
+      resetFields()
       setAddOpen(false)
       refresh()
     })
@@ -49,7 +57,7 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
   function handleEdit() {
     if (!editTarget || !newName.trim()) return
     startTransition(async () => {
-      await editStage(editTarget.id, newName, newDesc)
+      await editStage(editTarget.id, newName, newDesc, newEntry, newExit)
       setEditTarget(null)
       refresh()
     })
@@ -114,7 +122,13 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
                   onClick={() => handleMove(stage.id, 'down')}
                   className="h-6 w-6 p-0 text-xs">↓</Button>
                 <Button variant="ghost" size="sm" disabled={isPending}
-                  onClick={() => { setEditTarget(stage); setNewName(stage.name); setNewDesc(stage.description ?? '') }}
+                  onClick={() => {
+                    setEditTarget(stage)
+                    setNewName(stage.name)
+                    setNewDesc(stage.description ?? '')
+                    setNewEntry(stage.entryCriteria ?? '')
+                    setNewExit(stage.exitCriteria ?? '')
+                  }}
                   className="h-6 px-2 text-xs">Edit</Button>
                 <Button variant="ghost" size="sm" disabled={isPending}
                   onClick={() => setDeleteTarget(stage)}
@@ -165,7 +179,7 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
       </div>
 
       {/* Add Stage Dialog */}
-      <Dialog open={addOpen} onOpenChange={open => { if (!open) { setAddOpen(false); setNewName(''); setNewDesc('') } }}>
+      <Dialog open={addOpen} onOpenChange={open => { if (!open) { setAddOpen(false); resetFields() } }}>
         <DialogContent>
           <DialogHeader><DialogTitle>Add stage</DialogTitle></DialogHeader>
           <div className="space-y-3">
@@ -178,9 +192,19 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
               <textarea value={newDesc} onChange={e => setNewDesc(e.target.value)} rows={2} placeholder="Optional"
                 className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
             </div>
+            <div className="space-y-1.5">
+              <Label>Entry criteria</Label>
+              <textarea value={newEntry} onChange={e => setNewEntry(e.target.value)} rows={2} placeholder="Optional — what must be true before this stage begins"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Exit criteria</Label>
+              <textarea value={newExit} onChange={e => setNewExit(e.target.value)} rows={2} placeholder="Optional — what must be true before moving to the next stage"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
+            </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => { setAddOpen(false); setNewName(''); setNewDesc('') }}>Cancel</Button>
+            <Button variant="outline" onClick={() => { setAddOpen(false); resetFields() }}>Cancel</Button>
             <Button onClick={handleAdd} disabled={isPending || !newName.trim()}>
               {isPending ? 'Adding…' : 'Add stage'}
             </Button>
@@ -189,7 +213,7 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
       </Dialog>
 
       {/* Edit Stage Dialog */}
-      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) setEditTarget(null) }}>
+      <Dialog open={!!editTarget} onOpenChange={open => { if (!open) { setEditTarget(null); resetFields() } }}>
         <DialogContent>
           <DialogHeader><DialogTitle>Edit stage</DialogTitle></DialogHeader>
           <div className="space-y-3">
@@ -202,9 +226,19 @@ export function StageManager({ valueStreamId, stages, capabilities }: Props) {
               <textarea value={newDesc} onChange={e => setNewDesc(e.target.value)} rows={2}
                 className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
             </div>
+            <div className="space-y-1.5">
+              <Label>Entry criteria</Label>
+              <textarea value={newEntry} onChange={e => setNewEntry(e.target.value)} rows={2} placeholder="Optional — what must be true before this stage begins"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Exit criteria</Label>
+              <textarea value={newExit} onChange={e => setNewExit(e.target.value)} rows={2} placeholder="Optional — what must be true before moving to the next stage"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none" />
+            </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditTarget(null)}>Cancel</Button>
+            <Button variant="outline" onClick={() => { setEditTarget(null); resetFields() }}>Cancel</Button>
             <Button onClick={handleEdit} disabled={isPending || !newName.trim()}>
               {isPending ? 'Saving…' : 'Save'}
             </Button>

--- a/apps/govea/src/db/schema/value-streams.ts
+++ b/apps/govea/src/db/schema/value-streams.ts
@@ -29,6 +29,12 @@ export const valueStreamStages = pgTable('value_stream_stages', {
   valueStreamId: uuid('value_stream_id').notNull().references(() => valueStreams.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
   description: text('description'),
+  // #810 — optional plain-language gates for the stage. Entry criteria: what
+  // must be true before the stage begins. Exit criteria: what must be true
+  // before the stream can advance past it. Both nullable; existing stages and
+  // stages without criteria render cleanly.
+  entryCriteria: text('entry_criteria'),
+  exitCriteria: text('exit_criteria'),
   order: integer('order').notNull().default(0),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 })

--- a/apps/govea/tests/integration/value-stream-stage-criteria.test.ts
+++ b/apps/govea/tests/integration/value-stream-stage-criteria.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests: value stream stage entry/exit criteria (#810).
+ *
+ * Covers:
+ *  - addStage persists entry and exit criteria (and trims/normalises empties)
+ *  - editStage updates criteria; clearing a field stores null
+ *  - getValueStream surfaces criteria on each stage for display
+ *  - reordering stages (moveStage) preserves their criteria
+ *  - audit logging captures criteria on create and edit (before/after)
+ */
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { db } from '@/db/client'
+import { valueStreamStages, auditLog } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { addStage, editStage, moveStage, getValueStream } from '@/actions/value-streams'
+import {
+  createTestOrg, createTestUser, cleanupOrg, makeSession,
+  insertValueStream,
+  type TestOrg, type TestUser,
+} from './helpers/db'
+
+const mockAuth = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/auth', () => ({ auth: mockAuth }))
+
+async function stagesFor(vsId: string) {
+  return db.query.valueStreamStages.findMany({
+    where: eq(valueStreamStages.valueStreamId, vsId),
+    orderBy: (s, { asc }) => [asc(s.order)],
+  })
+}
+
+describe('value stream stage criteria (#810)', () => {
+  let org: TestOrg
+  let contributor: TestUser
+  let vs: { id: string }
+
+  beforeAll(async () => {
+    org = await createTestOrg()
+    contributor = await createTestUser(org.id, 'contributor')
+    vs = await insertValueStream(org.id)
+    mockAuth.mockResolvedValue(makeSession(contributor))
+  })
+
+  afterAll(() => cleanupOrg(org.id))
+
+  it('addStage persists entry and exit criteria', async () => {
+    await addStage(vs.id, 'Intake', 'Application received', 'Citizen has an account', 'Documents validated')
+
+    const [stage] = await stagesFor(vs.id)
+    expect(stage.name).toBe('Intake')
+    expect(stage.entryCriteria).toBe('Citizen has an account')
+    expect(stage.exitCriteria).toBe('Documents validated')
+  })
+
+  it('addStage stores null for blank / whitespace-only criteria', async () => {
+    await addStage(vs.id, 'Review', '', '   ', '')
+
+    const review = (await stagesFor(vs.id)).find(s => s.name === 'Review')!
+    expect(review.entryCriteria).toBeNull()
+    expect(review.exitCriteria).toBeNull()
+  })
+
+  it('addStage defaults criteria to null when the args are omitted', async () => {
+    await addStage(vs.id, 'Decision', 'Approve or deny')
+
+    const decision = (await stagesFor(vs.id)).find(s => s.name === 'Decision')!
+    expect(decision.entryCriteria).toBeNull()
+    expect(decision.exitCriteria).toBeNull()
+  })
+
+  it('editStage updates criteria and can clear them', async () => {
+    const intake = (await stagesFor(vs.id)).find(s => s.name === 'Intake')!
+
+    await editStage(intake.id, 'Intake', 'Application received', 'Citizen authenticated', 'All forms signed')
+    let updated = (await stagesFor(vs.id)).find(s => s.id === intake.id)!
+    expect(updated.entryCriteria).toBe('Citizen authenticated')
+    expect(updated.exitCriteria).toBe('All forms signed')
+
+    // Clearing a criterion stores null, not an empty string.
+    await editStage(intake.id, 'Intake', 'Application received', '', 'All forms signed')
+    updated = (await stagesFor(vs.id)).find(s => s.id === intake.id)!
+    expect(updated.entryCriteria).toBeNull()
+    expect(updated.exitCriteria).toBe('All forms signed')
+  })
+
+  it('getValueStream surfaces criteria on each stage', async () => {
+    const loaded = await getValueStream(vs.id)
+    expect(loaded).not.toBeNull()
+    const intake = loaded!.stages.find(s => s.name === 'Intake')!
+    expect(intake.exitCriteria).toBe('All forms signed')
+  })
+
+  it('reordering stages preserves their criteria', async () => {
+    const before = await stagesFor(vs.id)
+    const intake = before.find(s => s.name === 'Intake')!
+    const review = before.find(s => s.name === 'Review')!
+
+    // Give Review distinctive criteria so we can assert it survives the move.
+    await editStage(review.id, 'Review', '', 'Intake complete', 'Reviewer signed off')
+
+    // Move Intake down past Review and confirm both keep their own criteria.
+    await moveStage(intake.id, 'down')
+
+    const after = await stagesFor(vs.id)
+    const intakeAfter = after.find(s => s.id === intake.id)!
+    const reviewAfter = after.find(s => s.id === review.id)!
+
+    expect(intakeAfter.exitCriteria).toBe('All forms signed')
+    expect(reviewAfter.entryCriteria).toBe('Intake complete')
+    expect(reviewAfter.exitCriteria).toBe('Reviewer signed off')
+    // Order actually changed: Review now precedes Intake.
+    expect(reviewAfter.order).toBeLessThan(intakeAfter.order)
+  })
+
+  it('audit log captures criteria on stage create', async () => {
+    await addStage(vs.id, 'Audited Create', '', 'Entry X', 'Exit Y')
+    const created = (await stagesFor(vs.id)).find(s => s.name === 'Audited Create')!
+
+    const [entry] = await db.select().from(auditLog).where(
+      and(eq(auditLog.action, 'value_stream.stage.create'), eq(auditLog.entityId, created.id)),
+    )
+    expect(entry).toBeDefined()
+    expect(entry.entityType).toBe('value_stream_stage')
+    expect(entry.after).toMatchObject({ name: 'Audited Create', entryCriteria: 'Entry X', exitCriteria: 'Exit Y' })
+  })
+
+  it('audit log captures before/after criteria on stage edit', async () => {
+    const target = (await stagesFor(vs.id)).find(s => s.name === 'Audited Create')!
+
+    await editStage(target.id, 'Audited Create', '', 'Entry Z', 'Exit Y')
+
+    const entries = await db.select().from(auditLog).where(
+      and(eq(auditLog.action, 'value_stream.stage.edit'), eq(auditLog.entityId, target.id)),
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    const latest = entries[entries.length - 1]
+    expect(latest.before).toMatchObject({ entryCriteria: 'Entry X' })
+    expect(latest.after).toMatchObject({ entryCriteria: 'Entry Z', exitCriteria: 'Exit Y' })
+  })
+})


### PR DESCRIPTION
## Summary

Adds optional **entry criteria** and **exit criteria** to value stream stages, so each stage can state in plain language what must be true before it begins and what must be true before the stream advances. This makes the handoff between stages explicit — useful for describing operational readiness, governance checkpoints, and completion signals.

Closes #810.

## What changed

- **Schema** (`db/schema/value-streams.ts`): `value_stream_stages` gains nullable `entry_criteria` and `exit_criteria` text columns. Existing stages and stages without criteria are unaffected.
- **Actions** (`actions/value-streams.ts`): `addStage` / `editStage` accept the two new fields, normalise blank/whitespace-only input to `null`, and now write audit events (`value_stream.stage.create` / `value_stream.stage.edit`, entity type `value_stream_stage`) capturing the criteria in before/after. **These actions previously had no audit logging at all** — added to satisfy the audit acceptance criterion.
- **Stage manager** (`value-streams/[id]/stage-manager.tsx`): the Add and Edit dialogs gain Entry criteria / Exit criteria textareas; Edit seeds them from the stage; a shared `resetFields()` clears all fields on close/cancel.
- **Detail page** (`value-streams/[id]/page.tsx`): renders criteria under each stage only when present (a `<dl>` with labelled entry/exit), so stages without criteria add no visual clutter.
- **Reordering**: `moveStage` only swaps the `order` column, so criteria are preserved across reorders (covered by a test).
- **Backup export/import**: already dump/restore all stage columns generically (`findMany({})` + `replayJunction`), so criteria round-trip with no change needed there.

## Acceptance criteria

- [x] Stage data model supports optional entry + exit criteria.
- [x] Stage create/edit UI includes fields for both.
- [x] Detail view displays criteria under the appropriate stage when present.
- [x] Empty criteria add no clutter (conditional render).
- [x] Reordering preserves criteria.
- [x] Audit logging captures criteria changes on stage create/update.
- [x] Tests cover create, edit (incl. clearing), display, reorder, and audit.

## Testing

- New integration test `value-stream-stage-criteria.test.ts` — **8 tests**: create persists criteria, blank→null normalisation, omitted-args default, edit + clear, `getValueStream` surfaces criteria, reorder preserves criteria, audit-on-create, audit before/after on edit.
- Full integration suite: **1223/1223** passed.
- `tsc --noEmit` clean (the `@axe-core/playwright` error is a pre-existing missing local dep, present in CI's install).
- `lint` — 0 errors. Production `build` — passed in the prior run.
- **Display verified in the running app**: the detail page server-renders the criteria with correct structure and values (confirmed against a real stage). The interactive preview's click-navigation was glitching this session (bouncing to /dashboard for all routes, including unrelated ones), so verification was done via the rendered HTML rather than a screenshot.

Capability: po-value-streams
Capability: fd-value-streams
Persona: Enterprise Architect
Persona: Agency EA Coordinator
Persona: Department Director
Persona: CMS Administrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)