### PR TITLE
docs: conference-readiness pass — audience entry points + remove personal worktree script

### DIFF
--- a/.claude/start-worktree-dev.sh
+++ b/.claude/start-worktree-dev.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-exec /opt/homebrew/bin/pnpm \
-  -C "/Users/roballred/Repos/Claude/govea-app/.claude/worktrees/wizardly-hugle-fae68b" \
-  --filter govea \
-  dev

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ npm-debug.log*
 .idea
 *.swp
 
+# Claude Code session-local files (personal machine paths — see docs/AI-SESSION-START.md)
+.claude/settings.local.json
+.claude/start-worktree-dev.sh
+.claude/worktrees/
+
 # Temporary research and working files
 ea-research/
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,21 @@ GovEA is designed for public-sector teams that need useful enterprise architectu
 
 Persona definitions live in [business-architecture/personas](./business-architecture/personas/). Persona journey findings live in [docs/persona-journeys](./docs/persona-journeys/).
 
+## Where To Start
+
+Different readers need different doors into this repository:
+
+| If you are… | Start here |
+|---|---|
+| Evaluating GovEA for your agency | [What It Does](#what-it-does) above, then [Capabilities](./capabilities.md) for what is shipped today versus planned |
+| An architect assessing the design | [Architecture at a Glance](#architecture-at-a-glance) below, then the [Architecture Overview](./docs/architect/README.md) |
+| A practitioner asking "is this for people like me?" | [Personas](./business-architecture/personas/) and [persona journeys](./docs/persona-journeys/) |
+| A security reviewer | [Security Policy](./SECURITY.md) and [Security and Tenancy](./docs/architect/security-and-tenancy.md) |
+| A developer who wants to run it | [Quick Start](#quick-start) below |
+
 ## Current Shape
 
-The product is in active development. The shipped surface includes the core EA repository, traceability views, taxonomy, reporting, role-based access, audit, local/container development, and a growing set of import/export and admin capabilities.
+The product is in active development and is pre-1.0: evaluate freely, but treat any deployment as a development build until the [v0.9 Foundation Cleanup milestone](https://github.com/roballred/GovEA/milestone/1) completes. The shipped surface includes the core EA repository, traceability views, taxonomy, reporting, role-based access, audit, local/container development, and a growing set of import/export and admin capabilities.
 
 For detail, use these source-of-truth documents:
 
@@ -55,6 +67,25 @@ For detail, use these source-of-truth documents:
 | Data model | [docs/data-model.md](./docs/data-model.md) |
 | Standards for AI-assisted work | [Standards.md](./Standards.md) |
 
+## Architecture at a Glance
+
+GovEA is deliberately a simple system: one containerized web application in front of one PostgreSQL database. There is no microservice topology, no message bus, and no client-side data authority — that simplicity is a design decision, not an accident.
+
+```mermaid
+flowchart LR
+  Browser["Browser"] --> App["GovEA app container<br/>(Next.js, server-rendered)"]
+  App --> DB["PostgreSQL<br/>(system of record)"]
+  App -.-> IdP["Optional OIDC SSO<br/>(e.g. Microsoft Entra ID)"]
+```
+
+Three facts carry most of the design:
+
+- **Multi-tenant by organization.** Every content record belongs to exactly one organization, users hold per-organization roles, and cross-organization sharing is explicit and approval-based. Details in [Security and Tenancy](./docs/architect/security-and-tenancy.md).
+- **Audit-first.** Security-relevant mutations write to an audit log that is append-only at the database layer — even a compromised admin role cannot rewrite history.
+- **Portable by design.** GovEA runs anywhere containers run — a laptop, an agency data center, or a government cloud. The application carries no cloud-specific assumptions. Details in [Runtime and Deployment](./docs/architect/runtime-and-deployment.md).
+
+The full architecture set lives in [docs/architect](./docs/architect/).
+
 ## Tech Stack
 
 - **App:** Next.js App Router, React, TypeScript
@@ -63,8 +94,6 @@ For detail, use these source-of-truth documents:
 - **UI:** Tailwind CSS and shadcn/ui
 - **Testing:** TypeScript, ESLint, Vitest integration tests, Playwright smoke tests
 - **Deployment:** containerized app plus PostgreSQL
-
-For deeper technical notes, start with [docs/architect](./docs/architect/).
 
 ## Quick Start
 
@@ -152,6 +181,10 @@ Framework support is taxonomy-and-recipe-backed ([ADR-0002: ADM as Classificatio
 GovEA is container-friendly and designed to run against PostgreSQL. Local development can use Docker or Podman. Azure demo deployment helpers are present, but operator-specific Azure account configuration belongs in private operator environments, not this public repository.
 
 See [Runtime and Deployment](./docs/architect/runtime-and-deployment.md) for architecture details and [Release Pipeline Policy](./docs/release-pipeline.md) for deployment privacy guidance.
+
+## Security
+
+Vulnerability reporting, scope, and the coordinated-disclosure policy are in [SECURITY.md](./SECURITY.md). The security architecture — identity, roles, tenant isolation, federation, and audit — is described in [Security and Tenancy](./docs/architect/security-and-tenancy.md).
 
 ## License
 

--- a/docs/architect/README.md
+++ b/docs/architect/README.md
@@ -1,8 +1,10 @@
 # GovEA Application Architecture
 
-This folder captures the current application architecture for GovEA. It is intended for maintainers, contributors, and reviewers who need to understand how the product is assembled before changing it.
+This folder captures the current application architecture for GovEA. It serves two audiences: architects evaluating GovEA for their organization, and maintainers, contributors, and reviewers who need to understand how the product is assembled before changing it.
 
-These documents are implementation-facing. Product intent, personas, and capability definitions remain in `business-architecture/`; schema detail remains in `docs/data-model.md`.
+**The shape in thirty seconds:** GovEA is a server-rendered Next.js application over PostgreSQL, deployed as a single container. Multi-tenancy is enforced at the application layer — every content record is scoped to an organization, users hold per-organization roles, and cross-organization behavior is explicit and approval-based. Every security-relevant mutation writes to an audit log that a database trigger makes append-only. There is no microservice topology, no message bus, and no client-side data authority; that simplicity is deliberate, chosen so government teams can self-host and reason about the system without a platform team.
+
+These documents are implementation-facing. Product intent, personas, and capability definitions remain in `business-architecture/`; schema detail remains in `docs/data-model.md`. Significant decisions and their tradeoffs are recorded as ADRs under [`docs/decisions/`](../decisions/).
 
 ## Documents
 


### PR DESCRIPTION
Closes #889

## What changed

**README.md**
- New **Where To Start** table routing five reader types (agency evaluator, architect, practitioner, security reviewer, developer) to the right document.
- New **Architecture at a Glance** section: one small diagram plus the three load-bearing design facts (org-scoped multi-tenancy, append-only audit, container portability), each linking to the full architecture doc.
- Linked [SECURITY.md](../blob/main/SECURITY.md) — it was previously unreferenced from the README.
- One honest pre-1.0 status sentence consistent with SECURITY.md's hardening-status guidance.

**docs/architect/README.md**
- States the evaluating-architect audience explicitly and adds a thirty-second plain-language summary of the system shape; points at `docs/decisions/` for ADRs.

**Repo hygiene**
- Removed committed `.claude/start-worktree-dev.sh` — it hardcoded a personal absolute path and stale worktree pointer, against the policy documented in docs/AI-SESSION-START.md; nothing referenced it.
- Repo-level ignore rules for `.claude/settings.local.json`, `.claude/start-worktree-dev.sh`, and `.claude/worktrees/` (previously only protected by the maintainer's global gitignore).

## Traceability

- Capability: none — repository orientation docs and hygiene; flagged in #889 per pre-flight rule. Policy anchors: Standards.md docs-accuracy, risk-register R-002.
- Persona: consultant-si, enterprise-architect, business-stakeholder

## How it was tested

- `node scripts/lint-business-architecture.mjs` — OK (115 files).
- All new relative links and anchors verified against existing files/headings; mermaid blocks use GitHub-renderable syntax.
- `git grep` confirms no remaining committed personal paths, emails, or operator identifiers in tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)