### PR TITLE
fix(traceability): condense print/PDF layout (closes #922)

### DIFF
--- a/apps/govea/src/app/(admin)/traceability/page.tsx
+++ b/apps/govea/src/app/(admin)/traceability/page.tsx
@@ -82,7 +82,7 @@ function LayerLabel({ children }: { children: React.ReactNode }) {
 
 function Connector({ label }: { label: string }) {
   return (
-    <div className="flex flex-col items-center py-2 text-muted-foreground select-none">
+    <div data-trace-connector className="flex flex-col items-center py-2 text-muted-foreground select-none">
       <div className="w-px h-4 bg-border" />
       <span className="text-xs font-medium px-2 py-0.5 rounded border border-border bg-muted/40 my-1">
         {label}
@@ -920,19 +920,23 @@ export default async function TraceabilityPage({
 
   return (
     <div className="space-y-8">
-      {/* Print cover sheet (#559). */}
-      <PrintCoverSheet orgName="" title={title} />
+      {/* Print cover sheet (#559). #922: flow it inline (no forced page) since
+          the in-flow header below already carries the title. */}
+      <PrintCoverSheet orgName="" title={title} pageBreak={false} />
 
       <div className="space-y-1">
         <Link
           href={backHref}
+          data-print-hide="true"
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           {backLabel}
         </Link>
         <div className="flex items-start justify-between gap-3 flex-wrap">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+            {/* #922: hidden in print — the cover sheet supplies the title (with
+                the "As of <date>" line), so showing it again here duplicates. */}
+            <h1 data-print-hide="true" className="text-2xl font-bold tracking-tight">{title}</h1>
             <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p>
           </div>
           <PrintExportButton />
@@ -950,7 +954,7 @@ export default async function TraceabilityPage({
 
       <p className="text-xs text-muted-foreground pt-4 border-t">
         Traceability view — relationships reflect published, visible records only.
-        <Link href={backHref} className="ml-2 underline underline-offset-2 hover:text-foreground">
+        <Link href={backHref} data-print-hide="true" className="ml-2 underline underline-offset-2 hover:text-foreground">
           Edit links on the detail page.
         </Link>
       </p>
@@ -981,6 +985,7 @@ function ParticipantView({ participation }: { participation: TraceParticipation 
       <div className="space-y-1">
         <Link
           href={`${route.hrefBase}/${participation.id}`}
+          data-print-hide="true"
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           ← {route.label}
@@ -1028,7 +1033,7 @@ function ParticipantView({ participation }: { participation: TraceParticipation 
 
       <p className="text-xs text-muted-foreground pt-4 border-t">
         Traceability view — relationships reflect published, visible records only.
-        <Link href={`${route.hrefBase}/${participation.id}`} className="ml-2 underline underline-offset-2 hover:text-foreground">
+        <Link href={`${route.hrefBase}/${participation.id}`} data-print-hide="true" className="ml-2 underline underline-offset-2 hover:text-foreground">
           Edit links on the detail page.
         </Link>
       </p>

--- a/apps/govea/src/app/globals.css
+++ b/apps/govea/src/app/globals.css
@@ -66,6 +66,13 @@
      * above no longer reaches it. Zero the wrapper too, keyed off the same
      * data-print-main marker, so handouts stay edge-to-edge. */
     :has(> main[data-print-main]) { padding: 0 !important; margin: 0 !important; }
+    /* #922 — traceability connectors: the vertical rules and chevron are
+     * on-screen affordances that eat vertical space; on paper keep only the
+     * relationship verb (the middle label) so the spine condenses to a few
+     * pages instead of one row per hop. */
+    [data-trace-connector] { padding-top: 0 !important; padding-bottom: 0 !important; }
+    [data-trace-connector] > div,
+    [data-trace-connector] > span:last-child { display: none !important; }
     /* Common interactive controls that shouldn't appear on a handout. */
     button[type="button"]:not([data-print-keep]),
     .print-hide { display: none !important; }

--- a/apps/govea/src/components/print-cover-sheet.tsx
+++ b/apps/govea/src/components/print-cover-sheet.tsx
@@ -15,14 +15,22 @@ export function PrintCoverSheet({
   title,
   asOf = new Date(),
   confidenceLine,
+  pageBreak = true,
 }: {
   orgName: string
   title: string
   asOf?: Date
   confidenceLine?: string | null
+  /**
+   * Force a page break after the cover so it owns page 1 (default, suits
+   * standalone reports). Set false for views whose in-flow header already
+   * carries the title — the cover then flows inline instead of wasting a
+   * sheet. See #922 (traceability).
+   */
+  pageBreak?: boolean
 }) {
   return (
-    <div className="print-only" style={{ pageBreakAfter: 'always', padding: '2rem 0' }}>
+    <div className="print-only" style={{ pageBreakAfter: pageBreak ? 'always' : 'auto', padding: '2rem 0' }}>
       <p style={{ fontSize: 13, color: '#666', margin: 0 }}>{orgName}</p>
       <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0.5rem 0 0.25rem' }}>{title}</h1>
       <p style={{ fontSize: 13, color: '#666', margin: 0 }}>


### PR DESCRIPTION
Closes #922.

Makes the traceability print/PDF output presentation-ready for budget hearings and oversight sessions.

## Changes
- **Cover page** — `PrintCoverSheet` gains an opt-out `pageBreak` prop (defaults to the current behaviour, so the roadmap / executive / answers reports are unchanged). The traceability view opts out, so the cover flows inline instead of forcing a near-empty first sheet. The in-flow `<h1>` is hidden in print so the cover's title (which carries the "As of &lt;date&gt;" attribution) isn't duplicated.
- **Connectors** — `Connector` rows carry a `data-trace-connector` hook; in print the vertical rules and chevron are dropped and vertical padding zeroed, keeping only the relationship verb so the spine condenses to a few pages instead of one row per hop.
- **Chrome** — back-links and the "Edit links on the detail page" call-to-action are marked `data-print-hide` in both the root and participation views.

## Scope notes
- **Rail-gutter reclaim** (the third bullet of #922) is already handled on `main` via the `:has(> main[data-print-main])` rule added under #898 — no change needed here. The upstream AppShell fix is tracked in GovCore #148 so all `@govcore/nextkit` consumers benefit.
- Only the traceability view changes behaviour; the shared cover sheet stays backwards-compatible via the defaulted prop.

## Verification
- `eslint` clean on both changed `.tsx` files.
- `tsc` introduces no new errors in the changed files (pre-existing repo-wide errors are unbuilt `@govcore/*` workspace packages and a missing `@axe-core/playwright` dev dep, unrelated to this change).
- ⚠️ Print rendering itself was **not** visually verified locally (no print path reachable in this environment). Recommend confirming against a real PDF export after the next demo deploy — expect the capability trace to drop from its current length to ~2–3 full-width pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)