### PR TITLE
docs: org-settings sidecar + GovCore consumption model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,21 @@ SSO users default to Viewer. Admins promote as needed.
 
 ---
 
+## GovCore Platform Cutover
+
+GovEA is migrating off its bundled `@govea/core` onto the extracted **GovCore** platform (`@govcore/*` packages; GovEA is consumer zero). Design: [`docs/design/platform-core-extraction.md`](./docs/design/platform-core-extraction.md); phased runbook lives in the GovCore repo (`docs/govea-cutover.md`).
+
+**Status:** Phase 0 (RBAC) + Phase 1a (org-settings sidecar) are merged. `lib/rbac.ts` now wraps `createRbac()` from **`@govcore/rbac`**, and GovEA's role/permission vocabulary stays app-local. Next is Phase 1b (re-export `@govcore/schema`, switch to `govcore-migrate` + `drizzle-kit migrate`, retire `db:apply-triggers` — see Database Workflow below).
+
+**Consumption model — `link:` → npm, per package.** Each `@govcore/*` package is adopted in whichever stage it's in:
+- **npm (published):** `"@govcore/<name>": "^0.1.0"` from the registry. `@govcore/rbac` is here now.
+- **`link:` (unpublished):** `link:../../../GovCore/packages/<name>` at a sibling GovCore checkout. This needs the `.github/actions/setup-govcore-link` CI action (clones public GovCore into CI); delete that action once no linked packages remain.
+- **Invariant:** GovCore packages are **source-first** (`main: ./src/index.ts`, no built `dist/`) even on npm, so every consumed `@govcore/*` package MUST be listed in `transpilePackages` in `apps/govea/next.config.ts` — regardless of link vs npm.
+
+**Org config lives in a sidecar.** `organizations` is kept core-shaped (id/name/slug/timestamps) to map onto GovCore's platform table; all GovEA org configuration (theme, module flags, security/confidence/completeness settings, support tier, hierarchy, suspension, backup bookkeeping) is in the app-owned `organization_settings` table (1:1, PK=FK to `organizations`). Every org-insert path must create the settings row.
+
+---
+
 ## Database Workflow
 
 **Pre-production (current):** Use `db:push` to sync schema changes directly to the dev database. CI also uses `db:push --force` on a fresh database (see `.github/workflows/ci.yml` — both DB-backed jobs run `db:push --force` then `db:apply-triggers:container`, **not** `db:migrate`). No migration files needed — run `pnpm --filter govea db:push` after schema edits, then `db:apply-triggers` to install Postgres triggers and other DB-level constraints, then `db:seed` to repopulate.

--- a/docs/AI-SESSION-START.md
+++ b/docs/AI-SESSION-START.md
@@ -16,6 +16,17 @@ If anything below conflicts with [Standards.md](../Standards.md), **Standards.md
 
 ---
 
+## Platform cutover in progress (GovCore)
+
+GovEA is mid-migration onto the extracted **GovCore** platform (`@govcore/*`). Read the **GovCore Platform Cutover** section in [`CLAUDE.md`](../CLAUDE.md) before touching platform code (auth, RBAC, schema, audit, tenancy). Operational essentials:
+
+- RBAC already comes from **`@govcore/rbac`** (consumed from npm, `^0.1.0`); Phase 0 + 1a are merged, Phase 1b (`@govcore/schema`) is next.
+- Every consumed `@govcore/*` package must be in `transpilePackages` in `apps/govea/next.config.ts` (they're source-first, even on npm).
+- Org configuration lives in the `organization_settings` sidecar, not on `organizations` (kept core-shaped for the cutover).
+- Design: [`docs/design/platform-core-extraction.md`](./design/platform-core-extraction.md); phased runbook is in the GovCore repo.
+
+---
+
 ## Where current work lives
 
 | Question | Where to look |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -13,7 +13,8 @@ Recent product-shape changes reflected here:
 - persona types and persona tags are taxonomy-backed, not separate vocabulary tables
 - `principles.principle_type` is now taxonomy-backed text rather than a fixed enum
 - applications are surfaced for services and strategic objectives through capabilities, not through direct service/objective application joins
-- instance-admin schema and console primitives now exist, including `users.instance_role`, `organizations.is_system_org`, org suspension fields, and `break_glass_sessions`
+- instance-admin schema and console primitives now exist, including `users.instance_role`, `organization_settings.is_system_org`, org suspension fields, and `break_glass_sessions`
+- organization configuration (theme, module flags, security/confidence/completeness settings, support tier, hierarchy, suspension, backup bookkeeping) now lives in the app-owned `organization_settings` sidecar (1:1 with `organizations`), keeping the platform `organizations` table core-shaped for the GovCore cutover — see `docs/design/platform-core-extraction.md`
 
 For product intent, personas, and capability definitions, see `business-architecture/`.
 
@@ -42,6 +43,7 @@ Shared enum semantics:
 
 ```mermaid
 erDiagram
+  ORGANIZATIONS ||--|| ORGANIZATION_SETTINGS : configured_by
   ORGANIZATIONS ||--o{ USERS : has
   ORGANIZATIONS ||--o{ PERSONAS : owns
   ORGANIZATIONS ||--o{ CAPABILITIES : owns
@@ -80,19 +82,43 @@ erDiagram
 
 ### `organizations`
 
-Represents the tenant boundary for almost all business data.
+Represents the tenant boundary for almost all business data. Kept deliberately
+core-shaped (identity + timestamps only) so it maps cleanly onto the GovCore
+platform `organizations` table during the cutover; all GovEA-specific
+configuration lives in the `organization_settings` sidecar below.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `id` | UUID | Yes | Primary key |
 | `name` | text | Yes | Display name |
 | `slug` | text | Yes | Unique tenant slug |
+| `created_at` | timestamp | Yes | Defaults to `now()` |
+| `updated_at` | timestamp | Yes | Defaults to `now()` |
+
+### `organization_settings`
+
+App-owned sidecar holding all organization configuration GovCore's platform
+`organizations` table doesn't model. Exactly one row per organization
+(`organization_id` is both PK and FK), created alongside the org at every insert
+site; reads fall back to the `DEFAULT_*` constants in
+`src/db/schema/organization-settings.ts` when a column is null.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `organization_id` | UUID | Yes | PK **and** FK to `organizations.id`; `CASCADE` on delete |
 | `theme` | text | Yes | Theme id; defaults to `govea` |
 | `enabled_modules` | JSONB | Yes | Feature/module flags; defaults to `{}` |
+| `confidence_settings` | JSONB | No | Confidence-summary publication settings |
+| `completeness_settings` | JSONB | No | Completeness scoring / staleness settings |
+| `security_settings` | JSONB | No | Per-org password/lockout/session policy |
 | `is_system_org` | boolean | Yes | Marks the operator/system organization for instance administration; defaults to `false` |
-| `parent_id` | UUID | No | Self-reference for hierarchy; `SET NULL` on delete |
+| `parent_id` | UUID | No | Self-reference to `organizations.id` for hierarchy; `SET NULL` on delete |
 | `suspended_at` | timestamp | No | Set when an instance admin suspends the organization |
 | `suspended_reason` | text | No | Audit-facing reason for suspension |
+| `support_tier` | text | No | Operator-assigned support tier |
+| `internal_notes` | text | No | Operator-only governance notes |
+| `last_export_at` / `last_export_bytes` | timestamp / int | No | Most-recent backup export bookkeeping |
+| `last_import_at` / `last_import_bytes` | timestamp / int | No | Most-recent archive import bookkeeping |
 | `created_at` | timestamp | Yes | Defaults to `now()` |
 | `updated_at` | timestamp | Yes | Defaults to `now()` |
 

--- a/docs/design/togaf-overlay-slice-1.md
+++ b/docs/design/togaf-overlay-slice-1.md
@@ -158,7 +158,7 @@ The panel follows the `RelationshipPanel` visual pattern but is simpler — no s
 
 | Dependency | Status |
 |------------|--------|
-| `enabledModules` jsonb on organizations | Exists |
+| `enabled_modules` jsonb on `organization_settings` (sidecar) | Exists |
 | Module toggle UI in settings | Exists |
 | Application + capability data | Exists |
 | Audit trail | Exists (mappings should log add/remove via existing audit action) |


### PR DESCRIPTION
Brings the docs in line with what's now merged on `main`: the Phase 1a `organization_settings` sidecar (#886) and the `@govcore/rbac` npm switch (#887).

## Changes
- **`docs/data-model.md`** — `organizations` trimmed to core columns (id/name/slug/timestamps); new **`organization_settings`** sidecar table section + ER-diagram relation; "recent changes" note updated.
- **`CLAUDE.md`** — new **GovCore Platform Cutover** section: rbac from `@govcore/rbac`, the `link:` → npm consumption model, the source-first + `transpilePackages` invariant, and the sidecar.
- **`docs/AI-SESSION-START.md`** — a cutover callout so new sessions read the above before touching platform code.
- **`docs/design/togaf-overlay-slice-1.md`** — `enabled_modules` now on `organization_settings`, not `organizations`.

Docs-only; no `business-architecture/` files touched (docs-lint gate unaffected). Capability docs (`ac-security-settings`, `ac-site-settings`) were left as-is — they describe org-level settings without asserting a table, and `failedLoginAttempts`/`lockoutUntil` genuinely remain on `users`.

Capability: ac-site-settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)