### PR TITLE
feat(shell): adopt @govcore/nextkit GroupedSideNav for the sidebar groups (#898 phase 1)

### DIFF
--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.0",
     "@govcore/auth": "^0.9.0",
-    "@govcore/nextkit": "^0.5.0",
+    "@govcore/nextkit": "^0.8.0",
     "@govcore/rbac": "^0.1.0",
     "@govcore/schema": "^0.4.0",
     "@govcore/server": "^0.3.1",

--- a/apps/govea/package.json
+++ b/apps/govea/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.0",
     "@govcore/auth": "^0.9.0",
-    "@govcore/nextkit": "^0.8.0",
+    "@govcore/nextkit": "^0.8.1",
     "@govcore/rbac": "^0.1.0",
     "@govcore/schema": "^0.4.0",
     "@govcore/server": "^0.3.1",

--- a/apps/govea/src/actions/setup.ts
+++ b/apps/govea/src/actions/setup.ts
@@ -6,7 +6,10 @@ import { count } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
 import { redirect } from 'next/navigation'
 import { writeAuditLog } from '@/lib/audit'
-import { validatePassword } from '@/lib/password'
+// Import-light subpath — the @govcore/auth root pulls next-auth → next/server,
+// which vitest can't resolve (see lib/password.ts). Setup runs before any org
+// exists, so there's no per-org policy: core falls back to its minimum length.
+import { validatePassword } from '@govcore/auth/password'
 
 export async function isSetupComplete(): Promise<boolean> {
   const [result] = await db.select({ count: count() }).from(users)

--- a/apps/govea/src/actions/users.ts
+++ b/apps/govea/src/actions/users.ts
@@ -7,7 +7,11 @@ import bcrypt from 'bcryptjs'
 import { auth } from '@/lib/auth'
 import { isAdmin } from '@/lib/rbac'
 import { writeAuditLog } from '@/lib/audit'
-import { validatePassword } from '@/lib/password'
+// Import-light subpaths only — the @govcore/auth root pulls next-auth →
+// next/server, which vitest can't resolve (see lib/password.ts).
+import { validatePassword } from '@govcore/auth/password'
+import { adminResetPassword } from '@govcore/auth/password-flows'
+import { securitySettingsToPolicy } from '@/lib/password'
 import { getOrgSecuritySettings } from '@/lib/security-policy'
 import { upsertMembership, setMembershipActiveFlag } from '@govcore/tenancy'
 import { redirect } from 'next/navigation'
@@ -107,7 +111,7 @@ export async function createUser(formData: FormData) {
   const password = formData.get('password') as string
   const role = formData.get('role') as 'admin' | 'contributor' | 'viewer'
 
-  const policy = await getOrgSecuritySettings(orgId)
+  const policy = securitySettingsToPolicy(await getOrgSecuritySettings(orgId))
   const pwValidation = validatePassword(password, policy)
   if (!pwValidation.valid) throw new Error(pwValidation.message)
 
@@ -363,17 +367,11 @@ export async function editUser(userId: string, formData: FormData) {
     updatedAt: new Date(),
   }
 
-  if (newPassword) {
-    const policy = await getOrgSecuritySettings(orgId)
-    const pwValidation = validatePassword(newPassword, policy)
-    if (!pwValidation.valid) throw new Error(pwValidation.message)
-    updates.passwordHash = await bcrypt.hash(newPassword, 12)
-    // #527 — reset password-change clock + clear lockout state when an
-    // admin resets a user's password. Mirrors the self-service path.
-    updates.lastPasswordChangedAt = new Date()
-    updates.failedLoginAttempts = 0
-    updates.lockoutUntil = null
-  }
+  // Resolve the policy before opening the transaction — it's a read, and an
+  // operator reset must enforce the same rules as the self-service path.
+  const policy = newPassword
+    ? securitySettingsToPolicy(await getOrgSecuritySettings(orgId))
+    : null
 
   await db.transaction(async (tx) => {
     await tx.update(users).set(updates).where(
@@ -392,5 +390,27 @@ export async function editUser(userId: string, formData: FormData) {
       before: { name: before?.name, email: before?.email, role: before?.role },
       after: { name, email, role },
     })
+
+    // #894 — the operator reset is @govcore/auth's adminResetPassword: it
+    // enforces the policy, rehashes at GovEA's cost factor, stamps
+    // lastPasswordChangedAt (so the #527 expiry redirect keeps working),
+    // clears lockout state, and writes a distinct auth.password_reset event
+    // attributed to the operator — previously this reset was invisible,
+    // folded into the generic user.edit audit above.
+    //
+    // Runs on `tx` (a tx satisfies core's GovcoreDb; core's own transaction
+    // nests as a savepoint) so the profile edit and the reset still commit
+    // together. A rejected password throws, rolling the whole edit back —
+    // matching the previous behavior, where validation threw before any write.
+    if (newPassword) {
+      const reset = await adminResetPassword(tx, {
+        userId,
+        newPassword,
+        actorUserId: session.user.id,
+        policy,
+        rounds: 12,
+      })
+      if (!reset.ok) throw new Error(reset.message)
+    }
   })
 }

--- a/apps/govea/src/components/app-shell.tsx
+++ b/apps/govea/src/components/app-shell.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useState, useEffect, useCallback, type ReactNode, type KeyboardEvent } from 'react'
+import { useState, useEffect, type ReactNode } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import type { Role } from '@/lib/rbac'
 import { DarkModeToggle } from '@govcore/nextkit/theming'
+import { GroupedSideNav, type NavGroup as CoreNavGroup } from '@govcore/nextkit'
 import { TourButton } from '@/components/product-tour'
 import { isModuleEnabled, moduleForPath } from '@/lib/modules'
-import { groupSlug, readOpenGroup, writeOpenGroup } from '@/lib/nav-groups'
 
 // ── Nav structure ─────────────────────────────────────────────────────────────
 
@@ -116,52 +116,52 @@ function SidebarContent({
   const isContributor = role === 'admin' || role === 'contributor'
   const isViewer = role === 'viewer'
 
-  // #662 single-open accordion. Default-collapsed on first load; storage
-  // holds at most one open group at a time under `nav.openGroup`. The
-  // initial render renders all-collapsed so SSR + hydration agree; an
-  // effect syncs from localStorage after mount.
-  const [openGroup, setOpenGroup] = useState<string | null>(null)
+  // #898 — the collapsible group accordion is now @govcore/nextkit's
+  // GroupedSideNav (branded tone). GovEA still owns role/module gating: filter
+  // groups + items here, compute `active` per item, and mark the group holding
+  // the active route `defaultOpen` (nextkit's native <details> accordion opens
+  // it with no client JS). The ungrouped links (Dashboard/Overview/
+  // Notifications) and the Platform Admin footer stay bespoke below — they
+  // carry a badge, a tour anchor, and a distinct treatment GroupedSideNav's
+  // plain items don't model.
+  const isActive = (href: string) => pathname === href || pathname.startsWith(href + '/')
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const stored = readOpenGroup(window.localStorage)
-    if (stored !== null) setOpenGroup(stored)
-  }, [])
+  const visibleGroups: CoreNavGroup[] = NAV_GROUPS
+    .filter(g => !g.adminOnly || isAdmin)
+    .filter(g => !(g.viewerHidden && isViewer))
+    .map(group => {
+      const items = group.items
+        .filter(
+          item =>
+            (!item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])) &&
+            (!item.contributorOnly || isContributor) &&
+            !(item.viewerHidden && isViewer)
+        )
+        .map(item => ({ href: item.href, label: item.label, active: isActive(item.href) }))
+      return { label: group.label, items, defaultOpen: items.some(i => i.active) }
+    })
+    .filter(group => group.items.length > 0)
 
-  // Open exactly one group; clicking the currently-open group collapses it.
-  // Setting `force=true` always opens (used by the global helper below so
-  // the product tour can pre-open a group regardless of current state).
-  const setOpenGroupAndPersist = useCallback((label: string | null) => {
-    setOpenGroup(label)
-    if (typeof window !== 'undefined') {
-      writeOpenGroup(label, window.localStorage)
-    }
-  }, [])
-
-  const toggleGroup = useCallback((label: string) => {
-    setOpenGroupAndPersist(openGroup === label ? null : label)
-  }, [openGroup, setOpenGroupAndPersist])
-
-  const onGroupKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>, label: string) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      toggleGroup(label)
-    }
-  }, [toggleGroup])
-
-  // #662 — expose a global hook so the product tour can ensure a parent
-  // nav group is open before highlighting a child link. Idempotent;
-  // setting the same group again is a no-op. Cleared on unmount.
+  // #662/#898 — expose the product-tour hook over nextkit's native accordion:
+  // opening a group is `details.open = true` on the `data-nav-group` element
+  // GroupedSideNav emits (both the desktop and mobile sidebars carry one, so
+  // set every match). Replaces the old controlled-state setter; the tour code
+  // still just calls `window.__goveaOpenNavGroup(label)`. Cross-session
+  // persistence of the open group is intentionally dropped (GovCore #103 —
+  // the active group auto-opens via defaultOpen, which is the case that
+  // mattered).
   useEffect(() => {
     if (typeof window === 'undefined') return
     const w = window as unknown as { __goveaOpenNavGroup?: (label: string) => void }
     w.__goveaOpenNavGroup = (label: string) => {
-      setOpenGroupAndPersist(label)
+      document
+        .querySelectorAll<HTMLDetailsElement>(`[data-nav-group="${label.replace(/"/g, '\\"')}"]`)
+        .forEach(el => { el.open = true })
     }
     return () => {
       delete w.__goveaOpenNavGroup
     }
-  }, [setOpenGroupAndPersist])
+  }, [])
 
   return (
     <nav aria-label={navLabel} className="flex flex-col h-full overflow-y-auto py-4 px-3 gap-1">
@@ -172,7 +172,7 @@ function SidebarContent({
         data-tour="dashboard"
         className={cn(
           'rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          pathname === '/dashboard' || pathname.startsWith('/dashboard/')
+          isActive('/dashboard')
             ? 'bg-white/15 text-white'
             : 'text-white/70 hover:bg-white/10 hover:text-white'
         )}
@@ -186,7 +186,7 @@ function SidebarContent({
         onClick={onClose}
         className={cn(
           'rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          pathname === '/overview' || pathname.startsWith('/overview/')
+          isActive('/overview')
             ? 'bg-white/15 text-white'
             : 'text-white/70 hover:bg-white/10 hover:text-white'
         )}
@@ -204,7 +204,7 @@ function SidebarContent({
         onClick={onClose}
         className={cn(
           'flex items-center justify-between gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-          pathname === '/notifications' || pathname.startsWith('/notifications/')
+          isActive('/notifications')
             ? 'bg-white/15 text-white'
             : 'text-white/70 hover:bg-white/10 hover:text-white'
         )}
@@ -217,98 +217,14 @@ function SidebarContent({
         ) : null}
       </Link>
 
-      <div className="mt-2 space-y-4">
-        {NAV_GROUPS
-          .filter(g => !g.adminOnly || isAdmin)
-          .filter(g => !(g.viewerHidden && isViewer))
-          .map(group => {
-          const visibleItems = group.items.filter(
-            item =>
-              (!item.moduleKey || isModuleEnabled(enabledModules, item.moduleKey as Parameters<typeof isModuleEnabled>[1])) &&
-              (!item.contributorOnly || isContributor) &&
-              !(item.viewerHidden && isViewer)
-          )
-          if (visibleItems.length === 0) return null
-          // Single-open accordion (#662). The group is open if it's the
-          // currently-open one OR it contains the active route (the
-          // containing-active-route guard keeps the active-link highlight
-          // visible without requiring the user to expand the group
-          // manually). The containing-active group also "wins" against
-          // the user's explicit open group when both apply — same group.
-          const containsActive = visibleItems.some(item =>
-            pathname === item.href || pathname.startsWith(item.href + '/')
-          )
-          const effectiveOpen = openGroup === group.label || containsActive
-          const groupId = `navgroup-${groupSlug(group.label)}`
-          return (
-            <div key={group.label}>
-              <button
-                type="button"
-                aria-expanded={effectiveOpen}
-                aria-controls={groupId}
-                onClick={() => toggleGroup(group.label)}
-                onKeyDown={(e) => onGroupKeyDown(e, group.label)}
-                data-tour={group.label === 'Business Architecture' ? 'nav-business-arch' : group.label === 'Strategy' ? 'nav-strategy' : group.label === 'Reports' ? 'nav-reports' : undefined}
-                /* #662: top-level group rows are visually a little more
-                   prominent than child links — slightly larger text, more
-                   padding, brighter idle color — but still clearly the
-                   header for a sub-list, not a full nav item. */
-                className="flex w-full items-center justify-between px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-white/60 select-none rounded-sm hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40 transition-colors"
-              >
-                <span>{group.label}</span>
-                {/* Disclosure triangle: rotates 90° when open. */}
-                <svg
-                  className={cn(
-                    'h-3 w-3 shrink-0 transition-transform duration-150 ease-out',
-                    effectiveOpen ? 'rotate-90' : 'rotate-0'
-                  )}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2.5}
-                  aria-hidden="true"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                </svg>
-              </button>
-              <div
-                id={groupId}
-                hidden={!effectiveOpen}
-                className="mt-0.5 space-y-0.5"
-              >
-                {visibleItems.map(item => {
-                  const active = pathname === item.href || pathname.startsWith(item.href + '/')
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      onClick={onClose}
-                      data-tour={
-                        item.href === '/personas'      ? 'nav-personas'      :
-                        item.href === '/value-streams' ? 'nav-value-streams' :
-                        item.href === '/capabilities'  ? 'nav-capabilities'  :
-                        item.href === '/services'      ? 'nav-services'      :
-                        item.href === '/applications'  ? 'nav-applications'  :
-                        item.href === '/adrs'          ? 'nav-adrs'          :
-                        item.href === '/roadmap'       ? 'nav-roadmap'       :
-                        undefined
-                      }
-                      className={cn(
-                        'block rounded-md px-3 py-2 text-sm transition-colors',
-                        active
-                          ? 'bg-white/15 text-white font-medium'
-                          : 'text-white/70 hover:bg-white/10 hover:text-white'
-                      )}
-                    >
-                      {item.label}
-                    </Link>
-                  )
-                })}
-              </div>
-            </div>
-          )
-        })}
-      </div>
+      {/* Collapsible sections — @govcore/nextkit GroupedSideNav on the branded
+          rail (#898). A distinct aria-label keeps the two nav landmarks unique. */}
+      <GroupedSideNav
+        groups={visibleGroups}
+        ariaLabel={`${navLabel} sections`}
+        tone="branded"
+        className="mt-2 w-full"
+      />
 
       {/* Platform Admin section — instance admins only */}
       {isInstanceAdmin && (

--- a/apps/govea/src/components/product-tour.tsx
+++ b/apps/govea/src/components/product-tour.tsx
@@ -12,53 +12,43 @@ const ROLE_COPY: Record<Role, string> = {
 }
 
 /**
- * Map data-tour identifiers to the nav group that owns them (#662).
+ * Map each nav step's element selector to the nav group that owns it (#662/#898).
  *
- * Children of a collapsed group are hidden via `hidden` on the panel
- * <div>, which makes driver.js unable to highlight them. Before each
- * step targeting a child, we call `window.__goveaOpenNavGroup(group)`
- * to ensure the parent is open. Group-label steps themselves
- * (nav-business-arch / nav-strategy / nav-reports) also call the
- * helper so the group expands on focus.
+ * The sidebar's groups are now @govcore/nextkit's GroupedSideNav (a native
+ * <details> accordion), so tour steps target the rendered DOM directly: a group
+ * header by its `[data-nav-group="<label>"]` attribute, a child link by its
+ * `a[href="/…"]`. A collapsed group hides its children, which driver.js can't
+ * highlight, so before each such step we call `window.__goveaOpenNavGroup(group)`
+ * (AppShell registers it) to open the parent first.
  *
- * Top-level targets that aren't inside a collapsible group (dashboard,
- * search, role-badge) are intentionally absent from the map.
+ * Top-level targets outside a collapsible group (dashboard, search, role-badge)
+ * are intentionally absent.
  */
-const NAV_TOUR_GROUPS: Record<string, string> = {
-  'nav-business-arch': 'Business Architecture',
-  'nav-personas':      'Business Architecture',
-  'nav-value-streams': 'Business Architecture',
-  'nav-capabilities':  'Business Architecture',
-  'nav-services':      'Business Architecture',
-  'nav-applications':  'Portfolio',
-  'nav-adrs':          'Portfolio',
-  'nav-strategy':      'Strategy',
-  'nav-roadmap':       'Strategy',
-  'nav-reports':       'Reports',
-}
-
-/** Extract the `data-tour` token from a `[data-tour="..."]` element selector. */
-function tourTokenFromSelector(selector: string): string | null {
-  const m = selector.match(/\[data-tour="([^"]+)"\]/)
-  return m ? m[1] : null
+const NAV_GROUP_FOR_SELECTOR: Record<string, string> = {
+  '[data-nav-group="Business Architecture"]': 'Business Architecture',
+  'a[href="/personas"]':                      'Business Architecture',
+  'a[href="/value-streams"]':                 'Business Architecture',
+  'a[href="/capabilities"]':                  'Business Architecture',
+  'a[href="/services"]':                      'Business Architecture',
+  'a[href="/applications"]':                  'Portfolio',
+  'a[href="/adrs"]':                          'Portfolio',
+  '[data-nav-group="Strategy"]':              'Strategy',
+  'a[href="/roadmap"]':                       'Strategy',
+  '[data-nav-group="Reports"]':               'Reports',
 }
 
 /**
- * Builds the onHighlightStarted callback for a step. If the step targets a
- * nav child whose parent group is collapsible, the callback opens that
- * group via the global helper registered by AppShell. No-op for steps
- * outside the nav-group accordion (Dashboard, Search, role badge).
+ * Builds the onHighlightStarted callback for a step. If the step targets a nav
+ * element inside a collapsible group, the callback opens that group via the
+ * global helper registered by AppShell. No-op for steps outside the nav-group
+ * accordion (Dashboard, Search, role badge).
  */
 function makeNavGroupOpener(elementSelector: string): (() => void) | undefined {
-  const token = tourTokenFromSelector(elementSelector)
-  if (!token) return undefined
-  const group = NAV_TOUR_GROUPS[token]
+  const group = NAV_GROUP_FOR_SELECTOR[elementSelector]
   if (!group) return undefined
   return () => {
     const w = window as unknown as { __goveaOpenNavGroup?: (label: string) => void }
-    if (typeof w.__goveaOpenNavGroup === 'function') {
-      w.__goveaOpenNavGroup(group)
-    }
+    w.__goveaOpenNavGroup?.(group)
   }
 }
 
@@ -82,7 +72,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-business-arch"]',
+        element: '[data-nav-group="Business Architecture"]',
         popover: {
           title: 'Business Architecture',
           description: 'Document who you serve, what your organization does, and how value flows. These records anchor everything else in the catalog.',
@@ -91,7 +81,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-personas"]',
+        element: 'a[href="/personas"]',
         popover: {
           title: 'Personas',
           description: 'Add the people your services are built for — residents, businesses, staff, and partner agencies. Link them to capabilities and services to track who each part of your architecture serves.',
@@ -100,7 +90,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-value-streams"]',
+        element: 'a[href="/value-streams"]',
         popover: {
           title: 'Value Streams',
           description: 'Map how work moves from a triggering event to an outcome. Link stages to capabilities to see where gaps or handoff problems exist.',
@@ -109,7 +99,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-capabilities"]',
+        element: 'a[href="/capabilities"]',
         popover: {
           title: 'Capabilities',
           description: 'Record what your organization does, independent of which systems do it. Link capabilities to applications to track how each function is currently enabled.',
@@ -118,7 +108,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-services"]',
+        element: 'a[href="/services"]',
         popover: {
           title: 'Services',
           description: 'Document what you deliver to the public. Link services to the personas who use them and the capabilities that power them.',
@@ -127,7 +117,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-applications"]',
+        element: 'a[href="/applications"]',
         popover: {
           title: 'Applications',
           description: 'Your technology inventory — lifecycle status, capability links, and the decisions behind each system. Filter by lifecycle to surface risks.',
@@ -136,7 +126,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-adrs"]',
+        element: 'a[href="/adrs"]',
         popover: {
           title: 'Decisions',
           description: 'Record the why behind major technology choices. Superseded decisions stay visible so future teams understand the full context.',
@@ -145,7 +135,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-strategy"]',
+        element: '[data-nav-group="Strategy"]',
         popover: {
           title: 'Strategy',
           description: 'Link capabilities to objectives and running initiatives to show which parts of your architecture are connected to mission outcomes.',
@@ -154,7 +144,7 @@ function buildTour(role: Role) {
         },
       },
       {
-        element: '[data-tour="nav-roadmap"]',
+        element: 'a[href="/roadmap"]',
         popover: {
           title: 'Roadmap',
           description: 'A timeline of active and planned initiatives. Useful for stakeholder reviews and communicating what\'s changing and when.',

--- a/apps/govea/src/lib/password.ts
+++ b/apps/govea/src/lib/password.ts
@@ -1,25 +1,28 @@
 /**
- * Shared password policy for all credential-creation paths.
+ * The bridge between GovEA's per-org security settings and `@govcore/auth`'s
+ * password policy (#894).
  *
- * Reads the per-org policy from the caller's `organizations.securitySettings`
- * row (#527). Callers that don't have a policy in hand (e.g. setup, where
- * no org exists yet) get the documented hard-coded fallback:
- * `FALLBACK_MIN_LENGTH = 8`.
+ * The policy *rules* (min length, character classes) and their validator now
+ * live in `@govcore/auth` — import `validatePassword` / `FALLBACK_MIN_LENGTH`
+ * from `@govcore/auth/password` rather than re-implementing them here. What
+ * stays app-side is the mapping below, because GovEA reads its policy from a
+ * typed `organization_settings` column while core takes a plain options bag.
+ *
+ * Import from the `@govcore/auth/password` subpath, never the package root: the
+ * root entry pulls `createAuth` → `next-auth` → `next/server`, which vitest
+ * cannot resolve, and that breaks every suite loading a module that imports it.
  *
  * OWASP A07 — Identification and Authentication Failures
  */
 import type { SecuritySettings } from '@/db/schema'
-import type { PasswordPolicy } from '@govcore/auth/password-flows'
-
-/** Fallback when no per-org policy is available (setup / pre-org paths). */
-export const FALLBACK_MIN_LENGTH = 8
+import type { PasswordPolicy } from '@govcore/auth/password'
 
 /**
  * Map GovEA's typed `SecuritySettings` column to `@govcore/auth`'s `PasswordPolicy`.
  * The password rules are 1:1 (min length + require upper/lower/digit/special), so
- * core's flows enforce exactly the same policy; the extra `SecuritySettings` fields
- * core doesn't model (expiry, lockout thresholds) stay app-side. Lets us keep the
- * column as the source of truth while adopting `@govcore/auth`'s change/reset flows.
+ * core enforces exactly the same policy; the extra `SecuritySettings` fields core
+ * doesn't model (expiry, lockout thresholds) stay app-side. This lets the column
+ * remain the source of truth while core owns the validation and the flows.
  */
 export function securitySettingsToPolicy(s: SecuritySettings): PasswordPolicy {
   return {
@@ -29,46 +32,4 @@ export function securitySettingsToPolicy(s: SecuritySettings): PasswordPolicy {
     requireDigit: s.requireDigit,
     requireSpecial: s.requireSpecial,
   }
-}
-
-/** @deprecated retained as named export for back-compat with the original code path. */
-export const PASSWORD_MIN_LENGTH = FALLBACK_MIN_LENGTH
-
-export type PasswordValidationResult =
-  | { valid: true }
-  | { valid: false; message: string }
-
-/**
- * Validate a password against an optional per-org policy. When `policy` is
- * undefined, the FALLBACK_MIN_LENGTH minimum is the only rule enforced —
- * matching the pre-#527 behavior so legacy callers don't accidentally
- * become more permissive than before.
- */
-export function validatePassword(
-  password: string | null | undefined,
-  policy?: SecuritySettings | null,
-): PasswordValidationResult {
-  if (!password || password.trim() === '') {
-    return { valid: false, message: 'Password is required' }
-  }
-
-  const minLength = policy?.passwordMinLength ?? FALLBACK_MIN_LENGTH
-  if (password.length < minLength) {
-    return { valid: false, message: `Password must be at least ${minLength} characters` }
-  }
-
-  if (policy?.requireUppercase && !/[A-Z]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one uppercase letter' }
-  }
-  if (policy?.requireLowercase && !/[a-z]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one lowercase letter' }
-  }
-  if (policy?.requireDigit && !/[0-9]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one digit' }
-  }
-  if (policy?.requireSpecial && !/[^A-Za-z0-9]/.test(password)) {
-    return { valid: false, message: 'Password must include at least one special character' }
-  }
-
-  return { valid: true }
 }

--- a/apps/govea/tests/integration/security-settings.test.ts
+++ b/apps/govea/tests/integration/security-settings.test.ts
@@ -26,7 +26,10 @@ import bcrypt from 'bcryptjs'
 import { saveSecuritySettings, getSecuritySettingsForUi } from '@/actions/security-settings'
 import { changeOwnPassword } from '@/actions/change-password'
 import { createUser, editUser } from '@/actions/users'
-import { validatePassword, FALLBACK_MIN_LENGTH } from '@/lib/password'
+// #894 — the validator + fallback now come from @govcore/auth; GovEA keeps only
+// the SecuritySettings → PasswordPolicy mapper.
+import { validatePassword, FALLBACK_MIN_LENGTH } from '@govcore/auth/password'
+import { securitySettingsToPolicy } from '@/lib/password'
 import { isPasswordExpired, mergeWithDefaults } from '@/lib/security-policy'
 import {
   createTestOrg, createTestUser, cleanupOrg, makeSession, type TestUser,
@@ -117,7 +120,7 @@ describe('security settings (#527)', () => {
   // ── validatePassword honours per-org policy ───────────────────────────────
 
   it('validatePassword: each rule fires the right error message', () => {
-    const strict = {
+    const settings = {
       passwordMinLength: 12,
       requireUppercase: true,
       requireLowercase: true,
@@ -128,6 +131,10 @@ describe('security settings (#527)', () => {
       lockoutDurationMinutes: 30,
       passwordExpiryDays: 0,
     }
+    // The org policy still lives in the SecuritySettings column; securitySettingsToPolicy
+    // is the seam that hands it to core's validator, so exercise it end to end.
+    const strict = securitySettingsToPolicy(settings)
+
     expect(validatePassword('', strict)).toMatchObject({ valid: false })
     expect(validatePassword('Short1!', strict)).toMatchObject({ valid: false, message: expect.stringMatching(/12/) })
     expect(validatePassword('alllowercase1!', strict)).toMatchObject({ valid: false, message: expect.stringMatching(/uppercase/i) })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
       '@govcore/nextkit':
-        specifier: ^0.8.0
-        version: 0.8.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
+        specifier: ^0.8.1
+        version: 0.8.1(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
       '@govcore/rbac':
         specifier: ^0.1.0
         version: 0.1.0
@@ -994,8 +994,8 @@ packages:
       next: ^15.0.0
       react: ^19.0.0
 
-  '@govcore/nextkit@0.8.0':
-    resolution: {integrity: sha512-b31CpCP8ADEK2fBEomZ1vEWo0wQG8JQW0M/35P3ccScw4ctd0NkDAgGoFolIulMzxmkAhr+ZE9Mcsz0S0iH4dw==}
+  '@govcore/nextkit@0.8.1':
+    resolution: {integrity: sha512-KRrS0atkIl+VhC+cIxAD/cw7KEFzFyuEfEpvmruktltKFV0COhlJYE2fTP3a4M2Sd78xHo5NAMgyDgNwZEcGpg==}
     peerDependencies:
       react: ^19.0.0
 
@@ -5234,7 +5234,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@govcore/nextkit@0.8.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))':
+  '@govcore/nextkit@0.8.1(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))':
     dependencies:
       '@govcore/support': 0.2.4(postgres@3.4.8)
       '@govcore/theme': 0.2.0(tailwindcss@3.4.19(tsx@4.21.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(next@15.5.19(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.8)(react@19.2.4)
       '@govcore/nextkit':
-        specifier: ^0.5.0
-        version: 0.5.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
+        specifier: ^0.8.0
+        version: 0.8.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))
       '@govcore/rbac':
         specifier: ^0.1.0
         version: 0.1.0
@@ -976,9 +976,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@govcore/audit@0.1.3':
-    resolution: {integrity: sha512-RXR3sf5ar+bv3Vf/jXXhEFpGF6PLNnUdMj5A2BNrJlc1lps8KV0cBPSGRFuLvPOKDZNhM6IfcFo3rPrRc+TUXQ==}
-
   '@govcore/audit@0.1.4':
     resolution: {integrity: sha512-HOMOCIPEK+rbm0zXvH4rtPPl9zwqaG31LAfIAGBuvuUpvXqMHRzdQUUXUz1r1qand2YXt1spdbpkluYX7aoHcQ==}
 
@@ -997,17 +994,13 @@ packages:
       next: ^15.0.0
       react: ^19.0.0
 
-  '@govcore/nextkit@0.5.0':
-    resolution: {integrity: sha512-xe/lpeAWdwpKAI+jjskLWjiuymgYIi/xYCy5Dwgzp5J7d4ber10lUa7Fxya3ZFQmX4ilKgcdMk4z7eGUE7pzYA==}
+  '@govcore/nextkit@0.8.0':
+    resolution: {integrity: sha512-b31CpCP8ADEK2fBEomZ1vEWo0wQG8JQW0M/35P3ccScw4ctd0NkDAgGoFolIulMzxmkAhr+ZE9Mcsz0S0iH4dw==}
     peerDependencies:
       react: ^19.0.0
 
   '@govcore/rbac@0.1.0':
     resolution: {integrity: sha512-Ea5IAfaqjPIJSG3wfWqTsnm7lFa2P45lRbPGGhpJRup/RisI8T4BwNZ/RLMjFVsChP+BsEPiClyzdftxnafsaQ==}
-
-  '@govcore/schema@0.3.0':
-    resolution: {integrity: sha512-tWbAnx0geqll4jSfsQtt2zTlaTfuDaXoiCGp4rz6Br0+hmCWVNFlk5zqLwQHiPvrSuHHzNuClkubrb6nCEZVjQ==}
-    hasBin: true
 
   '@govcore/schema@0.4.0':
     resolution: {integrity: sha512-aeLyV3L4w6cp5KIh+v9Ka8I6KH/Jbyes/vAq7COmRpGdfP/W+HUk9slAkh1QjD2bETRW8tCmJ+60ffBkY87H2w==}
@@ -1020,8 +1013,8 @@ packages:
     resolution: {integrity: sha512-ylw9QErBGaD4v1ksisXh61JavkUqTG/EIxwUNS7mrPTLRzfsdFb0mrFhX10cIM9v+RPCUDpAunn9bH9cExEORg==}
     hasBin: true
 
-  '@govcore/support@0.2.2':
-    resolution: {integrity: sha512-aWk35TIyQ5Y2LHKA8jKq6LgQUI+DsQ+IofZeUOy0+nxvHRoXqtfAQiGDxF93TQGFcJsAxIGIq96xYo5EY59c/A==}
+  '@govcore/support@0.2.4':
+    resolution: {integrity: sha512-GHo2cH+WwNQRyJq+7hQ3SUBLiFaRbwIg2+dR6x+GIDo0L9W26wupaAhccFHEMiFrnf7ncU53WpwFtwLlNJ0ufA==}
 
   '@govcore/tenancy@0.3.1':
     resolution: {integrity: sha512-ubWtSMvlWFfIeyU6PultgSIDuT75hHtMPHqHbRGYOQ6vxDSRES9TwXXDFHSeEPs4pMVjMGc4pBa9SwiKuN/eRw==}
@@ -5081,41 +5074,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@govcore/audit@0.1.3(postgres@3.4.8)':
-    dependencies:
-      '@govcore/schema': 0.3.0
-      drizzle-orm: 0.45.2(postgres@3.4.8)
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-
   '@govcore/audit@0.1.4(postgres@3.4.8)':
     dependencies:
       '@govcore/schema': 0.4.0
@@ -5276,9 +5234,9 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@govcore/nextkit@0.5.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))':
+  '@govcore/nextkit@0.8.0(postgres@3.4.8)(react@19.2.4)(tailwindcss@3.4.19(tsx@4.21.0))':
     dependencies:
-      '@govcore/support': 0.2.2(postgres@3.4.8)
+      '@govcore/support': 0.2.4(postgres@3.4.8)
       '@govcore/theme': 0.2.0(tailwindcss@3.4.19(tsx@4.21.0))
       react: 19.2.4
     transitivePeerDependencies:
@@ -5314,40 +5272,6 @@ snapshots:
       - tailwindcss
 
   '@govcore/rbac@0.1.0': {}
-
-  '@govcore/schema@0.3.0':
-    dependencies:
-      drizzle-orm: 0.45.2(postgres@3.4.8)
-      postgres: 3.4.8
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - prisma
-      - sql.js
-      - sqlite3
 
   '@govcore/schema@0.4.0':
     dependencies:
@@ -5462,10 +5386,10 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@govcore/support@0.2.2(postgres@3.4.8)':
+  '@govcore/support@0.2.4(postgres@3.4.8)':
     dependencies:
-      '@govcore/audit': 0.1.3(postgres@3.4.8)
-      '@govcore/schema': 0.3.0
+      '@govcore/audit': 0.2.0(postgres@3.4.8)
+      '@govcore/schema': 0.4.0
       drizzle-orm: 0.45.2(postgres@3.4.8)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'


### PR DESCRIPTION
Part of #898 (phase 1 of 2 — see "what's still open")
Capability: none — GovCore shell cutover, platform-shell infrastructure (no EA capability applies)

Replaces GovEA's hand-rolled collapsible group accordion in `SidebarContent` with **`@govcore/nextkit`'s `GroupedSideNav`** (branded tone), so the grouped-sidebar markup + accordion are shared with GovCRM instead of maintained as a third copy. Rides on GovCore #103 → **`@govcore/nextkit@0.8.0`** (branded tone, `data-nav-group` hook), bumped here.

## What stays GovEA's
- **Role/module gating** — GovEA filters `NAV_GROUPS` + items and computes `active` per item, then hands `NavGroup[]` to `GroupedSideNav`.
- **Active group auto-opens** via `defaultOpen` (native `<details>`, no client JS; SSR-safe, no open-on-hydrate flash).
- **Bespoke chrome** — Dashboard/Overview/Notifications (badge) and the Platform Admin footer stay hand-written; `GroupedSideNav`'s plain items model none of the badge / tour-anchor / violet treatment.

## Product tour (the delicate part — it has no e2e net, so verified by inspection)
- `__goveaOpenNavGroup` is reimplemented over the native accordion: `details.open = true` on the `data-nav-group` element `GroupedSideNav` emits (every match, desktop + mobile). This is **synchronous DOM**, so the group is open before driver.js measures the child — more reliable than the old path, which set React state and relied on an async re-render.
- Step selectors retargeted from `[data-tour="nav-*"]` (gone with the hand-rolled items) to the rendered DOM: group headers by `[data-nav-group="<label>"]`, child links by `a[href="/…"]`. Dashboard / search / role-badge steps are unchanged.

## Behavior changes (both acceptable)
- **Single-open accordion.** Native `<details name>` allows one open section, vs the old "active group + one remembered group" that could show two. This is convergence on GovCore's accordion, not a defect.
- **Cross-session open-group persistence dropped.** GovCore #103 explicitly flagged this as acceptable; the active group still auto-opens. `lib/nav-groups.ts` is now unused — a follow-up cleanup (left in place so its unit test isn't disturbed here).

## Verification — please note the gate
GovEA needs Postgres to run and I have no local DB, so I **could not exercise this in a browser**; CI is the gate. Locally green: `tsc --noEmit` (Type check job's command) and `lint` (0 errors). What to watch in CI:
- **axe e2e** — `GroupedSideNav` nests a second `<nav>` (unique `aria-label`: "… sections") inside GovEA's sidebar `<nav>`. Multiple nav landmarks with distinct names is WCAG-valid and I expect axe-clean, but the axe gate is the real check.
- **e2e / build** — the tour retarget has no dedicated e2e, so build + the general e2e smoke are what confirm nothing regressed at load.

## What's still open on #898
The wholesale `AppShell` swap (retiring `app-shell.tsx` entirely) stays blocked on **GovCore #102's responsive mobile-drawer gap** — GovEA's shell has a mobile drawer `AppShell` doesn't yet provide. This PR is the zero-new-core-work slice; #898 stays open for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)