### PR TITLE
a11y(nav): give the duplicate nav landmarks distinct accessible names (#872)

### DIFF
--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -101,6 +101,7 @@ function SidebarContent({
   isInstanceAdmin,
   unreadNotificationCount,
   onClose,
+  navLabel,
 }: {
   role: Role
   pathname: string
@@ -108,6 +109,8 @@ function SidebarContent({
   isInstanceAdmin?: boolean
   unreadNotificationCount?: number
   onClose?: () => void
+  /** #872 — distinguishes the desktop vs mobile nav landmarks for AT. */
+  navLabel: string
 }) {
   const isAdmin = role === 'admin'
   const isContributor = role === 'admin' || role === 'contributor'
@@ -161,7 +164,7 @@ function SidebarContent({
   }, [setOpenGroupAndPersist])
 
   return (
-    <nav className="flex flex-col h-full overflow-y-auto py-4 px-3 gap-1">
+    <nav aria-label={navLabel} className="flex flex-col h-full overflow-y-auto py-4 px-3 gap-1">
       {/* Dashboard */}
       <Link
         href="/dashboard"
@@ -437,7 +440,7 @@ export function AppShell({
             GovEA
           </Link>
         </div>
-        <SidebarContent role={role} pathname={pathname} enabledModules={enabledModules} isInstanceAdmin={isInstanceAdmin} unreadNotificationCount={unreadNotificationCount} />
+        <SidebarContent navLabel="Primary" role={role} pathname={pathname} enabledModules={enabledModules} isInstanceAdmin={isInstanceAdmin} unreadNotificationCount={unreadNotificationCount} />
       </aside>
 
       {/* ── Mobile overlay backdrop ── */}
@@ -457,7 +460,6 @@ export function AppShell({
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         )}
         style={{ backgroundColor: sidebarBg, borderColor: sidebarBorder }}
-        aria-label="Navigation"
       >
         {/* Mobile sidebar header */}
         <div
@@ -475,7 +477,7 @@ export function AppShell({
             </svg>
           </button>
         </div>
-        <SidebarContent role={role} pathname={pathname} enabledModules={enabledModules} isInstanceAdmin={isInstanceAdmin} onClose={() => setSidebarOpen(false)} />
+        <SidebarContent navLabel="Primary (mobile)" role={role} pathname={pathname} enabledModules={enabledModules} isInstanceAdmin={isInstanceAdmin} onClose={() => setSidebarOpen(false)} />
       </aside>
 
       {/* ── Main content area ── */}


### PR DESCRIPTION
## Summary
The sidebar `<nav>` had no accessible name and is rendered twice (desktop sidebar + mobile drawer), so assistive tech saw two undifferentiated "navigation" landmarks. This labels them distinctly.

## Change
- `SidebarContent` takes a `navLabel` prop applied as the `<nav aria-label>`: **"Primary"** (desktop) and **"Primary (mobile)"** (drawer).
- Dropped the now-redundant `aria-label="Navigation"` on the mobile `<aside>` — the inner `<nav>` is the labelled landmark.

## Verification
Confirmed live: `document.querySelectorAll('nav')` exposes `aria-label` `"Primary"` and `"Primary (mobile)"`; the skip link + `main#main[tabindex=-1]` (from #858) remain intact.

`tsc` clean · `lint` 0 errors.

## Scope note
This issue originally also bundled "add `DialogDescription` to dialogs that lack it." That turned out to be a ~60-dialog mechanical sweep and a **dev-only Radix warning** (dialogs are already labelled by their title), disproportionate to bundle here. It's split into **#877** (milestone v1.5), and #872 is re-scoped to the nav-landmark fix this PR completes.

Capability: fd-navigation
Persona: All — accessibility (keyboard & screen-reader users)

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)