### PR TITLE
a11y: add "Skip to main content" link (#858)

### DIFF
--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -407,6 +407,18 @@ export function AppShell({
     <div className="min-h-screen bg-background">
       {themeStyle && <style dangerouslySetInnerHTML={{ __html: themeStyle }} />}
 
+      {/* #858 — skip link: the first focusable element on every page, so
+          keyboard / screen-reader users can bypass the sidebar nav and jump
+          straight to content (WCAG 2.4.1 Bypass Blocks). Visually hidden until
+          focused. */}
+      <a
+        href="#main"
+        data-print-hide="true"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-3 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      >
+        Skip to main content
+      </a>
+
       {/* ── Desktop sidebar (fixed, always visible on lg+) ── */}
       <aside
         data-print-hide="true"
@@ -548,8 +560,10 @@ export function AppShell({
           </div>
         </header>
 
-        {/* Page content */}
-        <main data-print-main className="flex-1 p-4 lg:p-6">
+        {/* Page content. id + tabIndex make this the skip-link target (#858):
+            activating "Skip to main content" moves focus here so the next Tab
+            continues from the content, not the top of the nav. */}
+        <main id="main" tabIndex={-1} data-print-main className="flex-1 p-4 lg:p-6 focus:outline-none">
           {children}
         </main>
       </div>


### PR DESCRIPTION
## Summary
Adds a "Skip to main content" link — the first focusable element on every authenticated page — so keyboard and screen-reader users can bypass the sidebar (Dashboard, Overview, Notifications, and 6 nav groups) instead of tabbing through it on every navigation.

*WCAG 2.4.1 Bypass Blocks (Level A).* First item from the UI/UX accessibility review.

## Changes
- New skip `<a href="#main">` as the first child of the app shell, `sr-only` until focused (`focus:not-sr-only` + positioned, high-contrast, 2px ring).
- `<main>` gets `id="main"` and `tabIndex={-1}` so activating the link moves focus into the content region (the next Tab continues from content, not the top of the nav).
- `data-print-hide` on the link so it never shows in print/PDF output.
- Single file touched: `apps/govea/src/components/app-shell.tsx`.

## Testing
- `tsc --noEmit` clean (the `@axe-core/playwright` error is a pre-existing missing local dep, present in CI's install).
- `lint` 0 errors.
- Production `build` passed.

## ⚠️ Live verification blocked by infra (not this change)
I could not visually confirm the link in the running app because the **local dev Postgres is corrupted** — login fails with `PostgresError FATAL 58030 read_relmap_file` ("could not read relation mapping file"), and the podman VM's SSH handshake is failing (recurring this session). Auth is DB-gated, so no authenticated page (where `AppShell` renders) is reachable until the dev DB is restored. The change itself is static markup with no data dependency, and the standard recovery (truncate + reseed, or recreate the container) is a separate infra step.

**Recommend:** once the dev DB is healthy, confirm by pressing Tab on any page — the "Skip to main content" pill should appear top-left, and activating it should move focus to the content. Happy to drive that verification then.

Capability: fd-navigation
Persona: All — accessibility (keyboard & screen-reader users)

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)