### PR TITLE
a11y(forms): mark decorative required "*" aria-hidden (#871)

### DIFF
--- a/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
@@ -378,7 +378,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
           </p>
           <form action={handleWire} className="space-y-3">
             <div className="space-y-1.5">
-              <Label htmlFor="wire-entity-type">Entity type <span className="text-destructive">*</span></Label>
+              <Label htmlFor="wire-entity-type">Entity type <span aria-hidden="true" className="text-destructive">*</span></Label>
               <select
                 id="wire-entity-type"
                 name="entityType"
@@ -467,7 +467,7 @@ function TermFields({
   return (
     <>
       <div className="space-y-1.5">
-        <Label htmlFor="term-name">Name <span className="text-destructive">*</span></Label>
+        <Label htmlFor="term-name">Name <span aria-hidden="true" className="text-destructive">*</span></Label>
         <Input
           id="term-name"
           name="name"

--- a/apps/govea/src/components/custom-field-inputs.tsx
+++ b/apps/govea/src/components/custom-field-inputs.tsx
@@ -24,7 +24,7 @@ export function CustomFieldInputs({ fields, values = {} }: Props) {
           <div key={field.name} className="space-y-1.5">
             <Label>
               {field.name}
-              {field.required && <span className="text-destructive ml-0.5">*</span>}
+              {field.required && <span aria-hidden="true" className="text-destructive ml-0.5">*</span>}
             </Label>
 
             {field.type === 'text' && (

--- a/apps/govea/src/components/domain-combobox.tsx
+++ b/apps/govea/src/components/domain-combobox.tsx
@@ -83,7 +83,7 @@ export function DomainCombobox({
       {label && (
         <Label htmlFor={`combobox-${name}`}>
           {label}
-          {required && <span className="text-destructive ml-0.5">*</span>}
+          {required && <span aria-hidden="true" className="text-destructive ml-0.5">*</span>}
         </Label>
       )}
 

--- a/apps/govea/src/components/taxonomy-ui.tsx
+++ b/apps/govea/src/components/taxonomy-ui.tsx
@@ -38,7 +38,7 @@ export function TaxonomyInputs({
         <div key={def.id} className="space-y-1.5">
           <Label>
             {def.typeName}
-            {def.required && <span className="text-destructive ml-0.5">*</span>}
+            {def.required && <span aria-hidden="true" className="text-destructive ml-0.5">*</span>}
           </Label>
           {def.selectionMode === 'multi' ? (
             <div className="rounded-md border border-input bg-transparent px-3 py-2 max-h-36 overflow-y-auto space-y-1">


### PR DESCRIPTION
## Summary
Audit for #871 found the issue's core acceptance criteria were **already met**: every field that shows a required `*` also sets the native `required` attribute on its focusable control (domain combobox, custom-field inputs, taxonomy term inputs/selects). The required state is already exposed programmatically, and the `*` glyph is non-color markup.

The remaining real refinement: the decorative red `*` wasn't `aria-hidden`, so screen readers announce a confusing "asterisk" *in addition to* the already-announced required state. This marks those decorative markers `aria-hidden="true"` so AT relies on the native `required` attribute alone.

## Change
- `aria-hidden="true"` on the required `*` in: `domain-combobox`, `custom-field-inputs`, `taxonomy-ui`, and the taxonomy table's entity-type + term-name fields (5 markers).

## Deliberately out of scope
- The **glossary Definition** `*` is left announced: it's a `MarkdownEditor` whose `required` sits on a hidden input rather than the focusable textarea, so the `*` is still its only AT cue. Properly exposing required on the editor's textarea (and verifying its label association) belongs with the MarkdownEditor work — noted for follow-up, related to #867.

## Testing
`tsc --noEmit` clean · `lint` 0 errors. Attribute-only change (no logic/imports), so no build/runtime impact.

Capability group: cms/frontend-display
Persona: All — accessibility (esp. CMS Administrator)

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)