### PR TITLE
fix(glossary): selecting an active reference source populates the definition (#849)

### DIFF
--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -21,7 +21,7 @@ import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
 import { MarkdownEditor } from '@/components/markdown-editor'
-import { GlossarySourceSelect, initialSourceSelection } from '@/components/glossary-source-select'
+import { GlossarySourceSelect, initialSourceSelection, definitionForSourceSelection } from '@/components/glossary-source-select'
 
 type GlossaryRow = GlossaryTerm & {
   organization: { id: string; name: string } | null
@@ -440,6 +440,15 @@ function TermForm({
     onDirty?.()
   }
 
+  // Selecting an active source in the dropdown also adopts its definition text
+  // when it has one (#849) — selecting the source IS using its definition.
+  // None / Custom / a source without text leave the current definition intact.
+  function handleSelectSource(value: string) {
+    setActiveSource(value)
+    setDefinition(prev => definitionForSourceSelection(value, sources, prev))
+    onDirty?.()
+  }
+
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -546,7 +555,7 @@ function TermForm({
         defaultSourceUrl={term?.definitionSourceUrl}
         onChange={onDirty}
         selectedSource={activeSource}
-        onSelectedSourceChange={v => { setActiveSource(v); onDirty?.() }}
+        onSelectedSourceChange={handleSelectSource}
       />
 
       <DialogFooter>

--- a/apps/govea/src/components/glossary-edit-button.tsx
+++ b/apps/govea/src/components/glossary-edit-button.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MarkdownEditor } from '@/components/markdown-editor'
-import { GlossarySourceSelect, initialSourceSelection, type GlossarySourceOption } from '@/components/glossary-source-select'
+import { GlossarySourceSelect, initialSourceSelection, definitionForSourceSelection, type GlossarySourceOption } from '@/components/glossary-source-select'
 
 interface GlossaryEditButtonProps {
   termId: string
@@ -39,6 +39,14 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
   function adoptSourceAsDefinition(s: GlossarySourceOption) {
     setDefinition(s.definition ?? '')
     if (s.name) setActiveSource(s.name)
+  }
+
+  // Selecting an active source in the dropdown also adopts its definition text
+  // when it has one (#849). None / Custom / a source without text leave the
+  // current definition intact.
+  function handleSelectSource(value: string) {
+    setActiveSource(value)
+    setDefinition(prev => definitionForSourceSelection(value, sources, prev))
   }
 
   if (!editing) {
@@ -126,7 +134,7 @@ export function GlossaryEditButton({ termId, sources, initial }: GlossaryEditBut
             defaultSource={initial.definitionSource}
             defaultSourceUrl={initial.definitionSourceUrl}
             selectedSource={activeSource}
-            onSelectedSourceChange={setActiveSource}
+            onSelectedSourceChange={handleSelectSource}
           />
         </div>
 

--- a/apps/govea/src/components/glossary-source-select.tsx
+++ b/apps/govea/src/components/glossary-source-select.tsx
@@ -26,6 +26,28 @@ export function initialSourceSelection(defaultSource: string | null | undefined,
 }
 
 /**
+ * Resolve the term definition when an active reference source is selected (#849).
+ *
+ * Selecting a saved source that carries definition text adopts that text as the
+ * term definition — this is the behavior users repeatedly expected (the active
+ * source selection IS "use this source's definition"). "None", "Custom source",
+ * and a saved source without definition text all leave the current definition
+ * untouched, so original/custom definitions are never clobbered.
+ *
+ * Pure and exported so both edit surfaces (list/dialog TermForm and the
+ * detail-page GlossaryEditButton) share one definition and it can be unit-tested
+ * in the node-only test env.
+ */
+export function definitionForSourceSelection(
+  selection: string,
+  sources: GlossarySourceOption[],
+  currentDefinition: string,
+): string {
+  const picked = sources.find(s => s.name === selection)
+  return picked?.definition ? picked.definition : currentDefinition
+}
+
+/**
  * Active-reference-source selector (#837 / #849).
  *
  * Picks which saved source attributes the term definition, emitting
@@ -131,6 +153,7 @@ export function GlossarySourceSelect({
           {isSafeUrl(effectiveUrl)
             ? <a href={effectiveUrl!} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:underline">{effectiveName}</a>
             : <span className="font-medium">{effectiveName}</span>}.
+          {active?.definition && ' Its definition text has been used as the term definition above.'}
         </p>
       )}
 

--- a/apps/govea/tests/unit/glossary-source-definition.test.ts
+++ b/apps/govea/tests/unit/glossary-source-definition.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for definitionForSourceSelection (#849).
+ *
+ * This is the coupling that regressed three times (#837 → #839 → #851 → #852):
+ * selecting an active reference source must populate the term definition with
+ * that source's text. The behavior lives in a pure function so both edit
+ * surfaces share it and it can be covered in the node-only test env (there is no
+ * jsdom/component-render setup).
+ *
+ * Capability: po-glossary, cm-content-authoring
+ */
+import { describe, it, expect } from 'vitest'
+import { definitionForSourceSelection, initialSourceSelection, type GlossarySourceOption } from '@/components/glossary-source-select'
+
+const SOURCES: GlossarySourceOption[] = [
+  { name: 'TOGAF 10', url: 'https://www.opengroup.org/togaf', definition: 'A business or technical capability.' },
+  { name: 'NIST SP 800-145', url: 'https://csrc.nist.gov/pubs/sp/800/145/final', definition: 'On-demand network access to shared resources.' },
+  { name: 'Name only', url: '', definition: '' }, // saved source with no definition text
+]
+
+const CUSTOM = '__custom__'
+const NONE = ''
+
+describe('definitionForSourceSelection (#849)', () => {
+  it('adopts the selected saved source definition text', () => {
+    expect(definitionForSourceSelection('TOGAF 10', SOURCES, 'old text'))
+      .toBe('A business or technical capability.')
+    expect(definitionForSourceSelection('NIST SP 800-145', SOURCES, 'old text'))
+      .toBe('On-demand network access to shared resources.')
+  })
+
+  it('leaves the current definition untouched for "None"', () => {
+    expect(definitionForSourceSelection(NONE, SOURCES, 'my original definition'))
+      .toBe('my original definition')
+  })
+
+  it('leaves the current definition untouched for "Custom source"', () => {
+    expect(definitionForSourceSelection(CUSTOM, SOURCES, 'my custom definition'))
+      .toBe('my custom definition')
+  })
+
+  it('leaves the current definition untouched for a saved source with no definition text', () => {
+    expect(definitionForSourceSelection('Name only', SOURCES, 'keep me'))
+      .toBe('keep me')
+  })
+
+  it('leaves the current definition untouched for an unknown selection', () => {
+    expect(definitionForSourceSelection('Renamed away', SOURCES, 'keep me'))
+      .toBe('keep me')
+  })
+
+  it('selecting a source then switching to None preserves the adopted text', () => {
+    // Simulates the dropdown flow: pick a source (adopts text), then pick None
+    // (attribution clears, but the definition the editor adopted stays).
+    const adopted = definitionForSourceSelection('TOGAF 10', SOURCES, '')
+    expect(adopted).toBe('A business or technical capability.')
+    expect(definitionForSourceSelection(NONE, SOURCES, adopted)).toBe(adopted)
+  })
+})
+
+// Guards the selection-state helper the edit surfaces use to seed the dropdown,
+// so attribution and the definition coupling start from a consistent value.
+describe('initialSourceSelection', () => {
+  const names = SOURCES.map(s => s.name)
+
+  it('returns the saved source name when the attribution matches one', () => {
+    expect(initialSourceSelection('TOGAF 10', names)).toBe('TOGAF 10')
+  })
+
+  it('returns CUSTOM for free-text attribution that matches no saved source', () => {
+    expect(initialSourceSelection('Some Book, p.42', names)).toBe(CUSTOM)
+  })
+
+  it('returns NONE when there is no attribution', () => {
+    expect(initialSourceSelection(null, names)).toBe(NONE)
+    expect(initialSourceSelection('', names)).toBe(NONE)
+  })
+})


### PR DESCRIPTION
## Why this is reopened (third pass)

#851 and #852 both closed #849, but the user re-reported on **2026-06-18**:

> while editing a glossary item, selecting an authoritative/reference source still does **not** populate the Definition field with the selected source's definition text.

The prior fixes added per-source **"Use as the term definition"** buttons but left the **"Active reference source" dropdown** setting *attribution only*. So the action users naturally reach for — picking the source in the dropdown — changed who the definition was attributed to without filling the definition. The split between "select source" and "use as definition" was the recurring confusion.

## Fix

Couple selection to the definition. Choosing a saved source that has definition text now **adopts that text as the term `definition` AND sets the matching `definitionSource` / `definitionSourceUrl` together**, in *both* edit surfaces. **None**, **Custom source**, or a saved source with no definition text leave the current definition untouched — so original/custom definitions are never clobbered.

- **`glossary-source-select.tsx`**: new pure `definitionForSourceSelection(selection, sources, current)` holds the coupling logic in one place; the dropdown hint now notes the source's definition text was applied.
- **`glossary-table.tsx` (`TermForm`, list/dialog edit)** and **`glossary-edit-button.tsx` (detail-page edit)**: the dropdown's `onSelectedSourceChange` routes through the shared helper, populating the Definition field on selection. The per-source buttons remain for discoverability and now do the same coupled thing.
- **`tests/unit/glossary-source-definition.test.ts`**: covers adopt / None / Custom / no-text-source / unknown-selection and the seed-selection helper.

## Acceptance criteria

- [x] List/dialog edit makes the "use this source definition" ↔ "active reference source" relationship clear and saves text + attribution together (selecting the source *is* using its definition).
- [x] Detail-page edit exposes saved source definitions and lets you use one as the term definition (verified live — see below).
- [x] Selecting a saved source persists its text into `glossary_terms.definition`.
- [x] …and persists matching `definitionSource` / `definitionSourceUrl`.
- [x] Original/custom definitions remain supported (None/Custom never overwrite the definition).
- [x] Regression coverage: the coupling logic that regressed three times is now a unit-tested pure function (the node-only test env has no component renderer, so the logic lives where it can be tested directly), plus the existing server-persistence integration test.
- [x] Permissions unchanged: viewers still can't edit (server action gates on `canEdit`; detail edit on `canMutate`).

## Testing

- New unit suite (9 cases) + existing glossary integration suites: **34/34** pass.
- `tsc --noEmit` clean (the `@axe-core/playwright` error is a pre-existing missing local dep, present in CI's install); `lint` 0 errors.
- **Verified live in the running app** (the step missed by the prior two "verified manually" fixes): on the *detail-page* edit of "Zero Trust Architecture", selecting **NIST SP 800-207** then **Gartner Glossary** in the dropdown immediately replaced the Definition field with each source's text; selecting **None** cleared attribution but kept the adopted text; **Save** persisted the Gartner definition text **and** `definitionSource` + `definitionSourceUrl` to the DB. Seed row restored afterward.

Capability: po-glossary
Capability: cm-content-authoring
Persona: CMS Administrator
Persona: Junior EA Analyst
Persona: Department Director
Persona: Business Stakeholder

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)