### PR TITLE
a11y(contrast): fix default-theme color-contrast on authoring surfaces (#862)

### DIFF
--- a/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
+++ b/apps/govea/src/app/(admin)/glossary/glossary-table.tsx
@@ -491,7 +491,7 @@ function TermForm({
           <button
             type="button"
             onClick={addSource}
-            className="text-xs text-blue-600 hover:underline"
+            className="text-xs text-blue-700 hover:underline"
           >
             + Add source
           </button>
@@ -535,7 +535,7 @@ function TermForm({
               <button
                 type="button"
                 onClick={() => adoptSourceAsDefinition(s)}
-                className="text-xs font-medium text-blue-600 hover:underline"
+                className="text-xs font-medium text-blue-700 hover:underline"
               >
                 {activeSource === s.name && definition === s.definition
                   ? '✓ Used as the term definition'

--- a/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
+++ b/apps/govea/src/app/(admin)/taxonomy/taxonomy-table.tsx
@@ -220,7 +220,7 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
                   <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b bg-muted/20">
                     <span className="text-xs text-muted-foreground shrink-0">Used on:</span>
                     {typeDefs.length === 0 && (
-                      <span className="text-xs text-muted-foreground/50 italic">not wired to any entity type</span>
+                      <span className="text-xs text-muted-foreground italic">not wired to any entity type</span>
                     )}
                     {typeDefs.map(def => {
                       const label = ENTITY_TYPES.find(e => e.value === def.entityType)?.label ?? def.entityType
@@ -230,8 +230,8 @@ export function TaxonomyTable({ types, values, role, principleTypeUsage, definit
                           className="inline-flex items-center gap-1 rounded-full bg-violet-100 text-violet-700 border border-violet-200 px-2 py-0.5 text-xs font-medium"
                         >
                           {label}
-                          {def.selectionMode === 'multi' && <span className="opacity-60">(multi)</span>}
-                          {def.required && <span className="opacity-60">*</span>}
+                          {def.selectionMode === 'multi' && <span className="font-normal">(multi)</span>}
+                          {def.required && <span aria-hidden="true">*</span>}
                           {canDelete && (
                             <button
                               type="button"

--- a/apps/govea/src/app/globals.css
+++ b/apps/govea/src/app/globals.css
@@ -20,7 +20,10 @@
     --secondary-foreground: 222 47% 11%;
 
     --muted: 214 32% 95%;
-    --muted-foreground: 215 16% 47%;
+    /* #862 — darkened from 47% to 40% L so muted text clears 4.5:1 on the
+       tinted bg-muted/* cards (settings, taxonomy, dialogs). Darkening only
+       raises contrast, so no other surface regresses. */
+    --muted-foreground: 215 16% 40%;
 
     --accent: 214 32% 95%;
     --accent-foreground: 222 47% 11%;

--- a/apps/govea/src/components/confidence-settings.tsx
+++ b/apps/govea/src/components/confidence-settings.tsx
@@ -79,7 +79,9 @@ export function ConfidenceSettingsForm({ initial }: ConfidenceSettingsFormProps)
       {/* Public visibility toggle — gated on authenticated being on */}
       <div className={cn(
         'flex items-center justify-between rounded-lg border bg-card px-4 py-3',
-        !authenticatedVisibility && 'opacity-60',
+        // #862 — convey "inactive" with a dashed border instead of opacity;
+        // opacity dimming pushed the muted sub-text below 4.5:1 contrast.
+        !authenticatedVisibility && 'border-dashed',
       )}>
         <div>
           <p className="text-sm font-medium">Also show to unauthenticated viewers</p>

--- a/apps/govea/tests/e2e/specs/a11y.spec.ts
+++ b/apps/govea/tests/e2e/specs/a11y.spec.ts
@@ -27,6 +27,8 @@ const AUTHED_ROUTES = [
   // ones that currently pass the serious/critical gate live here; surfaces with
   // known violations are quarantined in KNOWN_A11Y_GAPS below.
   '/data',
+  // #862 — contrast fixed; /taxonomy now passes the gate.
+  '/taxonomy',
 ] as const
 
 // #874 — authoring surfaces with KNOWN serious/critical violations, captured by
@@ -35,10 +37,10 @@ const AUTHED_ROUTES = [
 // the `test.fixme(...)` line for a route once its linked issue is fixed and the
 // scan passes.
 const KNOWN_A11Y_GAPS: { route: string; rules: string; issues: string }[] = [
-  { route: '/glossary',      rules: 'select-name',                       issues: '#867' },
-  { route: '/value-streams', rules: 'select-name',                       issues: '#867' },
-  { route: '/settings',      rules: 'select-name, label, color-contrast', issues: '#867, #871, #862' },
-  { route: '/taxonomy',      rules: 'color-contrast',                    issues: '#862' },
+  { route: '/glossary',      rules: 'select-name',         issues: '#867' },
+  { route: '/value-streams', rules: 'select-name',         issues: '#867' },
+  // #862 contrast fixed here; the remaining gaps are unlabeled selects/forms.
+  { route: '/settings',      rules: 'select-name, label',  issues: '#867, #871' },
 ]
 
 async function runAxe(page: import('@playwright/test').Page, route: string) {
@@ -106,8 +108,7 @@ test.describe('accessibility — interactive states', () => {
   test.use({ storageState: 'tests/e2e/.auth/admin.json' })
 
   test('glossary "New term" dialog has no serious/critical WCAG violations', async ({ page }) => {
-    // #874 — known gap: color-contrast in the dialog (#862). Remove when fixed.
-    test.fixme(true, 'Known a11y gap (color-contrast) in the dialog — tracked in #862. Remove when fixed.')
+    // #862 — the dialog's color-contrast gap is fixed; this scan now gates.
     await page.goto('/glossary')
     await page.waitForLoadState('networkidle')
     await page.getByRole('button', { name: '+ New Glossary Term' }).click()


### PR DESCRIPTION
## Summary
The extended axe scan (#874) found **serious `color-contrast` violations on the default `govea` theme** — on `/settings`, `/taxonomy`, and the glossary "New term" dialog (correcting the earlier assumption that the default theme was clean). This fixes the measured offenders and gates the now-passing surfaces.

## Changes
- **`globals.css`**: darken light `--muted-foreground` 47% → 40% L so muted text clears 4.5:1 on the tinted `bg-muted/*` cards. Darkening only *raises* contrast, so no other surface regresses; dark theme already passed and is unchanged.
- **`taxonomy-table`**: drop the `/50` opacity on the "not wired…" hint; the `(multi)` / `*` pill labels used `opacity-60` (opacity caps contrast) — replaced with `font-normal` / `aria-hidden` decorative `*`.
- **`confidence-settings`**: the inactive public-visibility section used `opacity-60`, pushing its sub-text below threshold — now conveyed with a **dashed border** instead.
- **glossary form**: small `text-blue-600` links ("Add source", "Use as the term definition") → `blue-700` (passes at `text-xs`).
- **`a11y.spec`**: `/taxonomy` and the glossary dialog now pass → moved to the gated set / un-quarantined. `/settings` keeps only its `select-name` + `label` gaps (#867/#871).

## Verification (axe as the measurement loop)
Iterated with axe-core until **`color-contrast` count = 0** across `/settings`, `/taxonomy`, and the glossary dialog. Spec green: **11 passed, 4 quarantined** (remaining are #867/#871 labeling gaps). `tsc` / `lint` / production `build` clean.

## Why `Refs`, not `Closes`
This resolves the **default-theme** contrast failures axe can measure. #862's remaining scope — auditing the **non-default shipped themes** (different header backgrounds) — needs each theme measured and stays open (v1.5). I'll comment that status on the issue.

Capability: fd-theming
Persona: All — accessibility (esp. CMS Viewer, Elected Official)

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)