### PR TITLE
refactor(iam): adopt @govcore/auth adminResetPassword + validator (#894)

### DIFF
--- a/apps/govea/src/actions/setup.ts
+++ b/apps/govea/src/actions/setup.ts
@@ -6,7 +6,10 @@ import { count } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
 import { redirect } from 'next/navigation'
 import { writeAuditLog } from '@/lib/audit'
-import { validatePassword } from '@/lib/password'
+// Import-light subpath — the @govcore/auth root pulls next-auth → next/server,
+// which vitest can't resolve (see lib/password.ts). Setup runs before any org
+// exists, so there's no per-org policy: core falls back to its minimum length.
+import { validatePassword } from '@govcore/auth/password'
 
 export async function isSetupComplete(): Promise<boolean> {
   const [result] = await db.select({ count: count() }).from(users)

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -7,7 +7,11 @@ import bcrypt from 'bcryptjs'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
-import { validatePassword } from '@/lib/password'
+// Import-light subpaths only — the @govcore/auth root pulls next-auth →
+// next/server, which vitest can't resolve (see lib/password.ts).
+import { validatePassword } from '@govcore/auth/password'
+import { adminResetPassword } from '@govcore/auth/password-flows'
+import { securitySettingsToPolicy } from '@/lib/password'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
 import { upsertMembership, setMembershipActiveFlag } from '@govcore/tenancy'
 import { redirect } from 'next/navigation'
@@ -107,7 +111,7 @@ export async function createUser(formData: FormData) {
   const password = formData.get('password') as string
   const role = formData.get('role') as 'admin' | 'contributor' | 'viewer'
 
-  const policy = await getOrgSecuritySettings(orgId)
+  const policy = securitySettingsToPolicy(await getOrgSecuritySettings(orgId))
   const pwValidation = validatePassword(password, policy)
   if (!pwValidation.valid) throw new Error(pwValidation.message)
 
@@ -363,17 +367,11 @@ export async function editUser(userId: string, formData: FormData) {
     updatedAt: new Date(),
   }
 
-  if (newPassword) {
-    const policy = await getOrgSecuritySettings(orgId)
-    const pwValidation = validatePassword(newPassword, policy)
-    if (!pwValidation.valid) throw new Error(pwValidation.message)
-    updates.passwordHash = await bcrypt.hash(newPassword, 12)
-    // #527 — reset password-change clock + clear lockout state when an
-    // admin resets a user's password. Mirrors the self-service path.
-    updates.lastPasswordChangedAt = new Date()
-    updates.failedLoginAttempts = 0
-    updates.lockoutUntil = null
-  }
+  // Resolve the policy before opening the transaction — it's a read, and an
+  // operator reset must enforce the same rules as the self-service path.
+  const policy = newPassword
+    ? securitySettingsToPolicy(await getOrgSecuritySettings(orgId))
+    : null
 
   await db.transaction(async (tx) => {
     await tx.update(users).set(updates).where(
@@ -392,5 +390,27 @@ export async function editUser(userId: string, formData: FormData) {
       before: { name: before?.name, email: before?.email, role: before?.role },
       after: { name, email, role },
     })
+
+    // #894 — the operator reset is @govcore/auth's adminResetPassword: it
+    // enforces the policy, rehashes at GovEA's cost factor, stamps
+    // lastPasswordChangedAt (so the #527 expiry redirect keeps working),
+    // clears lockout state, and writes a distinct auth.password_reset event
+    // attributed to the operator — previously this reset was invisible,
+    // folded into the generic user.edit audit above.
+    //
+    // Runs on `tx` (a tx satisfies core's GovcoreDb; core's own transaction
+    // nests as a savepoint) so the profile edit and the reset still commit
+    // together. A rejected password throws, rolling the whole edit back —
+    // matching the previous behavior, where validation threw before any write.
+    if (newPassword) {
+      const reset = await adminResetPassword(tx, {
+        userId,
+        newPassword,
+        actorUserId: session.user.id,
+        policy,
+        rounds: 12,
+      })
+      if (!reset.ok) throw new Error(reset.message)
+    }
   })
 }

--- a/apps/govea/src/lib/password.ts
+++ b/apps/govea/src/lib/password.ts
@@ -1,25 +1,28 @@
 /**
- * Shared password policy for all credential-creation paths.
+ * The bridge between GovEA's per-org security settings and `@govcore/auth`'s
+ * password policy (#894).
  *
- * Reads the per-org policy from the caller's `organizations.securitySettings`
- * row (#527). Callers that don't have a policy in hand (e.g. setup, where
- * no org exists yet) get the documented hard-coded fallback:
- * `FALLBACK_MIN_LENGTH = 8`.
+ * The policy *rules* (min length, character classes) and their validator now
+ * live in `@govcore/auth` — import `validatePassword` / `FALLBACK_MIN_LENGTH`
+ * from `@govcore/auth/password` rather than re-implementing them here. What
+ * stays app-side is the mapping below, because GovEA reads its policy from a
+ * typed `organization_settings` column while core takes a plain options bag.
+ *
+ * Import from the `@govcore/auth/password` subpath, never the package root: the
+ * root entry pulls `createAuth` → `next-auth` → `next/server`, which vitest
+ * cannot resolve, and that breaks every suite loading a module that imports it.
  *
  * OWASP A07 — Identification and Authentication Failures
  */
 import type { SecuritySettings } from '@/db/schema'
-import type { PasswordPolicy } from '@govcore/auth/password-flows'
-
-/** Fallback when no per-org policy is available (setup / pre-org paths). */
-export const FALLBACK_MIN_LENGTH = 8
+import type { PasswordPolicy } from '@govcore/auth/password'
 
 /**
  * Map GovEA's typed `SecuritySettings` column to `@govcore/auth`'s `PasswordPolicy`.
  * The password rules are 1:1 (min length + require upper/lower/digit/special), so
- * core's flows enforce exactly the same policy; the extra `SecuritySettings` fields
- * core doesn't model (expiry, lockout thresholds) stay app-side. Lets us keep the
- * column as the source of truth while adopting `@govcore/auth`'s change/reset flows.
+ * core enforces exactly the same policy; the extra `SecuritySettings` fields core
+ * doesn't model (expiry, lockout thresholds) stay app-side. This lets the column
+ * remain the source of truth while core owns the validation and the flows.
  */
 export function securitySettingsToPolicy(s: SecuritySettings): PasswordPolicy {
   return {
@@ -29,46 +32,4 @@ export function securitySettingsToPolicy(s: SecuritySettings): PasswordPolicy {
     requireDigit: s.requireDigit,
     requireSpecial: s.requireSpecial,
   }
-}
-
-/** @deprecated retained as named export for back-compat with the original code path. */
-export const PASSWORD_MIN_LENGTH = FALLBACK_MIN_LENGTH
-
-export type PasswordValidationResult =
-  | { valid: true }
-  | { valid: false; message: string }
-
-/**
- * Validate a password against an optional per-org policy. When `policy` is
- * undefined, the FALLBACK_MIN_LENGTH minimum is the only rule enforced —
- * matching the pre-#527 behavior so legacy callers don't accidentally
- * become more permissive than before.
- */
-export function validatePassword(
-  password: string | null | undefined,
-  policy?: SecuritySettings | null,
-): PasswordValidationResult {
-  if (!password || password.trim() === '') {
-    return { valid: false, message: 'Password is required' }
-  }
-
-  const minLength = policy?.passwordMinLength ?? FALLBACK_MIN_LENGTH
-  if (password.length < minLength) {
-    return { valid: false, message: `Password must be at least ${minLength} characters` }
-  }
-
-  if (policy?.requireUppercase && !/[A-Z]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one uppercase letter' }
-  }
-  if (policy?.requireLowercase && !/[a-z]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one lowercase letter' }
-  }
-  if (policy?.requireDigit && !/[0-9]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one digit' }
-  }
-  if (policy?.requireSpecial && !/[^A-Za-z0-9]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one special character' }
-  }
-
-  return { valid: true }
 }

--- a/apps/govea/tests/integration/security-settings.test.ts
+++ b/apps/govea/tests/integration/security-settings.test.ts
@@ -26,7 +26,10 @@ import bcrypt from 'bcryptjs'
 import { saveSecuritySettings, getSecuritySettingsForUi } from '@/actions/security-settings'
 import { changeOwnPassword } from '@/actions/change-password'
 import { createUser, editUser } from '@/actions/users'
-import { validatePassword, FALLBACK_MIN_LENGTH } from '@/lib/password'
+// #894 — the validator + fallback now come from @govcore/auth; GovEA keeps only
+// the SecuritySettings → PasswordPolicy mapper.
+import { validatePassword, FALLBACK_MIN_LENGTH } from '@govcore/auth/password'
+import { securitySettingsToPolicy } from '@/lib/password'
 import { isPasswordExpired, mergeWithDefaults } from '@/lib/security-policy'
 import {
   createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
@@ -117,7 +120,7 @@ describe('security settings (#527)', () => {
   // ── validatePassword honours per-org policy ───────────────────────────────
 
   it('validatePassword: each rule fires the right error message', () => {
-    const strict = {
+    const settings = {
       passwordMinLength: 12,
       requireUppercase: true,
       requireLowercase: true,
@@ -128,6 +131,10 @@ describe('security settings (#527)', () => {
       lockoutDurationMinutes: 30,
       passwordExpiryDays: 0,
     }
+    // The org policy still lives in the SecuritySettings column; securitySettingsToPolicy
+    // is the seam that hands it to core's validator, so exercise it end to end.
+    const strict = securitySettingsToPolicy(settings)
+
     expect(validatePassword('', strict)).toMatchObject({ valid: false })
     expect(validatePassword('Short1!', strict)).toMatchObject({ valid: false, message: expect.stringMatching(/12/) })
     expect(validatePassword('alllowercase1!', strict)).toMatchObject({ valid: false, message: expect.stringMatching(/uppercase/i) })


### PR DESCRIPTION
Closes #894
Capability: `iam-user-management`

Completes the `@govcore/auth` password-flows cutover started in #905 (self-service change). **No GovCore work was needed** — everything used here was already published.

## What changed
**`editUser`'s operator reset → `adminResetPassword`.** It was still inline: validate, `bcrypt.hash(newPassword, 12)`, then hand-stamp `lastPasswordChangedAt` / `failedLoginAttempts` / `lockoutUntil`. Core does all of that *and* writes a distinct **`auth.password_reset`** event attributed to the operator — previously an admin resetting someone's password was invisible in the audit trail, folded into the generic `user.edit` event. That's the behavior improvement the issue predicted.

It runs on the existing `tx` (a `tx` satisfies core's `GovcoreDb`; core's own transaction nests as a savepoint), so the profile edit and the reset still commit together. A rejected password throws and rolls the whole edit back — matching the old behavior, where validation threw before any write.

**`lib/password.ts` drops `validatePassword`.** I diffed it against core's before deleting: byte-for-byte the same rules — same `'Password is required'` empty-check, same `FALLBACK_MIN_LENGTH = 8`, same per-rule messages, same result shape. The only real difference was the policy *parameter type*, so what stays app-side is `securitySettingsToPolicy` — the seam between GovEA's typed `SecuritySettings` column (which also carries `passwordExpiryDays` + lockout thresholds core doesn't model) and core's `PasswordPolicy` bag. The column remains the source of truth, per the issue's recommendation; `passwordPolicyFromMetadata` stays unused.

The two remaining callers import core's validator directly: `createUser` (maps the org policy) and `setup` (no policy — pre-org, so core's fallback applies).

**Import-light subpaths only** (`@govcore/auth/password`, `/password-flows`). The package root pulls `createAuth → next-auth → next/server`, which vitest can't resolve — the trap that cost #909 a release cycle. `dist/password.js` is verified free of any next-auth reference.

## Acceptance
- [x] `@govcore/auth` consumed; local `validatePassword` deleted (`change-password.ts` is already the thin wrapper from #905)
- [x] `editUser` reset uses `adminResetPassword`; `auth.password_reset` attributed to the operator
- [x] `SecuritySettings → PasswordPolicy` mapper in place; `rounds: 12` preserves GovEA's cost factor
- [x] Expiry redirect still works — core stamps `lastPasswordChangedAt`
- [ ] Change-password + user-edit tests green (CI)

## How it was verified
- `pnpm --filter govea exec tsc --noEmit` — clean (the Type check job's command).
- `pnpm --filter govea lint` — 0 errors.
- Covered by existing integration tests, which pin the behavior and are the gate (Postgres, CI): `users.test.ts` (short password → `/at least 8 characters/i` **and hash unchanged**; 8+ → hash updated), `security-settings.test.ts` (per-rule messages via the mapper; `createUser` → `/digit/i`; `editUser` reset clears lockout + resets the timestamp).
- `security-settings.test.ts` updated to import the validator/fallback from core and route the org settings through `securitySettingsToPolicy`, exercising the mapper end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)