### PR TITLE
docs: bring architecture docs current with GovCore platform adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Three facts carry most of the design:
 - **Audit-first.** Security-relevant mutations write to an audit log that is append-only at the database layer — even a compromised admin role cannot rewrite history.
 - **Portable by design.** GovEA runs anywhere containers run — a laptop, an agency data center, or a government cloud. The application carries no cloud-specific assumptions. Details in [Runtime and Deployment](./docs/architect/runtime-and-deployment.md).
 
+GovEA also separates its reusable platform machinery (identity, tenancy, RBAC, audit) from its enterprise-architecture domain. That platform layer is being extracted into [GovCore](https://github.com/roballred/GovCore), a separately versioned set of `@govcore/*` packages GovEA consumes as dependencies — so the same hardened multi-tenant foundation can support other government applications. See [Platform Foundation](./docs/architect/application-overview.md#platform-foundation-govcore).
+
 The full architecture set lives in [docs/architect](./docs/architect/).
 
 ## Tech Stack
@@ -91,6 +93,7 @@ The full architecture set lives in [docs/architect](./docs/architect/).
 - **App:** Next.js App Router, React, TypeScript
 - **Database:** PostgreSQL with Drizzle ORM
 - **Auth:** Auth.js with local development auth and OIDC SSO architecture
+- **Platform foundation:** [GovCore](https://github.com/roballred/GovCore) — the reusable multi-tenant platform (identity, tenancy, RBAC, audit) that GovEA is built on, consumed as `@govcore/*` packages
 - **UI:** Tailwind CSS and shadcn/ui
 - **Testing:** TypeScript, ESLint, Vitest integration tests, Playwright smoke tests
 - **Deployment:** containerized app plus PostgreSQL

--- a/docs/architect/application-overview.md
+++ b/docs/architect/application-overview.md
@@ -2,6 +2,18 @@
 
 GovEA is a Next.js App Router application for maintaining an enterprise architecture repository. The implementation is intentionally simple: server-rendered pages, server actions for mutations, Drizzle for typed database access, and PostgreSQL as the system of record.
 
+## Platform Foundation (GovCore)
+
+GovEA separates its **platform plane** — the reusable machinery of identity, multi-tenancy, RBAC, audit, federation, and support access — from its **enterprise-architecture domain** (capabilities, goals, applications, and the rest of the repository model). The platform plane is being extracted into [**GovCore**](https://github.com/roballred/GovCore), a separately versioned set of `@govcore/*` packages that GovEA consumes as ordinary dependencies. GovEA is *consumer zero*: the first application built on GovCore, and the source the platform code is extracted from.
+
+For an architect, the practical shape today is:
+
+- **What GovEA consumes from GovCore now:** the RBAC engine. `apps/govea/src/lib/rbac.ts` builds GovEA's roles with `createRbac()` from `@govcore/rbac` (consumed from npm at `^0.1.0`); GovEA keeps its own `admin/contributor/viewer` role map and permission vocabulary app-local.
+- **What is prepared but not yet delegated:** the `organizations` table is deliberately kept core-shaped (id/name/slug/timestamps) so it can map onto GovCore's platform schema, with all GovEA configuration moved to the app-owned `organization_settings` sidecar. Auth, tenancy, audit, federation, and support access still live in `apps/govea/src` and will move to `@govcore/*` in later phases.
+- **What stays in GovEA permanently:** every EA domain entity and its logic. The litmus test is ownership of trust vs. ownership of meaning — if a table exists so the platform can answer "is this actor allowed to act in this org, and did we record it," it belongs in GovCore; if it carries `organization_id` because it is EA content, it stays here.
+
+The full extraction plan, phase status, and boundary rationale are in [`docs/design/platform-core-extraction.md`](../design/platform-core-extraction.md). The sections below describe GovEA as it runs today.
+
 ## Primary Runtime Shape
 
 ```mermaid
@@ -25,7 +37,7 @@ flowchart LR
 |---|---|---|
 | Routes and pages | `apps/govea/src/app/` | URL structure, server-rendered pages, route groups, and page-level data loading |
 | Server actions | `apps/govea/src/actions/` | Mutations, role gates, validation, relationship updates, and audit calls |
-| Domain helpers | `apps/govea/src/lib/` | Cross-cutting behavior such as RBAC, federation, confidence, audit, search, URL helpers, and support access |
+| Domain helpers | `apps/govea/src/lib/` | Cross-cutting behavior such as federation, confidence, audit, search, URL helpers, and support access. RBAC role math is provided by `@govcore/rbac`; `lib/rbac.ts` supplies GovEA's role/permission map and user-shaped wrappers |
 | Database schema | `apps/govea/src/db/schema/` | Drizzle table definitions, enums, and relationship tables |
 | Seed data | `apps/govea/src/db/seeds/` | Demo, dogfood, test, scale, and TOGAF-overlay fixture data |
 | UI components | `apps/govea/src/components/` | Shared page widgets, shell components, forms, banners, diagrams, and controls |
@@ -83,7 +95,7 @@ Middleware performs coarse route protection. Server actions and domain helpers p
 | Concern | Current implementation |
 |---|---|
 | Authentication | Auth.js with local credentials and optional OIDC SSO (current provider wiring targets Microsoft Entra ID); deploy-stable logout endpoint with a logged-out marker guarding against post-logout session resurrection (ADR-0003) |
-| Authorization | Per-membership org roles with an active-organization context (#693), plus separate `instance_admin` operating role |
+| Authorization | Per-membership org roles with an active-organization context (#693), plus separate `instance_admin` operating role; the role/permission math is supplied by `@govcore/rbac` |
 | Audit | Audit log made append-only by a DB trigger; covers content, identity, instance, and support-access events with IP/user-agent on auth events and an instance telemetry view |
 | Taxonomy & recipes | Org-scoped controlled vocabularies reused across entity types; curated sets (e.g. TOGAF 10) install idempotently through the recipe engine, with audience markers hiding framework jargon from viewers |
 | Reports | Generic group-by-taxonomy report engine with presets, plus completeness surfaces such as the duplicate-candidates report |
@@ -94,8 +106,9 @@ Middleware performs coarse route protection. Server actions and domain helpers p
 
 ## Planned Architectural Seams
 
-Two decided roadmap items change what an architect should expect from this shape:
+Three in-flight items change what an architect should expect from this shape:
 
+- **GovCore platform extraction (in progress)** — the platform plane (auth, tenancy, RBAC, audit, federation, support access) moves out of `apps/govea/src` into versioned `@govcore/*` packages, phase by phase. RBAC has already moved; auth, schema, and tenancy follow. The extraction also lands architectural hardening GovEA doesn't have today — database-enforced tenant isolation (Postgres Row-Level Security), a two-role database split, and a `tenantAction` wrapper that makes the tenant-boundary pattern the path of least resistance. See [`docs/design/platform-core-extraction.md`](../design/platform-core-extraction.md).
 - **REST API foundation (#775, v1.0)** — `/api/v1` read/write endpoints with token auth, RBAC/audit parity with the UI, generated OpenAPI, and bulk import. Route handlers join server actions as a first-class mutation surface; the same authorization helpers must serve both.
 - **First Tier-1 sync: ServiceNow ITSM/CMDB (#382, v2.0)** — built on the REST API foundation; integrations populate context and never silently overwrite architect-authored content.
 

--- a/docs/architect/runtime-and-deployment.md
+++ b/docs/architect/runtime-and-deployment.md
@@ -62,6 +62,8 @@ Common local paths:
 
 `db:migrate` exists in `package.json` but is intentionally not the current command — pre-production uses `db:push --force` everywhere, including CI. The switch to migrations happens when the first real tenant data exists; CLAUDE.md tracks the checklist.
 
+The [GovCore platform extraction](./application-overview.md#platform-foundation-govcore) reaches this seam first. When GovEA adopts `@govcore/schema`, the **platform** tables (organizations, users, memberships, audit, federation, support sessions) move to a core-owned migration stream run by `govcore-migrate`, while GovEA's own domain tables can stay on `db:push` until they need durable migrations too. Adopting GovCore is therefore what trips the "switch to migrations" criterion for the platform layer specifically — the platform schema is migration-based from the moment it is consumed, because a shared, versioned library cannot ship throwaway schema. See [`platform-core-extraction.md`](../design/platform-core-extraction.md) §5.
+
 Podman is preferred when available, but the compose helper can fall back to Docker.
 
 ## Runtime Configuration

--- a/docs/architect/security-and-tenancy.md
+++ b/docs/architect/security-and-tenancy.md
@@ -35,6 +35,8 @@ Since #693, the user–organization relationship is a membership model, not a co
 
 `instance_admin` is stored on the user, separately from membership roles. It does not mean the user owns every organization's architecture content.
 
+The role/permission math — which permissions each role holds and how roles rank — is provided by `@govcore/rbac` (see [Platform Foundation](./application-overview.md#platform-foundation-govcore)). The role *definitions* above stay app-local in `apps/govea/src/lib/rbac.ts`; GovCore ships the generic machinery, GovEA supplies its own vocabulary.
+
 ## Route Protection
 
 Middleware handles coarse protection. Per [ADR-0003](../decisions/0003-middleware-reads-tokens-never-writes.md) it decodes the session JWT **read-only** via `getToken` and never writes session cookies — the only session-cookie writers are the Auth.js endpoints and the logout handler:
@@ -132,6 +134,8 @@ Hardening already in place:
 - Security response headers ship on every response (X-Frame-Options DENY, nosniff, referrer policy, HSTS) with a Content-Security-Policy in **report-only** mode pending nonce/hash rollout (#743; enforcement is #765)
 - Org theme values are allowlisted before injection into the inline `<style>` tag, making style-tag breakout structurally impossible (#769)
 - Open hardening work is tracked in the v1.0 security wave: MFA for local credentials (#761), CI dependency/code scanning (#762), CSV formula-injection neutralization (#763), database TLS enforcement (#764), audit retention for public-records compliance (#767)
+
+**Where the tenant boundary is enforced today, and where it's headed.** Right now organization isolation is enforced in *application logic*: server actions resolve the active organization server-side and filter every query by `organization_id` (the pattern above). It is correct but relies on each action following the pattern. The [GovCore platform extraction](./application-overview.md#platform-foundation-govcore) will add defense in depth at the database layer — Postgres Row-Level Security policies keyed to a transaction-local organization setting, plus a two-role database split so the application's runtime role cannot bypass RLS or drop the audit-immutability trigger. After that cutover, a query that forgets its `organization_id` filter returns only the active org's rows instead of leaking across tenants. This is designed, not yet shipped; see [`platform-core-extraction.md`](../design/platform-core-extraction.md) §13.1–13.2.
 
 ## Security Design Notes
 

--- a/docs/design/platform-core-extraction.md
+++ b/docs/design/platform-core-extraction.md
@@ -1,8 +1,8 @@
 # Platform Core Extraction — Reusable Multi-Tenant Foundation
 
 **Initiative:** GovCore — a standalone platform-core initiative (its own repo, backlog, versioning, and release lifecycle), independent of GovEA's roadmap. GovEA is the first consumer, not the owner.
-**Status:** Proposal — core decisions locked; Phase 0–1 work breakdown in §12
-**Author:** AI-assisted · drafted 2026-06-19 · last updated 2026-06-21
+**Status:** In progress — core decisions locked; **Phase 0 shipped** and GovEA consumer-side prep for Phase 1 landed. See "Delivery status" below and the §12 checklist.
+**Author:** AI-assisted · drafted 2026-06-19 · last updated 2026-07-01
 **Audience:** Maintainer + architecture reviewers
 **License:** MIT (§11.7)
 **Supersedes:** the skeletal `packages/core` (`@govea/core`) as the long-term home for platform-plane code
@@ -16,6 +16,21 @@
 > and (2026-06-21) building the full content engine (Appendix B). §11's open list is now effectively
 > closed. Binding decisions are recorded here; they can graduate into the GovCore repo's own ADRs
 > once it exists.
+
+## Delivery status (as of 2026-07-01)
+
+This document began as a proposal; parts of it are now shipped. What's true in the code today:
+
+| Milestone | State | Evidence in GovEA |
+|---|---|---|
+| **Phase 0 — repo + generic RBAC** | **Shipped** | The `GovCore` repo exists ([github.com/roballred/GovCore](https://github.com/roballred/GovCore)); `@govcore/rbac` is published to npm and consumed at `^0.1.0`. `apps/govea/src/lib/rbac.ts` builds GovEA's role machinery with `createRbac()` from `@govcore/rbac`, keeping GovEA's `admin/contributor/viewer` map and 7-permission vocabulary app-local (§13.3). |
+| **Consumer-side prep for Phase 1** | **Shipped** | GovEA's `organizations` table is now core-shaped (id/name/slug/timestamps); all app configuration moved to the app-owned `organization_settings` sidecar (1:1, PK=FK), so `organizations` can map onto `@govcore/schema`'s platform table at the Phase 1 cutover without a data reshuffle. See `docs/data-model.md`. |
+| **Phase 1 — platform schema + migrations + RLS + two-role DB** | **Next / not started** | GovEA still runs `db:push` for all tables (ADR-008 pre-production policy). Adopting `@govcore/schema` + `govcore-migrate` for the platform tables is the ADR-008 cutover moment (§5). |
+| **Phases 2–5, content engine (Appendix B)** | **Not started** | — |
+
+**Consumption model in effect today:** `@govcore/rbac` is consumed as a published npm package (`^0.1.0`), not a `link:` workspace dependency; the earlier CI clone action for linked packages has been removed. GovCore packages are **source-first** (they ship TypeScript, no built `dist/`), so every consumed `@govcore/*` package is listed in `transpilePackages` in `apps/govea/next.config.ts`.
+
+The rest of this document (the numbered sections and appendices) is the **design of record** for the phases still ahead. Where a section describes future behavior (RLS, `tenantAction`, the migrate runner, the content engine), treat it as the target design, not a description of shipped code.
 
 ---
 
@@ -641,13 +656,13 @@ GovCore is a **standalone initiative**: its own repository, backlog, versioning,
 
 Binding decisions are recorded in this document (the §1 decisions table and the §13 resolutions). References to existing GovEA ADRs (ADR-0003, ADR-008, ADR-0002) are **provenance** — behavior the extraction must preserve — not new artifacts; GovCore will keep its own ADRs once its repo exists.
 
-### Phase 0 — repo skeleton + generic RBAC
+### Phase 0 — repo skeleton + generic RBAC — ✅ shipped
 
-- [ ] Stand up the GovCore repository: package skeletons, changesets, CI (typecheck, lint, edge-safety import gate, `examples/minimal-app` build).
-- [ ] Ship `@govcore/rbac` as a **generic `createRbac`** factory (§13.3); GovEA's `admin/contributor/viewer` map is the default export.
-- [ ] GovEA consumes `@govcore/rbac`; the `rbac-single-source` test stays green (one definition, now produced by `createRbac(...)`).
+- [x] Stand up the GovCore repository: package skeletons, changesets, CI (typecheck, lint, edge-safety import gate, `examples/minimal-app` build).
+- [x] Ship `@govcore/rbac` as a **generic `createRbac`** factory (§13.3); GovEA's `admin/contributor/viewer` map is the default export.
+- [x] GovEA consumes `@govcore/rbac` (from npm, `^0.1.0`); the `rbac-single-source` test stays green (one definition, now produced by `createRbac(...)`).
 
-**Done when:** `@govcore/rbac` is generic, GovEA builds on it with no behavior change, and `examples/minimal-app` compiles in CI.
+**Done:** `@govcore/rbac` is generic, GovEA builds on it with no behavior change, and `examples/minimal-app` compiles in CI. GovEA additionally moved its org configuration into the `organization_settings` sidecar (consumer-side prep so `organizations` is core-shaped ahead of Phase 1).
 
 ### Phase 1 — platform schema + migrations + RLS + two-role DB
 


### PR DESCRIPTION
Closes #891

## Why

GovEA now consumes the extracted **GovCore** platform (`@govcore/rbac` from npm; `lib/rbac.ts` builds roles via `createRbac()`), and the `organizations` table was reshaped core-shaped with config moved to the `organization_settings` sidecar. But the human-facing architecture docs and README still described GovEA as a self-contained monolith and never mentioned GovCore — so an architect reading the repo saw `@govcore/rbac` in the dependencies with no explanation. The design doc also still read "Proposal" with Phase 0 as unchecked boxes, though Phase 0 shipped.

## What changed

- **docs/architect/application-overview.md** — new **Platform Foundation (GovCore)** section: the platform/consumer boundary, what GovEA consumes today (RBAC) vs. what's prepared (core-shaped `organizations`) vs. what stays in-app permanently (EA domain), with the trust-vs-meaning litmus test. RBAC credited to `@govcore/rbac` in the domain-helper and authorization rows. GovCore extraction added as the first in-flight architectural seam.
- **docs/architect/security-and-tenancy.md** — RBAC math comes from `@govcore/rbac` (role *definitions* stay app-local); honest note on tenant-boundary enforcement: app-layer today, DB-enforced Row-Level Security + two-role split coming with GovCore.
- **docs/architect/runtime-and-deployment.md** — adopting `@govcore/schema` introduces `govcore-migrate` for platform tables and is what trips the platform-layer migration cutover.
- **README.md** — GovCore in the tech stack and the Architecture-at-a-Glance section.
- **docs/design/platform-core-extraction.md** — status updated from "Proposal" to reflect Phase 0 shipped + consumer-side prep landed; new **Delivery status** table; §12 Phase 0 boxes checked.

Everything not yet built (RLS, `tenantAction`, `govcore-migrate`, the content engine) is explicitly marked **designed, not shipped**, so the docs don't overstate the current build.

## Traceability

- Capability: none — architecture reference docs; flagged in #891 per pre-flight. Provenance: `iam-role-based-access-control`.
- Persona: enterprise-architect, domain-architect, consultant-si

## How it was tested

- `node scripts/lint-business-architecture.mjs` — OK (115 files).
- Cross-checked every claim against the code: `apps/govea/package.json` (`@govcore/rbac`: ^0.1.0), `lib/rbac.ts` (`createRbac`), `next.config.ts` (`transpilePackages`), `schema/organizations.ts` (core-shaped comment), `data-model.md` (sidecar).
- New anchor links (`#platform-foundation-govcore`) and relative doc links verified against existing headings/files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)