### PR TITLE
a11y(dialog): silence Radix missing-description warning systemically (#877)

### DIFF
--- a/apps/govea/src/components/ui/dialog.tsx
+++ b/apps/govea/src/components/ui/dialog.tsx
@@ -27,11 +27,18 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, "aria-describedby": ariaDescribedBy, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      // #877 — pass aria-describedby through explicitly. When a caller doesn't
+      // supply one (and renders no <DialogDescription>), this is the documented
+      // `aria-describedby={undefined}` opt-out that silences Radix's missing-
+      // description dev warning — the dialog stays accessible via its DialogTitle
+      // (aria-labelledby). A caller that DOES render a <DialogDescription> still
+      // associates it: Radix sets aria-describedby from context, which wins.
+      aria-describedby={ariaDescribedBy}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className


### PR DESCRIPTION
## Summary
~60 `DialogContent` instances render a `DialogTitle` but no `DialogDescription`, so Radix logs **`Missing \`Description\` or \`aria-describedby={undefined}\``** on every dialog open (confirmed live — the warning fires repeatedly). The dialogs are already accessible (labelled by their title via `aria-labelledby`), so this is dev-console noise — but it drowns out real warnings, and a 60-dialog hand-sweep would be disproportionate.

## Change (one file)
`DialogContent` now destructures `aria-describedby` and passes it through explicitly:
- **No description provided** → the value is `undefined`, which is Radix's *documented opt-out* → warning silenced, dialog still labelled by its title.
- **A `<DialogDescription>` is rendered** → still associated: Radix sets `aria-describedby` from context, applied after the spread props, so it wins over our pass-through. (Verified against the Radix 1.1.15 source.)

## Verification (empirical — this is why I tested rather than trusted the source)
- Before: opening the glossary "New term" dialog logged the warning 12×.
- After (fresh server): **zero** warnings; the dialog retains its `aria-labelledby` title id and `aria-describedby` is correctly absent.
- `tsc` / `lint` / production `build` clean.

## Why systemic instead of per-dialog
The earlier plan was to add a `DialogDescription` to each dialog (~60 edits). This single change resolves the warning everywhere, keeps every dialog accessible, and leaves `DialogDescription` fully working for any dialog that wants a real description (the shared confirm dialog from #870 already uses one and still associates correctly).

Capability group: cms/frontend-display
Persona: All — accessibility

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)