### PR TITLE
ux(a11y): replace window.confirm publish gates with an accessible Dialog (#870)

### DIFF
--- a/apps/govea/src/app/(admin)/adrs/adr-table.tsx
+++ b/apps/govea/src/app/(admin)/adrs/adr-table.tsx
@@ -22,6 +22,7 @@ import type { EntityTaxonomyValue } from '@/db/schema'
 import { DomainOwnerFormSection } from '@/components/domain-owner-form-section'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
+import { useConfirmDialog } from '@/components/confirm-dialog'
 
 type ADRRow = ADR & {
   organization: { id: string; name: string } | null
@@ -75,6 +76,7 @@ const VISIBILITY_LABELS: Record<string, string> = {
 export function ADRTable({ adrs, capabilities, applications, initiatives, objectives, role, currentOrgId, currentUserId, taxonomyDefinitions, taxonomyValueMap, orgUsers }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [statusFilter, setStatusFilter] = useState('all')
   const [taxonomyFilters, setTaxonomyFilters] = useState<Record<string, string>>({})
   const [createOpen, setCreateOpen] = useState(false)
@@ -154,7 +156,7 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
         // #381 PR-3 publish-time debt gate: confirm + re-submit with ack.
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('Publishing requires acknowledgment')) {
-          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nAccept anyway? Your acknowledgment will be logged in the audit trail.')) {
+          if (await confirm({ title: 'Accept anyway?', description: `${msg} Your acknowledgment will be logged in the audit trail.`, confirmLabel: 'Accept anyway' })) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editADR(editTarget.id, formData)
             editDirty.reset()
@@ -501,6 +503,8 @@ export function ADRTable({ adrs, capabilities, applications, initiatives, object
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {confirmDialog}
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/applications/application-table.tsx
+++ b/apps/govea/src/app/(admin)/applications/application-table.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
+import { useConfirmDialog } from '@/components/confirm-dialog'
 import { DomainBadge } from '@/components/domain-badge'
 import type { Role } from '@/lib/rbac'
 import { MarkdownEditor } from '@/components/markdown-editor'
@@ -251,6 +252,7 @@ type ViewMode = 'table' | 'portfolio'
 export function ApplicationTable({ applications, capabilities, role, currentOrgId, currentUserId, taxonomyDefinitions, taxonomyValueMap, customFieldDefs, orgUsers }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
+  const { confirm, confirmDialog } = useConfirmDialog()
 
   const [viewMode, setViewMode] = useState<ViewMode>('table')
   const [importOpen, setImportOpen] = useState(false)
@@ -348,7 +350,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         // #381 PR-3 publish-time debt gate: confirm + re-submit with ack.
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('Publishing requires acknowledgment')) {
-          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
+          if (await confirm({ title: 'Publish anyway?', description: `${msg} Your acknowledgment will be logged in the audit trail.`, confirmLabel: 'Publish anyway' })) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editApplication(editTarget.id, formData)
             editDirty.reset()
@@ -359,7 +361,7 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
         }
         // #567 Part B — publish-readiness gate.
         if (msg.includes('Publishing this') && msg.includes('makes the record harder to use')) {
-          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? The missing fields will be logged in the audit trail.')) {
+          if (await confirm({ title: 'Publish anyway?', description: `${msg} The missing fields will be logged in the audit trail.`, confirmLabel: 'Publish anyway' })) {
             formData.set('acknowledgePublishIncomplete', 'on')
             await editApplication(editTarget.id, formData)
             setEditTarget(null)
@@ -979,6 +981,8 @@ export function ApplicationTable({ applications, capabilities, role, currentOrgI
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {confirmDialog}
     </div>
   )
 }

--- a/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
+++ b/apps/govea/src/app/(admin)/capabilities/capability-table.tsx
@@ -24,6 +24,7 @@ import { buildCapabilityTree, flattenTree, collectDescendantIds, resolveCapabili
 import { submitWithDuplicateAck } from '@/lib/duplicate-name-client'
 import { useDirtyTracker, confirmDiscard } from '@/lib/use-dirty-dialog'
 import { EmptyStateCTA } from '@/components/empty-state-cta'
+import { useConfirmDialog } from '@/components/confirm-dialog'
 import { DomainOwnerFormSection } from '@/components/domain-owner-form-section'
 
 type CapabilityRow = Pick<Capability, 'id' | 'name' | 'description' | 'domain' | 'behaviors' | 'rules' | 'capabilityType' | 'status' | 'visibility' | 'createdAt' | 'organizationId' | 'domainOwnerUserId'> & {
@@ -71,6 +72,7 @@ const TYPE_STYLES: Record<string, string> = {
 export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyDefinitions, taxonomyValueMap, role, currentOrgId, currentUserId, orgUsers }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
+  const { confirm, confirmDialog } = useConfirmDialog()
 
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('all')
@@ -201,7 +203,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
         // open debt and no ack. We prompt the user, then re-submit with the ack.
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('Publishing requires acknowledgment')) {
-          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? Your acknowledgment will be logged in the audit trail.')) {
+          if (await confirm({ title: 'Publish anyway?', description: `${msg} Your acknowledgment will be logged in the audit trail.`, confirmLabel: 'Publish anyway' })) {
             formData.set('acknowledgeOpenDebt', 'on')
             await editCapability(editTarget.id, formData)
             editDirty.reset()
@@ -212,7 +214,7 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
         }
         // #567 Part B — publish-readiness gate: prompt + ack-retry pattern.
         if (msg.includes('Publishing this') && msg.includes('makes the record harder to use')) {
-          if (typeof window !== 'undefined' && window.confirm(msg + '\n\nPublish anyway? The missing fields will be logged in the audit trail.')) {
+          if (await confirm({ title: 'Publish anyway?', description: `${msg} The missing fields will be logged in the audit trail.`, confirmLabel: 'Publish anyway' })) {
             formData.set('acknowledgePublishIncomplete', 'on')
             await editCapability(editTarget.id, formData)
             editDirty.reset()
@@ -701,6 +703,8 @@ export function CapabilityTable({ capabilities, personas, domainTerms, taxonomyD
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {confirmDialog}
     </div>
   )
 }

--- a/apps/govea/src/components/confirm-dialog.tsx
+++ b/apps/govea/src/components/confirm-dialog.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useCallback, useState, type ReactNode } from 'react'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Shared confirmation dialog (#870).
+ *
+ * Replaces ad-hoc `window.confirm()` prompts with the styled, accessible Dialog
+ * primitive (focus trap, ESC, labelled by title + described by body). Exposed as
+ * a promise-based hook so a synchronous-looking flow stays readable:
+ *
+ *   const { confirm, confirmDialog } = useConfirmDialog()
+ *   // …
+ *   if (await confirm({ title: 'Publish anyway?', description: msg })) { … }
+ *   // render {confirmDialog} once in the component tree
+ *
+ * `confirm()` resolves `true` on the confirm button and `false` on cancel /
+ * dismiss (ESC, overlay, close).
+ */
+export interface ConfirmOptions {
+  title: string
+  description?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  /** Use `destructive` for delete-style actions; defaults to the primary style. */
+  variant?: 'default' | 'destructive'
+}
+
+interface PendingConfirm extends ConfirmOptions {
+  resolve: (result: boolean) => void
+}
+
+export function useConfirmDialog() {
+  const [pending, setPending] = useState<PendingConfirm | null>(null)
+
+  const confirm = useCallback(
+    (options: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        setPending({ ...options, resolve })
+      }),
+    [],
+  )
+
+  const settle = useCallback((result: boolean) => {
+    setPending((current) => {
+      current?.resolve(result)
+      return null
+    })
+  }, [])
+
+  const confirmDialog = (
+    <Dialog open={!!pending} onOpenChange={(open) => { if (!open) settle(false) }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{pending?.title}</DialogTitle>
+          {/* Always render a description node so the dialog is described, not
+              just labelled (avoids Radix's missing-aria-describedby warning). */}
+          <DialogDescription className={pending?.description ? undefined : 'sr-only'}>
+            {pending?.description ?? 'Confirm this action.'}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => settle(false)}>
+            {pending?.cancelLabel ?? 'Cancel'}
+          </Button>
+          <Button variant={pending?.variant ?? 'default'} onClick={() => settle(true)}>
+            {pending?.confirmLabel ?? 'Confirm'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+
+  return { confirm, confirmDialog }
+}


### PR DESCRIPTION
## Summary
Confirmation patterns were mixed: delete flows used the styled `Dialog` primitive, but the publish-/accept-anyway debt-gate prompts used native `window.confirm` — unstyled, no focus trap, inconsistent. This standardizes those onto an accessible Dialog.

## Change
- **New `useConfirmDialog()` hook** (`components/confirm-dialog.tsx`): a promise-based confirm so the call site stays readable (`if (await confirm({…})) { … }`). Renders the Radix `Dialog` (focus trap, ESC, overlay dismiss) with a `DialogTitle` + always-present `DialogDescription`.
- **Migrated all 5 `window.confirm` sites**: capabilities (2), applications (2), ADRs (1) — the publish-requires-acknowledgment and publish-readiness gates.
- Because the shared dialog always renders a description, these confirmations are now programmatically described (also chips away at #872).

The only remaining `window.confirm` reference is in the new component's doc comment.

## Testing
- `tsc --noEmit` clean · `lint` 0 errors · production `build` passed.
- The migrated branches are the existing debt-gate retry flows (server throws → confirm → re-submit with ack); behavior is unchanged apart from the dialog UI.

## Notes
Error-feedback `window.alert` calls (a different concern) are tracked separately in #860 and are out of scope here.

Capability group: cms/frontend-display
Persona: All — accessibility (esp. CMS Administrator)

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)