### PR TITLE
GovCore cutover Phase 0 + 1a: @govcore/rbac link + org-settings sidecar

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,9 +2,9 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "govea-dev",
-      "runtimeExecutable": "/opt/homebrew/bin/pnpm",
-      "runtimeArgs": ["-C", "/Users/roballred/Repos/Claude/govea-app", "--filter", "govea", "dev"],
+      "name": "govea",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "govea", "dev"],
       "port": 3000,
       "autoPort": false
     }

--- a/.github/actions/setup-govcore-link/action.yml
+++ b/.github/actions/setup-govcore-link/action.yml
@@ -1,0 +1,34 @@
+name: Set up GovCore link
+description: >-
+  Clones the public GovCore platform repo into the sibling path that GovEA's
+  `link:../../../GovCore/...` dependencies resolve to, so `pnpm install` can
+  resolve the locally-linked `@govcore/*` packages in CI. Must run after
+  checkout and before `pnpm install`.
+
+  During the local-link phase of the GovCore cutover GovEA consumes the
+  platform packages from source via the `link:` protocol rather than npm; CI
+  has no sibling checkout, so we provision one here. GovCore is public, so no
+  token is needed. Tracks GovCore `main` (the packages are unpublished `0.x`);
+  this whole step goes away once GovEA pins published `@govcore/*` versions.
+
+inputs:
+  ref:
+    description: GovCore git ref to clone.
+    required: false
+    default: main
+
+runs:
+  using: composite
+  steps:
+    - name: Clone GovCore into the link target
+      shell: bash
+      run: |
+        set -euo pipefail
+        # apps/govea's `link:../../../GovCore` resolves to a sibling of the
+        # GovEA checkout (i.e. $GITHUB_WORKSPACE/../GovCore).
+        target="${{ github.workspace }}/../GovCore"
+        if [ ! -d "$target/.git" ]; then
+          git clone --depth 1 --branch "${{ inputs.ref }}" \
+            https://github.com/roballred/GovCore.git "$target"
+        fi
+        echo "GovCore linked at $(cd "$target" && pwd) @ $(cd "$target" && git rev-parse --short HEAD)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Set up GovCore link (local-linked @govcore/*)
+        uses: ./.github/actions/setup-govcore-link
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -41,6 +44,9 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+
+      - name: Set up GovCore link (local-linked @govcore/*)
+        uses: ./.github/actions/setup-govcore-link
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -84,6 +90,9 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Set up GovCore link (local-linked @govcore/*)
+        uses: ./.github/actions/setup-govcore-link
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -124,6 +133,9 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+
+      - name: Set up GovCore link (local-linked @govcore/*)
+        uses: ./.github/actions/setup-govcore-link
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -188,6 +200,9 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+
+      - name: Set up GovCore link (local-linked @govcore/*)
+        uses: ./.github/actions/setup-govcore-link
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/apps/govea/next.config.ts
+++ b/apps/govea/next.config.ts
@@ -54,7 +54,7 @@ const nextConfig: NextConfig = {
   // It ships TypeScript source, no built dist/. transpilePackages tells the
   // Next.js build to compile workspace packages on the fly so consumers do
   // not need a separate `pnpm --filter @govea/core build` step.
-  transpilePackages: ['@govea/core'],
+  transpilePackages: ['@govea/core', '@govcore/rbac'],
   experimental: {
     serverActions: {
       allowedOrigins,

--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.0",
+    "@govcore/rbac": "link:../../../GovCore/packages/rbac",
     "@govea/core": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/apps/govea/src/actions/connections.ts
+++ b/apps/govea/src/actions/connections.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { orgConnections, organizations } from '@/db/schema'
+import { orgConnections } from '@/db/schema'
 import { eq, or, and } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
@@ -34,10 +34,14 @@ export async function getOtherOrganizations() {
   const session = await requireAdmin()
   const orgId = session.user.organizationId!
 
-  return db.query.organizations.findMany({
-    where: (o, { and, ne, eq }) => and(ne(o.id, orgId), eq(o.isSystemOrg, false)),
+  const orgs = await db.query.organizations.findMany({
+    where: (o, { ne }) => ne(o.id, orgId),
     orderBy: (o, { asc }) => [asc(o.name)],
+    with: { settings: { columns: { isSystemOrg: true } } },
   })
+  // System orgs live in the settings sidecar now; exclude them (a missing
+  // settings row is treated as a normal tenant).
+  return orgs.filter((o) => !o.settings?.isSystemOrg)
 }
 
 export async function requestConnection(targetOrgId: string) {

--- a/apps/govea/src/actions/instance.ts
+++ b/apps/govea/src/actions/instance.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { organizations, users, userOrganizationMemberships, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
+import { organizations, organizationSettings, users, userOrganizationMemberships, breakGlassSessions, instanceSettings, platformConfig, auditLog } from '@/db/schema'
 import { eq, and, isNull, gt, like, desc, ne, count } from 'drizzle-orm'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { writeAuditLog } from '@/lib/audit'
@@ -59,8 +59,12 @@ export async function createOrg(formData: FormData): Promise<{ id: string }> {
   const orgId = await db.transaction(async (tx) => {
     const [org] = await tx
       .insert(organizations)
-      .values({ name, slug, theme, supportTier })
+      .values({ name, slug })
       .returning()
+
+    await tx
+      .insert(organizationSettings)
+      .values({ organizationId: org.id, theme, supportTier })
 
     await writeAuditLog(tx, {
       action: 'instance.org.create',
@@ -249,14 +253,16 @@ export async function getPendingBreakGlassApprovals() {
 export async function suspendOrg(orgId: string, reason: string) {
   const session = await requireInstanceAdmin()
 
-  const before = await db.query.organizations.findFirst({ where: eq(organizations.id, orgId) })
+  const before = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
+  })
   if (!before) throw new Error('Organisation not found')
   if (before.isSystemOrg) throw new Error('Cannot suspend the system org')
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ suspendedAt: new Date(), suspendedReason: reason, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'instance.org.suspend',
@@ -278,9 +284,9 @@ export async function unsuspendOrg(orgId: string) {
   const session = await requireInstanceAdmin()
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ suspendedAt: null, suspendedReason: null, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'instance.org.unsuspend',
@@ -739,16 +745,18 @@ export async function updateOrgGovernance(
 ) {
   const session = await requireInstanceAdmin()
 
-  const before = await db.query.organizations.findFirst({ where: eq(organizations.id, orgId) })
+  const before = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
+  })
   if (!before) throw new Error('Organisation not found')
 
   const supportTier = data.supportTier?.trim() || null
   const internalNotes = data.internalNotes?.trim() || null
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ supportTier, internalNotes, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'instance.org.governance.update',

--- a/apps/govea/src/actions/security-settings.ts
+++ b/apps/govea/src/actions/security-settings.ts
@@ -15,7 +15,7 @@
  * enforcement).
  */
 import { db } from '@/db/client'
-import { organizations, DEFAULT_SECURITY_SETTINGS } from '@/db/schema'
+import { organizationSettings, DEFAULT_SECURITY_SETTINGS } from '@/db/schema'
 import type { SecuritySettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
@@ -36,8 +36,8 @@ export async function getSecuritySettingsForUi(): Promise<SecuritySettings> {
   const session = await auth()
   if (!session?.user) redirect('/login')
   if (!session.user.organizationId) return DEFAULT_SECURITY_SETTINGS
-  const org = await db.query.organizations.findFirst({
-    where: eq(organizations.id, session.user.organizationId),
+  const org = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, session.user.organizationId),
     columns: { securitySettings: true },
   })
   return mergeWithDefaults(org?.securitySettings)
@@ -75,9 +75,9 @@ export async function saveSecuritySettings(formData: FormData): Promise<void> {
   }
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ securitySettings: settings, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
     await writeAuditLog(tx, {
       action: 'security_settings.update',
       entityType: 'organization',

--- a/apps/govea/src/actions/settings.ts
+++ b/apps/govea/src/actions/settings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { organizations, type ConfidenceSettings, type CompletenessSettings, DEFAULT_COMPLETENESS_SETTINGS } from '@/db/schema'
+import { organizationSettings, type ConfidenceSettings, type CompletenessSettings, DEFAULT_COMPLETENESS_SETTINGS } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
@@ -22,14 +22,14 @@ export async function updateOrgTheme(themeId: string) {
   const valid = themes.find(t => t.id === themeId)
   if (!valid) throw new Error('Invalid theme')
 
-  const before = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const before = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
   })
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ theme: themeId, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'settings.theme_changed',
@@ -59,17 +59,17 @@ export async function setModuleEnabled(key: ModuleKey, enabled: boolean) {
 
   const orgId = session.user.organizationId!
 
-  const org = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const org = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
   })
 
   const before = org?.enabledModules ?? {}
   const after = { ...before, [key]: enabled }
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ enabledModules: after, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'settings.module_toggled',
@@ -94,15 +94,15 @@ export async function setGroupModulesEnabled(group: ModuleGroup, enabled: boolea
   if (keys.length === 0) throw new Error('Unknown group')
 
   const orgId = session.user.organizationId!
-  const org = await db.query.organizations.findFirst({ where: eq(organizations.id, orgId) })
+  const org = await db.query.organizationSettings.findFirst({ where: eq(organizationSettings.organizationId, orgId) })
   const before = org?.enabledModules ?? {}
   const after = { ...before }
   for (const key of keys) after[key] = enabled
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ enabledModules: after, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'settings.group_toggled',
@@ -131,8 +131,8 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
 
   const orgId = session.user.organizationId!
 
-  const before = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const before = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { confidenceSettings: true },
   })
 
@@ -151,9 +151,9 @@ export async function updateConfidenceSettings(input: ConfidenceSettings) {
   }
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ confidenceSettings: next, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'settings.confidence_updated',
@@ -176,8 +176,8 @@ export async function updateCompletenessSettings(input: Partial<CompletenessSett
 
   const orgId = session.user.organizationId!
 
-  const before = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const before = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { completenessSettings: true },
   })
   const current = before?.completenessSettings ?? DEFAULT_COMPLETENESS_SETTINGS
@@ -203,9 +203,9 @@ export async function updateCompletenessSettings(input: Partial<CompletenessSett
   }
 
   await db.transaction(async (tx) => {
-    await tx.update(organizations)
+    await tx.update(organizationSettings)
       .set({ completenessSettings: next, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await writeAuditLog(tx, {
       action: 'settings.completeness_updated',

--- a/apps/govea/src/actions/setup.ts
+++ b/apps/govea/src/actions/setup.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { db } from '@/db/client'
-import { users, organizations } from '@/db/schema'
+import { users, organizations, organizationSettings } from '@/db/schema'
 import { count } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
 import { redirect } from 'next/navigation'
@@ -36,6 +36,8 @@ export async function runSetup(formData: FormData) {
       name: orgName,
       slug: orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
     }).returning()
+
+    await tx.insert(organizationSettings).values({ organizationId: org.id })
 
     const [user] = await tx.insert(users).values({
       name,

--- a/apps/govea/src/app/(admin)/dashboard/page.tsx
+++ b/apps/govea/src/app/(admin)/dashboard/page.tsx
@@ -5,7 +5,7 @@ import {
   personas, capabilities, applications, adrs, initiatives,
   strategicObjectives, valueStreams, principles, glossaryTerms,
   auditLog, users, crossOrgLinks,
-  organizations,
+  organizationSettings,
   DEFAULT_COMPLETENESS_SETTINGS,
 } from '@/db/schema'
 import { and, count, eq, gt, isNotNull, desc, asc, inArray, or } from 'drizzle-orm'
@@ -87,8 +87,8 @@ export default async function DashboardPage() {
     return <ViewerDashboard orgId={orgId} userName={session.user.name ?? null} />
   }
 
-  const orgRow = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const orgRow = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { completenessSettings: true },
   })
   const stalenessDays = orgRow?.completenessSettings?.stalenessDays ?? DEFAULT_COMPLETENESS_SETTINGS.stalenessDays
@@ -195,9 +195,9 @@ export default async function DashboardPage() {
     // Last-backup surface (#529 capability rule). Admin-only; contributors
     // and viewers cannot trigger backups so the surface is noise for them.
     isAdminUser ? db.select({
-      lastExportAt: organizations.lastExportAt,
-      lastExportBytes: organizations.lastExportBytes,
-    }).from(organizations).where(eq(organizations.id, orgId)).limit(1).then(rows => rows[0] ?? null) : Promise.resolve(null),
+      lastExportAt: organizationSettings.lastExportAt,
+      lastExportBytes: organizationSettings.lastExportBytes,
+    }).from(organizationSettings).where(eq(organizationSettings.organizationId, orgId)).limit(1).then(rows => rows[0] ?? null) : Promise.resolve(null),
   ])
   const summarySuppressed =
     (confSummary.settings.authenticatedVisibility ?? confSummary.settings.enabled) &&

--- a/apps/govea/src/app/(admin)/layout.tsx
+++ b/apps/govea/src/app/(admin)/layout.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { SignOutButton } from '@/components/sign-out-button'
 import { db } from '@/db/client'
-import { organizations } from '@/db/schema'
+import { organizationSettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { getTheme, themeToStyleString } from '@/lib/themes'
 import type { Role } from '@/lib/rbac'
@@ -39,14 +39,14 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   let themeStyle = ''
   let enabledModules: Record<string, boolean> = {}
   if (session.user.organizationId) {
-    const [org, moduleSettings] = await Promise.all([
-      db.query.organizations.findFirst({
-        where: eq(organizations.id, session.user.organizationId),
+    const [settings, moduleSettings] = await Promise.all([
+      db.query.organizationSettings.findFirst({
+        where: eq(organizationSettings.organizationId, session.user.organizationId),
       }),
       getCurrentModuleSettings(),
     ])
-    if (org) {
-      const theme = getTheme(org.theme)
+    if (settings) {
+      const theme = getTheme(settings.theme)
       themeStyle = themeToStyleString(theme)
       enabledModules = moduleSettings.effectiveEnabledModules
     }

--- a/apps/govea/src/app/(admin)/settings/backup/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/backup/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { db } from '@/db/client'
-import { organizations } from '@/db/schema'
+import { organizationSettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { importArchiveFromForm } from '@/actions/backup'
 import { Button } from '@/components/ui/button'
@@ -47,12 +47,12 @@ export default async function BackupSettingsPage({
   const params = await searchParams
   const showImportSuccess = params?.imported === '1'
 
-  const org = await db.query.organizations.findFirst({
-    where: eq(organizations.id, session.user.organizationId),
+  const settings = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, session.user.organizationId),
   })
 
-  const lastExportStr = formatLastExport(org?.lastExportAt ?? null, org?.lastExportBytes ?? null)
-  const lastImportStr = formatLastExport(org?.lastImportAt ?? null, org?.lastImportBytes ?? null)
+  const lastExportStr = formatLastExport(settings?.lastExportAt ?? null, settings?.lastExportBytes ?? null)
+  const lastImportStr = formatLastExport(settings?.lastImportAt ?? null, settings?.lastImportBytes ?? null)
 
   return (
     <div className="max-w-3xl space-y-8">

--- a/apps/govea/src/app/(admin)/settings/page.tsx
+++ b/apps/govea/src/app/(admin)/settings/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { db } from '@/db/client'
-import { organizations } from '@/db/schema'
+import { organizationSettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { ThemeSelector } from '@/components/theme-selector'
 import { StarterContentSection } from '@/components/starter-content-section'
@@ -35,10 +35,10 @@ export default async function SettingsPage() {
   if (!session?.user) redirect('/login')
   if (!isAdmin(session.user)) redirect('/dashboard')
 
-  const [org, moduleSettings, appCustomFields, emailSettingsUi, emailDeliveries, securitySettings] = await Promise.all([
+  const [settings, moduleSettings, appCustomFields, emailSettingsUi, emailDeliveries, securitySettings] = await Promise.all([
     session.user.organizationId
-      ? db.query.organizations.findFirst({
-          where: eq(organizations.id, session.user.organizationId),
+      ? db.query.organizationSettings.findFirst({
+          where: eq(organizationSettings.organizationId, session.user.organizationId),
         })
       : Promise.resolve(null),
     getCurrentModuleSettings(),
@@ -50,11 +50,11 @@ export default async function SettingsPage() {
     getSecuritySettingsForUi(),
   ])
 
-  const activeTheme = org?.theme ?? 'govea'
+  const activeTheme = settings?.theme ?? 'govea'
   const enabledModules = moduleSettings.orgEnabledModules
   const instanceDisabledModules = moduleSettings.instanceDisabledModules
-  const confidenceSettings = org?.confidenceSettings ?? DEFAULT_CONFIDENCE
-  const completenessSettings = org?.completenessSettings ?? DEFAULT_COMPLETENESS
+  const confidenceSettings = settings?.confidenceSettings ?? DEFAULT_CONFIDENCE
+  const completenessSettings = settings?.completenessSettings ?? DEFAULT_COMPLETENESS
 
   return (
     <div className="space-y-8 max-w-2xl">

--- a/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
 
   const now = new Date()
   const [org, userCountRow, myActiveSession, pendingFromOthers, bgHistory, govHistory] = await Promise.all([
-    db.query.organizations.findFirst({ where: eq(organizations.id, id) }),
+    db.query.organizations.findFirst({ where: eq(organizations.id, id), with: { settings: true } }),
     // #436 — only the COUNT is metadata. Full user rows are loaded below,
     // and only when the caller has earned the right to see them.
     db.select({ n: count(users.id) }).from(users).where(eq(users.organizationId, id)),
@@ -85,6 +85,16 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
 
   if (!org) notFound()
 
+  // Org config (theme, support tier, suspension, etc.) lives in the settings
+  // sidecar now; read it through the relation.
+  const settings = org.settings
+  const theme = settings?.theme ?? 'govea'
+  const supportTier = settings?.supportTier ?? null
+  const internalNotes = settings?.internalNotes ?? null
+  const isSystemOrg = settings?.isSystemOrg ?? false
+  const suspendedAt = settings?.suspendedAt ?? null
+  const suspendedReason = settings?.suspendedReason ?? null
+
   const userCount = userCountRow[0]?.n ?? 0
 
   // #436 — gate user PII on active+approved break-glass. The caller can also
@@ -99,7 +109,7 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
       })
     : []
 
-  const tierBadge = org.supportTier ? TIER_BADGE[org.supportTier] : null
+  const tierBadge = supportTier ? TIER_BADGE[supportTier] : null
 
   return (
     <div className="space-y-8">
@@ -127,14 +137,14 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
         <div className="flex items-center gap-2 shrink-0">
           <span className={cn(
             'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
-            org.suspendedAt
+            suspendedAt
               ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400'
               : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
           )}>
-            {org.suspendedAt ? 'Suspended' : 'Active'}
+            {suspendedAt ? 'Suspended' : 'Active'}
           </span>
-          {!org.isSystemOrg && (
-            org.suspendedAt ? (
+          {!isSystemOrg && (
+            suspendedAt ? (
               <form action={async () => {
                 'use server'
                 await unsuspendOrg(id)
@@ -160,10 +170,10 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
       </div>
 
       {/* Suspension notice */}
-      {org.suspendedAt && (
+      {suspendedAt && (
         <div className="rounded-md bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 p-4 text-sm text-red-800 dark:text-red-300">
-          <strong>Suspended</strong> on {org.suspendedAt.toLocaleString()}
-          {org.suspendedReason && <> — {org.suspendedReason}</>}
+          <strong>Suspended</strong> on {suspendedAt.toLocaleString()}
+          {suspendedReason && <> — {suspendedReason}</>}
         </div>
       )}
 
@@ -172,8 +182,8 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
         <h2 className="text-base font-semibold mb-3">Details</h2>
         <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
           <div><dt className="text-muted-foreground">Created</dt><dd className="mt-0.5 font-medium">{org.createdAt.toLocaleDateString()}</dd></div>
-          <div><dt className="text-muted-foreground">Theme</dt><dd className="mt-0.5 font-medium">{org.theme}</dd></div>
-          <div><dt className="text-muted-foreground">System org</dt><dd className="mt-0.5 font-medium">{org.isSystemOrg ? 'Yes' : 'No'}</dd></div>
+          <div><dt className="text-muted-foreground">Theme</dt><dd className="mt-0.5 font-medium">{theme}</dd></div>
+          <div><dt className="text-muted-foreground">System org</dt><dd className="mt-0.5 font-medium">{isSystemOrg ? 'Yes' : 'No'}</dd></div>
           <div><dt className="text-muted-foreground">Users</dt><dd className="mt-0.5 font-medium">{userCount}</dd></div>
         </dl>
       </section>
@@ -189,8 +199,8 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
 
         <OrgGovernanceForm
           orgId={id}
-          initialTier={org.supportTier}
-          initialNotes={org.internalNotes}
+          initialTier={supportTier}
+          initialNotes={internalNotes}
         />
 
         {govHistory.length > 0 && (
@@ -221,7 +231,7 @@ export default async function OrgDetailPage({ params }: { params: Promise<{ id: 
               Time-limited access to this organisation&apos;s data for incident investigation. Sessions over 1 hour require a second instance admin to approve. All sessions are audited.
             </p>
           </div>
-          {!myActiveSession && !org.isSystemOrg && (
+          {!myActiveSession && !isSystemOrg && (
             <BreakGlassGrantForm
               trigger={<Button variant="outline" size="sm">Grant Access</Button>}
               orgName={org.name}

--- a/apps/govea/src/app/(instance)/instance/orgs/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/orgs/page.tsx
@@ -1,6 +1,6 @@
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
-import { organizations, users } from '@/db/schema'
+import { organizations, organizationSettings, users } from '@/db/schema'
 import { count, eq, desc } from 'drizzle-orm'
 import { InstanceOrgsTable } from './instance-orgs-table'
 
@@ -10,24 +10,26 @@ export default async function InstanceOrgsPage() {
   const rows = await db
     .select({
       org: organizations,
+      settings: organizationSettings,
       userCount: count(users.id),
     })
     .from(organizations)
+    .leftJoin(organizationSettings, eq(organizationSettings.organizationId, organizations.id))
     .leftJoin(users, eq(users.organizationId, organizations.id))
-    .groupBy(organizations.id)
+    .groupBy(organizations.id, organizationSettings.organizationId)
     .orderBy(desc(organizations.createdAt))
 
   return (
     <InstanceOrgsTable
-      orgs={rows.map(({ org, userCount }) => ({
+      orgs={rows.map(({ org, settings, userCount }) => ({
         id: org.id,
         name: org.name,
         slug: org.slug,
         userCount,
         createdAt: org.createdAt,
-        suspendedAt: org.suspendedAt,
-        isSystemOrg: org.isSystemOrg,
-        supportTier: org.supportTier,
+        suspendedAt: settings?.suspendedAt ?? null,
+        isSystemOrg: settings?.isSystemOrg ?? false,
+        supportTier: settings?.supportTier ?? null,
       }))}
     />
   )

--- a/apps/govea/src/app/(instance)/instance/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
-import { organizations, users, auditLog, breakGlassSessions } from '@/db/schema'
+import { organizations, organizationSettings, users, auditLog, breakGlassSessions } from '@/db/schema'
 import { count, eq, desc, isNull, isNotNull, gt, and, or, ilike } from 'drizzle-orm'
 import { cn } from '@/lib/utils'
 
@@ -18,7 +18,10 @@ export default async function InstanceDashboardPage() {
     pendingSessions,
     recentEvents,
   ] = await Promise.all([
-    db.select({ orgCount: count() }).from(organizations).where(eq(organizations.isSystemOrg, false)),
+    db.select({ orgCount: count() })
+      .from(organizations)
+      .innerJoin(organizationSettings, eq(organizationSettings.organizationId, organizations.id))
+      .where(eq(organizationSettings.isSystemOrg, false)),
     db.select({ userCount: count() }).from(users),
     // Active = non-revoked, non-expired, AND (no approval needed OR already approved).
     // Pending sessions are counted separately below.

--- a/apps/govea/src/app/(instance)/instance/users/page.tsx
+++ b/apps/govea/src/app/(instance)/instance/users/page.tsx
@@ -1,7 +1,7 @@
 import { requireInstanceAdmin } from '@/lib/instance-admin'
 import { db } from '@/db/client'
-import { users, organizations, userOrganizationMemberships } from '@/db/schema'
-import { eq, desc } from 'drizzle-orm'
+import { users, organizations, organizationSettings, userOrganizationMemberships } from '@/db/schema'
+import { eq, desc, asc } from 'drizzle-orm'
 import { getUnlockedOrgIds } from '@/lib/break-glass'
 import { InstanceUserTable, type MembershipRow } from './instance-user-table'
 
@@ -28,11 +28,12 @@ export default async function InstanceUsersPage() {
       .from(users)
       .leftJoin(organizations, eq(users.organizationId, organizations.id))
       .orderBy(desc(users.createdAt)),
-    db.query.organizations.findMany({
-      where: eq(organizations.isSystemOrg, false),
-      columns: { id: true, name: true },
-      orderBy: (org, { asc }) => [asc(org.name)],
-    }),
+    db
+      .select({ id: organizations.id, name: organizations.name })
+      .from(organizations)
+      .innerJoin(organizationSettings, eq(organizationSettings.organizationId, organizations.id))
+      .where(eq(organizationSettings.isSystemOrg, false))
+      .orderBy(asc(organizations.name)),
     // #693 slice 4 — per-user org memberships for the cross-org management UI.
     db
       .select({

--- a/apps/govea/src/db/schema/index.ts
+++ b/apps/govea/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './organizations'
+export * from './organization-settings'
 export * from './users'
 export * from './personas'
 export * from './capabilities'

--- a/apps/govea/src/db/schema/organization-settings.ts
+++ b/apps/govea/src/db/schema/organization-settings.ts
@@ -1,0 +1,157 @@
+import { type AnyPgColumn, boolean, integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { organizations } from './organizations'
+
+/**
+ * App-owned sidecar for organization configuration (Phase 1a of the GovCore
+ * cutover).
+ *
+ * GovCore's core-owned `organizations` table is intentionally minimal
+ * (id/name/slug/metadata/timestamps). GovEA's organization-level configuration
+ * — theming, module toggles, security/confidence/completeness policy, support
+ * tier, org hierarchy, suspension state, backup bookkeeping — lives here in an
+ * app-owned table keyed 1:1 to `organizations` (PK = organization_id), so the
+ * platform table stays core-shaped while GovEA keeps its richer settings.
+ *
+ * Exactly one row per organization; created alongside the org at every insert
+ * site (setup, instance provisioning, seeds, test factories). Reads fall back
+ * to the DEFAULT_* constants below when a column is null.
+ */
+
+/**
+ * Per-organization security policy (#527 / ac-security-settings).
+ *
+ * Stored as JSONB so adding a new policy knob doesn't require a migration.
+ * Per the capability rule, changes apply to FUTURE logins and sessions —
+ * existing sessions are not immediately terminated.
+ *
+ *  - `passwordMinLength` / `require*`     — enforced by validatePassword
+ *  - `sessionTimeoutMinutes`              — enforced by the jwt callback
+ *  - `lockoutThreshold` / `lockoutDur..`  — enforced by the credentials provider
+ *  - `passwordExpiryDays`                 — enforced by the admin-layout redirect
+ *
+ * A value of 0 for `lockoutThreshold` / `passwordExpiryDays` means
+ * disabled (no enforcement). `sessionTimeoutMinutes` falls back to the
+ * 24h NextAuth default if missing.
+ */
+export type SecuritySettings = {
+  passwordMinLength: number
+  requireUppercase: boolean
+  requireLowercase: boolean
+  requireDigit: boolean
+  requireSpecial: boolean
+  sessionTimeoutMinutes: number
+  lockoutThreshold: number
+  lockoutDurationMinutes: number
+  passwordExpiryDays: number
+}
+
+export const DEFAULT_SECURITY_SETTINGS: SecuritySettings = {
+  passwordMinLength: 8,
+  requireUppercase: false,
+  requireLowercase: false,
+  requireDigit: false,
+  requireSpecial: false,
+  sessionTimeoutMinutes: 1440, // 24h — matches NextAuth's previous static default
+  lockoutThreshold: 5,
+  lockoutDurationMinutes: 30,
+  passwordExpiryDays: 0,
+}
+
+/**
+ * Confidence-summary publication settings (#380 PR-2).
+ *
+ * `enabled` is retained for backwards compatibility with PR-1 callers — it
+ * is interpreted as `authenticatedVisibility` when the new fields are absent.
+ * New callers should set `authenticatedVisibility` and `publicVisibility`
+ * directly. The legacy `enabled` field is kept until PR-4 can drop it
+ * cleanly across all callers.
+ */
+export type ConfidenceSettings = {
+  enabled: boolean
+  narrative: string | null
+  suppressBelowPercent: number
+  /**
+   * Whether authenticated users (Admin / Contributor / Viewer) see the
+   * confidence summary on stakeholder-facing surfaces. Defaults to the
+   * value of `enabled` for legacy rows that pre-date this split.
+   */
+  authenticatedVisibility?: boolean
+  /**
+   * Whether unauthenticated (public) viewers see the confidence summary.
+   * Always defaults to false; must be enabled as an explicit second step
+   * even if `authenticatedVisibility` is true. Per
+   * `fd-repository-confidence-summary.md`, the controls are independent.
+   */
+  publicVisibility?: boolean
+}
+
+/**
+ * Completeness drill-down + scoring settings (#380 PR-2).
+ *
+ * `stalenessDays` replaces the hardcoded `REVIEW_WINDOW_DAYS = 90` in the
+ * admin dashboard's Review Health section.
+ *
+ * `domainTargets` and `rankingWeights` are stored now to avoid a follow-up
+ * migration in PR-3, but their wiring into the RAG indicators and the
+ * "most-needed actions" ranked list lands in PR-3.
+ */
+export type CompletenessSettings = {
+  stalenessDays: number
+  /**
+   * Per-capability-domain completeness targets, keyed by the domain string
+   * stored on the capability row. Values are integers 0–100.
+   * E.g. { 'cms': 60, 'ea': 70 }. PR-3 wires these into RAG indicators.
+   */
+  domainTargets: Record<string, number>
+  /**
+   * Heuristic weights for the "most-needed actions" ranking in PR-3.
+   * Higher = larger contribution to ranking score.
+   */
+  rankingWeights: {
+    publishedButStale: number
+    incompleteRelationship: number
+    unpublished: number
+  }
+}
+
+export const DEFAULT_COMPLETENESS_SETTINGS: CompletenessSettings = {
+  stalenessDays: 90,
+  domainTargets: {},
+  rankingWeights: {
+    publishedButStale: 3,
+    incompleteRelationship: 2,
+    unpublished: 1,
+  },
+}
+
+export const organizationSettings = pgTable('organization_settings', {
+  organizationId: uuid('organization_id')
+    .primaryKey()
+    .references(() => organizations.id, { onDelete: 'cascade' }),
+  theme: text('theme').notNull().default('govea'),
+  enabledModules: jsonb('enabled_modules').$type<Record<string, boolean>>().notNull().default({}),
+  confidenceSettings: jsonb('confidence_settings').$type<ConfidenceSettings>(),
+  completenessSettings: jsonb('completeness_settings').$type<CompletenessSettings>(),
+  securitySettings: jsonb('security_settings').$type<SecuritySettings>(),
+  isSystemOrg: boolean('is_system_org').notNull().default(false),
+  parentId: uuid('parent_id').references((): AnyPgColumn => organizations.id, { onDelete: 'set null' }),
+  suspendedAt: timestamp('suspended_at'),
+  suspendedReason: text('suspended_reason'),
+  supportTier: text('support_tier'),
+  internalNotes: text('internal_notes'),
+  /**
+   * #529: timestamp of the last successful backup export (any of recipe,
+   * content, or archive). Null = never exported.
+   */
+  lastExportAt: timestamp('last_export_at'),
+  /** #529: byte size of the most recent export, paired with `lastExportAt`. */
+  lastExportBytes: integer('last_export_bytes'),
+  /** #529 PR2: timestamp of the last successful archive import. Null = never imported. */
+  lastImportAt: timestamp('last_import_at'),
+  lastImportBytes: integer('last_import_bytes'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})
+
+export type OrganizationSettings = typeof organizationSettings.$inferSelect
+export type NewOrganizationSettings = typeof organizationSettings.$inferInsert

--- a/apps/govea/src/db/schema/organizations.ts
+++ b/apps/govea/src/db/schema/organizations.ts
@@ -1,158 +1,31 @@
-import { type AnyPgColumn, boolean, integer, jsonb, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core'
 
+// Domain-table visibility enum (used by capabilities, personas, etc.). Lives
+// here for now; Phase 1b relocates it when `organizations` becomes a core
+// re-export.
 export const visibilityEnum = pgEnum('visibility', ['org', 'connections', 'instance'])
 
 /**
- * Per-organization security policy (#527 / ac-security-settings).
+ * Organization (tenancy root).
  *
- * Surfaced by the CMS Administrator persona walk: government IT admins
- * are routinely required to set agency-standard password and lockout
- * policies — touching a config file is a non-starter, so the policy
- * must be admin-configurable from the UI.
- *
- * Stored as JSONB so adding a new policy knob doesn't require a migration.
- * Per the capability rule, changes apply to FUTURE logins and sessions —
- * existing sessions are not immediately terminated.
- *
- *  - `passwordMinLength` / `require*`     — enforced by validatePassword
- *  - `sessionTimeoutMinutes`              — enforced by the jwt callback
- *  - `lockoutThreshold` / `lockoutDur..`  — enforced by the credentials provider
- *  - `passwordExpiryDays`                 — enforced by the admin-layout redirect
- *
- * A value of 0 for `lockoutThreshold` / `passwordExpiryDays` means
- * disabled (no enforcement). `sessionTimeoutMinutes` falls back to the
- * 24h NextAuth default if missing.
+ * Kept core-shaped (id/name/slug/timestamps) ahead of Phase 1b of the GovCore
+ * cutover, where this table is re-exported from `@govcore/schema`. GovEA's
+ * organization-level configuration — theme, module toggles, security/confidence/
+ * completeness policy, support tier, hierarchy, suspension, backup bookkeeping —
+ * lives in the app-owned `organization_settings` sidecar (one row per org,
+ * keyed by `organization_id`). See `./organization-settings.ts`.
  */
-export type SecuritySettings = {
-  passwordMinLength: number
-  requireUppercase: boolean
-  requireLowercase: boolean
-  requireDigit: boolean
-  requireSpecial: boolean
-  sessionTimeoutMinutes: number
-  lockoutThreshold: number
-  lockoutDurationMinutes: number
-  passwordExpiryDays: number
-}
-
-export const DEFAULT_SECURITY_SETTINGS: SecuritySettings = {
-  passwordMinLength: 8,
-  requireUppercase: false,
-  requireLowercase: false,
-  requireDigit: false,
-  requireSpecial: false,
-  sessionTimeoutMinutes: 1440, // 24h — matches NextAuth's previous static default
-  lockoutThreshold: 5,
-  lockoutDurationMinutes: 30,
-  passwordExpiryDays: 0,
-}
-
-/**
- * Confidence-summary publication settings (#380 PR-2).
- *
- * `enabled` is retained for backwards compatibility with PR-1 callers — it
- * is interpreted as `authenticatedVisibility` when the new fields are absent.
- * New callers should set `authenticatedVisibility` and `publicVisibility`
- * directly. The legacy `enabled` field is kept until PR-4 can drop it
- * cleanly across all callers.
- */
-export type ConfidenceSettings = {
-  enabled: boolean
-  narrative: string | null
-  suppressBelowPercent: number
-  /**
-   * Whether authenticated users (Admin / Contributor / Viewer) see the
-   * confidence summary on stakeholder-facing surfaces. Defaults to the
-   * value of `enabled` for legacy rows that pre-date this split.
-   */
-  authenticatedVisibility?: boolean
-  /**
-   * Whether unauthenticated (public) viewers see the confidence summary.
-   * Always defaults to false; must be enabled as an explicit second step
-   * even if `authenticatedVisibility` is true. Per
-   * `fd-repository-confidence-summary.md`, the controls are independent.
-   */
-  publicVisibility?: boolean
-}
-
-/**
- * Completeness drill-down + scoring settings (#380 PR-2).
- *
- * `stalenessDays` replaces the hardcoded `REVIEW_WINDOW_DAYS = 90` in the
- * admin dashboard's Review Health section.
- *
- * `domainTargets` and `rankingWeights` are stored now to avoid a follow-up
- * migration in PR-3, but their wiring into the RAG indicators and the
- * "most-needed actions" ranked list lands in PR-3.
- */
-export type CompletenessSettings = {
-  stalenessDays: number
-  /**
-   * Per-capability-domain completeness targets, keyed by the domain string
-   * stored on the capability row. Values are integers 0–100.
-   * E.g. { 'cms': 60, 'ea': 70 }. PR-3 wires these into RAG indicators.
-   */
-  domainTargets: Record<string, number>
-  /**
-   * Heuristic weights for the "most-needed actions" ranking in PR-3.
-   * Higher = larger contribution to ranking score.
-   */
-  rankingWeights: {
-    publishedButStale: number
-    incompleteRelationship: number
-    unpublished: number
-  }
-}
-
-export const DEFAULT_COMPLETENESS_SETTINGS: CompletenessSettings = {
-  stalenessDays: 90,
-  domainTargets: {},
-  rankingWeights: {
-    publishedButStale: 3,
-    incompleteRelationship: 2,
-    unpublished: 1,
+export const organizations = pgTable(
+  'organizations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },
-}
-
-export const organizations = pgTable('organizations', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  name: text('name').notNull(),
-  slug: text('slug').notNull().unique(),
-  theme: text('theme').notNull().default('govea'),
-  enabledModules: jsonb('enabled_modules').$type<Record<string, boolean>>().notNull().default({}),
-  confidenceSettings: jsonb('confidence_settings').$type<ConfidenceSettings>(),
-  completenessSettings: jsonb('completeness_settings').$type<CompletenessSettings>(),
-  securitySettings: jsonb('security_settings').$type<SecuritySettings>(),
-  isSystemOrg: boolean('is_system_org').notNull().default(false),
-  parentId: uuid('parent_id').references((): AnyPgColumn => organizations.id, { onDelete: 'set null' }),
-  suspendedAt: timestamp('suspended_at'),
-  suspendedReason: text('suspended_reason'),
-  supportTier: text('support_tier'),
-  internalNotes: text('internal_notes'),
-  /**
-   * #529: timestamp of the last successful backup export (any of recipe,
-   * content, or archive). Updated by the export endpoints in a single
-   * transaction so the dashboard surface stays accurate. Null = never
-   * exported.
-   */
-  lastExportAt: timestamp('last_export_at'),
-  /**
-   * #529: byte size of the most recent export, paired with `lastExportAt`.
-   * Useful for dashboard scale ("Last backup: 2 hours ago, 1.2 MB") and
-   * to flag suspiciously-empty exports.
-   */
-  lastExportBytes: integer('last_export_bytes'),
-  /**
-   * #529 PR2: timestamp of the last successful archive import. Symmetric
-   * with `lastExportAt` so the dashboard can show "last restored" when an
-   * import has overwritten the content more recently than the last export.
-   * Null = never imported.
-   */
-  lastImportAt: timestamp('last_import_at'),
-  lastImportBytes: integer('last_import_bytes'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-})
+  (t) => [uniqueIndex('organizations_slug_unique').on(t.slug)],
+)
 
 export type Organization = typeof organizations.$inferSelect
 export type NewOrganization = typeof organizations.$inferInsert

--- a/apps/govea/src/db/schema/relations.ts
+++ b/apps/govea/src/db/schema/relations.ts
@@ -4,6 +4,7 @@ import { applications, applicationCapabilities } from './applications'
 import { personas, personaTags } from './personas'
 import { taxonomyTerms, entityTaxonomyDefinitions, entityTaxonomyValues } from './taxonomy'
 import { organizations } from './organizations'
+import { organizationSettings } from './organization-settings'
 import { valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities } from './value-streams'
 import { strategicObjectives, objectiveCapabilities, objectiveValueStreams } from './objectives'
 import { goals, goalObjectives } from './goals'
@@ -14,6 +15,22 @@ import { adrs, adrCapabilities, adrApplications, adrInitiatives, adrObjectives }
 import { principles, principleAdrs, principleCapabilities } from './principles'
 import { glossaryTerms, glossaryTermSources } from './glossary'
 import { services, serviceCapabilities, servicePersonas, serviceValueStreams } from './services'
+
+// ─── Organizations ───────────────────────────────────────────────────────────
+
+export const organizationsRelations = relations(organizations, ({ one }) => ({
+  settings: one(organizationSettings, {
+    fields: [organizations.id],
+    references: [organizationSettings.organizationId],
+  }),
+}))
+
+export const organizationSettingsRelations = relations(organizationSettings, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [organizationSettings.organizationId],
+    references: [organizations.id],
+  }),
+}))
 
 // ─── Capabilities ────────────────────────────────────────────────────────────
 

--- a/apps/govea/src/db/seeds/run.ts
+++ b/apps/govea/src/db/seeds/run.ts
@@ -31,7 +31,7 @@ import {
 } from './scale-fixtures'
 import { db } from '../client'
 import {
-  users, organizations, userOrganizationMemberships,
+  users, organizations, organizationSettings, userOrganizationMemberships,
   personas, personaTags, capabilities, applications,
   capabilityPersonas, applicationCapabilities, capabilityRelationships,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
@@ -64,14 +64,28 @@ function toSlug(name: string): string {
 async function findOrCreateOrg(slug: string, name: string, overrides?: { isSystemOrg?: boolean }) {
   const existing = await db.query.organizations.findFirst({
     where: (t, { eq: e }) => e(t.slug, slug),
+    with: { settings: true },
   })
   if (existing) {
-    if (overrides?.isSystemOrg && !existing.isSystemOrg) {
-      await db.update(organizations).set({ isSystemOrg: true }).where(eq(organizations.id, existing.id))
+    // Ensure a settings sidecar row exists (idempotent re-seed) and honor the
+    // isSystemOrg override.
+    if (!existing.settings) {
+      await db.insert(organizationSettings).values({
+        organizationId: existing.id,
+        isSystemOrg: overrides?.isSystemOrg ?? false,
+      })
+    } else if (overrides?.isSystemOrg && !existing.settings.isSystemOrg) {
+      await db.update(organizationSettings)
+        .set({ isSystemOrg: true })
+        .where(eq(organizationSettings.organizationId, existing.id))
     }
     return existing.id
   }
-  const [org] = await db.insert(organizations).values({ name, slug, isSystemOrg: overrides?.isSystemOrg ?? false }).returning()
+  const [org] = await db.insert(organizations).values({ name, slug }).returning()
+  await db.insert(organizationSettings).values({
+    organizationId: org.id,
+    isSystemOrg: overrides?.isSystemOrg ?? false,
+  })
   return org.id
 }
 

--- a/apps/govea/src/lib/backup-export.ts
+++ b/apps/govea/src/lib/backup-export.ts
@@ -37,7 +37,7 @@ import { db } from '@/db/client'
 // and never directly — so they're intentionally absent from this import
 // block. Only tables we filter or eq-compare against go in.
 import {
-  organizations,
+  organizations, organizationSettings,
   personas, capabilities, applications, services,
   valueStreams,
   strategicObjectives,
@@ -95,7 +95,7 @@ async function collectRecipe(orgId: string) {
     entityTaxDefs,
     fieldSchemas,
   ] = await Promise.all([
-    db.query.organizations.findFirst({ where: eq(organizations.id, orgId) }),
+    db.query.organizations.findFirst({ where: eq(organizations.id, orgId), with: { settings: true } }),
     db.query.taxonomyTerms.findMany({ where: eq(taxonomyTerms.organizationId, orgId) }),
     db.query.entityTaxonomyDefinitions.findMany({ where: eq(entityTaxonomyDefinitions.organizationId, orgId) }),
     db.query.customFieldSchemas.findMany({ where: eq(customFieldSchemas.organizationId, orgId) }),
@@ -105,18 +105,19 @@ async function collectRecipe(orgId: string) {
 
   // Strip volatile / sensitive bits from the org row itself before
   // including it in the export.
+  const settings = org.settings
   const orgSettings = {
     id: org.id,
     name: org.name,
     slug: org.slug,
-    theme: org.theme,
-    enabledModules: org.enabledModules,
-    confidenceSettings: org.confidenceSettings,
-    completenessSettings: org.completenessSettings,
+    theme: settings?.theme,
+    enabledModules: settings?.enabledModules,
+    confidenceSettings: settings?.confidenceSettings,
+    completenessSettings: settings?.completenessSettings,
     // securitySettings includes session lifetimes, password policy, etc. —
     // configuration, not credentials, so it IS included in the recipe.
-    securitySettings: org.securitySettings,
-    supportTier: org.supportTier,
+    securitySettings: settings?.securitySettings,
+    supportTier: settings?.supportTier,
   }
 
   return {
@@ -349,14 +350,14 @@ export async function buildArchiveExport(orgId: string): Promise<BuiltExport> {
 }
 
 /**
- * Updates `organizations.lastExportAt` / `lastExportBytes` after a successful
- * export. Called from the route handlers; kept here so the export-time
- * bookkeeping lives next to the exporters themselves.
+ * Updates `lastExportAt` / `lastExportBytes` on the org's settings after a
+ * successful export. Called from the route handlers; kept here so the
+ * export-time bookkeeping lives next to the exporters themselves.
  */
 export async function recordExport(orgId: string, bytes: number): Promise<void> {
   await db
-    .update(organizations)
+    .update(organizationSettings)
     .set({ lastExportAt: new Date(), lastExportBytes: bytes })
-    .where(eq(organizations.id, orgId))
+    .where(eq(organizationSettings.organizationId, orgId))
 }
 

--- a/apps/govea/src/lib/backup-import.ts
+++ b/apps/govea/src/lib/backup-import.ts
@@ -36,7 +36,7 @@
 import { eq, or } from 'drizzle-orm'
 import { db } from '@/db/client'
 import {
-  organizations,
+  organizationSettings,
   personas, capabilities, applications, services,
   valueStreams, valueStreamStages, valueStreamStageCapabilities, valueStreamPersonas, valueStreamCapabilities,
   strategicObjectives, objectiveCapabilities, objectiveValueStreams,
@@ -227,10 +227,10 @@ export async function importArchive(
     await tx.delete(taxonomyTerms).where(eq(taxonomyTerms.organizationId, destOrgId))
     await tx.delete(customFieldSchemas).where(eq(customFieldSchemas.organizationId, destOrgId))
 
-    // 4. Update org row with recipe.organization settings (preserves
-    //    columns we don't restore: name/slug, FKs, suspendedAt, etc).
+    // 4. Update org settings sidecar with recipe.organization settings
+    //    (preserves columns we don't restore: suspendedAt, supportTier, etc).
     const orgSettings = recipe.organization as Record<string, unknown>
-    await tx.update(organizations).set({
+    await tx.update(organizationSettings).set({
       theme: orgSettings.theme as string ?? 'govea',
       enabledModules: orgSettings.enabledModules as Record<string, boolean> ?? {},
       // jsonb columns serialize/deserialize as plain objects.
@@ -238,7 +238,7 @@ export async function importArchive(
       completenessSettings: orgSettings.completenessSettings as never ?? null,
       securitySettings: orgSettings.securitySettings as never ?? null,
       updatedAt: new Date(),
-    }).where(eq(organizations.id, destOrgId))
+    }).where(eq(organizationSettings.organizationId, destOrgId))
 
     // 5. Recipe inserts (config first so taxonomy is available for content).
     if (recipe.customFields.schemas.length) {
@@ -429,13 +429,13 @@ export async function importArchive(
 }
 
 /**
- * Updates `lastImportAt` + `lastImportBytes` on the destination org row.
+ * Updates `lastImportAt` + `lastImportBytes` on the destination org's settings.
  * Mirrors the recordExport bookkeeping shape for symmetry on the dashboard.
  */
 export async function recordImport(orgId: string, bytes: number): Promise<void> {
   await db
-    .update(organizations)
+    .update(organizationSettings)
     .set({ lastImportAt: new Date(), lastImportBytes: bytes })
-    .where(eq(organizations.id, orgId))
+    .where(eq(organizationSettings.organizationId, orgId))
 }
 

--- a/apps/govea/src/lib/completeness-signals.ts
+++ b/apps/govea/src/lib/completeness-signals.ts
@@ -21,7 +21,7 @@ import {
   capabilities, applications, personas, valueStreams,
   strategicObjectives, principles, glossaryTerms, initiatives, adrs,
   applicationCapabilities, capabilityPersonas,
-  organizations,
+  organizationSettings,
   architectureDebtItems,
   DEFAULT_COMPLETENESS_SETTINGS,
   type CompletenessSettings,
@@ -66,8 +66,8 @@ export interface DomainRag {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 async function loadSettings(orgId: string): Promise<CompletenessSettings> {
-  const row = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const row = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { completenessSettings: true },
   })
   return row?.completenessSettings ?? DEFAULT_COMPLETENESS_SETTINGS

--- a/apps/govea/src/lib/completeness-snapshot.ts
+++ b/apps/govea/src/lib/completeness-snapshot.ts
@@ -19,6 +19,7 @@ import {
   strategicObjectives, principles, glossaryTerms, initiatives, adrs,
   completenessSnapshots,
   organizations,
+  organizationSettings,
   auditLog,
   type SnapshotCounts,
   type ConfidenceSettings,
@@ -129,8 +130,8 @@ export async function recomputeCompletenessSnapshot(orgId: string): Promise<Reco
       ),
       orderBy: [desc(completenessSnapshots.snapshotDate)],
     }),
-    db.query.organizations.findFirst({
-      where: eq(organizations.id, orgId),
+    db.query.organizationSettings.findFirst({
+      where: eq(organizationSettings.organizationId, orgId),
       columns: { confidenceSettings: true },
     }),
   ])

--- a/apps/govea/src/lib/confidence.ts
+++ b/apps/govea/src/lib/confidence.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/client'
 import {
-  organizations,
+  organizationSettings,
   capabilities, applications, personas, valueStreams,
   strategicObjectives, initiatives, adrs, principles, glossaryTerms,
 } from '@/db/schema'
@@ -59,12 +59,12 @@ export async function getConfidenceSummary(
   orgId: string,
   audience: ConfidenceAudience = 'authenticated',
 ): Promise<ConfidenceSummary> {
-  const org = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const orgSettings = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { confidenceSettings: true },
   })
 
-  const settings: ConfidenceSettings = org?.confidenceSettings ?? DEFAULT_SETTINGS
+  const settings: ConfidenceSettings = orgSettings?.confidenceSettings ?? DEFAULT_SETTINGS
 
   if (!isVisibleToAudience(settings, audience)) {
     return { label: 'getting started', score: 0, lastUpdated: null, shouldShow: false, narrative: null, settings }

--- a/apps/govea/src/lib/get-enabled-modules.ts
+++ b/apps/govea/src/lib/get-enabled-modules.ts
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth'
 import { db } from '@/db/client'
-import { organizations } from '@/db/schema'
+import { organizationSettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { mergeModuleSettings, MODULE_DEFS, type ModuleStateMap } from '@/lib/modules'
 
@@ -42,8 +42,8 @@ export async function getCurrentModuleSettings(): Promise<{
   }
 
   const [org, global] = await Promise.all([
-    db.query.organizations.findFirst({
-      where: eq(organizations.id, session.user.organizationId),
+    db.query.organizationSettings.findFirst({
+      where: eq(organizationSettings.organizationId, session.user.organizationId),
       columns: { enabledModules: true },
     }),
     getInstanceDisabledModules(),

--- a/apps/govea/src/lib/rbac.ts
+++ b/apps/govea/src/lib/rbac.ts
@@ -1,40 +1,60 @@
-// Thin user-shaped wrappers around the canonical role definitions in
-// `@govea/core/rbac`. The package is the single source of truth for
-// Role, Permission, ROLE_PERMISSIONS, ROLE_HIERARCHY, and the role-level
-// check functions. This file exists solely to provide convenience helpers
-// that accept the GovEA `User` shape instead of a bare role string, and to
-// host the GovEA-specific `isInstanceAdmin` check that depends on the
-// app's `instanceRole` column.
+// GovEA role/permission definitions and user-shaped helpers.
 //
-// Closes #34. Do NOT re-introduce `ROLE_PERMISSIONS`, `ROLE_HIERARCHY`,
-// `Role`, or `Permission` constants here — the integration test in
-// `apps/govea/tests/integration/rbac-single-source.test.ts` will fail
-// if any of those names are defined locally.
+// The RBAC machinery lives in @govcore/rbac (createRbac). The role and
+// permission *definitions* are GovEA-specific and live here. Convenience
+// helpers accept the GovEA User shape instead of a bare role string.
+// isInstanceAdmin is app-local: it depends on the GovEA instanceRole column.
 
+import { createRbac } from '@govcore/rbac'
 import type { User } from '@/db/schema'
-import {
-  type Role,
-  type Permission,
-  ROLE_HIERARCHY,
-  hasPermission,
-  roleAtLeast,
-  roleCanEdit,
-  roleIsAdmin,
-} from '@govea/core'
 
-export type { Role, Permission }
-export { ROLE_HIERARCHY, hasPermission }
+export type Role = 'admin' | 'contributor' | 'viewer'
+
+export type Permission =
+  | 'content:read'
+  | 'content:create'
+  | 'content:edit'
+  | 'content:delete'
+  | 'content:publish'
+  | 'users:manage'
+  | 'settings:manage'
+
+const rolePermissions: Record<Role, Permission[]> = {
+  admin: [
+    'content:read',
+    'content:create',
+    'content:edit',
+    'content:delete',
+    'content:publish',
+    'users:manage',
+    'settings:manage',
+  ],
+  contributor: ['content:read', 'content:create', 'content:edit', 'content:publish'],
+  viewer: ['content:read'],
+}
+
+const hierarchy: Record<Role, number> = {
+  admin: 3,
+  contributor: 2,
+  viewer: 1,
+}
+
+export const rbac = createRbac<Role, Permission>({ rolePermissions, hierarchy })
+
+export function hasPermission(role: Role, permission: Permission): boolean {
+  return rbac.hasPermission(role, permission)
+}
 
 export function hasRole(user: Pick<User, 'role'>, minimum: Role): boolean {
-  return roleAtLeast(user.role, minimum)
+  return rbac.roleAtLeast(user.role, minimum)
 }
 
 export function canEdit(user: Pick<User, 'role'>): boolean {
-  return roleCanEdit(user.role)
+  return rbac.roleAtLeast(user.role, 'contributor')
 }
 
 export function isAdmin(user: Pick<User, 'role'>): boolean {
-  return roleIsAdmin(user.role)
+  return user.role === 'admin'
 }
 
 export function isInstanceAdmin(user: { instanceRole?: string | null }): boolean {

--- a/apps/govea/src/lib/security-policy.ts
+++ b/apps/govea/src/lib/security-policy.ts
@@ -12,17 +12,17 @@
  * controls off.
  */
 import { db } from '@/db/client'
-import { organizations, DEFAULT_SECURITY_SETTINGS } from '@/db/schema'
+import { organizationSettings, DEFAULT_SECURITY_SETTINGS } from '@/db/schema'
 import type { SecuritySettings } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 
 export async function getOrgSecuritySettings(orgId: string | null): Promise<SecuritySettings> {
   if (!orgId) return mergeWithDefaults(undefined)
-  const org = await db.query.organizations.findFirst({
-    where: eq(organizations.id, orgId),
+  const settings = await db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
     columns: { securitySettings: true },
   })
-  return mergeWithDefaults(org?.securitySettings)
+  return mergeWithDefaults(settings?.securitySettings)
 }
 
 /**

--- a/apps/govea/tests/integration/backup-export.test.ts
+++ b/apps/govea/tests/integration/backup-export.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db/client'
-import { organizations, personas } from '@/db/schema'
+import { organizationSettings, personas } from '@/db/schema'
 import {
   buildRecipeExport,
   buildContentExport,
@@ -159,8 +159,8 @@ describe('exclude discipline', () => {
 describe('recordExport', () => {
   it('updates lastExportAt + lastExportBytes on the org row', async () => {
     await recordExport(orgA.id, 12345)
-    const after = await db.query.organizations.findFirst({
-      where: eq(organizations.id, orgA.id),
+    const after = await db.query.organizationSettings.findFirst({
+      where: eq(organizationSettings.organizationId, orgA.id),
       columns: { lastExportAt: true, lastExportBytes: true },
     })
     expect(after?.lastExportBytes).toBe(12345)

--- a/apps/govea/tests/integration/backup-import.test.ts
+++ b/apps/govea/tests/integration/backup-import.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { eq, and } from 'drizzle-orm'
 import { db } from '@/db/client'
 import {
-  organizations, personas, capabilities,
+  organizationSettings, personas, capabilities,
   strategies, strategyGoals, strategyCapabilities,
   crossOrgLinks, auditLog,
 } from '@/db/schema'
@@ -249,8 +249,8 @@ describe('audit log', () => {
 describe('recordImport', () => {
   it('updates lastImportAt + lastImportBytes', async () => {
     await recordImport(orgA.id, 67890)
-    const row = await db.query.organizations.findFirst({
-      where: eq(organizations.id, orgA.id),
+    const row = await db.query.organizationSettings.findFirst({
+      where: eq(organizationSettings.organizationId, orgA.id),
       columns: { lastImportAt: true, lastImportBytes: true },
     })
     expect(row?.lastImportBytes).toBe(67890)

--- a/apps/govea/tests/integration/completeness-settings.test.ts
+++ b/apps/govea/tests/integration/completeness-settings.test.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import { db } from '@/db/client'
 import {
-  organizations,
+  organizationSettings,
   DEFAULT_COMPLETENESS_SETTINGS,
 } from '@/db/schema'
 import { getConfidenceSummary, isVisibleToAudience } from '@/lib/confidence'
@@ -90,7 +90,7 @@ describe('isVisibleToAudience', () => {
 
 describe('getConfidenceSummary audience parameter', () => {
   it('returns shouldShow=false when public visibility is off', async () => {
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({
         confidenceSettings: {
           enabled: true,
@@ -100,7 +100,7 @@ describe('getConfidenceSummary audience parameter', () => {
           publicVisibility: false,
         },
       })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
 
     const auth = await getConfidenceSummary(org.id, 'authenticated')
     const pub = await getConfidenceSummary(org.id, 'public')
@@ -109,7 +109,7 @@ describe('getConfidenceSummary audience parameter', () => {
   })
 
   it('returns shouldShow=true for public when both flags are on', async () => {
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({
         confidenceSettings: {
           enabled: true,
@@ -119,14 +119,14 @@ describe('getConfidenceSummary audience parameter', () => {
           publicVisibility: true,
         },
       })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
 
     const pub = await getConfidenceSummary(org.id, 'public')
     expect(pub.shouldShow).toBe(true)
   })
 
   it('legacy enabled=true row remains visible to authenticated callers', async () => {
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({
         confidenceSettings: {
           enabled: true,
@@ -135,7 +135,7 @@ describe('getConfidenceSummary audience parameter', () => {
           // No authenticatedVisibility / publicVisibility — legacy row shape
         },
       })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
 
     const auth = await getConfidenceSummary(org.id, 'authenticated')
     expect(auth.shouldShow).toBe(true)
@@ -145,7 +145,7 @@ describe('getConfidenceSummary audience parameter', () => {
   })
 
   it('default audience is authenticated', async () => {
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({
         confidenceSettings: {
           enabled: true,
@@ -155,7 +155,7 @@ describe('getConfidenceSummary audience parameter', () => {
           publicVisibility: false,
         },
       })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
 
     const defaultCall = await getConfidenceSummary(org.id)
     const explicitAuth = await getConfidenceSummary(org.id, 'authenticated')

--- a/apps/govea/tests/integration/completeness-signals.test.ts
+++ b/apps/govea/tests/integration/completeness-signals.test.ts
@@ -22,7 +22,7 @@ import { db } from '@/db/client'
 import {
   capabilities, applications, personas,
   applicationCapabilities, capabilityPersonas,
-  organizations,
+  organizationSettings,
   DEFAULT_COMPLETENESS_SETTINGS,
 } from '@/db/schema'
 import {
@@ -39,9 +39,9 @@ let org: TestOrg
 
 beforeAll(async () => {
   org = await createTestOrg({ name: 'Signals Org', slug: `sig-${randomUUID().slice(0, 8)}` })
-  await db.update(organizations)
+  await db.update(organizationSettings)
     .set({ completenessSettings: DEFAULT_COMPLETENESS_SETTINGS })
-    .where(eq(organizations.id, org.id))
+    .where(eq(organizationSettings.organizationId, org.id))
 })
 
 afterAll(async () => {
@@ -224,14 +224,14 @@ describe('getMostNeededActions', () => {
 describe('getDomainRagBuckets', () => {
   beforeEach(async () => {
     // Set domain targets: 'cms' = 60, 'ea' = 80, 'finance' has no target
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({
         completenessSettings: {
           ...DEFAULT_COMPLETENESS_SETTINGS,
           domainTargets: { cms: 60, ea: 80 },
         },
       })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
   })
 
   it('green when published-rate ≥ target', async () => {

--- a/apps/govea/tests/integration/completeness-snapshot.test.ts
+++ b/apps/govea/tests/integration/completeness-snapshot.test.ts
@@ -21,7 +21,7 @@ import {
   capabilities, applications, personas, valueStreams,
   strategicObjectives, principles, glossaryTerms, initiatives, adrs,
   completenessSnapshots,
-  organizations,
+  organizationSettings,
 } from '@/db/schema'
 import {
   recomputeCompletenessSnapshot,
@@ -64,9 +64,9 @@ beforeAll(async () => {
   await seedOrgContent(org.id)
   // Mark the org's confidenceSettings enabled so getConfidenceSummary returns real data
   await db
-    .update(organizations)
+    .update(organizationSettings)
     .set({ confidenceSettings: ENABLED_CONFIDENCE })
-    .where(eq(organizations.id, org.id))
+    .where(eq(organizationSettings.organizationId, org.id))
 })
 
 afterAll(async () => {

--- a/apps/govea/tests/integration/completeness-trend.test.ts
+++ b/apps/govea/tests/integration/completeness-trend.test.ts
@@ -16,7 +16,7 @@ import { and, eq, lt } from 'drizzle-orm'
 import { db } from '@/db/client'
 import {
   capabilities, applications,
-  organizations,
+  organizationSettings,
   completenessSnapshots,
   auditLog,
   DEFAULT_COMPLETENESS_SETTINGS,
@@ -54,9 +54,9 @@ function dateNDaysAgo(n: number): Date {
 
 beforeAll(async () => {
   org = await createTestOrg({ name: 'Trend Org', slug: `trend-${randomUUID().slice(0, 8)}` })
-  await db.update(organizations)
+  await db.update(organizationSettings)
     .set({ completenessSettings: DEFAULT_COMPLETENESS_SETTINGS })
-    .where(eq(organizations.id, org.id))
+    .where(eq(organizationSettings.organizationId, org.id))
 })
 
 afterAll(async () => {
@@ -129,9 +129,9 @@ describe('recomputeCompletenessSnapshot — suppression transition audit', () =>
 
   beforeEach(async () => {
     // Set the org to enabled with a 50% suppression threshold for these tests.
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({ confidenceSettings: { enabled: true, narrative: null, suppressBelowPercent: 50, authenticatedVisibility: true, publicVisibility: false } })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
     // audit_log is append-only at the DB level (#417), so we can't delete
     // between tests — capture the baseline count and assert on the delta.
     baseline = await readTransitionAuditCount()
@@ -250,9 +250,9 @@ describe('recomputeCompletenessSnapshot — suppression transition audit', () =>
   })
 
   it('does NOT write an audit row when authenticated visibility is off', async () => {
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({ confidenceSettings: { enabled: false, narrative: null, suppressBelowPercent: 50, authenticatedVisibility: false, publicVisibility: false } })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizationSettings.organizationId, org.id))
 
     await db.insert(completenessSnapshots).values({
       organizationId: org.id,

--- a/apps/govea/tests/integration/helpers/db.ts
+++ b/apps/govea/tests/integration/helpers/db.ts
@@ -10,7 +10,7 @@
  */
 import { db } from '@/db/client'
 import {
-  organizations, users, capabilities, initiatives, adrs, auditLog,
+  organizations, organizationSettings, users, capabilities, initiatives, adrs, auditLog,
   personas, applications, strategicObjectives, principles, valueStreams, services,
   glossaryTerms, strategies, strategyGoals, goals,
 } from '@/db/schema'
@@ -45,8 +45,12 @@ export async function createTestOrg(
 
   const [org] = await db
     .insert(organizations)
-    .values({ id: randomUUID(), name, slug, theme: 'govea', enabledModules: {} })
+    .values({ id: randomUUID(), name, slug })
     .returning()
+
+  await db
+    .insert(organizationSettings)
+    .values({ organizationId: org.id, theme: 'govea', enabledModules: {} })
 
   return { id: org.id, name: org.name, slug: org.slug }
 }
@@ -116,6 +120,13 @@ export function makeSession(user: TestUser, overrides?: { instanceRole?: 'instan
 export async function findOrg(orgId: string) {
   return db.query.organizations.findFirst({
     where: eq(organizations.id, orgId),
+  })
+}
+
+/** Returns the org's settings sidecar row (theme, modules, policy, etc.). */
+export async function findOrgSettings(orgId: string) {
+  return db.query.organizationSettings.findFirst({
+    where: eq(organizationSettings.organizationId, orgId),
   })
 }
 

--- a/apps/govea/tests/integration/instance-actions.test.ts
+++ b/apps/govea/tests/integration/instance-actions.test.ts
@@ -19,12 +19,12 @@ import {
   suspendUserAccount, reactivateUserAccount,
 } from '@/actions/instance'
 import { db } from '@/db/client'
-import { breakGlassSessions, auditLog, instanceSettings, organizations, users, userOrganizationMemberships } from '@/db/schema'
+import { breakGlassSessions, auditLog, instanceSettings, organizationSettings, users, userOrganizationMemberships } from '@/db/schema'
 import { eq, and, isNull, or, desc } from 'drizzle-orm'
 import { getEnabledModules } from '@/lib/get-enabled-modules'
 import { getPlatformAuditEvents } from '@/lib/audit-view'
 import {
-  createTestOrg, createTestUser, cleanupOrg, makeSession, findOrg, findUser,
+  createTestOrg, createTestUser, cleanupOrg, makeSession, findOrgSettings, findUser,
   type TestUser,
 } from './helpers/db'
 
@@ -183,7 +183,7 @@ describe('suspendOrg', () => {
     asInstanceAdmin()
     await suspendOrg(targetOrgId, 'Non-payment')
 
-    const org = await findOrg(targetOrgId)
+    const org = await findOrgSettings(targetOrgId)
     expect(org!.suspendedAt).not.toBeNull()
     expect(org!.suspendedReason).toBe('Non-payment')
   })
@@ -206,7 +206,7 @@ describe('unsuspendOrg', () => {
     asInstanceAdmin()
     await unsuspendOrg(targetOrgId)
 
-    const org = await findOrg(targetOrgId)
+    const org = await findOrgSettings(targetOrgId)
     expect(org!.suspendedAt).toBeNull()
     expect(org!.suspendedReason).toBeNull()
   })
@@ -260,9 +260,9 @@ describe('setInstanceModuleAvailability', () => {
   it('forces the module off for an org even when the org enabled it', async () => {
     asInstanceAdmin()
 
-    await db.update(organizations)
+    await db.update(organizationSettings)
       .set({ enabledModules: { personas: true }, updatedAt: new Date() })
-      .where(eq(organizations.id, orgId))
+      .where(eq(organizationSettings.organizationId, orgId))
 
     await setInstanceModuleAvailability('personas', false)
 

--- a/apps/govea/tests/integration/instance-hardening.test.ts
+++ b/apps/govea/tests/integration/instance-hardening.test.ts
@@ -49,6 +49,7 @@ import {
   auditLog,
   instanceSettings,
   organizations,
+  organizationSettings,
   users as usersTable,
 } from '@/db/schema'
 import { eq, and, isNull, or } from 'drizzle-orm'
@@ -59,7 +60,7 @@ import {
   createTestUser,
   cleanupOrg,
   makeSession,
-  findOrg,
+  findOrgSettings,
   findUser,
   type TestUser,
 } from './helpers/db'
@@ -245,16 +246,20 @@ describe('grantBreakGlass — multiple concurrent grants', () => {
 
 describe('suspendOrg — edge cases', () => {
   it('refuses to suspend the system org', async () => {
-    // Create a system org directly — createTestOrg does not support isSystemOrg
+    // Create a system org directly — createTestOrg does not support isSystemOrg.
+    // isSystemOrg lives in the settings sidecar now, so create both rows.
     const [sysOrg] = await db
       .insert(organizations)
       .values({
         id: randomUUID(),
         name: 'Hardening Test System Org',
         slug: `sys-org-${randomUUID().slice(0, 8)}`,
-        isSystemOrg: true,
       })
       .returning()
+    await db.insert(organizationSettings).values({
+      organizationId: sysOrg.id,
+      isSystemOrg: true,
+    })
 
     try {
       asAdmin(adminA)
@@ -280,15 +285,15 @@ describe('suspendOrg — edge cases', () => {
     await suspendOrg(targetOrgId, 'Isolation test')
 
     // bystander org must remain untouched
-    const bystander = await findOrg(bystander0rgId)
+    const bystander = await findOrgSettings(bystander0rgId)
     expect(bystander!.suspendedAt).toBeNull()
     expect(bystander!.suspendedReason).toBeNull()
 
     // Clean up
     await db
-      .update(organizations)
+      .update(organizationSettings)
       .set({ suspendedAt: null, suspendedReason: null, updatedAt: new Date() })
-      .where(eq(organizations.id, targetOrgId))
+      .where(eq(organizationSettings.organizationId, targetOrgId))
   })
 })
 
@@ -374,7 +379,7 @@ describe('updateOrgGovernance', () => {
       internalNotes: 'Hardening test notes',
     })
 
-    const org = await findOrg(targetOrgId)
+    const org = await findOrgSettings(targetOrgId)
     expect(org!.supportTier).toBe('premium')
     expect(org!.internalNotes).toBe('Hardening test notes')
   })
@@ -421,7 +426,7 @@ describe('updateOrgGovernance', () => {
       internalNotes: '  trimmed notes  ',
     })
 
-    const org = await findOrg(targetOrgId)
+    const org = await findOrgSettings(targetOrgId)
     expect(org!.supportTier).toBe('community')
     expect(org!.internalNotes).toBe('trimmed notes')
   })
@@ -433,7 +438,7 @@ describe('updateOrgGovernance', () => {
       internalNotes: '   ',
     })
 
-    const org = await findOrg(targetOrgId)
+    const org = await findOrgSettings(targetOrgId)
     expect(org!.supportTier).toBeNull()
     expect(org!.internalNotes).toBeNull()
   })

--- a/apps/govea/tests/integration/rbac-single-source.test.ts
+++ b/apps/govea/tests/integration/rbac-single-source.test.ts
@@ -1,48 +1,33 @@
 /**
- * RBAC single-source-of-truth regression test (#34).
+ * RBAC single-source-of-truth regression test.
  *
- * Asserts that:
- *   1. The canonical RBAC types and constants live in @govea/core/rbac.
- *   2. apps/govea/src/lib/rbac.ts re-exports the same types and constants
- *      from @govea/core (functional equivalence on Permission checks).
- *   3. The app-side rbac module does NOT redefine ROLE_PERMISSIONS or
- *      ROLE_HIERARCHY locally — a literal string check guards against the
- *      duplication coming back the next time someone edits the file.
+ * Phase 0 of the GovCore cutover: the RBAC machinery now lives in
+ * @govcore/rbac (createRbac). GovEA's role/permission definitions are
+ * app-local (GovEA-specific); the generic engine is the shared source.
  *
- * If this test fails after a refactor, you have either:
- *   - changed the role/permission shape without updating @govea/core
- *     (fix: update the canonical definitions and re-run the test), or
- *   - re-introduced parallel definitions in the app's rbac module
- *     (fix: import from @govea/core instead).
+ * Verifies:
+ *   1. The rbac instance's permission checks are correct.
+ *   2. User-shaped helpers in lib/rbac.ts delegate to the rbac instance.
+ *   3. isInstanceAdmin remains app-local (depends on GovEA user shape).
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import * as core from '@govea/core'
 import * as appRbac from '@/lib/rbac'
 
-describe('RBAC single source of truth', () => {
-  it('re-exports Permission check from @govea/core', () => {
+describe('RBAC single source of truth (@govcore/rbac)', () => {
+  it('hasPermission returns correct results', () => {
     expect(appRbac.hasPermission('admin', 'users:manage')).toBe(true)
     expect(appRbac.hasPermission('contributor', 'users:manage')).toBe(false)
     expect(appRbac.hasPermission('viewer', 'content:read')).toBe(true)
     expect(appRbac.hasPermission('viewer', 'content:create')).toBe(false)
   })
 
-  it('app-side hasPermission delegates to core (identical references)', () => {
-    // appRbac re-exports `hasPermission` from core, so the function
-    // reference must be identical.
-    expect(appRbac.hasPermission).toBe(core.hasPermission)
+  it('rbac instance has correct role hierarchy', () => {
+    expect(appRbac.rbac.hierarchy.admin).toBe(3)
+    expect(appRbac.rbac.hierarchy.contributor).toBe(2)
+    expect(appRbac.rbac.hierarchy.viewer).toBe(1)
   })
 
-  it('app-side ROLE_HIERARCHY delegates to core', () => {
-    expect(appRbac.ROLE_HIERARCHY).toBe(core.ROLE_HIERARCHY)
-    expect(appRbac.ROLE_HIERARCHY.admin).toBe(3)
-    expect(appRbac.ROLE_HIERARCHY.contributor).toBe(2)
-    expect(appRbac.ROLE_HIERARCHY.viewer).toBe(1)
-  })
-
-  it('app-side user-shaped helpers wrap the core role-level checks', () => {
+  it('user-shaped helpers wrap the rbac instance', () => {
     const admin = { role: 'admin' as const }
     const contributor = { role: 'contributor' as const }
     const viewer = { role: 'viewer' as const }
@@ -62,18 +47,5 @@ describe('RBAC single source of truth', () => {
     expect(appRbac.isInstanceAdmin({ instanceRole: 'instance_admin' })).toBe(true)
     expect(appRbac.isInstanceAdmin({ instanceRole: null })).toBe(false)
     expect(appRbac.isInstanceAdmin({})).toBe(false)
-  })
-
-  it('does not redefine ROLE_PERMISSIONS or ROLE_HIERARCHY in the app rbac source', () => {
-    // String-level guard: blocks the duplicated-definition pattern from
-    // creeping back in. Catches "const ROLE_PERMISSIONS" / "const
-    // ROLE_HIERARCHY" anywhere in the app's rbac module.
-    const source = readFileSync(
-      join(__dirname, '..', '..', 'src', 'lib', 'rbac.ts'),
-      'utf-8',
-    )
-
-    expect(source).not.toMatch(/^\s*(?:export\s+)?const\s+ROLE_PERMISSIONS\b/m)
-    expect(source).not.toMatch(/^\s*(?:export\s+)?const\s+ROLE_HIERARCHY\s*[:=]/m)
   })
 })

--- a/apps/govea/tests/integration/security-settings.test.ts
+++ b/apps/govea/tests/integration/security-settings.test.ts
@@ -17,7 +17,7 @@
 import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { db } from '@/db/client'
 import {
-  organizations, users, auditLog,
+  organizationSettings, users, auditLog,
   DEFAULT_SECURITY_SETTINGS,
 } from '@/db/schema'
 import { and, eq } from 'drizzle-orm'
@@ -98,7 +98,7 @@ describe('security settings (#527)', () => {
     // Submit a deliberately hostile passwordMinLength of -1; expect clamp to 6.
     const fd = policyFormData({ passwordMinLength: -1, requireDigit: 'on', sessionTimeoutMinutes: 2 })
     await saveSecuritySettings(fd)
-    const org = await db.query.organizations.findFirst({ where: eq(organizations.id, orgId) })
+    const org = await db.query.organizationSettings.findFirst({ where: eq(organizationSettings.organizationId, orgId) })
     expect(org?.securitySettings?.passwordMinLength).toBe(6)
     expect(org?.securitySettings?.requireDigit).toBe(true)
     expect(org?.securitySettings?.sessionTimeoutMinutes).toBe(5) // clamped from 2 → min 5

--- a/apps/govea/tests/integration/seed-cleanup.test.ts
+++ b/apps/govea/tests/integration/seed-cleanup.test.ts
@@ -52,8 +52,6 @@ describe('removeRetiredOrgs', () => {
     const [org] = await db.insert(organizations).values({
       name: 'Retired Test Org',
       slug,
-      theme: 'govea',
-      enabledModules: {},
     }).returning()
 
     // Cascade test: a user row + a capability row that point at the org.
@@ -95,8 +93,6 @@ describe('removeRetiredOrgs', () => {
     await db.insert(organizations).values({
       name: 'Retired Idempotent',
       slug,
-      theme: 'govea',
-      enabledModules: {},
     })
 
     const first = await removeRetiredOrgs([slug])

--- a/apps/govea/tests/integration/settings.test.ts
+++ b/apps/govea/tests/integration/settings.test.ts
@@ -11,7 +11,7 @@ import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from 'vites
 import { setModuleEnabled, updateOrgTheme } from '@/actions/settings'
 import {
   createTestOrg, createTestUser, cleanupOrg,
-  makeSession, findOrg, getAuditLogs,
+  makeSession, findOrgSettings, getAuditLogs,
   type TestUser,
 } from './helpers/db'
 
@@ -44,14 +44,14 @@ describe('settings / setModuleEnabled', () => {
 
   it('admin can disable a module', async () => {
     await setModuleEnabled('personas', false)
-    const org = await findOrg(orgId)
+    const org = await findOrgSettings(orgId)
     expect(org?.enabledModules?.['personas']).toBe(false)
   })
 
   it('admin can re-enable a disabled module', async () => {
     await setModuleEnabled('personas', false)
     await setModuleEnabled('personas', true)
-    const org = await findOrg(orgId)
+    const org = await findOrgSettings(orgId)
     expect(org?.enabledModules?.['personas']).toBe(true)
   })
 
@@ -60,7 +60,7 @@ describe('settings / setModuleEnabled', () => {
     await setModuleEnabled('personas', false)
     await setModuleEnabled('personas', true)
 
-    const org = await findOrg(orgId)
+    const org = await findOrgSettings(orgId)
     // personas re-enabled, capabilities still off
     expect(org?.enabledModules?.['personas']).toBe(true)
     expect(org?.enabledModules?.['capabilities']).toBe(false)
@@ -90,7 +90,7 @@ describe('settings / setModuleEnabled', () => {
 
   it('records before=true for keys not yet in enabledModules (absent-key semantics)', async () => {
     // glossary should not yet be in the record for a fresh test org
-    const org = await findOrg(orgId)
+    const org = await findOrgSettings(orgId)
     expect(org?.enabledModules?.['glossary']).toBeUndefined()
 
     const _before = await getAuditLogs(orgId, 'settings.module_toggled')
@@ -146,7 +146,7 @@ describe('settings / updateOrgTheme', () => {
     mockAuth.mockResolvedValue(makeSession(admin))
     await updateOrgTheme('servicenow')
 
-    const org = await findOrg(orgId)
+    const org = await findOrgSettings(orgId)
     expect(org?.theme).toBe('servicenow')
   })
 

--- a/docs/design/platform-core-extraction.md
+++ b/docs/design/platform-core-extraction.md
@@ -1,0 +1,898 @@
+# Platform Core Extraction — Reusable Multi-Tenant Foundation
+
+**Initiative:** GovCore — a standalone platform-core initiative (its own repo, backlog, versioning, and release lifecycle), independent of GovEA's roadmap. GovEA is the first consumer, not the owner.
+**Status:** Proposal — core decisions locked; Phase 0–1 work breakdown in §12
+**Author:** AI-assisted · drafted 2026-06-19 · last updated 2026-06-21
+**Audience:** Maintainer + architecture reviewers
+**License:** MIT (§11.7)
+**Supersedes:** the skeletal `packages/core` (`@govea/core`) as the long-term home for platform-plane code
+
+> **Single planning record.** Because GovCore is a separate initiative whose repository does not
+> exist yet, *this document is the one and only place the work is tracked* — design, decisions, and
+> work breakdown all live here. Nothing is filed as a GovEA issue, milestone, or ADR.
+>
+> **What's settled:** the decisions in the table below are locked, including the code-review
+> hardening (§13) — database-enforced tenant isolation (RLS + two-role DB), a generic `createRbac`,
+> and (2026-06-21) building the full content engine (Appendix B). §11's open list is now effectively
+> closed. Binding decisions are recorded here; they can graduate into the GovCore repo's own ADRs
+> once it exists.
+
+---
+
+## 1. Summary
+
+GovEA already contains a production-grade, multi-tenant **platform plane** — identity, organizations, memberships + active-org resolution, RBAC, audit, federation, and support-access (break-glass / act-as) sessions. Today that machinery is fused into `apps/govea/src`, and the only shared package (`@govea/core`) holds thin pure-function stubs (role tables, an audit-event shape, a content-type registry, a workflow state machine).
+
+This document proposes extracting the platform plane into a **separate, versioned repository** so GovEA and future multi-tenant apps consume it as published packages rather than re-implementing tenancy, auth, and audit each time.
+
+The design is deliberately **opinionated**: it assumes the GovEA stack (Next.js App Router + Drizzle + PostgreSQL + Auth.js). That trades portability for batteries-included reuse — a new same-stack app should be able to stand up a secure multi-tenant skeleton in well under a day.
+
+### Decisions locked for this proposal
+
+These were chosen explicitly and frame everything below:
+
+| Decision | Choice | Consequence |
+|---|---|---|
+| **Distribution** | Separate dedicated repo, now | Published, semver'd packages; cross-repo release discipline |
+| **Scope** | Platform plane **+ content engine** | Identity, tenancy, RBAC, audit, federation, support sessions — *plus* a comprehensive content engine (Appendix B). An app's specific entity *definitions* still live app-side, as configuration on top of the engine |
+| **Content modeling** | Build the **full content engine**, aiming to **model every content type** | `@govcore/content` compiles type definitions → real Drizzle tables + migrations, with relationships, computed fields, and per-type code hooks as first-class; generated actions/UI; recipes. Built **after** the platform-plane v1 as GovCore's second milestone. Decided 2026-06-21 — see Appendix B |
+| **Stack coupling** | Opinionated — assume the stack | Core ships ready-to-use Drizzle schema, Auth.js config, server actions, middleware |
+| **DB ownership** | Core owns the **platform tables *and* their migrations** | Core ships versioned migrations + a migrate runner for the platform schema; the app owns only its domain tables and their migrations. Removes the cross-app drift class |
+| **Tenant data portability** | Core owns **backup / restore to file** | Core ships the whole-tenant export/restore engine; the app registers which of its domain tables participate |
+| **Tenant isolation** | **Database-enforced (Postgres RLS) + two DB roles**, adopted at the Phase 1 cutover | Org boundary enforced by RLS policies + a transaction-local org GUC, not by app convention; owner/DDL role vs. non-owner runtime role. Commits all tenant DB access to run inside a tenant transaction. See §13.1–13.2 |
+| **RBAC shape** | **Generic `createRbac`** over an app-supplied role/permission map | Core ships the role machinery parameterized by the app's types; GovEA's `admin/contributor/viewer` map is the default export. See §13.3 |
+
+---
+
+## 1a. Architecture at a glance
+
+### Layering — what sits on what
+
+GovCore is the foundation layer; each app is a thin domain + UI layer composed on top. The app never re-implements the platform plane — it *configures* it.
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│  CONSUMER APP  (e.g. GovEA) — owns domain + UI                     │
+│                                                                    │
+│   UI / pages          Domain entities         Domain actions       │
+│   (brand theme)       capabilities, goals…     (tenantAction)       │
+│        │                    │                       │              │
+│        └──────────►  Composition layer  ◄───────────┘              │
+│              schema compose · createAuth() · createMiddleware()    │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │  depends on / configures (never reimplements)
+                             ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  GOVCORE   @govcore/*   — platform plane (reusable)                │
+│                                                                    │
+│   auth    middleware   tenancy   rbac   audit   federation         │
+│   support     backup      nextkit       theme (WCAG-AA)            │
+│                              │                                      │
+│       @govcore/schema  (table defs + platform migrations)          │
+└────────────────────────────┬─────────────────────────────────────┘
+                             ▼
+                  ┌─────────────────────────┐
+                  │      PostgreSQL         │
+                  │  platform tables +      │
+                  │  app domain tables      │
+                  └─────────────────────────┘
+```
+
+### Package dependency graph (no cycles)
+
+The DB-free packages (`schema`, `rbac`, `theme`, and `middleware`'s runtime) stay edge-safe so they can be imported into Next middleware without dragging in a DB client — this is what protects ADR-0003.
+
+```text
+EDGE-SAFE / DB-FREE  (importable in Next middleware, no DB client):
+   @govcore/schema       →  (no deps)
+   @govcore/rbac         →  (no deps)
+   @govcore/theme        →  (no deps)
+
+DB-TOUCHING:
+   @govcore/audit        →  schema
+   @govcore/tenancy      →  schema, rbac
+   @govcore/auth         →  schema, tenancy, rbac, audit
+   @govcore/federation   →  schema, tenancy, audit
+   @govcore/support      →  schema, tenancy, audit
+   @govcore/backup       →  schema, tenancy, audit
+
+NEXT.JS GLUE:
+   @govcore/middleware   →  auth, tenancy        (TYPES ONLY — stays edge-safe)
+   @govcore/nextkit      →  auth, tenancy, rbac, audit, federation, support, theme
+
+Arrows = "depends on". No cycles. The three edge-safe packages never import a
+DB client, which is what keeps middleware ADR-0003-compliant.
+```
+
+### Request lifecycle — the enforced tenant boundary
+
+Every authenticated mutation flows through the same gates, all owned by GovCore. The app supplies only the domain logic in the middle.
+
+```text
+Browser
+  │  request + session cookie
+  ▼
+@govcore/middleware ─────────────────────────────────────────────────
+  • read-only token decode (ADR-0003 — never writes session cookies)
+  • resurrection guard (#782) · maintenance · password-expiry routing
+  │
+  ├─ blocked / unauthenticated ──►  redirect to /login
+  │
+  └─ allowed ▼
+Server action (app)  ── wrapped in @govcore/nextkit tenantAction ─────
+  │
+  ├─►  @govcore/tenancy: resolveActiveMembership
+  │        └─ DB ──►  { organizationId, role }   (NEVER from caller input)
+  │
+  ├─►  @govcore/rbac gate:  hasPermission(role, 'content:edit')
+  │
+  ├─►  DB query/mutate   WHERE id = ?  AND organization_id = ?
+  │        └─ cross-org rows are invisible
+  │
+  └─►  @govcore/audit:  append-only INSERT
+           └─ Postgres trigger blocks UPDATE/DELETE (#417)
+  │
+  ▼
+Result ──►  Browser
+```
+
+---
+
+## 2. The core / app boundary
+
+The cleanest way to think about this: **the platform plane knows about *tenants, identity, and trust*. It knows nothing about *enterprise architecture*.** The boundary is a "who can do what, in which org, and how do we prove it" line.
+
+### In core (extract)
+
+Mapped to the real GovEA modules that move:
+
+| Capability | Today in GovEA | Notes for extraction |
+|---|---|---|
+| **Identity & auth** | `lib/auth.ts`, `lib/auth.config.ts`, `lib/sso-guard.ts`, `lib/password.ts`, `schema/users.ts` (`users`, `accounts`, `sessions`, `verificationTokens`) | Local credentials + OIDC SSO. Provider must be **configurable** — today it hard-imports `microsoft-entra-id`; core takes providers as input |
+| **Multi-tenancy** | `schema/organizations.ts`, `userOrganizationMemberships`, `lib/active-membership.ts`, `lib/membership-guards.ts`, `lib/membership-sync.ts`, `actions/active-org.ts`, `actions/memberships.ts` | The membership model + active-org resolution (#693) is the heart of tenancy. This is the highest-value extraction |
+| **RBAC** | `@govea/core/rbac` (already shared) + `lib/rbac.ts` wrappers | Role math is already in the package — but it **hardcodes GovEA's `admin/contributor/viewer` roles and 7-permission map.** "Promote it" is not enough: core must ship the machinery *generic over an app-supplied role/permission map* so a second app can define its own roles. See §13.3 |
+| **Audit** | `@govea/core/audit` (shape) + `lib/audit.ts` (writer), `lib/audit-view.ts`, `schema/audit.ts`, `db/sql/audit-immutable.sql` | Ship the writer **and** the append-only Postgres trigger SQL. Append-only at the DB layer (#417) is a security property, not an app detail |
+| **Federation** | `lib/federation.ts`, `lib/cross-org-link-helpers.ts`, `schema/federation.ts` (`org_connections`, `cross_org_links`), `actions/connections.ts`, `actions/cross-org-links.ts` | Visibility enum (`org` / `connections` / `instance`) and cross-org link rules |
+| **Support access** | `lib/break-glass.ts`, `lib/act-as.ts`, `schema/break-glass-sessions.ts`, `schema/act-as-sessions.ts`, `actions/act-as.ts`, `lib/instance-admin.ts` | Break-glass + act-as, instance-admin separation |
+| **Route protection** | `middleware.ts`, `lib/logout-marker.ts`, `lib/auth-redirect.ts`, `lib/request-context.ts`, `lib/security-policy.ts`; security response headers in `next.config.ts` (#743) | The hard-won security edge cases (ADR-0003 read-only token decode, #782 resurrection guard, #720 XFF anti-spoofing, #807 bind-address leak) are *exactly* what you don't want re-derived per app. CSP is **report-only** today; extract it as enforced + nonce-based (§13.6) |
+| **Instance console primitives** | `schema/instance-settings.ts`, `schema/platform-config.ts`, parts of `actions/instance.ts` | Maintenance mode, instance-level settings |
+| **Accessible base theme** | `lib/themes.ts` base tokens (the `globals.css` `:root`/`.dark` layer), the org-theme value allowlisting (#769), the theme/globals drift guard (#766/#770) | Core ships a **WCAG-AA base theme as the accessibility floor**; apps layer brand add-ons on top but cannot drop below it. See §6.7 |
+| **Tenant backup / restore to file** | `lib/backup-export.ts`, `lib/backup-import.ts`, `actions/backup.ts` | Core owns the whole-tenant **export/restore engine** (archive format, org-scoped extraction, integrity, audit, transactional restore). It walks both core tables and the **app's registered domain tables**. See §6.8 |
+
+### Stays in the app (do not extract)
+
+- **All EA domain entities and their tables**: capabilities, goals, objectives, initiatives, applications, services, personas, principles, ADRs, glossary, data-architecture, value-streams, strategies, architecture-debt.
+- **Domain logic** built on the traceability chain (`completeness-*`, `trace-participants`, `capability-tree`, `impact-analysis`, `duplicate-*`, `debt-*`).
+- **Entity *definitions* (but not the engine that runs them)**: *which* fields a Capability or a Permit has, its relationships, computed fields, and lifecycle hooks live app-side as **configuration** passed to the content engine. The engine itself — content-type registry, the definition→table compiler, workflow/lifecycle, taxonomy, recipes — is **core** (`@govcore/content`, Appendix B), a decision reversed on 2026-06-21. So GovEA still owns *what a Capability is*; GovCore owns *the machinery that turns that definition into tables, validation, actions, and UI*.
+- **Reports, and per-entity CSV import/export** (domain spreadsheet round-trips, `lib/csv.ts`). Distinct from whole-tenant backup/restore, which *is* core (§6.8): CSV import/export is "edit this entity type in a spreadsheet"; backup is "snapshot/move an entire organization." The app does register its domain tables into core's backup engine, but owns its own CSV mappings.
+- **Brand theme add-ons** — an app's own palette/logo/header treatment (GovEA's `govea` and `servicenow` theme defs are app-level add-ons). These *layer on top of* the core base theme and may only override brand vars, never weaken the accessibility floor (§6.7).
+
+### The litmus test
+
+> If a record carries `organization_id` because it is **EA content**, it stays in the app. If a table exists so the platform can answer *"is this actor allowed to act in this org, and did we record it,"* it goes to core.
+
+---
+
+## 3. Repository and package layout
+
+A single new repo, multiple published packages, so consumers depend only on what they use.
+
+**Repo name:** `GovCore`. Packages are published under the **`@govcore/*`** scope. The name deliberately signals "the core that GovEA (and the next gov app) is built on" — it is the foundation, not a GovEA sub-component.
+
+```
+GovCore/                      (new repo)
+├── packages/
+│   ├── schema/        @govcore/schema     table defs + enums + platform MIGRATIONS + migrate runner + trigger SQL
+│   ├── tenancy/       @govcore/tenancy    memberships, active-org resolution, org guards
+│   ├── rbac/          @govcore/rbac       roles, permissions, hierarchy (promote current @govea/core/rbac)
+│   ├── auth/          @govcore/auth       Auth.js config factory, SSO guard, password, session lifecycle
+│   ├── audit/         @govcore/audit      audit writer + view + append-only trigger contract
+│   ├── federation/    @govcore/federation org connections + cross-org links + visibility
+│   ├── support/       @govcore/support    break-glass + act-as + instance-admin
+│   ├── backup/        @govcore/backup     whole-tenant export/restore engine + domain-table registry
+│   ├── middleware/    @govcore/middleware Next middleware factory + logout marker + request context
+│   ├── theme/         @govcore/theme      WCAG-AA base tokens + Tailwind preset + safe theme-var injection
+│   ├── server/        @govcore/server     tenantAction + action context + tenant transaction (see §13.4)
+│   ├── testing/       @govcore/testing    test factories (createTestOrg/User, withActiveMembership) (see §13.4)
+│   ├── nextkit/       @govcore/nextkit    UI primitives + route guards + reusable instance-console React (§11.6) (tenantAction moved to @govcore/server)
+│   └── content/       @govcore/content    content engine: type-def → Drizzle compiler, lifecycle, taxonomy, recipes, generated actions/UI (Appendix B — second milestone)
+├── examples/
+│   └── minimal-app/                          reference consumer; doubles as an e2e fixture
+├── docs/
+└── .changeset/
+```
+
+**Dependency direction (no cycles):**
+
+```
+schema  ──>  (none)        # table defs are dep-free; the migrate runner is a separate entrypoint
+rbac    ──>  (none)
+audit   ──>  schema
+tenancy ──>  schema, rbac
+auth    ──>  schema, tenancy, rbac, audit
+federation ─> schema, tenancy, audit
+support ──>  schema, tenancy, audit
+backup  ──>  schema, tenancy, audit
+middleware ─> auth (types only), tenancy (types only)
+theme   ──>  (none)
+server  ──>  tenancy, rbac, audit              # the lean tenantAction seam (§13.4)
+testing ──>  schema, tenancy, auth             # test factories
+nextkit ──>  server, theme, federation, support, … (UI layer)
+content ──>  schema, tenancy, rbac, audit, server, nextkit   # content engine (Appendix B); built after platform-plane v1
+```
+
+> **Note:** the `@govcore/server` and `@govcore/testing` packages, and the `govcore.*` Postgres-schema namespacing, are refinements from the code-level review in **§13.4**. The §1a diagrams show the pre-§13 conceptual grouping; §3 and §13 are authoritative on final packaging.
+
+Keep `schema`'s **table-definition** export and `rbac` dependency-free so they can be imported into edge/middleware contexts and pure unit tests without dragging in DB clients. `@govcore/schema`'s migrate runner is a **separate entrypoint** (`@govcore/schema/migrate`) that *does* touch the DB — it is never imported by the edge bundle.
+
+### Why separate packages, not one `@govcore/core`
+
+The current `@govea/core` barrel re-exports everything from one entry. That's fine for stubs but becomes a liability the moment middleware (edge-safe, no Node APIs) and the audit writer (needs a DB client) live behind the same import. Splitting lets the edge bundle stay edge-safe and keeps `db`-touching code out of the middleware bundle — which is what ADR-0003 is protecting.
+
+---
+
+## 4. The opinionated stack contract
+
+Core assumes, and declares as **peer dependencies**, the host app provides:
+
+- `next` (App Router), `react`, `react-dom`
+- `next-auth@5` (+ `@auth/drizzle-adapter`)
+- `drizzle-orm` + a `postgres` (or `pg`) client
+- `zod`, `bcryptjs`
+
+Core does **not** bundle these; it expects one resolved copy in the app. Peer deps avoid the "two copies of Auth.js" class of bug and let the app control versions.
+
+What "opinionated" buys the consumer: they don't choose an auth library, an ORM, a tenancy model, or an audit format. They get GovEA's, already hardened. What it costs: an app that wants a different stack gets nothing reusable here — that is the accepted trade for the locked decision.
+
+### Configuration is injected, never hard-coded
+
+A non-negotiable carried over from GovEA's public-repo policy (operator-specific identifiers live in env, not source — see `lib/request-context.ts`'s `GOVEA_TRUSTED_PROXY_HOPS`). Core exposes **factories that take config**, not modules that read global env at import time:
+
+```ts
+// app: src/lib/auth.ts
+import { createAuth } from '@govcore/auth'
+import MicrosoftEntraID from 'next-auth/providers/microsoft-entra-id'
+import { db } from '@/db/client'
+import * as schema from '@/db/schema'
+
+export const { handlers, auth, signIn, signOut } = createAuth({
+  db,
+  schema,                       // app's composed schema (see §5)
+  providers: [MicrosoftEntraID({ /* app-owned secrets */ })],
+  trustedProxyHops: Number(process.env.TRUSTED_PROXY_HOPS ?? 1),
+  ssoGuard: defaultSsoGuard,    // "must map to pre-provisioned active user"
+})
+```
+
+The provider list is the clearest example of why this matters: GovEA's `lib/auth.ts` hard-imports `microsoft-entra-id`, but the *architecture* is "any OIDC provider + local credentials." The factory makes that real instead of aspirational.
+
+---
+
+## 5. Schema model — core owns the platform schema and its migrations
+
+This is the decision that most shapes the DB story, so it gets its own section.
+
+**Core owns the platform tables and their migrations end to end. The app owns its domain tables and their migrations. One database, two migration streams that never overlap.**
+
+`@govcore/schema` ships three things:
+
+1. **Table definitions** (Drizzle objects) — so the app writes type-safe queries and declares foreign keys *to* platform tables. Dependency-free, edge-safe.
+2. **Versioned migrations** for those tables — the exact DDL that creates/alters `organizations`, `users`, `user_organization_memberships`, `audit_log`, `org_connections`, `cross_org_links`, `break_glass_sessions`, `act_as_sessions`, instance settings — plus the append-only audit trigger as a raw-SQL migration step.
+3. **A migrate runner** (`@govcore/schema/migrate`, exposed as a `govcore-migrate` bin) that applies those migrations and records them in a core-owned tracking table (`__govcore_migrations`), kept separate from the app's own Drizzle journal.
+
+```ts
+// @govcore/schema — table definitions the app imports for queries + FKs
+export const visibilityEnum = pgEnum('visibility', ['org', 'connections', 'instance'])
+export const organizations = pgTable('organizations', { /* … */ })
+export const users = pgTable('users', { /* organizationId FK, … */ })
+// memberships, accounts, sessions, auditLog, orgConnections, crossOrgLinks, …
+```
+
+```ts
+// app: src/db/schema/index.ts — re-export core tables, add domain tables that FK to them
+export * from '@govcore/schema'             // organizations, users, memberships, audit_log, …
+import { organizations } from '@govcore/schema'
+
+export const capabilities = pgTable('capabilities', {
+  ...orgScoped(organizations),              // organization_id FK → core's organizations
+  name: text('name').notNull(),
+})
+```
+
+The app's migration job runs **core's migrations first, then its own**:
+
+```jsonc
+// app package.json
+"db:migrate": "govcore-migrate && drizzle-kit migrate"   // platform schema, then domain schema
+```
+
+Core emits the platform DDL; the app never writes or generates it. The app's Drizzle migrations only ever touch its *own* tables (they FK to core tables but don't create them). Because the platform DDL is authored once, in core, and shipped as immutable versioned files, **two consumer apps on the same `@govcore/schema` version have byte-identical platform schemas — the drift class is gone by construction, not by a test.**
+
+### The tenancy column contract
+
+Every tenant-scoped table — core's *and* the app's domain tables — must carry `organization_id uuid not null references organizations(id)`. Core publishes this as a documented contract plus a helper:
+
+```ts
+export const orgScoped = (orgs) => ({
+  organizationId: uuid('organization_id').notNull()
+    .references(() => orgs.id, { onDelete: 'cascade' }),
+})
+```
+
+So an app table becomes `pgTable('capabilities', { ...orgScoped(organizations), name: text(...) })`. Uniform tenant scoping is what makes the §7 query guards safe.
+
+### What core-owned migrations buy — and the one wrinkle
+
+- **No drift, and no conformance test to enforce it.** Because core authors the platform DDL, the app *can't* forget a column, weaken an FK, or skip the trigger — those statements live in core's migrations, not in app code. A lightweight `CORE_SCHEMA_VERSION` (written to `instance_settings` on boot) is still worth keeping for *observability* ("this instance runs platform schema vN"), but it is no longer load-bearing for correctness the way the earlier conformance test would have been.
+- **The append-only audit trigger ships inside a core migration.** Drizzle doesn't manage triggers, but a raw-SQL migration step does. `audit-immutable.sql` (already idempotent in GovEA, #417) becomes a core migration, so immutability is guaranteed by the same mechanism as the tables — not a separate `apply-triggers` step the app might skip.
+- **The pre-production wrinkle.** GovEA today runs `db:push --force` with *no* migration files (ADR-008) — its DB is throwaway pre-production. GovCore cannot work that way: a published library with external consumers and real tenant data is, by definition, past the throwaway stage, so **the platform layer is migration-based from day one.** An app may still `db:push` its *own domain* tables during its own pre-production phase, but it must run `govcore-migrate` for the platform tables. Put plainly: adopting GovCore is the event that trips AI-SESSION-START's "switch to migrations when the first real tenant exists" criterion — for the platform layer specifically. The extraction plan (§9) calls this out so it isn't a surprise.
+
+---
+
+## 6. The seams that make it reusable
+
+The value isn't the tables — it's the **enforced patterns**. Each is exported as a factory or a typed helper so the app can't accidentally bypass it.
+
+### 6.1 Active-organization resolution (the crown jewel)
+
+`resolveActiveMembership` (GovEA `lib/active-membership.ts`) is the single server-side answer to "which org am I acting in right now," feeding the JWT and session. Its selection order (last-selected → primary → oldest active, ignoring revoked memberships) is exactly the kind of rule every multi-tenant app re-derives badly. Core owns it once.
+
+### 6.2 The server-action tenant guard
+
+GovEA's security model (security-and-tenancy.md §"Tenant Boundary") is a five-step pattern every mutating action must follow. Core ships it as a wrapper so it's the path of least resistance:
+
+```ts
+import { tenantAction } from '@govcore/nextkit'
+
+export const renameCapability = tenantAction(
+  { permission: 'content:edit' },
+  async ({ ctx, db }, input) => {
+    // ctx.organizationId + ctx.role already resolved from the ACTIVE membership,
+    // never from caller-supplied values. Role gate already applied.
+    const row = await db.query.capabilities.findFirst({
+      where: and(eq(capabilities.id, input.id),
+                 eq(capabilities.organizationId, ctx.organizationId)), // org filter enforced
+    })
+    // …mutate…
+    await ctx.audit({ action: 'capability.rename', entityType: 'capability', entityId: input.id })
+  },
+)
+```
+
+This bakes in the four security design notes from GovEA: never trust caller-supplied `organizationId`/`role`, resolve role from active membership, load targets by `id` **and** `organization_id`, and write an audit event.
+
+Two things to note about this wrapper:
+
+- It **replaces real duplication.** Today each action file defines its own `requireContributor()` / `requireAdmin()` (e.g. `actions/capabilities.ts` lines 22–34) and repeats the `auth()` → redirect → role-check dance. `tenantAction` collapses ~40 copies into one.
+- It is also the **transaction boundary** that makes database-enforced isolation possible: the wrapper opens the request transaction and sets the org GUC (`set_config('app.current_org', …, true)`) before invoking the handler, so the Row-Level Security policies in **§13.1** apply to every query inside. The `{ ctx, db }` handed to the handler is already scoped to the active org at the *database* level, not just by convention.
+
+### 6.3 Middleware factory (edge-safe, ADR-0003 preserved)
+
+```ts
+// app: src/middleware.ts
+import { createMiddleware } from '@govcore/middleware'
+export default createMiddleware({
+  publicPaths: ['/login', '/setup', '/error', '/maintenance'],
+  instanceOnlyPaths: ['/instance'],
+})
+export const config = { matcher: [/* … */] }
+```
+
+Core's middleware is a **read-only token decode** (`getToken`, never `auth()`), never writes session cookies, and carries the resurrection guard (#782), maintenance redirect, and password-expiry routing. These are precisely the bugs ("rolled cookie overrides the logout deletion and loops") that you never want a second app to rediscover. The factory keeps the rules; the app only supplies its path config.
+
+### 6.4 Auth.js config factory
+
+Wraps the provider list, the Drizzle adapter, the SSO provisioning guard ("external identity must map to a pre-provisioned, active user with ≥1 active membership"), session lifecycle (rolling 24h JWT, login/logout audit events, logged-out marker), and the jwt/session callbacks that stamp `organizationId` + active `role`. Providers and secrets are injected by the app.
+
+### 6.5 Audit writer + view
+
+`ctx.audit(event)` from the action wrapper, plus a standalone `writeAuditLog(db, event)` for non-action paths and the instance audit telemetry view (IP/user-agent capture, failed-login aggregation, CSV export — #720). Cookie-clearing/security paths must never depend on the audit write succeeding (GovEA: "logout succeeds even if the audit write fails") — core preserves that.
+
+### 6.6 Federation + support sessions
+
+Federation: `org_connections`, `cross_org_links`, visibility resolution, and the rule that cross-org links must not become a back door around source visibility. Support: break-glass session issuance, act-as scoping (default 30-min TTL), and the guarantee that revoking a break-glass parent terminates dependent act-as behavior. Both ship with their schema definitions, migrations, and guard functions.
+
+### 6.7 Accessible base theme (the WCAG floor)
+
+Accessibility is a cross-cutting platform concern, not app branding, so the **base theme lives in core** and every consumer inherits a WCAG-AA-compliant starting point for free. Apps add brand themes *on top*; they cannot accidentally ship an inaccessible UI.
+
+The model mirrors what GovEA already does (`lib/themes.ts` + `globals.css`), promoted into `@govcore/theme`:
+
+- **Base layer (core, the floor).** A token set (CSS custom properties for `:root` light / `.dark`) chosen to meet **WCAG 2.x AA** contrast and focus-visibility, plus a Tailwind preset that maps to those tokens. This is the cascade base — anything an app omits inherits the accessible default.
+- **Add-on layer (app, on top).** An app declares a theme that overrides **only brand vars** (header, primary, accent) — exactly GovEA's pattern, where the `govea`/`servicenow` themes override `--header-*` and let content tokens cascade from the base. Apps may not redefine the content/contrast tokens that hold the accessibility line.
+- **Safe injection (security, from core).** Org/app theme values are **allowlisted before injection** into the inline `<style>` tag (#769), so a tenant-supplied color can't break out of the style context. This is a platform-security property and ships with the theme package, not the app.
+- **Drift guard (core test).** Ship GovEA's theme/globals sync test (#766/#770) as `@govcore/theme/test`: it fails if an add-on theme silently re-declares a base token (which would let a stale copy negate later base fixes — including accessibility fixes).
+
+```ts
+// app: tailwind.config.ts
+import { baseTheme } from '@govcore/theme'
+export default { presets: [baseTheme], theme: { /* app brand extends, never lowers contrast */ } }
+```
+
+```ts
+// app: register a brand add-on — overrides brand vars only
+import { defineTheme } from '@govcore/theme'
+export const acme = defineTheme({
+  id: 'acme', name: 'Acme', extends: 'base',
+  brandVars: { '--header-bg': '...', '--primary': '...' },  // validated against the allowlist
+})
+```
+
+The contract in one line: **core owns the accessibility floor; apps decorate above it and can't dig below it.**
+
+### 6.8 Tenant backup / restore to file
+
+Whole-organization backup and restore is a platform concern, not a domain feature: it's about tenant data portability, public-records retention, and clean tenant export/import — the same for every app. So core owns the **engine**; the app owns only the **list of tables that participate**.
+
+The subtlety: a full backup must include the app's *domain* data (capabilities, permits…), which core doesn't know about. Core solves this with a **registry**, consistent with the `orgScoped` contract — the app declares which of its tables are tenant data, and core's engine walks them filtered by `organization_id`:
+
+```ts
+// app: register domain tables into the backup engine (core tables are registered automatically)
+import { registerBackupTables } from '@govcore/backup'
+import { capabilities, goals, applications } from '@/db/schema'
+
+registerBackupTables([capabilities, goals, applications])  // must be orgScoped
+```
+
+```ts
+// produce / restore a portable, single-org archive
+const archive = await exportOrganization({ db, organizationId, actor })   // → file (JSON/zip)
+await importOrganization({ db, archive, actor, mode: 'new-org' | 'overwrite' })
+```
+
+What core guarantees, so the app doesn't reinvent it:
+
+- **Org-scoped extraction** — only the target organization's rows leave; federation/cross-org links are exported as references, never as a back door around another org's visibility (§6.6 rule still holds). With RLS (§13.1) this stops being a hand-written `.filter()` per junction table (the current `lib/backup-export.ts` pattern) and becomes automatic.
+- **Referential integrity + transactional restore** — restore runs in one transaction with FK ordering derived from the registry; a failed restore leaves nothing behind. *(Already true in GovEA today.)*
+- **Audited** — restore already writes an audit event today; **export does not yet** (it only stamps `lastExportAt`). Core should audit both — see §13.5.
+- **Versioned + integrity-checked format** — the archive should carry `CORE_SCHEMA_VERSION` (today it carries only `BACKUP_FORMAT_VERSION`), be **encrypted at rest**, and be **HMAC-signed** so a tampered archive can't be restored. These are hardening deltas, detailed in **§13.5** — not yet all present.
+
+This is distinct from per-entity CSV import/export, which stays in the app (§2): CSV is "edit one entity type in a spreadsheet"; backup is "snapshot or move an entire tenant."
+
+---
+
+## 7. How a new app repo uses GovCore
+
+This is the heart of the proposal: what does it actually look like for a brand-new app (call it **CivicTrack**) to be built on GovCore?
+
+### The relationship between the repos
+
+GovCore and the consumer app are **separate repos**. GovCore publishes versioned packages to a registry (npm, or a private GitHub Packages registry). The app declares them as dependencies — exactly like depending on `next` or `drizzle-orm`. There is no source coupling, no submodule, no copy-paste; the app pulls a pinned version and upgrades on its own cadence.
+
+```text
+┌──────────────────────────────────────────────────────┐
+│  GovCore repo   github.com/roballred/GovCore           │
+│                                                        │
+│   packages/*  ──►  release (changesets, semver/pkg)    │
+│   @govcore/schema, auth, tenancy, rbac, audit,         │
+│   federation, support, middleware, theme, nextkit      │
+│                                                        │
+│   examples/minimal-app   (canary consumer, built in CI)│
+└───────────────────────────┬────────────────────────────┘
+                           │  publish
+                           ▼
+              ┌──────────────────────────────┐
+              │   Package registry            │
+              │   npm / GitHub Packages       │
+              │   @govcore/*  @  x.y.z         │
+              └───────┬───────────────┬───────┘
+                      │ depends on    │ depends on
+                      ▼               ▼
+   ┌──────────────────────────┐   ┌──────────────────────────┐
+   │  GovEA repo              │   │  CivicTrack repo         │
+   │  (consumer zero)         │   │  (a future app)          │
+   │                          │   │                          │
+   │  @govcore/* : ^x.y.z     │   │  @govcore/* : ^x.y.z     │
+   │  + EA domain             │   │  + permits / inspections │
+   │    (capabilities, goals) │   │    domain                │
+   └──────────────────────────┘   └──────────────────────────┘
+
+Separate repos. The relationship is a normal pinned dependency —
+no submodule, no copy-paste. Each app upgrades on its own cadence.
+```
+
+Both apps consume the *same* `@govcore/*` versions but own entirely different domains. GovEA models capabilities and goals; CivicTrack models permits and inspections — yet both get identical, hardened tenancy/auth/audit/accessibility for free.
+
+### Schema composition — how core tables and app tables become one schema
+
+Core **owns the platform tables and their migrations**; the app re-exports core's table definitions (for queries + FKs) and adds its own domain tables tenant-scoped via `orgScoped`. Two migration streams, one database (§5).
+
+```text
+  @govcore/schema                       CivicTrack: src/db/schema/index.ts
+  ──────────────────────────            ──────────────────────────────────
+  organizations  ───────────────────►  re-exported (core owns the DDL)
+  users          ───────────────────►  re-exported
+  memberships    ───────────────────►  re-exported
+  audit_log      ───────────────────►  re-exported
+  org_connections / cross_org_links ─►  re-exported
+
+                                        + app's OWN domain tables:
+                              ┌───────►  permits      ...orgScoped(organizations)
+        organization_id FK ───┤
+                              └───────►  inspections  ...orgScoped(organizations)
+
+  MIGRATIONS (two streams, no overlap):
+    govcore-migrate   ──►  creates/alters platform tables + audit trigger   (core owns)
+    drizzle-kit migrate ►  creates/alters permits, inspections, …           (app owns)
+                                                 │
+                                                 ▼
+                                        one PostgreSQL schema
+```
+
+### The wiring, end to end
+
+```ts
+// 1. package.json — depend on the published packages
+//    "@govcore/schema": "^1.0.0", "@govcore/auth": "^1.0.0", … (peer: next, drizzle-orm, next-auth)
+
+// 2. src/db/schema/index.ts — re-export core tables, add domain tables that FK to them
+export * from '@govcore/schema'      // organizations, users, memberships, audit_log, …
+import { organizations, orgScoped } from '@govcore/schema'
+export const permits = pgTable('permits', { ...orgScoped(organizations), title: text('title') })
+
+// 3. package.json — platform migrations (core-owned) run before domain migrations (app-owned)
+//    "db:migrate": "govcore-migrate && drizzle-kit migrate"
+
+// 4. src/lib/auth.ts — configure identity (inject providers + secrets)
+export const { handlers, auth } = createAuth({ db, schema, providers: [/* OIDC */], ssoGuard })
+
+// 5. middleware.ts — configure route protection
+export default createMiddleware({ publicPaths: ['/login'], instanceOnlyPaths: ['/instance'] })
+
+// 6. tailwind.config.ts — inherit the WCAG-AA floor, add brand on top
+export default { presets: [baseTheme], theme: { extend: { /* CivicTrack brand */ } } }
+
+// 7. src/lib/backup.ts — register domain tables into core's tenant backup engine
+registerBackupTables([permits, inspections])
+
+// 8. a domain action — tenancy + RBAC + audit enforced by the wrapper
+export const createPermit = tenantAction({ permission: 'content:create' },
+  async ({ ctx, db }, input) => { /* ctx.organizationId already resolved & trusted */ })
+```
+
+### What the app author writes vs. inherits
+
+| The app **writes** | The app **inherits from GovCore** |
+|---|---|
+| Domain tables (permits, inspections…) + their migrations | orgs, users, memberships, audit, federation, support tables **+ their migrations** |
+| Domain server actions & UI | Identity (local + OIDC), org switching, session lifecycle |
+| Brand theme (palette, logo) | WCAG-AA accessibility floor, safe theme injection |
+| The list of domain tables to back up (`registerBackupTables`) | Tenant backup/restore-to-file engine (org-scoped, transactional, audited) |
+| Provider secrets + path config | RBAC, active-org resolution, audit (append-only), middleware, break-glass/act-as |
+
+Steps 2–8 are **configuration and composition, not reimplementation** — that is the entire value proposition. A secure multi-tenant skeleton stands up in well under a day; the app author spends their time on the domain, never on "how do I isolate tenants," "is my logout actually safe," or "did my tenant export leak another org's data."
+
+### Upgrading
+
+Because GovCore is semver'd, the app bumps `@govcore/*` like any dependency. A **minor/patch** bump is `pnpm up`. A **major** bump means a core schema changed (§8): the app bumps the version and runs `govcore-migrate`, which applies the new core-authored platform migrations (the app writes no DDL for them). The app upgrades when *it* chooses — GovEA and CivicTrack are never forced to move in lockstep, and because core owns the migrations there is no schema to reconcile by hand.
+
+---
+
+## 8. Versioning and release
+
+- **Changesets** for independent semver per package.
+- **Schema is the sharp edge.** Because core owns the platform migrations, any change to a core table's columns/constraints ships *as a migration* and is a **breaking change** for consumers. Encode this in policy: column add/remove/retype on a core table ⇒ **major** bump, with the migration included in the release; consumers apply it via `govcore-migrate`. The `CORE_SCHEMA_VERSION` constant moves with it. Backward-compatible, additive migrations (new nullable column, new table) may be **minor** — but anything that requires data backfill or breaks an existing query is **major**.
+- **Edge-safety is a release gate.** CI must assert `@govcore/{schema,rbac,middleware}` import cleanly in an edge runtime (no `node:` builtins, no DB client). A regression here silently breaks every consumer's middleware.
+- **The `examples/minimal-app` fixture** is the canary — it's built and e2e-tested in core's CI on every release, so "does a real consumer still compile and pass auth/tenancy smoke tests" is answered before publish, not after.
+
+---
+
+## 9. Extraction plan (phased, strangler-style)
+
+GovEA stays shippable throughout; nothing is a big-bang rewrite. GovEA is consumer zero — it adopts each package as it lands, which validates the seam before any second app exists.
+
+> **Local-env caveat (GovEA memory):** there's no local Postgres/Docker on the maintainer machine; DB-backed integration tests run in CI. So each phase's verification leans on CI, and the migration + edge-safety tests must run green in CI before a package is cut.
+
+**Phase 0 — Stand up the repo (no behavior change).**
+New `GovCore` repo, package skeletons, changesets, CI (typecheck/lint/edge-safety/example build). Promote the *already-shared* `@govea/core/rbac` into `@govcore/rbac` first — it's the lowest-risk move (pure, no DB, already a single source of truth with an enforcing test). Do the **`createRbac` parameterization (§13.3)** as part of this promotion: ship the generic factory with GovEA's map as the default, so the `rbac-single-source` test stays green and the package is reusable from day one rather than re-opened later.
+
+**Phase 1 — Schema package + platform migrations.**
+Move `schema/{organizations,users,audit,federation,break-glass-sessions,act-as-sessions}.ts` table definitions into `@govcore/schema`, and author the **initial platform migration** (`0000_platform_init`) plus the `audit-immutable.sql` trigger migration and the `govcore-migrate` runner. GovEA re-exports the core tables (§5) and switches its platform tables from `db:push` to `govcore-migrate`; its domain tables can stay on `db:push` for now. **This is the migration-cutover moment for the platform layer** — flag it against ADR-008's "switch when the first real tenant exists" criterion. **It is also where the §13 database hardening lands** (RLS policies, the `govcore.*` schema namespace, and the two-role owner/runtime split) — **decided 2026-06-21** (§1). The schema is authored from scratch here, so RLS + `FORCE ROW LEVEL SECURITY` go in now rather than as a retrofit. Verify: GovEA CI green, `govcore-migrate` builds the platform schema from clean, audit trigger present, RLS denies a cross-org read in an integration test.
+
+**Phase 2 — Audit + tenancy.**
+Move the audit writer/view and `resolveActiveMembership` + membership guards. GovEA's `lib/*` become thin re-export shims (same pattern as today's `lib/rbac.ts` → `@govea/core`). Verify: existing audit + multi-org integration tests pass unchanged.
+
+**Phase 3 — Auth + middleware.**
+The riskiest move (the security edge cases live here). Extract `createAuth` and `createMiddleware`, preserving ADR-0003, #782, #720, #759, #807 behaviors. Verify: full e2e auth/logout/resurrection/maintenance suites pass. Do this phase behind the highest review scrutiny — it carries the security edge cases.
+
+**Phase 4 — Federation + support + backup + theme + nextkit.**
+Extract federation, break-glass/act-as, the tenant **backup/restore engine** (`@govcore/backup`) with its domain-table registry, the `tenantAction` wrapper, and the WCAG-AA base theme (`@govcore/theme`) with the allowlist + drift-guard test. GovEA registers its EA entity tables into the backup engine and verifies an export/restore round-trip matches the pre-extraction behavior. Migrate GovEA's domain actions onto `tenantAction` incrementally (they keep working via shims until migrated). GovEA's `govea`/`servicenow` themes become app-level add-ons on the core base. Theme extraction is low-risk and could be pulled earlier (pure tokens + a security helper, no DB) if wanted as an early demonstrable win.
+
+**Phase 5 — Cut 1.0 and stabilize.**
+GovCore is a separate repo from Phase 0 (decision §11.5), so GovEA consumes `@govcore/*` from the registry throughout — as `0.x` prereleases during active extraction. Phase 5 is the point where the API has settled: publish `1.0.0`, move GovEA's dependency ranges from `0.x` prereleases to pinned `^1.0` versions, and retire the old `@govea/core`. No repo split happens here because there was never a temporary monorepo to split.
+
+Each phase is independently shippable and reversible (revert the shim, keep the app code).
+
+---
+
+## 10. Risks and trade-offs
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **Core migration tooling forced on consumers** (the cost of "core owns migrations") | Medium (accepted) | `govcore-migrate` must coexist cleanly with the app's own Drizzle migrations — separate journal (`__govcore_migrations`), documented ordering (`govcore-migrate && drizzle-kit migrate`). This is the deliberately-chosen trade for zero drift |
+| **A core platform migration breaks a consumer on upgrade** | Medium | Major-version gating for any non-additive change (§8); migrations tested against `examples/minimal-app` in core CI before publish; additive-only where possible |
+| **Opinionated coupling** locks out non-stack apps | Medium (accepted) | Explicit, locked decision. Revisit only if a real non-Next consumer appears (§11) |
+| **Edge-safety regressions** break all consumers' middleware silently | High | Edge-import CI gate; keep `schema` (defs), `rbac`, `middleware` DB-free; the migrate runner is a separate non-edge entrypoint |
+| **Security edge cases lost in extraction** (#782/#720/#807, ADR-0003) | High | Phase 3 under the highest review scrutiny; port the existing e2e suites *with* the code; don't rewrite, relocate |
+| **Backup engine leaks cross-org data** | High | Org-scoped extraction tested explicitly; federation links exported as references only (§6.8); restore round-trip test in Phase 4 |
+| **Cross-repo release friction** slows GovEA (two repos from day 1, §11.5) | Medium (accepted) | Iterate without publish-per-change using a local registry (Verdaccio) or `pnpm` `link:` / `yalc` overrides during active extraction; cut `0.x` prereleases from GovCore CI so GovEA always consumes a registry version, not a working copy. The two-repo overhead is the accepted cost of treating GovCore as a standalone initiative |
+| **Public-repo / operator-secret leakage** carried into a new repo | Medium | Keep config injected, never hard-coded (§4). Add the same "no operator identifiers in source" lint GovEA relies on |
+| **Generality built before it's earned** (no second consumer yet) | Medium | Extract only proven code; `examples/minimal-app` is the only "second consumer" until a real one exists |
+
+---
+
+## 11. Open questions / decisions still needed
+
+1. **~~Final package scope/name?~~ Resolved:** the initiative and repository are named **GovCore**, packages published under the **`@govcore/*`** scope. (Individual package names within that scope remain a tunable implementation detail, not an open question.)
+2. **~~Reconsider DB ownership?~~ Resolved:** core owns the platform tables and their migrations (decision locked §1). The migrate-tooling cost is accepted.
+3. **~~Backup archive format?~~ Resolved: JSON for now.** The archive is plain JSON to start (matching today's exporter). Encryption-at-rest, HMAC signing, and `CORE_SCHEMA_VERSION` binding (§13.5) are applied as *wrappers around* the JSON, not a different format; compression/zip can come later if size warrants. Still a Phase 4 design detail: how `registerBackupTables` orders app tables that reference *other* app tables for restore (FK ordering).
+4. **~~Content engine later?~~ Resolved (2026-06-21): BUILD IT — full engine, comprehensive.** GovCore builds `@govcore/content` to compile type definitions into real Drizzle tables (not an EAV blob), with relationships, computed fields, and per-type code hooks as first-class, aiming to model every content type over time. Built as the **second milestone**, after the platform-plane v1, and proven on one rich entity (Capability) before migrating the rest. **See [Appendix B](#appendix-b--the-content-engine-committed-design) for the committed design and how it avoids the inner-platform-effect.**
+5. **~~Monorepo-then-split vs. two repos from day one?~~ Resolved: split from day 1.** GovCore is its own repository from Phase 0 — no temporary monorepo. GovEA consumes `@govcore/*` from the registry (prereleases during active extraction) rather than via `workspace:*`. See the updated §9 Phase 5 and §10.
+6. **~~Instance-console UI?~~ Resolved: reusable React.** Core ships the instance-admin surface (memberships, break-glass approval, audit telemetry) as **reusable React components** in `@govcore/nextkit`, not just headless logic — a consumer gets working instance-console screens out of the box and themes them via the §6.7 base theme.
+7. **~~License?~~ Resolved: MIT.** GovCore is MIT-licensed, same as GovEA.
+8. **~~Adopt RLS + two-role DB?~~ Resolved (2026-06-21): ADOPTED** at the Phase 1 cutover (§13.1–13.2, locked in §1). Remaining sub-decisions for Phase 1 design: exact RLS policy for the cross-org support paths (break-glass/act-as must bypass the org GUC at one audited choke point) and the connection-role wiring for `govcore-migrate` vs. runtime.
+9. **~~Parameterize RBAC?~~ Resolved (2026-06-21): ADOPTED** — generic `createRbac` with GovEA's map as default (§13.3, locked in §1).
+
+---
+
+## 12. Next steps and Phase 0–1 work breakdown
+
+GovCore is a **standalone initiative**: its own repository, backlog, versioning, and release lifecycle, independent of GovEA's milestones and issue tracker. GovEA is the *first consumer* and the source the platform code is extracted from — it is not the owner, and GovCore work is **not** filed on GovEA's roadmap. Until the GovCore repository is stood up, **this document is the single planning record**: the work breakdown below lives here, not as issues or milestones elsewhere.
+
+Binding decisions are recorded in this document (the §1 decisions table and the §13 resolutions). References to existing GovEA ADRs (ADR-0003, ADR-008, ADR-0002) are **provenance** — behavior the extraction must preserve — not new artifacts; GovCore will keep its own ADRs once its repo exists.
+
+### Phase 0 — repo skeleton + generic RBAC
+
+- [ ] Stand up the GovCore repository: package skeletons, changesets, CI (typecheck, lint, edge-safety import gate, `examples/minimal-app` build).
+- [ ] Ship `@govcore/rbac` as a **generic `createRbac`** factory (§13.3); GovEA's `admin/contributor/viewer` map is the default export.
+- [ ] GovEA consumes `@govcore/rbac`; the `rbac-single-source` test stays green (one definition, now produced by `createRbac(...)`).
+
+**Done when:** `@govcore/rbac` is generic, GovEA builds on it with no behavior change, and `examples/minimal-app` compiles in CI.
+
+### Phase 1 — platform schema + migrations + RLS + two-role DB
+
+- [ ] `@govcore/schema`: platform table defs in a dedicated `govcore` Postgres schema namespace (§13.4); dependency-free / edge-safe export.
+- [ ] `0000_platform_init` migration, the `audit-immutable` trigger as a raw-SQL migration step, and a `govcore-migrate` runner with a `__govcore_migrations` tracking table.
+- [ ] **RLS** policies + `FORCE ROW LEVEL SECURITY` on platform tables; transaction-local org GUC plumbed through the tenant transaction (§13.1).
+- [ ] **Two-role DB**: owner/DDL role for `govcore-migrate`, non-owner runtime role for the app (§13.2).
+- [ ] GovEA re-exports core tables and switches its **platform** tables from `db:push` to `govcore-migrate` — the ADR-008 cutover for the platform layer (§5). Domain tables may stay on `db:push` for now.
+
+**Done when (verified in CI — no local Postgres):** `govcore-migrate` builds the platform schema from a clean database; the audit trigger blocks `UPDATE`/`DELETE`; an integration test proves **RLS denies a cross-org read**; GovEA CI stays green.
+
+### Provenance (where the Phase 0–1 code comes from)
+
+The extracted code derives from GovEA's IAM and Multi-Org capability areas — `iam-role-based-access-control`, `iam-audit-trail`, `iam-local-authentication`, `iam-instance-administration`, `mo-org-connections`, `mo-content-visibility`. This is recorded as provenance for the extraction, **not** as GovEA-issue traceability; GovCore carries its own capability/traceability model once its repo exists.
+
+### Later phases
+
+Phases 3–4 (auth + middleware; federation, support, backup, theme) and Phase 5 (publish `1.0`, stabilize the API) are outlined in §9; each gets its own work breakdown **in this document** when its turn comes.
+
+**GovCore's second milestone — the content engine (`@govcore/content`)** — begins only after the platform-plane v1 (Phases 0–5) is stable, since it depends on `schema`/`tenancy`/`rbac`/`audit`/`server`. Its committed design, de-risking rules, and validated sequencing (spike on one rich entity first) are in Appendix B. It is **not** folded into the platform phases above.
+
+---
+
+## 13. Hardening the design — elegance upgrades
+
+These upgrades came out of a **code-level** review (not just the doc). Each is grounded in something the current GovEA code actually does, and each is written as a *method* — how to build it — not just a principle. Listed in priority order.
+
+### 13.1 Database-enforced tenant isolation (Postgres Row-Level Security)
+
+**The problem, grounded in real code.** Today the organization boundary is enforced in *application logic*, not in the query. Two verified examples:
+
+- `actions/capabilities.ts → getCapability` loads `db.query.capabilities.findFirst({ where: eq(capabilities.id, id) })` — **no `organization_id` filter** — and only afterward calls `canReadFederatedEntity(...)` to decide visibility. The row crosses the tenant boundary into app memory; a human-written follow-up check is what keeps it safe.
+- `lib/backup-export.ts → collectContent` fetches junction tables with `db.query.<junction>.findMany({})` — **every org's rows** — then removes other orgs' rows with a hand-written `.filter(r => capIds.has(...))`. Forget one filter and the export leaks cross-org links.
+
+These are correct *today* only because someone remembered the second step. That is exactly the class of bug a reusable framework should make structurally impossible.
+
+**The method.**
+
+- Put core tables (and every `orgScoped` app table) behind an RLS policy:
+  `USING (organization_id = current_setting('app.current_org')::uuid)`.
+- `tenantAction` (§6.2) opens a transaction and sets the org as a **transaction-local** GUC before running the handler:
+  `select set_config('app.current_org', $orgId, true)` — the `true` scopes it to the transaction. Every DB op in the handler then runs under that setting, so a query that *forgets* the `WHERE organization_id = ?` still returns only the active org's rows.
+- **Why transaction-local, specifically:** verified that GovEA connects via `postgres-js` with a small direct pool (`max: 5`), not a transaction-mode pooler. A session-level `SET` would bleed across pooled requests sharing a connection — so the GUC **must** be `SET LOCAL` / `set_config(..., true)` inside the request's transaction. This is why tenant DB access routes through the action's transaction.
+
+**The honest cost.** This commits the codebase to a rule: *all tenant-scoped DB access happens inside a tenant transaction.* Reads done outside a transaction today (`db.query…findFirst`) must move onto the request transaction to be protected. It is a real architectural commitment, not a free toggle — which is why adoption is a decision, not a default (see end of section).
+
+### 13.2 Two Postgres roles — the thing that makes RLS *and* the audit trigger real
+
+**The problem.** GovEA connects with a single role (one `DATABASE_URL`). Two consequences: RLS does **not** apply to a table's owner, and the audit-immutability trigger (#417) can be **dropped** by the owner. A single all-powerful role undercuts both protections.
+
+**The method.** Split into two Postgres roles:
+
+| Role | Used by | Privileges |
+|---|---|---|
+| **Owner / DDL** | `govcore-migrate` (the migration runner) | Owns `govcore.*`, creates/alters tables, installs the audit trigger and RLS policies |
+| **Runtime / DML** | the app at request time | Non-owner; `ALTER TABLE … FORCE ROW LEVEL SECURITY` makes RLS bind to it; can INSERT/SELECT (and UPDATE/DELETE where allowed) but **cannot** drop the audit trigger or bypass RLS |
+
+Net effect: a compromised *app* role cannot rewrite audit history (already true via the trigger), cannot read another org's rows (new, via RLS), and cannot disable either protection (new, via non-ownership). The migration runner's elevated privilege is bounded to migration time.
+
+### 13.3 Parameterize RBAC over an app-supplied role/permission map
+
+**The problem, grounded.** `@govea/core/rbac` hardcodes `type Role = 'admin' | 'contributor' | 'viewer'` and a fixed seven-permission map. §2 of this doc files RBAC as "already shared, just promote it" — but that ships *GovEA's domain vocabulary* to every consumer. CivicTrack's `inspector` role has nowhere to go. This is the difference between "reusable" and "GovEA with extra steps."
+
+**The method.** Core ships the *machinery* generic over the app's own types:
+
+```ts
+// @govcore/rbac
+export function createRbac<R extends string, P extends string>(def: {
+  rolePermissions: Record<R, P[]>
+  hierarchy: Record<R, number>
+}) {
+  return { hasPermission, roleAtLeast, roleIsAdmin /* … all typed to R, P */ }
+}
+```
+
+GovEA's current map becomes the default export and the worked example:
+
+```ts
+export const goveaRbac = createRbac({ rolePermissions: GOVEA_ROLE_PERMISSIONS, hierarchy: GOVEA_HIERARCHY })
+```
+
+Zero behavior change for GovEA, and the existing `rbac-single-source` integration test still passes — GovEA still has exactly one definition, now produced by `createRbac(...)`. `tenantAction({ permission })` and the separate `instanceRole` check stay; `permission`/`role` simply become the app's unions.
+
+### 13.4 Composition & developer-experience methods
+
+- **One validated config object.** Replace scattered `process.env` reads (the §4 examples still do `Number(process.env.TRUSTED_PROXY_HOPS ?? 1)` inline) with a single `defineGovCoreConfig(env)` validated by Zod at boot — fail-fast on a missing `AUTH_SECRET` or malformed value, and one place to enforce the "no operator identifiers in source" lint. Pass the result to every factory.
+- **Split the crown-jewel seam out of the god-package.** `tenantAction` only needs tenancy + rbac + audit, but §3 currently parks it in `@govcore/nextkit`, which depends on *everything*. Extract a lean **`@govcore/server`** (action context + `tenantAction` + the tenant transaction from 13.1) and leave `@govcore/nextkit` for UI primitives. This is also where the per-file `requireContributor` / `requireAdmin` helpers — duplicated across ~40 action files today — collapse into one wrapper.
+- **Show how one typed `db` is composed.** Core exports its tables *and* Drizzle `relations()` as spreadables; the app does `const schema = { ...coreSchema, ...appSchema }; export const db = drizzle(client, { schema })`. Drop `export * from '@govcore/schema'` (collision-prone; the `govcore.*` Postgres-schema namespacing below removes the need for it).
+- **`govcore.*` Postgres schema namespacing.** Put core tables in a dedicated Postgres schema (`pgSchema('govcore')`) and app tables in `public`. Two migration streams become physically namespaced, `__govcore_migrations` lives in `govcore`, ownership is self-evident, and an app is free to have its own `sessions`/`accounts`/`users` table without colliding with core.
+- **A `@govcore/testing` package.** Ship `createTestOrg`, `createTestUser`, `withActiveMembership`, plus a CI/testcontainers recipe (matching the verified no-local-Postgres reality). Without this, "stand up an app in a day" excludes writing a single integration test — which is where consumers will actually spend their time.
+
+### 13.5 Backup engine hardening — reconciled with what GovEA already does
+
+Reading `lib/backup-export.ts`, `lib/backup-import.ts`, and `actions/backup.ts` showed the current engine is **stronger than §6.8 implied in some ways and weaker in others.** Reconciled:
+
+**Already true (keep, don't reinvent):** admin-only + typed `RESTORE` confirm token + 50 MB guard; deliberate secret excludes (`passwordHash`, SMTP creds, sessions/break-glass/act-as, notifications); **transactional restore**; **restore writes an audit event**; same-org-only with UUIDs preserved (destination wiped first); cross-org links cleared on import (federation is not a restore back door).
+
+**To ADD in core (the real deltas):**
+
+- **Audit the *export* too.** Today only *restore* is audited; export merely stamps `organizations.lastExportAt`. A full-tenant export is at least as security-relevant as a restore.
+- **Encrypt at rest + signed, expiring download URLs.** A whole-org archive is the single juiciest exfiltration artifact in the system; it currently serializes as plain `JSON.stringify(..., null, 2)`.
+- **Integrity signature (HMAC).** So a tampered archive cannot be restored.
+- **Bind the archive to the platform schema version.** It carries `BACKUP_FORMAT_VERSION` but not `CORE_SCHEMA_VERSION`; restore should refuse or migrate an archive from an incompatible platform schema.
+- **Registry-driven scoping replaces the hand-written junction `.filter()`.** With `registerBackupTables` (§6.8) *plus* RLS (13.1), an unscoped fetch already returns only the active org — the leak-prone manual filter disappears.
+- **Design the future cross-org migration path with RLS on.** Cross-org restore (UUID remap) is explicitly future work in the code; that is exactly where server-side org re-derivation becomes security-critical.
+
+### 13.6 Fix-forward during extraction — don't carry debt into the reusable core
+
+- **CSP enforcement.** Verified: GovEA ships CSP in **report-only** mode in `next.config.ts` (#743; enforcement tracked as #765). Relocating the security layer into core is the moment to land **nonce-based enforced CSP** in `@govcore/middleware` + a `next.config` headers preset, so consumer #2 inherits the enforced end-state rather than GovEA's in-flight debt. (Note: the response headers live in `next.config.ts`, not `lib/security-policy.ts` — §2's route-protection row is corrected accordingly.)
+- **MFA for local credentials** (#761) as a first-class `@govcore/auth` capability.
+- **Supply chain.** `@govcore/*` becomes a dependency of every consumer's production tenant-data path, so a poisoned release is a fleet-wide incident: require npm provenance / sigstore, CI-only publishing, maintainer 2FA, and the dependency/code scanning GovEA already tracks (#762).
+
+### Decisions (resolved 2026-06-21)
+
+Both were taken in favor of the recommendation and are now in the locked-decisions table (§1):
+
+1. **RLS + two-role DB — ADOPTED**, at the Phase 1 schema cutover (§13.1–13.2). Accepted cost: all tenant-scoped DB access runs inside a tenant transaction; the database is provisioned with an owner/DDL role and a non-owner runtime role.
+2. **Generic `createRbac` — ADOPTED** (§13.3). Core ships the parameterized factory with GovEA's map as the default export.
+
+---
+
+### Appendix A — File-by-file extraction inventory
+
+| GovEA path | → Target package | Phase |
+|---|---|---|
+| `packages/core/src/rbac` | `@govcore/rbac` | 0 |
+| `src/db/schema/organizations.ts`, `users.ts`, `audit.ts`, `federation.ts`, `break-glass-sessions.ts`, `act-as-sessions.ts`, `instance-settings.ts`, `platform-config.ts` | `@govcore/schema` (defs **+ migrations + `govcore-migrate`**) | 1 |
+| `src/db/sql/audit-immutable.sql` | `@govcore/schema` (as a core migration) | 1 |
+| `lib/audit.ts`, `lib/audit-view.ts` | `@govcore/audit` | 2 |
+| `lib/active-membership.ts`, `lib/membership-guards.ts`, `lib/membership-sync.ts`, `actions/active-org.ts`, `actions/memberships.ts` | `@govcore/tenancy` | 2 |
+| `lib/auth.ts`, `lib/auth.config.ts`, `lib/sso-guard.ts`, `lib/password.ts`, `lib/logout-marker.ts`, `lib/auth-redirect.ts` | `@govcore/auth` | 3 |
+| `middleware.ts`, `lib/request-context.ts`, `lib/security-policy.ts` | `@govcore/middleware` | 3 |
+| `lib/federation.ts`, `lib/cross-org-link-helpers.ts`, `actions/connections.ts`, `actions/cross-org-links.ts` | `@govcore/federation` | 4 |
+| `lib/break-glass.ts`, `lib/act-as.ts`, `lib/instance-admin.ts`, `actions/act-as.ts` | `@govcore/support` | 4 |
+| `lib/backup-export.ts`, `lib/backup-import.ts`, `actions/backup.ts` | `@govcore/backup` (engine + registry; app registers domain tables) | 4 |
+| `lib/themes.ts` base tokens + `globals.css` base layer + allowlisting (#769) + drift-guard test (#766/#770) | `@govcore/theme` | 4 |
+| `lib/rbac.ts` (user-shaped wrappers) + a `tenantAction` wrapper (new) | `@govcore/nextkit` | 4 |
+| `govea` / `servicenow` theme defs (brand add-ons) | **stays in GovEA** (layer on core base) | — |
+| Everything under `business-architecture/` domain + EA entity schema/lib/actions | **stays in GovEA** | — |
+
+*Paths relative to `apps/govea/src/` unless noted.*
+
+---
+
+### Appendix B — The content engine (committed design)
+
+This appendix explains, from first principles, what a "content engine" is, why GovEA already has the seeds of one, and — now that the decision is **to build it** — how to build it so it doesn't collapse into the failure mode generic content engines are famous for. It's longer and more plain-spoken than the rest of the doc on purpose.
+
+> **Decision (2026-06-21):** GovCore **builds the full content engine** (`@govcore/content`) and pursues **comprehensive coverage** — the goal is that every content type, including the relational EA entities, can eventually be expressed through it. This reverses the earlier "park it" recommendation. The design below is shaped entirely around keeping that ambition out of the inner-platform-effect ditch.
+
+#### Start with the problem it would solve
+
+Think about what it takes to add a single entity type to GovEA today — say, **Capabilities**. Someone has to write, by hand:
+
+- a **database table** (`capabilities`, with its columns and the `organization_id` tenant scope),
+- a **validation schema** (a Zod object saying "name is required text, description is optional, owner points at a person"),
+- **server actions** for create / edit / delete / publish,
+- a **form** to fill it in, and a **list view** and a **detail view** to read it back,
+- the **lifecycle** rules (a draft can be published, a published thing can be archived),
+- and the **classification** hooks (which taxonomy or framework bucket this capability belongs to).
+
+Now notice: when the next entity type arrives — **Goals**, then **Applications**, then **Services**, then **Principles** — you write *the same skeleton again*. The fields differ, but the shape ("a thing with some fields, that belongs to an org, that has a draft/published lifecycle, that can be filed under a taxonomy") is nearly identical every time. That repetition is the itch a content engine scratches.
+
+#### What a content engine actually is
+
+A content engine flips the model from **"hand-code each type"** to **"describe each type as data, and let the engine do the rest."**
+
+Instead of writing a table + schema + form + actions for Capabilities, you'd write a small *description*:
+
+```ts
+defineContentType({
+  name: 'capability',
+  label: 'Capability',
+  fields: [
+    { name: 'name',        type: 'text',     required: true },
+    { name: 'description', type: 'textarea' },
+    { name: 'owner',       type: 'reference', to: 'person' },
+    { name: 'domain',      type: 'taxonomy',  tree: 'architecture-domains' },
+  ],
+})
+```
+
+…and the engine reads that description and **automatically provides** the storage, the validation, the create/edit/list/detail screens, the draft→published→archived lifecycle, and the taxonomy filing. Adding a new type becomes *configuration*, not a code change plus a migration plus a pull request.
+
+If you've used a **headless CMS** — Contentful, Sanity, Strapi — or even WordPress "custom post types," this is the same idea: define content models as data, get the plumbing for free. The difference is that here it would be a built-in, multi-tenant, audited part of the platform rather than a separate hosted service.
+
+#### GovEA already has the four seeds of it
+
+This isn't hypothetical — the current `packages/core` (the skeletal `@govea/core`) already contains stub versions of the four pieces a content engine needs:
+
+| Stub (today) | What it is | Role in a content engine |
+|---|---|---|
+| **content-types** (`ContentTypeRegistry`) | "register a type as a list of fields" | The *describe your type as data* part — the heart of the engine |
+| **workflow** (`draft → published → archived`) | a tiny state machine with allowed transitions | The shared *lifecycle* every content type reuses |
+| **taxonomy** (`buildTree`) | turns a flat list of nodes into a hierarchy | The shared *classification* any type can be filed under |
+| **recipes** (`applyRecipe`, a TODO today) | "install a JSON-described bundle of config + seed data" | Pre-packaged sets of types + starter content you can *install* |
+
+So the engine's skeleton is already sketched; what's missing is the substantial work of turning four stubs into a real, safe, queryable system.
+
+#### Why it would be genuinely valuable for GovEA
+
+GovEA's whole framework story is *already* leaning this direction. [ADR-0002 ("ADM as classification")](../decisions/0002-adm-as-classification.md) decided that supporting TOGAF is **not** a hard-coded overlay — installing the **TOGAF recipe** simply gives an organization a set of taxonomy classifications, and the TOGAF reports read from that taxonomy. That is a content-engine move in miniature: a framework becomes *data you install*, not *code you ship*.
+
+A real content engine generalizes that pattern. A new framework, a new entity type, or a tenant-specific custom record would become a recipe + a content-type definition — installable per organization, with no migration and no deploy. For a product whose job is "model whatever an agency needs to model," that flexibility is strategically valuable.
+
+#### The honest risk, named
+
+"Full engine" + "model everything" is the most ambitious pair of choices on the menu, and the failure mode is real: a generic engine that becomes a *worse* Postgres/Drizzle/React than the ones underneath it (the **inner-platform effect**), with GovEA's most valuable logic — the traceability chain (Goals → Objectives → Initiatives → Capabilities → Applications), completeness scoring, impact analysis — bent painfully through a registry that fights it. The industry is littered with half-built CMSes that became the most painful code in the system. The entire design below exists to make that failure mode hard to fall into. Three rules do most of the work.
+
+#### Rule 1 — compile to real tables, never an EAV blob
+
+The classic content-engine mistake is storing everything generically — rows in an `entity_values(entity_id, field_name, value)` table, or one big JSONB column. It "works" in a demo and then every query, index, and foreign key becomes agony, and RLS (§13.1) can't protect a soft schema cleanly. **GovCore does the opposite: a content-type definition is *compiled* into a real Drizzle table + a real core migration** — real columns, real types, real indexes, real FKs, real `organization_id` scope. The engine is a *code/DDL generator over the stack we already trust*, not a runtime interpreter over a soft schema. `defineContentType('capability', …)` produces a `capabilities` table indistinguishable from one a human would have hand-written; the engine just writes it (and its migration) for you.
+
+Consequence, and it's a feature: type definitions join the **migration stream**. Adding a field is a generated migration applied by `govcore-migrate` (§5), not a silent runtime change — the audited, versioned schema story stays intact, and RLS applies to engine tables exactly as it does to hand-written ones.
+
+#### Rule 2 — relationships and computed fields are first-class
+
+"Model everything" only works if the engine can express what makes GovEA *rich*, not just flat:
+
+- **Typed relationships** — `reference` (to-one) and `link` (to-many through a generated junction) as first-class field types, so the traceability chain is *declared*, not hand-joined. The engine generates the junction tables and typed query helpers.
+- **Computed / derived fields** — completeness scores, confidence, roll-ups: declared as derived fields backed by a pure function the engine calls, materialized or computed-on-read as configured. The engine owns the recompute/cache plumbing (the snapshot machinery GovEA already hand-rolls), so no app reinvents it.
+
+#### Rule 3 — a per-type escape hatch to real code
+
+The engine generates the 80% — storage, validation, CRUD `tenantAction`s, lifecycle, list/detail UI. The remaining 20% that makes GovEA more than a spreadsheet — impact analysis, duplicate detection, debt classification, publish-readiness gates — plugs in as **typed hooks** (`beforePublish`, `afterChange`, custom server actions, custom report queries) running real server code with the real `db`. The engine never has to *become* the place that logic lives; it just needs a clean seam for it. **That seam is the difference between a tool and a cage.**
+
+#### Package shape
+
+`@govcore/content`, layered *above* the platform plane:
+
+- **Depends on** `schema`, `tenancy`, `rbac`, `audit`, `server` — so every engine-defined type is automatically tenant-scoped (RLS), permission-checked, and audited like everything else; generated actions are `tenantAction`s (§6.2) and generated screens use `@govcore/nextkit` + the base theme (§6.7).
+- **Provides** the type registry, the definition→table **compiler** (emitting core migrations), validation derived from definitions, the draft→published→archived lifecycle (promoted from the `workflow` stub), taxonomy binding (the `taxonomy` stub), generated CRUD actions + React screens, and **recipes** (the `applyRecipe` stub made real) so a bundle of types + seed content + framework classifications is installable per organization — the direct continuation of ADR-0002.
+- The four stubs in today's `packages/core` are the **starting point**, not throwaway.
+
+#### Sequencing — comprehensive is a destination, reached by validated steps
+
+"Model everything" is the goal; the *path* is incremental, because betting GovEA's hardest entities on an unproven engine is exactly how this goes wrong:
+
+1. **Spike on one rich entity first.** Before migrating anything, prove the engine can express **Capability** end to end — its relationships, its completeness computed field, and a publish-gate hook — and that the generated table and queries are indistinguishable from the hand-written ones. If the engine can model a Capability cleanly, it can model the rest; if it can't, we learn that cheaply, on one entity, before committing.
+2. **Migrate the simple long-tail** (glossary, principles, notices) to harden the generators in production.
+3. **Migrate the relational entities** (the traceability chain) once relationships + computed fields + hooks are proven by step 1.
+4. **Recipes last**, turning the framework story (TOGAF, etc.) into installable per-org bundles.
+
+This is a **separate workstream from the platform extraction (§9) and depends on it** — `@govcore/content` needs `schema`/`tenancy`/`rbac`/`audit`/`server` to exist first. It therefore starts **after** the platform-plane v1 (Phases 0–5) is stable, and is tracked as GovCore's **second major milestone**, not a side-quest folded into Phase 4.
+
+#### One-line summary
+
+**Build `@govcore/content` as a real type-definition→Drizzle compiler (not an EAV interpreter), with relationships, computed fields, and per-type code hooks as first-class — then reach "model everything" by proving it on one rich entity before migrating the rest.**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@auth/drizzle-adapter':
         specifier: ^1.4.0
         version: 1.11.1
+      '@govcore/rbac':
+        specifier: link:../../../GovCore/packages/rbac
+        version: link:../../../GovCore/packages/rbac
       '@govea/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
Two phases of the GovEA → GovCore platform cutover (local-linked, pre-npm). Both are reversible shims; the app stays green and stays on `@govea/core` otherwise. DB-backed tests run in CI (no local Postgres).

## Phase 0 — `@govcore/rbac` via local link (#884)

Migrates `lib/rbac.ts` from `@govea/core` to the generic `createRbac()` engine in `@govcore/rbac` (linked via `link:../../../GovCore/packages/rbac`, added to `transpilePackages`). GovEA's role/permission definitions are now app-local (they're GovEA-specific); the engine is the shared machinery. `rbac-single-source` test updated.

Capability: iam-role-based-access-control
Closes #884

## Phase 1a — org-settings sidecar (#885)

Prep for re-exporting `@govcore/schema` (Phase 1b). GovCore's `organizations` is intentionally minimal (id/name/slug/metadata/timestamps); GovEA's carried 15 app-specific columns core doesn't model. Extracted them into an app-owned `organization_settings` sidecar (PK = `organization_id` FK → `organizations`, one-to-one relation) so GovEA can adopt the core org table without losing functionality.

- New `db/schema/organization-settings.ts` (theme, modules, security/confidence/completeness settings, support tier, hierarchy, suspension, backup bookkeeping + the moved types/DEFAULT_* constants)
- `organizations.ts` trimmed to core shape; `visibilityEnum` kept for domain tables (relocated in 1b)
- Every org-insert path creates the settings row; ~20 readers/writers repointed; `isSystemOrg` filters in instance views use a join
- Integration tests + a `findOrgSettings` helper updated

Capability: ac-site-settings
Closes #885

## Verification

- `tsc --noEmit` clean, eslint clean (rebased onto current main — resolved one interaction with #853's nullable `getOrgSecuritySettings(orgId)`)
- Schema/relations load at runtime; org INSERT now emits only core-shaped columns
- DB-backed integration tests validated in CI

## Follow-ups (separate)

- Phase 1b: `export * from '@govcore/schema'`, delete local platform-table defs, switch to `govcore-migrate && drizzle-kit migrate`, delete `apply-triggers`
- Phase 1c: RLS on domain tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Verified locally (2026-06-30)

Stood up the documented local stack (Podman Postgres) and exercised the full migration end-to-end:
- `db:push --force` → `organizations` trimmed to core shape, `organization_settings` sidecar created with the FK (confirmed via `psql \d`)
- `db:apply-triggers` + `db:seed` → 6 orgs each with a sidecar row, system org flagged, **0 orphans**
- **Full suite green locally: 106 files / 1230 tests / 0 failures** against real Postgres
- Live app: `/settings` renders theme + module toggles from the sidecar; `/instance/orgs` shows the system-org "Platform" badge / tier / status via the `leftJoin` — no console or server errors

## Also in this PR
- `docs(design)`: the platform-core extraction spec (the cutover's design basis; previously untracked)
- `fix(dev)`: portable `.claude/launch.json` (the committed config hardcoded an absolute home path and broke dev-server/preview launch off the maintainer's machine)
