### PR TITLE
feat(auth): adopt @govcore/auth changePassword for self-service (part of #894)

### DIFF
--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.0",
-    "@govcore/auth": "^0.6.0",
+    "@govcore/auth": "^0.7.0",
     "@govcore/nextkit": "^0.5.0",
     "@govcore/rbac": "^0.1.0",
     "@govcore/schema": "^0.4.0",

--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.0",
-    "@govcore/auth": "^0.4.1",
+    "@govcore/auth": "^0.6.0",
     "@govcore/nextkit": "^0.5.0",
     "@govcore/rbac": "^0.1.0",
     "@govcore/schema": "^0.4.0",

--- a/apps/govea/src/actions/change-password.ts
+++ b/apps/govea/src/actions/change-password.ts
@@ -3,22 +3,24 @@
 /**
  * Self-service password change (#527).
  *
- * Reachable from /change-password — either voluntarily, or because the
- * middleware redirected the user after their password expired per the
- * org's `passwordExpiryDays` policy.
+ * Reachable from /change-password — either voluntarily, or because middleware
+ * redirected the user after their password expired per the org's
+ * `passwordExpiryDays` policy.
  *
- * Distinct from the admin-side `editUser` flow which can reset another
- * user's password without knowing the current one. This action ALWAYS
- * verifies the current password.
+ * The flow itself now lives in `@govcore/auth` (`changePassword`, GovCore #66 —
+ * GovEA #894): it verifies the current password, enforces the policy, rejects
+ * reuse, rehashes, clears lockout, and stamps `lastPasswordChangedAt` (so the
+ * expiry redirect keeps working), auditing `auth.password_changed` /
+ * `auth.password_change_failed` — all in one transaction. This wrapper is the
+ * thin GovEA seam: read the session, resolve the org's policy from the
+ * `securitySettings` column (still the source of truth, mapped to core's
+ * `PasswordPolicy`), and map the typed result to the form's `{ ok, message }`.
  */
-import { db } from '@/db/client'
-import { users } from '@/db/schema'
-import { eq } from 'drizzle-orm'
-import bcrypt from 'bcryptjs'
-import { auth } from '@/lib/auth'
+import { changePassword } from '@govcore/auth'
 import { redirect } from 'next/navigation'
-import { writeAuditLog } from '@/lib/audit'
-import { validatePassword } from '@/lib/password'
+import { db } from '@/db/client'
+import { auth } from '@/lib/auth'
+import { securitySettingsToPolicy } from '@/lib/password'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
 
 export type ChangePasswordResult =
@@ -28,70 +30,26 @@ export type ChangePasswordResult =
 export async function changeOwnPassword(formData: FormData): Promise<ChangePasswordResult> {
   const session = await auth()
   if (!session?.user) redirect('/login')
-  const userId = session.user.id
 
   const currentPassword = (formData.get('currentPassword') as string) ?? ''
   const newPassword = (formData.get('newPassword') as string) ?? ''
   const confirmPassword = (formData.get('confirmPassword') as string) ?? ''
 
+  // Confirmation match is a form concern; core takes only current + new.
   if (newPassword !== confirmPassword) {
     return { ok: false, message: 'New password and confirmation do not match' }
   }
 
-  const user = await db.query.users.findFirst({ where: eq(users.id, userId) })
-  if (!user || !user.passwordHash) {
-    return { ok: false, message: 'Account does not have a local password (SSO-only)' }
-  }
+  const policy = securitySettingsToPolicy(await getOrgSecuritySettings(session.user.organizationId))
 
-  const currentValid = await bcrypt.compare(currentPassword, user.passwordHash)
-  if (!currentValid) {
-    await writeAuditLog(db, {
-      action: 'auth.password_change_failed',
-      entityType: 'user',
-      entityId: userId,
-      userId,
-      organizationId: user.organizationId,
-      metadata: { reason: 'current_password_mismatch' },
-    })
-    return { ok: false, message: 'Current password is incorrect' }
-  }
-
-  // Validate against the org's policy. We could have skipped this for the
-  // expiry-forced path, but a forced rotation that lets the user keep a
-  // 4-character password is theater — enforce the policy unconditionally.
-  const policy = await getOrgSecuritySettings(user.organizationId)
-  const validation = validatePassword(newPassword, policy)
-  if (!validation.valid) {
-    return { ok: false, message: validation.message }
-  }
-
-  // Disallow reusing the current password — the bare minimum reuse check.
-  // (A full N-password history is a separate column + much larger feature.)
-  if (await bcrypt.compare(newPassword, user.passwordHash)) {
-    return { ok: false, message: 'New password must be different from the current password' }
-  }
-
-  const newHash = await bcrypt.hash(newPassword, 12)
-  const now = new Date()
-  await db.transaction(async (tx) => {
-    await tx.update(users)
-      .set({
-        passwordHash: newHash,
-        lastPasswordChangedAt: now,
-        // Successful password change also clears any lingering lockout state.
-        failedLoginAttempts: 0,
-        lockoutUntil: null,
-        updatedAt: now,
-      })
-      .where(eq(users.id, userId))
-    await writeAuditLog(tx, {
-      action: 'auth.password_changed',
-      entityType: 'user',
-      entityId: userId,
-      userId,
-      organizationId: user.organizationId,
-    })
+  // rounds: 12 preserves GovEA's bcrypt cost factor (core defaults to 10).
+  const result = await changePassword(db, {
+    userId: session.user.id,
+    currentPassword,
+    newPassword,
+    policy,
+    rounds: 12,
   })
 
-  return { ok: true }
+  return result.ok ? { ok: true } : { ok: false, message: result.message }
 }

--- a/apps/govea/src/actions/change-password.ts
+++ b/apps/govea/src/actions/change-password.ts
@@ -16,7 +16,7 @@
  * `securitySettings` column (still the source of truth, mapped to core's
  * `PasswordPolicy`), and map the typed result to the form's `{ ok, message }`.
  */
-import { changePassword } from '@govcore/auth'
+import { changePassword } from '@govcore/auth/password-flows'
 import { redirect } from 'next/navigation'
 import { db } from '@/db/client'
 import { auth } from '@/lib/auth'

--- a/apps/govea/src/actions/change-password.ts
+++ b/apps/govea/src/actions/change-password.ts
@@ -51,5 +51,19 @@ export async function changeOwnPassword(formData: FormData): Promise<ChangePassw
     rounds: 12,
   })
 
-  return result.ok ? { ok: true } : { ok: false, message: result.message }
+  if (result.ok) return { ok: true }
+
+  // The flow moved to @govcore/auth, but keep GovEA's original form wording so
+  // the UX (and the change-password tests) don't shift. weak-password falls
+  // through to core's policy message (same rules, same phrasing).
+  switch (result.reason) {
+    case 'no-local-password':
+      return { ok: false, message: 'Account does not have a local password (SSO-only)' }
+    case 'current-incorrect':
+      return { ok: false, message: 'Current password is incorrect' }
+    case 'reused':
+      return { ok: false, message: 'New password must be different from the current password' }
+    default:
+      return { ok: false, message: result.message }
+  }
 }

--- a/apps/govea/src/lib/password.ts
+++ b/apps/govea/src/lib/password.ts
@@ -9,7 +9,7 @@
  * OWASP A07 — Identification and Authentication Failures
  */
 import type { SecuritySettings } from '@/db/schema'
-import type { PasswordPolicy } from '@govcore/auth'
+import type { PasswordPolicy } from '@govcore/auth/password-flows'
 
 /** Fallback when no per-org policy is available (setup / pre-org paths). */
 export const FALLBACK_MIN_LENGTH = 8

--- a/apps/govea/src/lib/password.ts
+++ b/apps/govea/src/lib/password.ts
@@ -9,9 +9,27 @@
  * OWASP A07 — Identification and Authentication Failures
  */
 import type { SecuritySettings } from '@/db/schema'
+import type { PasswordPolicy } from '@govcore/auth'
 
 /** Fallback when no per-org policy is available (setup / pre-org paths). */
 export const FALLBACK_MIN_LENGTH = 8
+
+/**
+ * Map GovEA's typed `SecuritySettings` column to `@govcore/auth`'s `PasswordPolicy`.
+ * The password rules are 1:1 (min length + require upper/lower/digit/special), so
+ * core's flows enforce exactly the same policy; the extra `SecuritySettings` fields
+ * core doesn't model (expiry, lockout thresholds) stay app-side. Lets us keep the
+ * column as the source of truth while adopting `@govcore/auth`'s change/reset flows.
+ */
+export function securitySettingsToPolicy(s: SecuritySettings): PasswordPolicy {
+  return {
+    minLength: s.passwordMinLength,
+    requireUppercase: s.requireUppercase,
+    requireLowercase: s.requireLowercase,
+    requireDigit: s.requireDigit,
+    requireSpecial: s.requireSpecial,
+  }
+}
 
 /** @deprecated retained as named export for back-compat with the original code path. */
 export const PASSWORD_MIN_LENGTH = FALLBACK_MIN_LENGTH

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.4.0
         version: 1.11.1
       '@govcore/auth':
-        specifier: ^0.4.1
-        version: 0.4.1(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.6.0
+        version: 0.6.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
       '@govcore/nextkit':
         specifier: ^0.5.0
         version: 0.5.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
@@ -981,6 +981,12 @@ packages:
 
   '@govcore/auth@0.4.1':
     resolution: {integrity: sha512-vAhPdf2jRL0LKqBOtTrq81ljleurIfBui/4DDwX2ghzARKAZZJmPUySmjlHVkGIQy+Ze7OFQ7NEWObA53IRVJQ==}
+    peerDependencies:
+      next: ^15.0.0
+      react: ^19.0.0
+
+  '@govcore/auth@0.6.0':
+    resolution: {integrity: sha512-Et0pWDnYbmjnUBcYUxXumNAB29MIeIFBYu3sweoKcUearaQH5eDa81tQWISTxm5GWLCJRU5P3MbvNOQpyFhAhQ==}
     peerDependencies:
       next: ^15.0.0
       react: ^19.0.0
@@ -5137,6 +5143,51 @@ snapshots:
       - sqlite3
 
   '@govcore/auth@0.4.1(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)':
+    dependencies:
+      '@auth/drizzle-adapter': 1.11.1
+      '@govcore/audit': 0.1.4(postgres@3.4.8)
+      '@govcore/schema': 0.4.0
+      '@govcore/tenancy': 0.3.1(postgres@3.4.8)
+      bcryptjs: 2.4.3
+      drizzle-orm: 0.45.2(postgres@3.4.8)
+      next: 15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 5.0.0-beta.30(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - nodemailer
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@govcore/auth@0.6.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)':
     dependencies:
       '@auth/drizzle-adapter': 1.11.1
       '@govcore/audit': 0.1.4(postgres@3.4.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.4.0
         version: 1.11.1
       '@govcore/auth':
-        specifier: ^0.6.0
-        version: 0.6.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.7.0
+        version: 0.7.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
       '@govcore/nextkit':
         specifier: ^0.5.0
         version: 0.5.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
@@ -985,8 +985,8 @@ packages:
       next: ^15.0.0
       react: ^19.0.0
 
-  '@govcore/auth@0.6.0':
-    resolution: {integrity: sha512-Et0pWDnYbmjnUBcYUxXumNAB29MIeIFBYu3sweoKcUearaQH5eDa81tQWISTxm5GWLCJRU5P3MbvNOQpyFhAhQ==}
+  '@govcore/auth@0.7.0':
+    resolution: {integrity: sha512-w+wZIASORV31wibCjUaLzcV71Sjnwm/vFIahLo/klhdswO+nCHMSH2fnM6L+yliHhRVHTyTvBPyBGCXJA8PBsg==}
     peerDependencies:
       next: ^15.0.0
       react: ^19.0.0
@@ -5187,7 +5187,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@govcore/auth@0.6.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)':
+  '@govcore/auth@0.7.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)':
     dependencies:
       '@auth/drizzle-adapter': 1.11.1
       '@govcore/audit': 0.1.4(postgres@3.4.8)


### PR DESCRIPTION
Part of #894 — the self-service slice of the `@govcore/auth` password-flows cutover.

## What changed
- **`src/actions/change-password.ts`** — `changeOwnPassword` becomes a thin wrapper over `@govcore/auth`'s **`changePassword`** (GovCore #66). Core verifies the current password, enforces the policy, rejects reuse, rehashes, **clears lockout**, **stamps `lastPasswordChangedAt`** (so the expiry redirect keeps working), and audits `auth.password_changed` / `auth.password_change_failed` — all in one transaction. `rounds: 12` preserves GovEA's bcrypt cost factor; the confirm-match stays a form-level check.
- **`src/lib/password.ts`** — add `securitySettingsToPolicy()` mapping GovEA's typed `SecuritySettings` column (kept as the policy source of truth) to core's `PasswordPolicy`. The rules are **1:1** (min length + require upper/lower/digit/special), so no policy weakening; expiry/lockout thresholds stay app-side.

## Deliberately deferred (follow-up on #894)
These want CI/runtime verification of the RLS + transaction boundary, so they're not in this PR:
- `editUser`'s admin reset path → `adminResetPassword` (adds the distinct `auth.password_reset` audit). Note `adminResetPassword` opens its own transaction, so it commits separately from the name/email/role update — behavior the issue endorses.
- Consolidating the **5 remaining `validatePassword` callers** (`setup`, `instance`, `users`, …) onto core and deleting the local copy.

## Verification
- `change-password.ts` + `lib/password.ts` are **type-clean**.
- Heads-up for review: raw `npx tsc` surfaces pre-existing errors in `auth.ts`/`auth.config.ts` about `lastPasswordChangedAt`/`passwordExpiryDays` on the session `User` — a next-auth augmentation merge artifact **unrelated to this PR** (present on main once `@govcore/auth` is installed; GovEA's `next build` merges `src/types/next-auth.d.ts`). Worth a separate look, but not caused here.
- DB-backed change-password behavior runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
